### PR TITLE
Code changes to fix the issue PP-228

### DIFF
--- a/pbs/src/include/pbs_python.h
+++ b/pbs/src/include/pbs_python.h
@@ -220,15 +220,6 @@ extern int  pbs_python_ext_alloc_python_script(
 extern void pbs_python_ext_quick_start_interpreter(void);
 extern void pbs_python_ext_quick_shutdown_interpreter(void);
 
-#define	PBS_PYTHON_RESTART_COUNTER	100 /* # of hook events to service    */
-/* before auto-restarting the     */
-/* interpreter (minize mem usage).*/
-
-#define PBS_PYTHON_OBJECTS_MAX_CREATED  1000    /* # of PBS Python objects    */
-/* created before also        */
-/* auto-restarting the        */
-/* interpreter to minimize    */
-/* mem  usage.                */
 
 /* -- END pbs_python_external.c implementations -- */
 


### PR DESCRIPTION
PP-228 Description: PBS Server is restarting Python interpreter too often

Solution: As we updated PBS to use Python 2.7.3 which is the latest and
last release of Python 2.x and it also fixes several memory leaks which
were there in Python 2.5.1, we NO longer need to restart Python Interpreter
for every 100 hook events to service or PBS Python objects reached to 1000.
So the resolution for this issue is to remove the code which does these
conditional checks.

Signed-off-by: Suresh Thelkar suresh.thelkar@altair.com
