### PR TITLE
PP-241 Address unresolved symbols when linking against libpbs.so

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -748,7 +748,7 @@ WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 
 _ _ _ _ _ _
 
-src/lib/Libifl/popen.c
+src/resmom/popen.c
 
 Copyright (c) 1988, 1993
      The Regents of the University of California.  All rights reserved.

--- a/src/include/mom_func.h
+++ b/src/include/mom_func.h
@@ -40,6 +40,7 @@
 extern "C" {
 #endif
 
+#include <stdio.h>
 
 #ifndef	MOM_MACH
 #include "mom_mach.h"
@@ -379,6 +380,11 @@ extern int init_x11_display(struct pfwdsock *, int, char *, char *, char *);
 extern int setcurrentworkdir(char *);
 extern int becomeuser(job *);
 extern int becomeuser_args(char *, uid_t, gid_t, gid_t);
+
+/* From popen.c */
+extern FILE *pbs_popen(const char *, const char *);
+extern int pbs_pkill(FILE *, int);
+extern int pbs_pclose(FILE *);
 
 /* Define for max xauth data*/
 #define X_DISPLAY_LEN   512

--- a/src/include/pbs_internal.h
+++ b/src/include/pbs_internal.h
@@ -397,12 +397,6 @@ DECLDIR int pbs_loadconf(int);
 
 DECLDIR char *pbs_get_tmpdir(void);
 
-DECLDIR FILE *pbs_popen(const char *, const char *);
-
-DECLDIR int pbs_pkill(FILE *, int);
-
-DECLDIR int pbs_pclose(FILE *);
-
 DECLDIR char *pbs_strsep(char **, const char *);
 
 DECLDIR int pbs_confirmresv(int, char *, char *, unsigned long, char *);

--- a/src/lib/Libpbs/Makefile.am
+++ b/src/lib/Libpbs/Makefile.am
@@ -244,7 +244,6 @@ libpbs_la_SOURCES = \
 	../Libifl/pbsD_confirmresv.c \
 	../Libifl/pbsD_defschreply.c \
 	../Libifl/pbsD_statrsc.c \
-	../Libifl/popen.c \
 	../Libifl/rpp.c \
 	../Libifl/strsep.c \
 	../Libifl/tcp_dis.c \

--- a/src/lib/Libpbs/Makefile.in
+++ b/src/lib/Libpbs/Makefile.in
@@ -279,8 +279,8 @@ am_libpbs_la_OBJECTS = libpbs_la-attr_fn_arst.lo \
 	libpbs_la-pbsD_submit_resv.lo libpbs_la-pbsD_stathook.lo \
 	libpbs_la-pbsD_delresv.lo libpbs_la-pbsD_statresv.lo \
 	libpbs_la-pbsD_confirmresv.lo libpbs_la-pbsD_defschreply.lo \
-	libpbs_la-pbsD_statrsc.lo libpbs_la-popen.lo libpbs_la-rpp.lo \
-	libpbs_la-strsep.lo libpbs_la-tcp_dis.lo libpbs_la-tm.lo \
+	libpbs_la-pbsD_statrsc.lo libpbs_la-rpp.lo libpbs_la-strsep.lo \
+	libpbs_la-tcp_dis.lo libpbs_la-tm.lo \
 	libpbs_la-xml_encode_decode.lo libpbs_la-pbs_messages.lo \
 	libpbs_la-cs.lo libpbs_la-cs_standard.lo \
 	libpbs_la-misc_utils.lo libpbs_la-munge_supp.lo \
@@ -748,7 +748,6 @@ libpbs_la_SOURCES = \
 	../Libifl/pbsD_confirmresv.c \
 	../Libifl/pbsD_defschreply.c \
 	../Libifl/pbsD_statrsc.c \
-	../Libifl/popen.c \
 	../Libifl/rpp.c \
 	../Libifl/strsep.c \
 	../Libifl/tcp_dis.c \
@@ -1057,7 +1056,6 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libpbs_la-pbs_quote_parse.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libpbs_la-pbs_secrets.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libpbs_la-pbs_statfree.Plo@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libpbs_la-popen.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libpbs_la-prepare_path.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libpbs_la-prt_job_err.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libpbs_la-ps_dis.Plo@am__quote@
@@ -2458,13 +2456,6 @@ libpbs_la-pbsD_statrsc.lo: ../Libifl/pbsD_statrsc.c
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='../Libifl/pbsD_statrsc.c' object='libpbs_la-pbsD_statrsc.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libpbs_la_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -c -o libpbs_la-pbsD_statrsc.lo `test -f '../Libifl/pbsD_statrsc.c' || echo '$(srcdir)/'`../Libifl/pbsD_statrsc.c
-
-libpbs_la-popen.lo: ../Libifl/popen.c
-@am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libpbs_la_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -MT libpbs_la-popen.lo -MD -MP -MF $(DEPDIR)/libpbs_la-popen.Tpo -c -o libpbs_la-popen.lo `test -f '../Libifl/popen.c' || echo '$(srcdir)/'`../Libifl/popen.c
-@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/libpbs_la-popen.Tpo $(DEPDIR)/libpbs_la-popen.Plo
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='../Libifl/popen.c' object='libpbs_la-popen.lo' libtool=yes @AMDEPBACKSLASH@
-@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libpbs_la_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -c -o libpbs_la-popen.lo `test -f '../Libifl/popen.c' || echo '$(srcdir)/'`../Libifl/popen.c
 
 libpbs_la-rpp.lo: ../Libifl/rpp.c
 @am__fastdepCC_TRUE@	$(AM_V_CC)$(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libpbs_la_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -MT libpbs_la-rpp.lo -MD -MP -MF $(DEPDIR)/libpbs_la-rpp.Tpo -c -o libpbs_la-rpp.lo `test -f '../Libifl/rpp.c' || echo '$(srcdir)/'`../Libifl/rpp.c

--- a/src/resmom/Makefile.am
+++ b/src/resmom/Makefile.am
@@ -85,6 +85,7 @@ pbs_mom_SOURCES = \
 	mom_main.c \
 	mom_server.c \
 	mom_vnode.c \
+	popen.c \
 	prolog.c \
 	requests.c \
 	rm_dep.h \

--- a/src/resmom/Makefile.in
+++ b/src/resmom/Makefile.in
@@ -202,7 +202,7 @@ am__pbs_mom_SOURCES_DIST = $(top_builddir)/src/server/job_attr_def.c \
 	${PBS_MACH}/mom_mach.h ${PBS_MACH}/mom_start.c \
 	${PBS_MACH}/pe_input.c catch_child.c mom_comm.c \
 	mom_hook_func.c mom_inter.c mom_main.c mom_server.c \
-	mom_vnode.c prolog.c requests.c rm_dep.h stage_func.c \
+	mom_vnode.c popen.c prolog.c requests.c rm_dep.h stage_func.c \
 	start_exec.c vnode_storage.c linux/alps.c \
 	irix6cpuset/allocnodes.c irix6cpuset/allocnodes.h \
 	irix6cpuset/collector.c irix6cpuset/collector.h \
@@ -234,10 +234,11 @@ am_pbs_mom_OBJECTS = pbs_mom-job_attr_def.$(OBJEXT) \
 	pbs_mom-catch_child.$(OBJEXT) pbs_mom-mom_comm.$(OBJEXT) \
 	pbs_mom-mom_hook_func.$(OBJEXT) pbs_mom-mom_inter.$(OBJEXT) \
 	pbs_mom-mom_main.$(OBJEXT) pbs_mom-mom_server.$(OBJEXT) \
-	pbs_mom-mom_vnode.$(OBJEXT) pbs_mom-prolog.$(OBJEXT) \
-	pbs_mom-requests.$(OBJEXT) pbs_mom-stage_func.$(OBJEXT) \
-	pbs_mom-start_exec.$(OBJEXT) pbs_mom-vnode_storage.$(OBJEXT) \
-	$(am__objects_1) $(am__objects_2) $(am__objects_3)
+	pbs_mom-mom_vnode.$(OBJEXT) pbs_mom-popen.$(OBJEXT) \
+	pbs_mom-prolog.$(OBJEXT) pbs_mom-requests.$(OBJEXT) \
+	pbs_mom-stage_func.$(OBJEXT) pbs_mom-start_exec.$(OBJEXT) \
+	pbs_mom-vnode_storage.$(OBJEXT) $(am__objects_1) \
+	$(am__objects_2) $(am__objects_3)
 pbs_mom_OBJECTS = $(am_pbs_mom_OBJECTS)
 am__DEPENDENCIES_1 =
 pbs_mom_DEPENDENCIES = $(top_builddir)/src/lib/Libattr/libattr.a \
@@ -528,7 +529,7 @@ pbs_mom_SOURCES = $(top_builddir)/src/server/job_attr_def.c \
 	${PBS_MACH}/mom_mach.h ${PBS_MACH}/mom_start.c \
 	${PBS_MACH}/pe_input.c catch_child.c mom_comm.c \
 	mom_hook_func.c mom_inter.c mom_main.c mom_server.c \
-	mom_vnode.c prolog.c requests.c rm_dep.h stage_func.c \
+	mom_vnode.c popen.c prolog.c requests.c rm_dep.h stage_func.c \
 	start_exec.c vnode_storage.c $(am__append_3) $(am__append_6) \
 	$(am__append_7)
 EXTRA_DIST = \
@@ -697,6 +698,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/pbs_mom-mom_start.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/pbs_mom-mom_vnode.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/pbs_mom-pe_input.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/pbs_mom-popen.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/pbs_mom-process_request.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/pbs_mom-prolog.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/pbs_mom-reply_send.Po@am__quote@
@@ -1038,6 +1040,20 @@ pbs_mom-mom_vnode.obj: mom_vnode.c
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='mom_vnode.c' object='pbs_mom-mom_vnode.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(pbs_mom_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -c -o pbs_mom-mom_vnode.obj `if test -f 'mom_vnode.c'; then $(CYGPATH_W) 'mom_vnode.c'; else $(CYGPATH_W) '$(srcdir)/mom_vnode.c'; fi`
+
+pbs_mom-popen.o: popen.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(pbs_mom_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -MT pbs_mom-popen.o -MD -MP -MF $(DEPDIR)/pbs_mom-popen.Tpo -c -o pbs_mom-popen.o `test -f 'popen.c' || echo '$(srcdir)/'`popen.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/pbs_mom-popen.Tpo $(DEPDIR)/pbs_mom-popen.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='popen.c' object='pbs_mom-popen.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(pbs_mom_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -c -o pbs_mom-popen.o `test -f 'popen.c' || echo '$(srcdir)/'`popen.c
+
+pbs_mom-popen.obj: popen.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(pbs_mom_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -MT pbs_mom-popen.obj -MD -MP -MF $(DEPDIR)/pbs_mom-popen.Tpo -c -o pbs_mom-popen.obj `if test -f 'popen.c'; then $(CYGPATH_W) 'popen.c'; else $(CYGPATH_W) '$(srcdir)/popen.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/pbs_mom-popen.Tpo $(DEPDIR)/pbs_mom-popen.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='popen.c' object='pbs_mom-popen.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(pbs_mom_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -c -o pbs_mom-popen.obj `if test -f 'popen.c'; then $(CYGPATH_W) 'popen.c'; else $(CYGPATH_W) '$(srcdir)/popen.c'; fi`
 
 pbs_mom-prolog.o: prolog.c
 @am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(pbs_mom_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -MT pbs_mom-prolog.o -MD -MP -MF $(DEPDIR)/pbs_mom-prolog.Tpo -c -o pbs_mom-prolog.o `test -f 'prolog.c' || echo '$(srcdir)/'`prolog.c

--- a/src/resmom/popen.c
+++ b/src/resmom/popen.c
@@ -82,7 +82,6 @@
 
 #include <sys/param.h>
 #include <sys/wait.h>
-#include "libpbs.h" /* so that pbs_popen etc are declared as DECLDIR for aif */
 
 extern pid_t fork_me(int sock);
 extern int kill_session(pid_t pid, int sig, int dir);


### PR DESCRIPTION
The set_nodelay() function is defined in libnet. Because it is an
inter-library dependency and the code itself is quite small, the
functionality was implemented directly within
pbs_connection_set_nodelay(). The fork_me() and kill_session()
references were due to three functions defined in libpbs...
pbs_popen, pbs_pkill, and pbs_pclose. Because these three
functions are only called by pbs_mom, they were moved out of libpbs
and into pbs_mom directly.

PP-241 #time 5h #resolve
