### PR TITLE
Fix for PP-242: MoM.reverts_to_defaults tries to delete vnode without id

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -11413,7 +11413,7 @@ class MoM(PBSService):
                 try:
                     _vs = self.server.status(VNODE, a, id=self.hostname)
                 except:
-                    _vs = self.server.status(VNODE, a, id=self.shorname)
+                    _vs = self.server.status(VNODE, a, id=self.shortname)
                 vs = []
                 for v in _vs:
                     if v[rav].split('.')[0] != v[rah].split('.')[0]:


### PR DESCRIPTION
Problem:
1) Mom.reverts_to_defaults is tries to call server.manager without vnode is while removing vnode from server list after deleting vnode def file
2) it tries to delete natural node where jobs are running. this is because Mom.reverts_to_defaults add natural node in vnodes list which is incorrect.

Fix:
1) if vnodes list is empty then don't call server.manager
2) don't add natural node name in vnodes list
