### PR TITLE
PP-256: Fix build on SLES10 and RHEL5

### DIFF
--- a/configure
+++ b/configure
@@ -13545,6 +13545,7 @@ for ac_header in  \
 	libpq-fe.h \
 	mach/mach.h \
 	nlist.h \
+	sys/eventfd.h \
 	sys/systeminfo.h \
 
 do :
@@ -13609,7 +13610,6 @@ for ac_header in  \
 	syscall.h \
 	syslog.h \
 	sys/epoll.h \
-	sys/eventfd.h \
 	sys/fcntl.h \
 	sys/file.h \
 	sys/ioctl.h \

--- a/configure.ac
+++ b/configure.ac
@@ -98,6 +98,7 @@ AC_CHECK_HEADERS([ \
 	libpq-fe.h \
 	mach/mach.h \
 	nlist.h \
+	sys/eventfd.h \
 	sys/systeminfo.h \
 ])
 
@@ -150,7 +151,6 @@ AC_CHECK_HEADERS([ \
 	syscall.h \
 	syslog.h \
 	sys/epoll.h \
-	sys/eventfd.h \
 	sys/fcntl.h \
 	sys/file.h \
 	sys/ioctl.h \


### PR DESCRIPTION
The sys/eventfd.h header was added as required and does not exist on older distros.
