### PR TITLE
If job in resv exceeds resv end time, future resv fails to confirm

### DIFF
--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -1575,7 +1575,7 @@ update_node_on_run(nspec *ns, resource_resv *resresv, char *job_state)
 	resource_resv **tmp_arr;
 	node_info *ninfo;
 	timed_event *te;
-	
+
 	if (ns == NULL || resresv == NULL)
 		return;
 
@@ -1693,17 +1693,17 @@ update_node_on_run(nspec *ns, resource_resv *resresv, char *job_state)
 			}
 		}
 	}
-	
+
 	for(te = resresv->server->calendar->next_event; te != NULL; te = te->next) {
 		if(te->event_type & TIMED_RUN_EVENT) {
 			if(te->event_ptr == resresv)
 				break;
 		}
 	}
-	
+
 	remove_te_list(&ninfo->node_events, te);
 
-	if (ninfo->bucket_ind != -1) {
+	if (ninfo->node_ind != -1 && ninfo->bucket_ind != -1) {
 		node_bucket *bkt = ninfo->server->buckets[ninfo->bucket_ind];
 		int ind = ninfo->node_ind;
 
@@ -1832,9 +1832,9 @@ update_node_on_end(node_info *ninfo, resource_resv *resresv, char *job_state)
 			}
 		}
 	}
-	
+
 	ind = ninfo->node_ind;
-	if (ind != -1) {
+	if (ind != -1 && ninfo->bucket_ind != -1) {
 		node_bucket *bkt = ninfo->server->buckets[ninfo->bucket_ind];
 
 		if (ninfo->node_events == NULL) {
@@ -5544,7 +5544,7 @@ node_info *find_node_by_indrank(node_info **ninfo_arr, int ind, int rank) {
 	if(ninfo_arr == NULL || *ninfo_arr == NULL)
 		return NULL;
 	
-	if(ninfo_arr[0] == NULL || ninfo_arr[0]->server == NULL || ninfo_arr[0]->server->unordered_nodes == NULL)
+	if(ninfo_arr[0] == NULL || ninfo_arr[0]->server == NULL || ninfo_arr[0]->server->unordered_nodes == NULL || ind == -1)
 		return find_node_by_rank(ninfo_arr, rank);
 	
 	return ninfo_arr[0]->server->unordered_nodes[ind];

--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -282,6 +282,7 @@ query_reservations(server_info *sinfo, struct batch_status *resvs)
 						 */
 						if (sinfo->server_time + rjob->duration > resresv->end) {
 							rjob->duration = resresv->end - sinfo->server_time;
+							rjob->hard_duration = rjob->duration;
 							if (rjob->end != UNSPECIFIED)
 								rjob->end = resresv->end;
 						}
@@ -1452,7 +1453,7 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 		}
 		if (!(simrc & TIMED_ERROR) && resv_start_time >= 0) {
 			clear_schd_error(err);
-			if ((ns = is_ok_to_run(nsinfo->policy, nsinfo, NULL, nresv, NO_FLAGS, err)) != NULL) {
+			if ((ns = is_ok_to_run(nsinfo->policy, nsinfo, NULL, nresv, NO_ALLPART, err)) != NULL) {
 				combine_nspec_array(ns);
 				tmp = create_execvnode(ns);
 				free_nspecs(ns);
@@ -1495,8 +1496,8 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 				(void) translate_fail_code(err, NULL, logmsg);
 
 				/* If the reservation is degraded, we log a message and continue */
-					snprintf(buf, MAX_LOG_SIZE, "Reservation Failed to Reconfirm: %s",
-						logmsg2);
+				snprintf(buf, MAX_LOG_SIZE, "Reservation Failed to Reconfirm: %s",
+					logmsg);
 				if (nresv->resv->resv_substate == RESV_DEGRADED) {
 					schdlog(PBSEVENT_RESV, PBS_EVENTCLASS_RESV, LOG_INFO,
 						nresv->name, buf);

--- a/src/scheduler/simulate.c
+++ b/src/scheduler/simulate.c
@@ -860,7 +860,7 @@ create_events(server_info *sinfo)
 	qsort(all, count_array((void **)all), sizeof(resource_resv *), cmp_events);
 
 	for (i = 0; all[i] != NULL && is_timed(all[i]); i++) {
-		if (all[i]->is_resv && all[i]->resv &&
+		if (all[i]->is_resv && all[i]->resv != NULL &&
 			all[i]->resv->resv_state == RESV_BEING_ALTERED)
 			continue;
 		/* only add a run event for a job or reservation if they're


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
If a job is running with exclusive placement in a reservation and its walltime exceeds the reservation end time then scheduler will not confirm any other reservation on the same node until the job ends.

It turns out there were two more problems that needed to be fixed in for reservations to work - 
Problem - 1 
Scheduler crashes when it simulates a job run even where the job is part of a reservation. The reason is that job's node info array points to node in reservation and those nodes do not have node index and bucket index set on them. This caused "find_node_by_indrank()" function to dereference an out of bounds location and crash scheduler.
A check for node_ind against '-1' value fixed the problem. Similar fix was needed in update_node_on_run/end

Problem - 2
While confirming the reservation (confirm_reservation) it fails in the call to is_ok_to_run because scheduler used to think that it can not fit the reservation with the available resources in partition metadata. This check was not needed because reservations don't need this metadata and check_nodes will eventually find whether the reservation can run or not.


#### Affected Platform(s)
All

#### Cause / Analysis / Design
In an ideal scenario, if a job's walltime exceeds the end time of reservation, scheduler should just consider job's end time as end time of the reservation. This was not happening and because of this we were putting end-event of the job with wrong end-time in the calendar.

#### Solution Description
Changed the code to calculate the time left on the job to match the time left for the reservation.

#### Testing logs/output
[pbs_soft_walltime.txt](https://github.com/PBSPro/pbspro/files/2129493/pbs_soft_walltime.txt)
[pbs_reservations.txt](https://github.com/PBSPro/pbspro/files/2129494/pbs_reservations.txt)



#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
