### PR TITLE
pbs.conf variables could not be overridden by environment variables for pbs_server

### DIFF
--- a/src/cmds/scripts/pbs_init.d.in
+++ b/src/cmds/scripts/pbs_init.d.in
@@ -846,7 +846,7 @@ pre_start_pbs()
 
 : main code
 # save env variables in a temp file
-env_save="/tmp/$$_`date +'%s'`_env_save"
+env_save="/tmp/$$_$(date +'%s')_env_save"
 declare -x > "${env_save}"
 
 conf=${PBS_CONF_FILE:-/etc/pbs.conf}

--- a/src/cmds/scripts/pbs_server
+++ b/src/cmds/scripts/pbs_server
@@ -35,7 +35,16 @@
 # "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
 # trademark licensing policies.
 
+# save env variables in a temp file
+env_save="/tmp/$$_$(date +'%s')_env_save"
+declare -x > "${env_save}"
+
 . ${PBS_CONF_FILE:-/etc/pbs.conf}
+
+# re-apply saved env variables
+. "${env_save}"
+
+rm -f "${env_save}"
 
 # Source the file that sets PGSQL_LIBSTR
 . "$PBS_EXEC"/libexec/pbs_pgsql_env.sh

--- a/test/tests/functional/pbs_highreslog.py
+++ b/test/tests/functional/pbs_highreslog.py
@@ -159,8 +159,6 @@ class TestHighResLogging(TestFunctional):
         """
         Check env variable overwrites the pbs.conf value
         """
-        self.skipTest("Unskip after pbs_server is is fixed to overwrite "
-                      "PBS_LOG_HIGHRES_TIMESTAMP value with env variable")
         a = {'PBS_LOG_HIGHRES_TIMESTAMP': 0}
         self.du.set_pbs_config(confs=a, append=True)
         conf_path = self.du.parse_pbs_config()


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* pbs.conf variables could not be overridden by environment variables for pbs_server.  If a variable is set in pbs.conf, the pbs.conf variable would be used regardless of what was in the environment.  This worked fine for the other daemons, just not for pbs_server.

* *Bugs: 
Steps to Reproduce:
set PBS_LOG_HIGHRES_TIMESTAMP=1 in pbs.conf
run PBS_LOG_HIGHRES_TIMESTAMP=0 /opt/pbs/sbin/pbs_server
highres timestamps will be seen in the server log.

#### Cause / Analysis / Design
* The pbs_server command that is run is not a binary.  It is a script which sets the LD_LIBRARY_PATH correctly and then runs the actual pbs_server binary.  The first thing the script does is source /etc/pbs.conf.  This will reset any environment variable with what is in pbs.conf.

#### Solution Description
* The fix is simple.  This same issue happened for the init script.  The fix is the same.  Before sourcing pbs.conf, save a copy of the environment.  After sourcing pbs.conf, source the saved copy of the environment.  This means that any pbs.conf variable that is set in the environment will be first set to the pbs.conf value and then reset back to the original value.

No new PTL test needs to be written.  The existing high res timestamp test TestHighResLogging.test_env_variable_overwrite will test the issue.

#### Testing logs/output
[ptl-init.log](https://github.com/PBSPro/pbspro/files/2333580/ptl-init.log)
[ptl-highres.log](https://github.com/PBSPro/pbspro/files/2333581/ptl-highres.log)

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
