### PR TITLE
test_restart_server fails because the sched_host name doesn't match

### DIFF
--- a/test/tests/functional/pbs_multi_sched.py
+++ b/test/tests/functional/pbs_multi_sched.py
@@ -601,7 +601,6 @@ class TestMultipleSchedulers(TestFunctional):
         sched_logs = os.path.join(
             self.server.pbs_conf['PBS_HOME'], 'sched_logs_sc1')
         a = {'sched_port': 15050,
-             'sched_host': self.server.hostname,
              'sched_priv': sched_priv,
              'sched_log': sched_logs,
              'scheduling': 'True',


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
On some Platform PTL consider different sched hostname then hostname get by the pbs.
i. e PBS takes hostname as server_host and ptl takes hostname as pbs_host
#### Describe Your Change
In mullti sched doesn't require to match sched hostname.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
