### PR TITLE
15019 errors for client commands under extreme load

### DIFF
--- a/src/lib/Libifl/pbsD_connect.c
+++ b/src/lib/Libifl/pbsD_connect.c
@@ -800,6 +800,12 @@ __pbs_connect_extend(char *server, char *extend_data)
 		}
 
 		reply = PBSD_rdrpy(out);
+		if (reply == NULL) {
+			/* failed to read reply from the given connection point,
+			 * connection might be dropped by the TCP stack.
+			 */
+			return -1;
+		}
 		PBSD_FreeReply(reply);
 #if defined(PBS_SECURITY) && (PBS_SECURITY == KRB5)
 	}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
When PBS server is under extreme load, a client's connect request might be dropped by the TCP stack at the server, rather abruptly (ECONNRESET). When this happens right after connect but before invoking pbs_iff for authentication, the reply from the server to the connect batch request returns NULL. The current code does not check for this error condition and proceeds (erroneously) to invoke pbs_iff.  This authentication request therefore, results in the error "Invalid Credential(15019)".

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Server will not go forward for authentication if the given connection has been dropped by the server TCP stack; in other words we will check that we have received a successful reply to the batch connect message from the server before proceeding with authentication.