### PR TITLE
[WIP]Avoid quasi-duplicate job resc_used updates in update_ajob_status and update_jobs_status

### DIFF
--- a/src/include/job.h
+++ b/src/include/job.h
@@ -548,6 +548,7 @@ struct job {
 	time_t		ji_joinalarm;	/* time of job's sister join job alarm */
 	/* also, time obit sent, all */
 	time_t		ji_overlmt_timestamp;	/*time the job exceeded limit*/
+	time_t		ji_last_resc_updated;   /*time last updated to server */
 	int		ji_jsmpipe;	/* pipe from child starter process */
 	int		ji_mjspipe;	/* pipe to   child starter for ack */
 	int		ji_jsmpipe2;	/* pipe for child starter process to send special requests to parent mom */

--- a/src/resmom/catch_child.c
+++ b/src/resmom/catch_child.c
@@ -1107,9 +1107,8 @@ update_ajob_status_using_cmd(job *pjob, int cmd, int use_rtn_list_ext)
 
 	/* now send info to server via rpp */
 
-	if (!(pjob->ji_last_resc_updated < time_now - min_check_poll))	{
+	if (pjob->ji_last_resc_updated >= (time_now - min_check_poll))
 		send_resc_used(cmd, 1, &rused);
-	} 
 
 	/* free svrattrl list */
 
@@ -1165,7 +1164,7 @@ update_jobs_status(void)
 	for (pjob = (job *)GET_NEXT(svr_alljobs);
 		pjob; pjob = (job *)GET_NEXT(pjob->ji_alljobs)) {
 			time_now = time(NULL);
-			if (pjob->ji_last_resc_updated > time_now - min_check_poll)	
+			if (pjob->ji_last_resc_updated >= (time_now - min_check_poll))	
 				continue;
 
 		if ((pjob->ji_qs.ji_svrflags & JOB_SVFLG_HERE) == 0)

--- a/src/server/job_func.c
+++ b/src/server/job_func.c
@@ -384,6 +384,7 @@ job_alloc(void)
 	pj->ji_parent2child_moms_status_pipe = -1;
 	pj->ji_updated = 0;
 	pj->ji_hook_running_bg_on = 0;
+	pj->ji_last_resc_updated = TM_NULL_EVENT;
 #if defined(PBS_SECURITY) && (PBS_SECURITY == KRB5)
 #if defined(HAVE_LIBKAFS) || defined(HAVE_LIBKOPENAFS)
 	pj->ji_extended.ji_ext.ji_pag = 0;


### PR DESCRIPTION
Avoid quasi-duplicate job resc_used updates in update_ajob_status and update_jobs_status

#### Describe Bug or Feature
Duplicate job resc_used updates are being sent from update_ajob_status and update_jobs_status
whenever a job update is to be sent.


#### Describe Your Change
A new job attribute pjob->ji_last_resc_updated is updated whenever a job update is sent to server. Before sending the next update we check if the last update sent time is less than current time - min_check_poll


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
