### PR TITLE
pbs_server daemon core dumps while setting "restrict_res_to_release_on_suspend" attribute

### DIFF
--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -8664,14 +8664,16 @@ int update_resources_rel(job *pjob, attribute *attrib, enum batch_op op)
 		 */
 		if ((prdef->rs_flags & ATR_DFLAG_RASSN) &&
 			(find_resc_entry(&pjob->ji_wattr[(int) JOB_ATR_resc_released_list], prdef) == NULL)) {
-			for (j = 0; j < server.sv_attr[(int)SVR_ATR_restrict_res_to_release_on_suspend].at_val.at_arst->as_usedptr; j++) {
-				if (strcmp(server.sv_attr[(int)SVR_ATR_restrict_res_to_release_on_suspend].at_val.at_arst->as_string[j],
-				    prdef->rs_name) == 0) {
-					presc = add_resource_entry(&pjob->ji_wattr[(int) JOB_ATR_resc_released_list], prdef);
-					if (presc == NULL)
-						return 1;
-					prdef->rs_set(&presc->rs_value, &presc_sq->rs_value, op);
-					break;
+			if (server.sv_attr[(int) SVR_ATR_restrict_res_to_release_on_suspend].at_val.at_arst) {
+				for (j = 0; j < server.sv_attr[(int)SVR_ATR_restrict_res_to_release_on_suspend].at_val.at_arst->as_usedptr; j++) {
+					if (strcmp(server.sv_attr[(int)SVR_ATR_restrict_res_to_release_on_suspend].at_val.at_arst->as_string[j],
+						prdef->rs_name) == 0) {
+							presc = add_resource_entry(&pjob->ji_wattr[(int) JOB_ATR_resc_released_list], prdef);
+							if (presc == NULL)
+								return 1;
+							prdef->rs_set(&presc->rs_value, &presc_sq->rs_value, op);
+							break;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
#### Describe Bug or Feature
pbs_server daemon core dumps while setting "restrict_res_to_release_on_suspend" attribute.

#### Describe Your Change
Changed code to run pbs_server daemon while setting "restrict_res_to_release_on_suspend" attribute.

#### Attach Test logs/Output
[Before_fix_logs.txt](https://github.com/PBSPro/pbspro/files/4388452/Before_fix_logs.txt)
[After_fix_logs.txt](https://github.com/PBSPro/pbspro/files/4388451/After_fix_logs.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
