### PR TITLE
New Sched attribute to throttle job attribute updates + refactoring

### DIFF
--- a/src/include/attribute.h
+++ b/src/include/attribute.h
@@ -574,14 +574,12 @@ extern int check_for_bgl_nodes(attribute *patr,  void *pobject,  int actmode);
 extern int action_sched_iteration(attribute *pattr, void *pobj, int actmode);
 extern int action_sched_priv(attribute *pattr, void *pobj, int actmode);
 extern int action_sched_log(attribute *pattr, void *pobj, int actmode);
-extern int action_sched_log_events(attribute *pattr, void *pobj, int actmode);
 extern int action_sched_user(attribute *pattr, void *pobj, int actmode);
 extern int action_sched_port(attribute *pattr, void *pobj, int actmode);
 extern int action_sched_host(attribute *pattr, void *pobj, int actmode);
 extern int action_sched_partition(attribute *pattr, void *pobj, int actmode);
 extern int action_sched_preempt_order(attribute *pattr, void *pobj, int actmode);
 extern int action_sched_preempt_common(attribute *pattr, void *pobj, int actmode);
-extern int action_sched_server_dyn_res_alarm(attribute *pattr, void *pobj, int actmode);
 extern int action_job_run_wait(attribute *pattr, void *pobj, int actmode);
 extern int action_throughput_mode(attribute *pattr, void *pobj, int actmode);
 

--- a/src/include/pbs_ifl.h
+++ b/src/include/pbs_ifl.h
@@ -330,6 +330,7 @@ extern "C" {
 #define ATTR_cred_renew_tool	"cred_renew_tool"
 #define ATTR_cred_renew_period	"cred_renew_period"
 #define ATTR_cred_renew_cache_period "cred_renew_cache_period"
+#define ATTR_attr_update_period "attr_update_period"
 
 /**
  * RPP_MAX_PKT_CHECK_DEFAULT controls the number of loops used to process

--- a/src/include/pbs_sched.h
+++ b/src/include/pbs_sched.h
@@ -100,6 +100,7 @@ enum sched_atr {
 	SCHED_ATR_log_events,
 	SCHED_ATR_job_sort_formula,
 	SCHED_ATR_server_dyn_res_alarm,
+	SCHED_ATR_attr_update_period,
 #include "site_sched_attr_enum.h"
 	/* This must be last */
 	SCHED_ATR_LAST

--- a/src/include/sched_cmds.h
+++ b/src/include/sched_cmds.h
@@ -58,7 +58,6 @@
 #define SCH_SCHEDULE_ETE_ON 15		/* eligible_time_enable is turned ON */
 #define SCH_SCHEDULE_RESV_RECONFIRM 16		/* Reconfirm a reservation */
 #define SCH_SCHEDULE_RESTART_CYCLE 17		/* Restart a scheduling cycle */
-#define SCH_ATTRS_CONFIGURE 18
 
 
 extern int schedule(int cmd, int sd, char *runjid);

--- a/src/lib/Libattr/master_sched_attr_def.xml
+++ b/src/lib/Libattr/master_sched_attr_def.xml
@@ -168,7 +168,7 @@
 	<member_at_free>free_null</member_at_free>
 	<member_at_action>NULL_FUNC</member_at_action>
 	<member_at_flags><both>NO_USER_SET</both></member_at_flags>
-	<member_at_type><both>ATR_TYPE_LONG</both></member_at_type>
+	<member_at_type><both>ATR_TYPE_BOOL</both></member_at_type>
 	<member_at_parent>PARENT_TYPE_SCHED</member_at_parent>
 	<member_verify_function>
 	<ECL>verify_datatype_bool</ECL>
@@ -487,7 +487,7 @@
         <member_at_set>set_l</member_at_set>
         <member_at_comp>comp_l</member_at_comp>
         <member_at_free>free_null</member_at_free>
-        <member_at_action>action_sched_log_events</member_at_action>
+        <member_at_action>NULL_FUNC</member_at_action>
         <member_at_flags><both>NO_USER_SET</both></member_at_flags>
         <member_at_type><both>ATR_TYPE_LONG</both></member_at_type>
         <member_at_parent>PARENT_TYPE_SCHED</member_at_parent>
@@ -519,7 +519,7 @@
 	<member_at_set>set_l</member_at_set>
 	<member_at_comp>comp_l</member_at_comp>
 	<member_at_free>free_null</member_at_free>
-	<member_at_action>action_sched_server_dyn_res_alarm</member_at_action>
+	<member_at_action>NULL_FUNC</member_at_action>
 	<member_at_flags><both>MGR_ONLY_SET</both></member_at_flags>
 	<member_at_type><both>ATR_TYPE_LONG</both></member_at_type>
 	<member_at_parent>PARENT_TYPE_SCHED</member_at_parent>
@@ -527,6 +527,22 @@
 	<ECL>verify_datatype_long</ECL>
 	<ECL>verify_value_zero_or_positive</ECL>
 	</member_verify_function>
+   </attributes>
+   <attributes> /* attr_update_period */
+    <member_name><both>ATTR_attr_update_period</both></member_name> <!-- "attr_update_period" -->
+    <member_at_decode>decode_l</member_at_decode>
+    <member_at_encode>encode_l</member_at_encode>
+    <member_at_set>set_l</member_at_set>
+    <member_at_comp>comp_l</member_at_comp>
+    <member_at_free>free_null</member_at_free>
+    <member_at_action>NULL_FUNC</member_at_action>
+    <member_at_flags><both>MGR_ONLY_SET</both></member_at_flags>
+    <member_at_type><both>ATR_TYPE_LONG</both></member_at_type>
+    <member_at_parent>PARENT_TYPE_SCHED</member_at_parent>
+    <member_verify_function>
+    <ECL>verify_datatype_long</ECL>
+    <ECL>verify_value_zero_or_positive</ECL>
+    </member_verify_function>
    </attributes>
 
     <tail>

--- a/src/scheduler/buckets.c
+++ b/src/scheduler/buckets.c
@@ -1119,7 +1119,7 @@ check_node_buckets(status *policy, server_info *sinfo, queue_info *qinfo, resour
 		}
 		/* If we can't fit in any placement set, span over all of them */
 		if (can_run == 0) {
-			if (sinfo->dont_span_psets) {
+			if (sc_attrs.do_not_span_psets) {
 				set_schd_error_codes(err, NEVER_RUN, CANT_SPAN_PSET);
 				return NULL;
 			}

--- a/src/scheduler/config.h
+++ b/src/scheduler/config.h
@@ -166,7 +166,6 @@
 #define PARSE_UPDATE_COMMENTS "update_comments"
 #define PARSE_RESV_CONFIRM_IGNORE "resv_confirm_ignore"
 #define PARSE_ALLOW_AOE_CALENDAR "allow_aoe_calendar"
-#define PARSE_OPT_BACKFILL_FUZZY_TIME "opt_backfill_fuzzy_time"
 
 /* deprecated */
 #define PARSE_PREEMPT_STARVING "preempt_starving"
@@ -225,6 +224,8 @@
 #define BF_MED 600
 #define BF_HIGH 3600
 #define BF_DEFAULT BF_LOW
+
+#define SCH_CYCLE_LEN_DFLT 1200
 
 #ifdef NAS /* attributes we may define in the server's resourcedef file */
 /* localmod 040 */

--- a/src/scheduler/constant.h
+++ b/src/scheduler/constant.h
@@ -622,6 +622,12 @@ enum runjob_mode {
 	RJ_EXECJOB_HOOK
 };
 
+enum preempt_sort_vals {
+	PS_MIN_T_SINCE_START,
+	PS_PREEMPT_PRIORITY,
+	PS_HIGH
+};
+
 #ifdef	__cplusplus
 }
 #endif

--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -324,7 +324,6 @@ struct status
 	unsigned sort_nodes:1;
 	unsigned backfill_prime:1;
 	unsigned preempting:1;
-	unsigned only_explicit_psets:1;		/* control if psets with unset resource are created */
 #ifdef NAS /* localmod 034 */
 	unsigned shares_track_only:1;
 #endif /* localmod 034 */
@@ -332,7 +331,6 @@ struct status
 	unsigned is_prime:1;
 	unsigned is_ded_time:1;
 	unsigned sync_fairshare_files:1;	/* sync fairshare files to disk */
-	unsigned int job_form_threshold_set:1;
 
 	struct sort_info *sort_by;		/* job sorting */
 	struct sort_info *node_sort;		/* node sorting */
@@ -340,9 +338,6 @@ struct status
 
 	unsigned prime_spill;			/* the amount of time a job can spill into the next prime state */
 	unsigned int backfill_depth;		/* number of top jobs to backfill around */
-
-	double job_form_threshold;		/* threshold in which jobs won't run */
-
 
 	resdef **resdef_to_check;		/* resources to match as definitions */
 	resdef **resdef_to_check_no_hostvnode;	/* resdef_to_check without host/vnode*/
@@ -366,6 +361,35 @@ struct status
 	unsigned long long iteration;		/* scheduler iteration count */
 };
 
+/*
+ * All attributes of the qmgr sched object
+ * Don't need log_events here, we use log_event_mask from Liblog/log_event.c
+ */
+struct schedattrs
+{
+	unsigned do_not_span_psets:1;
+	unsigned only_explicit_psets:1;
+	unsigned preempt_targets_enable:1;
+	unsigned sched_preempt_enforce_resumption:1;
+	unsigned throughput_mode:1;
+	long attr_update_period;
+	char *comment;
+	char *job_sort_formula;
+	double job_sort_formula_threshold;
+	int opt_backfill_fuzzy;
+	char *partition;
+	long preempt_queue_prio;
+	int preempt_prio[NUM_PPRIO][2];
+	struct preempt_ordering preempt_order[PREEMPT_ORDER_MAX + 1];
+	enum preempt_sort_vals preempt_sort;
+	enum runjob_mode runjob_mode; /* set to a numeric version of job_run_wait attribute value */
+	long sched_cycle_length;
+	char *sched_log;
+	char *sched_port;
+	char *sched_priv;
+	long server_dyn_res_alarm;
+};
+
 struct server_info
 {
 	unsigned has_soft_limit:1;	/* server has a soft user/grp limit set */
@@ -385,11 +409,7 @@ struct server_info
 	unsigned eligible_time_enable:1;/* controls if we accrue eligible_time  */
 	unsigned provision_enable:1;	/* controls if provisioning occurs */
 	unsigned power_provisioning:1;	/* controls if power provisioning occurs */
-	unsigned dont_span_psets:1;	/* dont_span_psets sched object attribute */
-	enum runjob_mode runjob_mode;	/* set to a numeric version of job_run_wait attribute value */
 	unsigned has_nonCPU_licenses:1;	/* server has non-CPU (e.g. socket-based) licenses */
-	unsigned enforce_prmptd_job_resumption:1;/* If set, preempted jobs will resume after the preemptor finishes */
-	unsigned preempt_targets_enable:1;/* if preemptable limit targets are enabled */
 	unsigned use_hard_duration:1;	/* use hard duration when creating the calendar */
 	unsigned pset_metadata_stale:1;	/* The placement set meta data is stale and needs to be regenerated before the next use */
 	char *name;			/* name of server */
@@ -400,9 +420,6 @@ struct server_info
 	int num_nodes;			/* number of nodes associated with the server */
 	int num_resvs;			/* number of reservations on the server */
 	int num_preempted;		/* number of jobs currently preempted */
-	long sched_cycle_len;		/* length of cycle in seconds */
-	char *partition;		/* partition associated */
-	long opt_backfill_fuzzy_time;	/* time window for fuzzy backfill opt */
 	char **node_group_key;		/* the node grouping resources */
 	state_count sc;			/* number of jobs in each state */
 	queue_info **queues;		/* array of queues */
@@ -415,6 +432,7 @@ struct server_info
 	resource_resv **jobs;		/* all the jobs in the server */
 	resource_resv **all_resresv;	/* a list of all jobs and adv resvs */
 	event_list *calendar;		/* the calendar of events */
+	char *job_sort_formula;	/* set via the JSF attribute of either the sched, or the server */
 
 	time_t server_time;		/* The time the server is at.  Could be in the
 					 * future if we're simulating
@@ -454,7 +472,6 @@ struct server_info
 	np_cache **npc_arr;
 
 	resource_resv *qrun_job;	/* used if running a job via qrun request */
-	char *job_formula;		/* formula used for sorting */
 	/* policy structure for the server.  This is an easy storage location for
 	 * the policy struct.  The policy struct will be passed around separately
 	 */
@@ -1131,18 +1148,13 @@ struct config
 	unsigned update_comments:1;	/* should we update comments or not */
 	unsigned prime_exempt_anytime_queues:1; /* backfill affects anytime queues */
 	unsigned assign_ssinodes:1;	/* assign the ssinodes resource */
-	unsigned preempt_suspend:1;	/* allow preemption through suspention */
-	unsigned preempt_chkpt:1;	/* allow preemption through checkpointing */
-	unsigned preempt_requeue:1;	/* allow preemption through requeueing */
 	unsigned preempt_starving:1;	/* once jobs become starving, it can preempt */
 	unsigned preempt_fairshare:1; /* normal jobs can preempt over usage jobs */
 	unsigned dont_preempt_starving:1; /* don't preempt staving jobs */
 	unsigned enforce_no_shares:1;	/* jobs with 0 shares don't run */
-	unsigned preempt_min_wt_used:1; /*allow preemption through min walltime used*/
 	unsigned node_sort_unused:1;	/* node sorting by unused/assigned is used */
 	unsigned resv_conf_ignore:1;  /* if we want to ignore dedicated time when confirming reservations.  Move to enum if ever expanded */
 	unsigned allow_aoe_calendar:1;        /* allow jobs requesting aoe in calendar*/
-	unsigned logstderr:1;               /* log to stderr as well as log file */
 #ifdef NAS /* localmod 034 */
 	unsigned prime_sto	:1;	/* shares_track_only--no enforce shares */
 	unsigned non_prime_sto:1;
@@ -1166,10 +1178,8 @@ struct config
 	int num_holidays;			/* number of actual holidays */
 	struct timegap ded_time[MAX_DEDTIME_SIZE];/* dedicated times */
 	int unknown_shares;			/* unknown group shares */
-	int preempt_queue_prio;			/* Queue prio that defines an express queue */
 	int max_preempt_attempts;		/* max num of preempt attempts per cyc*/
 	int max_jobs_to_check;			/* max number of jobs to check in cyc*/
-	long dflt_opt_backfill_fuzzy;		/* default time for the fuzzy backfill optimization */
 	char ded_prefix[PBS_MAXQUEUENAME +1];	/* prefix to dedicated queues */
 	char pt_prefix[PBS_MAXQUEUENAME +1];	/* prefix to primetime queues */
 	char npt_prefix[PBS_MAXQUEUENAME +1];	/* prefix to non primetime queues */
@@ -1182,12 +1192,8 @@ struct config
 	char **ignore_res;			/* resources - unset implies infinite */
 	int num_res_to_check;			/* the size of res_to_check */
 	time_t max_starve;			/* starving threshold */
-	int pprio[NUM_PPRIO][2];		/* premption priority levels */
-	int preempt_low;			/* lowest preemption level */
-	int preempt_normal;			/* preempt priority of normal_jobs */
 	/* order to preempt jobs */
 	struct sort_info *prime_node_sort;	/* node sorting primetime */
-	struct preempt_ordering preempt_order[PREEMPT_ORDER_MAX + 1];
 	struct sort_info *non_prime_node_sort;	/* node sorting non primetime */
 	struct dyn_res dynamic_res[MAX_SERVER_DYN_RES]; /* for server_dyn_res */
 	struct peer_queue peer_queues[NUM_PEERS];/* peer local -> remote queue map */

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -1302,7 +1302,7 @@ update_job_can_not_run(int pbs_sd, resource_resv *job, schd_error *err)
  * @retval	return value of the runjob call
  */
 static int
-send_runjob(int pbs_sd, int has_runjob_hook, char *jobid, char *execvnode)
+send_run_job(int pbs_sd, int has_runjob_hook, char *jobid, char *execvnode)
 {
 	if (sc_attrs.runjob_mode == RJ_EXECJOB_HOOK)
 		return pbs_runjob(pbs_sd, jobid, execvnode, NULL);
@@ -1321,7 +1321,7 @@ send_runjob(int pbs_sd, int has_runjob_hook, char *jobid, char *execvnode)
  * @param[in]	pbs_sd	-	pbs connection descriptor to the LOCAL server
  * @param[in]	rjob	-	the job to run
  * @param[in]	execvnode	-	the execvnode to run a multi-node job on
- * @param[in]	rj_mode	-	runjob mode to use
+ * @param[in]	has_runjob_hook	- does server have a runjob hook?
  * @param[out]	err	-	error struct to return errors
  *
  * @retval	0	: success
@@ -1329,7 +1329,7 @@ send_runjob(int pbs_sd, int has_runjob_hook, char *jobid, char *execvnode)
  * @retval -1	: error
  */
 int
-run_job(int pbs_sd, resource_resv *rjob, char *execvnode, server_info *sinfo, schd_error *err)
+run_job(int pbs_sd, resource_resv *rjob, char *execvnode, int has_runjob_hook, schd_error *err)
 {
 	char buf[100];	/* used to assemble queue@localserver */
 	char *errbuf;		/* comes from pbs_geterrmsg() */
@@ -1382,10 +1382,10 @@ run_job(int pbs_sd, resource_resv *rjob, char *execvnode, server_info *sinfo, sc
 				if (strlen(timebuf) > 0)
 					log_eventf(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_NOTICE, rjob->name,
 						"Job will run for duration=%s", timebuf);
-				rc = send_runjob(pbs_sd, sinfo->has_runjob_hook, rjob->name, execvnode);
+				rc = send_run_job(pbs_sd, has_runjob_hook, rjob->name, execvnode);
 			}
 		} else
-			rc = send_runjob(pbs_sd, sinfo->has_runjob_hook, rjob->name, execvnode);
+			rc = send_run_job(pbs_sd, has_runjob_hook, rjob->name, execvnode);
 	}
 
 	if (rc) {
@@ -1622,7 +1622,7 @@ run_update_resresv(status *policy, int pbs_sd, server_info *sinfo,
 					fflush(stdout);
 #endif /* localmod 031 */
 
-					pbsrc = run_job(pbs_sd, rr, execvnode, sinfo, err);
+					pbsrc = run_job(pbs_sd, rr, execvnode, sinfo->has_runjob_hook, err);
 
 #ifdef NAS_CLUSTER /* localmod 125 */
 					    ret = translate_runjob_return_code(pbsrc, resresv);

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -362,7 +362,7 @@ init_scheduling_cycle(status *policy, int pbs_sd, server_info *sinfo)
 			return 0;
 	}
 
-	if ((policy->fair_share || sinfo->job_formula != NULL) && sinfo->fairshare != NULL) {
+	if ((policy->fair_share || sinfo->job_sort_formula != NULL) && sinfo->fairshare != NULL) {
 		FILE *fp;
 		int resort = 0;
 		if ((fp = fopen(USAGE_TOUCH, "r")) != NULL) {
@@ -471,13 +471,13 @@ init_scheduling_cycle(status *policy, int pbs_sd, server_info *sinfo)
 
 
 				}
-				if (sinfo->job_formula != NULL) {
-					double threshold = policy->job_form_threshold;
-					resresv->job->formula_value = formula_evaluate(sinfo->job_formula, resresv, resresv->resreq);
+				if (sinfo->job_sort_formula != NULL) {
+					double threshold = sc_attrs.job_sort_formula_threshold;
+					resresv->job->formula_value = formula_evaluate(sinfo->job_sort_formula, resresv, resresv->resreq);
 					log_eventf(PBSEVENT_DEBUG2, PBS_EVENTCLASS_JOB, LOG_DEBUG, resresv->name, "Formula Evaluation = %.*f",
 						   float_digits(resresv->job->formula_value, FLOAT_NUM_DIGITS), resresv->job->formula_value);
 
-					if (!resresv->can_not_run && policy->job_form_threshold_set && resresv->job->formula_value <= threshold) {
+					if (!resresv->can_not_run && resresv->job->formula_value <= threshold) {
 						set_schd_error_codes(err, NOT_RUN, JOB_UNDER_THRESHOLD);
 						log_eventf(PBSEVENT_DEBUG2, PBS_EVENTCLASS_JOB, LOG_DEBUG, resresv->name, "Job's formula value %.*f is under threshold %.*f",
 							   float_digits(resresv->job->formula_value, FLOAT_NUM_DIGITS), resresv->job->formula_value, float_digits(threshold, 2), threshold);
@@ -546,6 +546,10 @@ schedule(int cmd, int sd, char *runjobid)
 			 */
 			reset_global_resource_ptrs();
 
+			/* Get config from the qmgr sched object */
+			if (!set_validate_sched_attrs(sd))
+				return 0;
+
 		case SCH_SCHEDULE_NEW:
 		case SCH_SCHEDULE_TERM:
 		case SCH_SCHEDULE_CMD:
@@ -562,18 +566,14 @@ schedule(int cmd, int sd, char *runjobid)
 			log_event(PBSEVENT_SCHED, PBS_EVENTCLASS_SCHED, LOG_INFO,
 				  "reconfigure", "Scheduler is reconfiguring");
 			reset_global_resource_ptrs();
-			if(schedinit(-1) != 0) {
+
+			/* Get config from sched_priv/ files */
+			if (schedinit(-1) != 0)
 				return 0;
-			}
-			break;
-		case SCH_ATTRS_CONFIGURE:
-			/*
-			 * This is required since there is a probability that scheduler's configuration has been changed at
-			 * server through qmgr.
-			 */
-			if (!validate_sched_attrs(connector)) {
+
+			/* Get config from the qmgr sched object */
+			if (!set_validate_sched_attrs(sd))
 				return 0;
-			}
 			break;
 		case SCH_QUIT:
 #ifdef PYTHON
@@ -658,6 +658,12 @@ scheduling_cycle(int sd, char *jobid)
 
 	log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_REQUEST, LOG_DEBUG,
 		  "", "Starting Scheduling Cycle");
+
+	/* Decide whether we need to send "can't run" type updates this cycle */
+	if (time(NULL) - last_attr_updates >= sc_attrs.attr_update_period)
+		send_job_attr_updates = 1;
+	else
+		send_job_attr_updates = 0;
 
 	update_cycle_status(&cstat, 0);
 
@@ -836,7 +842,7 @@ main_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rerr)
 
 	time(&cycle_start_time);
 	/* calculate the time which we've been in the cycle too long */
-	cycle_end_time = cycle_start_time + sinfo->sched_cycle_len;
+	cycle_end_time = cycle_start_time + sc_attrs.sched_cycle_length;
 
 	chk_lim_err = new_schd_error();
 	if(chk_lim_err == NULL)
@@ -977,7 +983,7 @@ main_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rerr)
 					}
 #else
 					sort_again = MAY_RESORT_JOBS;
-					if (njob->job->is_preempted == 0 || sinfo->enforce_prmptd_job_resumption == 0) { /* preempted jobs don't increase top jobs count */
+					if (njob->job->is_preempted == 0 || sc_attrs.sched_preempt_enforce_resumption == 0) { /* preempted jobs don't increase top jobs count */
 						if (qinfo->backfill_depth == UNSPECIFIED)
 							num_topjobs++;
 						else
@@ -1075,7 +1081,7 @@ main_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rerr)
 			end_cycle = 1;
 			log_eventf(PBSEVENT_SCHED, PBS_EVENTCLASS_SCHED, LOG_NOTICE, "toolong",
 				"Leaving the scheduling cycle: Cycle duration of %ld seconds has exceeded %s of %ld seconds",
-				(long)(cur_time - cycle_start_time), ATTR_sched_cycle_len, sinfo->sched_cycle_len);
+				(long)(cur_time - cycle_start_time), ATTR_sched_cycle_len, sc_attrs.sched_cycle_length);
 		}
 		if (conf.max_jobs_to_check != SCHD_INFINITY && (i + 1) >= conf.max_jobs_to_check) {
 			/* i begins with 0, hence i + 1 */
@@ -1288,7 +1294,7 @@ update_job_can_not_run(int pbs_sd, resource_resv *job, schd_error *err)
  * @brief	Send the relevant runjob request to server
  *
  * @param[in]	pbs_sd	-	pbs connection descriptor to the LOCAL server
- * @param[in]	rj_mode	-	runjob mode to use
+ * @param[in]	has_runjob_hook	- does server have a runjob hook?
  * @param[in]	jobid	-	id of the job to run
  * @param[in]	execvnode	-	the execvnode to run the job on
  *
@@ -1296,14 +1302,14 @@ update_job_can_not_run(int pbs_sd, resource_resv *job, schd_error *err)
  * @retval	return value of the runjob call
  */
 static int
-send_runjob(int pbs_sd, enum runjob_mode rj_mode, char *jobid, char *execvnode)
+send_runjob(int pbs_sd, int has_runjob_hook, char *jobid, char *execvnode)
 {
-	if (rj_mode == RJ_NOWAIT)
-		return pbs_asyrunjob(pbs_sd, jobid, execvnode, NULL);
-	else if (rj_mode == RJ_RUNJOB_HOOK)
+	if (sc_attrs.runjob_mode == RJ_EXECJOB_HOOK)
+		return pbs_runjob(pbs_sd, jobid, execvnode, NULL);
+	else if (sc_attrs.runjob_mode == RJ_RUNJOB_HOOK && has_runjob_hook)
 		return pbs_asyrunjob_ack(pbs_sd, jobid, execvnode, NULL);
 	else
-		return pbs_runjob(pbs_sd, jobid, execvnode, NULL);
+		return pbs_asyrunjob(pbs_sd, jobid, execvnode, NULL);
 }
 
 /**
@@ -1323,7 +1329,7 @@ send_runjob(int pbs_sd, enum runjob_mode rj_mode, char *jobid, char *execvnode)
  * @retval -1	: error
  */
 int
-run_job(int pbs_sd, resource_resv *rjob, char *execvnode, int rj_mode, schd_error *err)
+run_job(int pbs_sd, resource_resv *rjob, char *execvnode, server_info *sinfo, schd_error *err)
 {
 	char buf[100];	/* used to assemble queue@localserver */
 	char *errbuf;		/* comes from pbs_geterrmsg() */
@@ -1376,10 +1382,10 @@ run_job(int pbs_sd, resource_resv *rjob, char *execvnode, int rj_mode, schd_erro
 				if (strlen(timebuf) > 0)
 					log_eventf(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_NOTICE, rjob->name,
 						"Job will run for duration=%s", timebuf);
-				rc = send_runjob(pbs_sd, rj_mode, rjob->name, execvnode);
+				rc = send_runjob(pbs_sd, sinfo->has_runjob_hook, rjob->name, execvnode);
 			}
 		} else
-			rc = send_runjob(pbs_sd, rj_mode, rjob->name, execvnode);
+			rc = send_runjob(pbs_sd, sinfo->has_runjob_hook, rjob->name, execvnode);
 	}
 
 	if (rc) {
@@ -1616,10 +1622,10 @@ run_update_resresv(status *policy, int pbs_sd, server_info *sinfo,
 					fflush(stdout);
 #endif /* localmod 031 */
 
-					pbsrc = run_job(pbs_sd, rr, execvnode, sinfo->runjob_mode, err);
+					pbsrc = run_job(pbs_sd, rr, execvnode, sinfo, err);
 
 #ifdef NAS_CLUSTER /* localmod 125 */
-					ret = translate_runjob_return_code(pbsrc, resresv);
+					    ret = translate_runjob_return_code(pbsrc, resresv);
 #else
 					if (!pbsrc)
 						ret = 1;
@@ -1884,8 +1890,8 @@ should_backfill_with_job(status *policy, server_info *sinfo, resource_resv *resr
 		return 0;
 
 	/* Job is preempted and we're helping preempted jobs resume -- add to the calendar*/
-	if (resresv->job->is_preempted && sinfo->enforce_prmptd_job_resumption
-	    && (resresv->job->preempt >= conf.preempt_normal))
+	if (resresv->job->is_preempted && sc_attrs.sched_preempt_enforce_resumption
+	    && (resresv->job->preempt >= preempt_normal))
 		return 1;
 
 	/* Admin settable flag - don't add to calendar */
@@ -2439,9 +2445,34 @@ next_job(status *policy, server_info *sinfo, int flag)
 }
 
 /**
- * @brief
- *	Helper function used to copy the attribute values from batch_status to the corresponding
- *	scheduler global variables which hold its priv_dir, log_dir and partitions
+ * @brief	Initialize sc_attrs
+ */
+static void
+init_sc_attrs(void)
+{
+	sc_attrs.attr_update_period = 0;
+	sc_attrs.comment = NULL;
+	sc_attrs.do_not_span_psets = 0;
+	sc_attrs.job_sort_formula = NULL;
+	sc_attrs.job_sort_formula_threshold = INT_MIN;
+	sc_attrs.only_explicit_psets = 0;
+	sc_attrs.partition = NULL;
+	sc_attrs.preempt_queue_prio = 0;
+	sc_attrs.preempt_sort = PS_MIN_T_SINCE_START;
+	sc_attrs.runjob_mode = RJ_NOWAIT;
+	sc_attrs.preempt_targets_enable = 1;
+	sc_attrs.sched_cycle_length = SCH_CYCLE_LEN_DFLT;
+	sc_attrs.sched_log = NULL;
+	sc_attrs.sched_port = NULL;
+	sc_attrs.sched_preempt_enforce_resumption = 0;
+	sc_attrs.sched_priv = NULL;
+	sc_attrs.server_dyn_res_alarm = 0;
+	sc_attrs.throughput_mode = 1;
+	sc_attrs.opt_backfill_fuzzy = BF_DEFAULT;
+}
+
+/**
+ * @brief	Parse and cache sched object batch_status
  *
  * @param[in] status - populated batch_status after stating this scheduler from server
  *
@@ -2452,13 +2483,11 @@ next_job(status *policy, server_info *sinfo, int flag)
  * @mt-safe: No
  * @par Side Effects:
  *	None
- *
- *
  */
 static int
-sched_settings_frm_svr(struct batch_status *status)
+parse_sched_obj(struct batch_status *status)
 {
-	struct attrl *attr;
+	struct attrl *attrp;
 	char *tmp_priv_dir = NULL;
 	char *tmp_log_dir = NULL;
 	static char *priv_dir = NULL;
@@ -2467,39 +2496,189 @@ sched_settings_frm_svr(struct batch_status *status)
 	char *tmp_comment = NULL;
 	int clear_comment = 0;
 	int ret = 0;
+	long num;
+	char *endp;
+	char *tok;
+	char *save_ptr;
+	int i;
+	int j;
+	long prev_attr_u_period = sc_attrs.attr_update_period;
 
-	attr = status->attribs;
+	attrp = status->attribs;
+
+	init_sc_attrs();
+
+	log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_REQUEST, LOG_DEBUG,
+			  "", "Updating scheduler attributes");
 
 	/* resetting the following before fetching from batch_status. */
-	while (attr != NULL) {
+	while (attrp != NULL) {
+		if (!strcmp(attrp->name, ATTR_sched_cycle_len)) {
+			sc_attrs.sched_cycle_length = res_to_num(attrp->value, NULL);
+		} else if (!strcmp(attrp->name, ATTR_attr_update_period)) {
+			long newval;
 
-		if (attr->name != NULL && attr->value != NULL) {
-			if (!strcmp(attr->name, ATTR_sched_priv) && !dflt_sched) {
-				if ((tmp_priv_dir = string_dup(attr->value)) == NULL)
-					goto cleanup;
-			} else if (!strcmp(attr->name, ATTR_sched_log) && !dflt_sched) {
-				if ((tmp_log_dir = string_dup(attr->value)) == NULL)
-					goto cleanup;
-			} else if (!strcmp(attr->name, ATTR_comment) && !dflt_sched) {
-				if ((tmp_comment = string_dup(attr->value)) == NULL)
-					goto cleanup;
-			} else if (!strcmp(attr->name, ATTR_logevents)) {
-				char *endp;
-				long mask;
-				mask = strtol(attr->value, &endp, 10);
-				if (*endp != '\0')
-					goto cleanup;
-				*log_event_mask = mask;
-			} else if (!strcmp(attr->name, ATTR_sched_server_dyn_res_alarm)) {
-				char *endp;
-				long val;
-				val = strtol(attr->value, &endp, 10);
-				if (*endp != '\0')
-					goto cleanup;
-				server_dyn_res_alarm = val;
+			newval = res_to_num(attrp->value, NULL);
+			sc_attrs.attr_update_period = newval;
+			if (newval != prev_attr_u_period)
+				last_attr_updates = 0;
+		} else if (!strcmp(attrp->name, ATTR_partition)) {
+			free(sc_attrs.partition);
+			sc_attrs.partition = string_dup(attrp->value);
+		} else if (!strcmp(attrp->name, ATTR_do_not_span_psets)) {
+			sc_attrs.do_not_span_psets = res_to_num(attrp->value, NULL);
+		} else if (!strcmp(attrp->name, ATTR_only_explicit_psets)) {
+			sc_attrs.only_explicit_psets = res_to_num(attrp->value, NULL);
+		} else if (!strcmp(attrp->name, ATTR_sched_preempt_enforce_resumption)) {
+			if (!strcasecmp(attrp->value, ATR_FALSE))
+				sc_attrs.sched_preempt_enforce_resumption = 0;
+			else
+				sc_attrs.sched_preempt_enforce_resumption  = 1;
+		} else if (!strcmp(attrp->name, ATTR_preempt_targets_enable)) {
+			if (!strcasecmp(attrp->value, ATR_FALSE))
+				sc_attrs.preempt_targets_enable = 0;
+			else
+				sc_attrs.preempt_targets_enable = 1;
+		} else if (!strcmp(attrp->name, ATTR_job_sort_formula_threshold)) {
+			sc_attrs.job_sort_formula_threshold = res_to_num(attrp->value, NULL);
+		} else if (!strcmp(attrp->name, ATTR_throughput_mode)) {
+			sc_attrs.throughput_mode = res_to_num(attrp->value, NULL);
+		} else if (!strcmp(attrp->name, ATTR_opt_backfill_fuzzy)) {
+			num = strtol(attrp->value, &endp, 10);
+			if (*endp == '\0')
+				sc_attrs.opt_backfill_fuzzy = num;
+			else if (!strcasecmp(attrp->value, "off"))
+				sc_attrs.opt_backfill_fuzzy = BF_OFF;
+			else if (!strcasecmp(attrp->value, "low"))
+				sc_attrs.opt_backfill_fuzzy = BF_LOW;
+			else if (!strcasecmp(attrp->value, "med") || !strcasecmp(attrp->value, "medium"))
+				sc_attrs.opt_backfill_fuzzy = BF_MED;
+			else if (!strcasecmp(attrp->value, "high"))
+				sc_attrs.opt_backfill_fuzzy = BF_HIGH;
+			else
+				sc_attrs.opt_backfill_fuzzy = BF_DEFAULT;
+		} else if (!strcmp(attrp->name, ATTR_job_run_wait)) {
+			if (!strcmp(attrp->value, RUN_WAIT_NONE))
+				sc_attrs.runjob_mode = RJ_NOWAIT;
+			else if (!strcmp(attrp->value, RUN_WAIT_RUNJOB_HOOK)) {
+				sc_attrs.runjob_mode = RJ_RUNJOB_HOOK;
+			} else
+				sc_attrs.runjob_mode = RJ_EXECJOB_HOOK;
+		} else if (!strcmp(attrp->name, ATTR_sched_preempt_order)) {
+			tok = strtok_r(attrp->value, "\t ", &save_ptr);
+
+			if (tok != NULL && !isdigit(tok[0])) {
+				/* unset the defaults */
+				sc_attrs.preempt_order[0].order[0] = PREEMPT_METHOD_LOW;
+				sc_attrs.preempt_order[0].order[1] = PREEMPT_METHOD_LOW;
+				sc_attrs.preempt_order[0].order[2] = PREEMPT_METHOD_LOW;
+
+				sc_attrs.preempt_order[0].high_range = 100;
+				i = 0;
+				do {
+					if (isdigit(tok[0])) {
+						num = strtol(tok, &endp, 10);
+						if (*endp != '\0')
+							goto cleanup;
+						sc_attrs.preempt_order[i].low_range = num + 1;
+						i++;
+						sc_attrs.preempt_order[i].high_range = num;
+					} else {
+						for (j = 0; tok[j] != '\0' ; j++) {
+							switch (tok[j]) {
+								case 'S':
+									sc_attrs.preempt_order[i].order[j] = PREEMPT_METHOD_SUSPEND;
+									break;
+								case 'C':
+									sc_attrs.preempt_order[i].order[j] = PREEMPT_METHOD_CHECKPOINT;
+									break;
+								case 'R':
+									sc_attrs.preempt_order[i].order[j] = PREEMPT_METHOD_REQUEUE;
+									break;
+								case 'D':
+									sc_attrs.preempt_order[i].order[j] = PREEMPT_METHOD_DELETE;
+									break;
+							}
+						}
+					}
+					tok = strtok_r(NULL, "\t ", &save_ptr);
+				} while (tok != NULL && i < PREEMPT_ORDER_MAX);
+
+				sc_attrs.preempt_order[i].low_range = 0;
 			}
+		} else if (!strcmp(attrp->name, ATTR_sched_preempt_queue_prio)) {
+			sc_attrs.preempt_queue_prio = strtol(attrp->value, &endp, 10);
+			if (*endp != '\0')
+				goto cleanup;
+		} else if (!strcmp(attrp->name, ATTR_sched_preempt_prio)) {
+			long prio;
+			char **list;
+
+			prio = PREEMPT_PRIORITY_HIGH;
+			list = break_comma_list(attrp->value);
+			if (list != NULL) {
+				memset(sc_attrs.preempt_prio, 0, sizeof(sc_attrs.preempt_prio));
+				sc_attrs.preempt_prio[0][0] = PREEMPT_TO_BIT(PREEMPT_QRUN);
+				sc_attrs.preempt_prio[0][1] = prio;
+				prio -= PREEMPT_PRIORITY_STEP;
+				for (i = 0; list[i] != NULL; i++) {
+					num = preempt_bit_field(list[i]);
+					if (num >= 0) {
+						sc_attrs.preempt_prio[i + 1][0] = num;
+						sc_attrs.preempt_prio[i + 1][1] = prio;
+						prio -= PREEMPT_PRIORITY_STEP;
+					}
+				}
+				/* sc_attrs.preempt_prio is an int array of size[NUM_PPRIO][2] */
+				qsort(sc_attrs.preempt_prio, NUM_PPRIO, sizeof(int) * 2, preempt_cmp);
+
+				/* cache preemption priority for normal jobs */
+				for (i = 0; i < NUM_PPRIO && sc_attrs.preempt_prio[i][1] != 0; i++) {
+					if (sc_attrs.preempt_prio[i][0] == PREEMPT_TO_BIT(PREEMPT_NORMAL)) {
+						preempt_normal = sc_attrs.preempt_prio[i][1];
+						break;
+					}
+				}
+
+				free_string_array(list);
+			}
+		} else if (!strcmp(attrp->name, ATTR_sched_preempt_sort)) {
+			if (strcasecmp(attrp->value, "min_time_since_start") == 0)
+				sc_attrs.preempt_sort = PS_MIN_T_SINCE_START;
+			else
+				sc_attrs.preempt_sort = PS_PREEMPT_PRIORITY;
+		} else if (!strcmp(attrp->name, ATTR_job_sort_formula)) {
+			free(sc_attrs.job_sort_formula);
+			sc_attrs.job_sort_formula = read_formula();
+			if ((conf.prime_sort != NULL && conf.prime_sort[0].res_name != NULL) ||
+			(conf.non_prime_sort != NULL && conf.non_prime_sort[0].res_name != NULL))
+				log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_SCHED, LOG_DEBUG, __func__,
+						  "Job sorting formula and job_sort_key are incompatible.  "
+						  "The job sorting formula will be used.");
+		} else if (!strcmp(attrp->name, ATTR_sched_server_dyn_res_alarm)) {
+			num = strtol(attrp->value, &endp, 10);
+			if (*endp != '\0')
+				goto cleanup;
+
+			sc_attrs.server_dyn_res_alarm = num;
+		} else if (!strcmp(attrp->name, ATTR_sched_priv) && !dflt_sched) {
+			if ((tmp_priv_dir = string_dup(attrp->value)) == NULL)
+				goto cleanup;
+		} else if (!strcmp(attrp->name, ATTR_sched_log) && !dflt_sched) {
+			if ((tmp_log_dir = string_dup(attrp->value)) == NULL)
+				goto cleanup;
+		} else if (!strcmp(attrp->name, ATTR_comment) && !dflt_sched) {
+			if ((tmp_comment = string_dup(attrp->value)) == NULL)
+				goto cleanup;
+		} else if (!strcmp(attrp->name, ATTR_logevents)) {
+			char *endp;
+			long mask;
+			mask = strtol(attrp->value, &endp, 10);
+			if (*endp != '\0')
+				goto cleanup;
+			*log_event_mask = mask;
 		}
-		attr = attr->next;
+		attrp = attrp->next;
 	}
 
 	if (!dflt_sched) {
@@ -2709,7 +2888,7 @@ update_svr_schedobj(int connector, int cmd, int alarm_time)
 	if (cmd == SCH_ERROR || connector < 0)
 		return 1;
 
-	if (!validate_sched_attrs(connector)) {
+	if (!set_validate_sched_attrs(connector)) {
 		return 0;
 	}
 
@@ -2756,7 +2935,7 @@ update_svr_schedobj(int connector, int cmd, int alarm_time)
 
 /**
  * @brief
- *	Validates the sched object attributes changed from Server.
+ *	Set and validate the sched object attributes queried from Server
  *
  * @param[in] connector - socket descriptor to server
  *
@@ -2770,10 +2949,13 @@ update_svr_schedobj(int connector, int cmd, int alarm_time)
  *
  */
 int
-validate_sched_attrs(int connector)
+set_validate_sched_attrs(int connector)
 {
 	struct batch_status *ss = NULL;
 	struct batch_status *all_ss = NULL;
+
+	if (connector < 0)
+		return 0;
 
 	/* Stat the scheduler to get details of sched */
 
@@ -2786,7 +2968,7 @@ validate_sched_attrs(int connector)
 		pbs_statfree(all_ss);
 		return 0;
 	}
-	if (!sched_settings_frm_svr(ss)) {
+	if (!parse_sched_obj(ss)) {
 		pbs_statfree(all_ss);
 		return 0;
 	}

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -1306,7 +1306,7 @@ send_run_job(int pbs_sd, int has_runjob_hook, char *jobid, char *execvnode)
 {
 	if (sc_attrs.runjob_mode == RJ_EXECJOB_HOOK)
 		return pbs_runjob(pbs_sd, jobid, execvnode, NULL);
-	else if (sc_attrs.runjob_mode == RJ_RUNJOB_HOOK && has_runjob_hook)
+	else if ((sc_attrs.runjob_mode == RJ_RUNJOB_HOOK) && has_runjob_hook)
 		return pbs_asyrunjob_ack(pbs_sd, jobid, execvnode, NULL);
 	else
 		return pbs_asyrunjob(pbs_sd, jobid, execvnode, NULL);
@@ -1321,7 +1321,7 @@ send_run_job(int pbs_sd, int has_runjob_hook, char *jobid, char *execvnode)
  * @param[in]	pbs_sd	-	pbs connection descriptor to the LOCAL server
  * @param[in]	rjob	-	the job to run
  * @param[in]	execvnode	-	the execvnode to run a multi-node job on
- * @param[in]	has_runjob_hook	- does server have a runjob hook?
+ * @param[in]	has_runjob_hook	-	does server have a runjob hook?
  * @param[out]	err	-	error struct to return errors
  *
  * @retval	0	: success
@@ -1625,7 +1625,7 @@ run_update_resresv(status *policy, int pbs_sd, server_info *sinfo,
 					pbsrc = run_job(pbs_sd, rr, execvnode, sinfo->has_runjob_hook, err);
 
 #ifdef NAS_CLUSTER /* localmod 125 */
-					    ret = translate_runjob_return_code(pbsrc, resresv);
+					ret = translate_runjob_return_code(pbsrc, resresv);
 #else
 					if (!pbsrc)
 						ret = 1;

--- a/src/scheduler/fifo.h
+++ b/src/scheduler/fifo.h
@@ -181,7 +181,7 @@ int add_job_to_calendar(int pbs_sd, status *policy, server_info *sinfo, resource
  *	       first move it to the local server and then run it.
  *	       if it's a local job, just run it.
  */
-int run_job(int pbs_sd, resource_resv *rjob, char *execvnode, int throughput, schd_error *err);
+int run_job(int pbs_sd, resource_resv *rjob, char *execvnode, server_info *sinfo, schd_error *err);
 
 /*
  *	should_backfill_with_job - should we call add_job_to_calendar() with job
@@ -232,7 +232,7 @@ int scheduler_simulation_task(int pbs_sd, int debug);
 
 int update_svr_schedobj(int connector, int cmd, int alarm_time);
 
-int validate_sched_attrs(int connector);
+int set_validate_sched_attrs(int connector);
 
 
 #ifdef	__cplusplus

--- a/src/scheduler/fifo.h
+++ b/src/scheduler/fifo.h
@@ -181,7 +181,7 @@ int add_job_to_calendar(int pbs_sd, status *policy, server_info *sinfo, resource
  *	       first move it to the local server and then run it.
  *	       if it's a local job, just run it.
  */
-int run_job(int pbs_sd, resource_resv *rjob, char *execvnode, server_info *sinfo, schd_error *err);
+int run_job(int pbs_sd, resource_resv *rjob, char *execvnode, int had_runjob_hook, schd_error *err);
 
 /*
  *	should_backfill_with_job - should we call add_job_to_calendar() with job

--- a/src/scheduler/globals.c
+++ b/src/scheduler/globals.c
@@ -180,6 +180,13 @@ char *sc_name = NULL;
 int sched_port = -1;
 char *logfile = NULL;
 
+int preempt_normal;			/* preempt priority of normal_jobs */
+
 char path_log[_POSIX_PATH_MAX];
 int dflt_sched = 0;
-int server_dyn_res_alarm = 0;
+
+struct schedattrs sc_attrs;
+
+time_t last_attr_updates = 0;
+
+int send_job_attr_updates = 1;

--- a/src/scheduler/globals.h
+++ b/src/scheduler/globals.h
@@ -97,9 +97,16 @@ extern char *sc_name;
 extern int sched_port;
 extern char *logfile;
 
+extern int preempt_normal;			/* preempt priority of normal_jobs */
+
 extern char path_log[_POSIX_PATH_MAX];
 extern int dflt_sched;
-extern int server_dyn_res_alarm;
+
+extern struct schedattrs sc_attrs;
+
+extern time_t last_attr_updates;    /* timestamp of the last time attr updates were sent */
+
+extern int send_job_attr_updates;
 
 /**
  * @brief

--- a/src/scheduler/misc.c
+++ b/src/scheduler/misc.c
@@ -341,41 +341,6 @@ skip_line(char *line)
 }
 
 /**
- * @brief
- *		schdlog - write a log entry to the scheduler log file using log_record
- *
- * @param[in] event	-	the event type
- * @param[in] class	-	the event class
- * @param[in] sev   -	the severity of the log message
- * @param[in] name  -	the name of the object
- * @param[in] text  -	the text of the message
- *
- * @return nothing
- */
-
-void
-schdlog(int event, int class, int sev, const char *name, const char *text)
-{
-	struct tm *ptm;
-	if (text[0] != '\0') {
-		log_event(event, class, sev, name, text);
-		if (conf.logstderr) {
-			time_t logtime;
-
-			logtime = cstat.current_time + (time(NULL) - cstat.cycle_start);
-
-			ptm = localtime(&logtime);
-			if (ptm != NULL) {
-				fprintf(stderr, "%02d/%02d/%04d %02d:%02d:%02d;%s;%s\n",
-					ptm->tm_mon + 1, ptm->tm_mday, ptm->tm_year + 1900,
-					ptm->tm_hour, ptm->tm_min, ptm->tm_sec,
-					name, text);
-			}
-		}
-	}
-}
-
-/**
  *	@brief  combination of log_event() and translate_fail_code()
  *		If we're actually going to log a message, translate
  *		err into a message and then log it.  The translated

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -204,7 +204,7 @@ query_node_info_chunk(th_data_query_ninfo *data)
 			return;
 		}
 
-		if (node_in_partition(ninfo, sinfo->partition)) {
+		if (node_in_partition(ninfo, sc_attrs.partition)) {
 			if (first_talk_with_mom) {	/* need to acquire a lock for talk_with_mom the first time */
 				pthread_mutex_lock(&general_lock);
 				if (!first_talk_with_mom)
@@ -2702,7 +2702,7 @@ eval_selspec(status *policy, selspec *spec, place *placespec,
 	}
 
 	if (!can_fit) {
-		if (!resresv->server->dont_span_psets) {
+		if (!sc_attrs.do_not_span_psets) {
 			log_event(PBSEVENT_DEBUG3, PBS_EVENTCLASS_JOB, LOG_DEBUG, resresv->name,
 				"Request won't fit into any placement sets, will use all nodes");
 			resresv->can_not_fit = 1;

--- a/src/scheduler/node_partition.c
+++ b/src/scheduler/node_partition.c
@@ -899,7 +899,7 @@ find_alloc_np_cache(status *policy, np_cache ***pnpc_arr,
 	if (npc == NULL) {
 		int flags = NP_NO_ADD_NP_ARR;
 
-		if (policy->only_explicit_psets == 0)
+		if (sc_attrs.only_explicit_psets == 0)
 			flags |= NP_CREATE_REST;
 
 		/* didn't find node partition cache, need to allocate and create */
@@ -1223,7 +1223,7 @@ create_placement_sets(status *policy, server_info *sinfo)
 	sinfo->allpart = create_specific_nodepart(policy, "all", sinfo->unassoc_nodes, NO_FLAGS);
 	if (sinfo->has_multi_vnode) {
 		sinfo->hostsets = create_node_partitions(policy, sinfo->nodes,
-			resstr, policy->only_explicit_psets ? NO_FLAGS : NP_CREATE_REST, &num);
+			resstr, sc_attrs.only_explicit_psets ? NO_FLAGS : NP_CREATE_REST, &num);
 		if (sinfo->hostsets != NULL) {
 			sinfo->num_hostsets = num;
 			for (i = 0; sinfo->nodes[i] != NULL; i++) {
@@ -1253,7 +1253,7 @@ create_placement_sets(status *policy, server_info *sinfo)
 	if (sinfo->node_group_enable && sinfo->node_group_key != NULL) {
 		sinfo->nodepart = create_node_partitions(policy, sinfo->unassoc_nodes,
 			sinfo->node_group_key,
-			policy->only_explicit_psets ? NO_FLAGS : NP_CREATE_REST,
+			sc_attrs.only_explicit_psets ? NO_FLAGS : NP_CREATE_REST,
 			&sinfo->num_parts);
 
 		if (sinfo->nodepart != NULL) {
@@ -1287,7 +1287,7 @@ create_placement_sets(status *policy, server_info *sinfo)
 				ngkey = sinfo->node_group_key;
 
 			qinfo->nodepart = create_node_partitions(policy, ngroup_nodes,
-				ngkey, policy->only_explicit_psets ? NO_FLAGS : NP_CREATE_REST,
+				ngkey, sc_attrs.only_explicit_psets ? NO_FLAGS : NP_CREATE_REST,
 				&(qinfo->num_parts));
 			if (qinfo->nodepart != NULL) {
 				qsort(qinfo->nodepart, qinfo->num_parts,

--- a/src/scheduler/parse.c
+++ b/src/scheduler/parse.c
@@ -156,7 +156,6 @@ parse_config(char *fname)
 #endif
 
 	/* auto-set any internally needed config values before reading the file */
-
 	while (pbs_fgets_extend(&buf, &buf_size, fp) != NULL) {
 		errbuf[0] = '\0';
 		linenum++;
@@ -291,12 +290,6 @@ parse_config(char *fname)
 					conf.preempt_starving = num ? 1 : 0;
 				else if (!strcmp(config_name, PARSE_PREEMPT_FAIRSHARE))
 					conf.preempt_fairshare = num ? 1 : 0;
-				else if (!strcmp(config_name, PARSE_PREEMPT_SUSPEND))
-					conf.preempt_suspend = num ? 1 : 0;
-				else if (!strcmp(config_name, PARSE_PREEMPT_CHKPT))
-					conf.preempt_chkpt = num ? 1 : 0;
-				else if (!strcmp(config_name, PARSE_PREEMPT_REQUEUE))
-					conf.preempt_requeue = num ? 1 : 0;
 				else if (!strcmp(config_name, PARSE_ASSIGN_SSINODES))
 					conf.assign_ssinodes = num ? 1 : 0;
 				else if (!strcmp(config_name, PARSE_DONT_PREEMPT_STARVING))
@@ -739,21 +732,16 @@ parse_config(char *fname)
 				}
 				else if (!strcmp(config_name, PARSE_PREEMPT_ATTEMPTS))
 					conf.max_preempt_attempts = num;
-				else if(!strcmp(config_name, PARSE_OPT_BACKFILL_FUZZY_TIME))
-					conf.dflt_opt_backfill_fuzzy = num;
 				else if (!strcmp(config_name, PARSE_MAX_JOB_CHECK)) {
 					if (!strcmp(config_value, "ALL_JOBS"))
 						conf.max_jobs_to_check = SCHD_INFINITY;
 					else
 						conf.max_jobs_to_check = num;
-				}
-				else if (!strcmp(config_name, PARSE_CPUS_PER_SSINODE) ||
-					!strcmp(config_name, PARSE_MEM_PER_SSINODE)
-					) {
+				} else if (!strcmp(config_name, PARSE_CPUS_PER_SSINODE) ||
+					   !strcmp(config_name, PARSE_MEM_PER_SSINODE)) {
 					obsolete[0] = config_name;
 					obsolete[1] = "nothing";
-				}
-				else if (!strcmp(config_name, PARSE_SELECT_PROVISION)) {
+				} else if (!strcmp(config_name, PARSE_SELECT_PROVISION)) {
 					if (config_value != NULL) {
 						if (!strcmp(config_value, PROVPOLICY_AVOID))
 							conf.provision_policy = AVOID_PROVISION;
@@ -767,15 +755,13 @@ parse_config(char *fname)
 					conf.max_borrow = res_to_num(config_value, &type);
 					if (!type.is_time)
 						error = 1;
-				}
-				else if (!strcmp(config_name, PARSE_SHARES_TRACK_ONLY)) {
+				} else if (!strcmp(config_name, PARSE_SHARES_TRACK_ONLY)) {
 					if (prime == PRIME || prime == ALL)
 						conf.prime_sto = num ? 1 : 0;
 					if (prime == NON_PRIME || prime == ALL)
 						conf.non_prime_sto = num ? 1 : 0;
-				}
-				else if (!strcmp(config_name, PARSE_PER_SHARE_DEPTH) ||
-					!strcmp(config_name, PARSE_PER_SHARE_TOPJOBS)) {
+				} else if (!strcmp(config_name, PARSE_PER_SHARE_DEPTH) ||
+					   !strcmp(config_name, PARSE_PER_SHARE_TOPJOBS)) {
 					conf.per_share_topjobs = num;
 				}
 				/* localmod 038 */
@@ -785,8 +771,7 @@ parse_config(char *fname)
 				/* localmod 030 */
 				else if (!strcmp(config_name, PARSE_MIN_INTERRUPTED_CYCLE_LENGTH)) {
 					conf.min_intrptd_cycle_length = num;
-				}
-				else if (!strcmp(config_name, PARSE_MAX_CONS_INTERRUPTED_CYCLES)) {
+				} else if (!strcmp(config_name, PARSE_MAX_CONS_INTERRUPTED_CYCLES)) {
 					conf.max_intrptd_cycles = num;
 				}
 #endif
@@ -945,9 +930,6 @@ init_config()
 	memset(conf.non_prime_node_sort, 0, (MAX_SORTS + 1) *
 		sizeof(struct sort_info));
 
-	/* set any defaults other then OFF */
-	conf.preempt_min_wt_used = 1;
-
 	/* for backwards compatibility */
 	conf.update_comments = 1;
 
@@ -963,10 +945,6 @@ init_config()
 	conf.enforce_no_shares = 1;
 	conf.fairshare_decay_factor = .5;
 
-	/* don't want it to default to 0 and think all queues are express queues
-	conf.preempt_queue_prio = SCHD_INFINITY;
-	*/
-
 	conf.max_preempt_attempts = SCHD_INFINITY;
 	conf.max_jobs_to_check = SCHD_INFINITY;
 
@@ -975,9 +953,6 @@ init_config()
 
 	/* deprecated parameters which are needed to be set to true */
 	conf.assign_ssinodes = 1;
-	conf.preempt_suspend = 1;
-	conf.preempt_chkpt = 1;
-	conf.preempt_requeue = 1;
 	conf.preempt_starving = 1;
 	conf.preempt_fairshare = 1;
 	conf.prime_bf = 1;

--- a/src/scheduler/pbs_sched.c
+++ b/src/scheduler/pbs_sched.c
@@ -1336,6 +1336,7 @@ main(int argc, char *argv[])
 	pthread_mutex_init(&cleanup_lock, &attr);
 
 	FD_ZERO(&fdset);
+
 	for (go=1; go;) {
 		int	cmd;
 

--- a/src/scheduler/queue_info.c
+++ b/src/scheduler/queue_info.c
@@ -186,7 +186,7 @@ query_queues(status *policy, int pbs_sd, server_info *sinfo)
 			return NULL;
 		}
 
-		if (queue_in_partition(qinfo, sinfo->partition)) {
+		if (queue_in_partition(qinfo, sc_attrs.partition)) {
 			/* check if the queue is a dedicated time queue */
 			if (conf.ded_prefix[0] != '\0')
 				if (!strncmp(qinfo->name, conf.ded_prefix, strlen(conf.ded_prefix))) {

--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -194,7 +194,7 @@ query_reservations(server_info *sinfo, struct batch_status *resvs)
 		/* Check if this reservation belongs to this scheduler */
 		for (attrp = cur_resv->attribs; attrp != NULL; attrp = attrp->next) {
 			if (strcmp(attrp->name, ATTR_partition) == 0) {
-				if (sinfo->partition != NULL && (strcmp(attrp->value, sinfo->partition) != 0))
+				if (sc_attrs.partition != NULL && (strcmp(attrp->value, sc_attrs.partition) != 0))
 					ignore_resv = 1;
 				break;
 			}
@@ -1576,7 +1576,7 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 		 * will return an error
 		 */
 		snprintf(confirm_msg, LOG_BUF_SIZE, "%s:partition=%s", PBS_RESV_CONFIRM_SUCCESS,
-			 nsinfo->partition?nsinfo->partition:DEFAULT_PARTITION);
+			 sc_attrs.partition ? sc_attrs.partition : DEFAULT_PARTITION);
 
 		pbsrc = pbs_confirmresv(pbs_sd, nresv_parent->name, short_xc,
 			resv_start_time, confirm_msg);

--- a/src/scheduler/server_info.h
+++ b/src/scheduler/server_info.h
@@ -59,12 +59,6 @@ extern "C" {
 server_info *query_server(status *policy, int pbs_sd);
 
 /*
- *	query_sched_obj - query the server's scheduler object and convert
- *			  attributes to scheduler's internal data structures
- */
-int query_sched_obj(status *policy, struct batch_status *sched, server_info *sinfo);
-
-/*
  *	query_server_info - collect information out of a statserver call
  *			    into a server_info structure
  */

--- a/src/scheduler/simulate.c
+++ b/src/scheduler/simulate.c
@@ -750,7 +750,7 @@ calc_run_time(char *name, server_info *sinfo, int flags)
 		}
 
 		if (ns == NULL) /* event can not run */
-			ret = simulate_events(sinfo->policy, sinfo, SIM_NEXT_EVENT, &(sinfo->opt_backfill_fuzzy_time), &event_time);
+			ret = simulate_events(sinfo->policy, sinfo, SIM_NEXT_EVENT, &sc_attrs.opt_backfill_fuzzy, &event_time);
 
 #ifdef NAS /* localmod 030 */
 		if (check_for_cycle_interrupt(0)) {

--- a/src/server/pbsd_init.c
+++ b/src/server/pbsd_init.c
@@ -623,7 +623,7 @@ pbsd_init(int type)
 			/* Create and save default to DB*/
 			dflt_scheduler = sched_alloc(PBS_DFLT_SCHED_NAME);
 			set_sched_default(dflt_scheduler, 0);
-			(void)sched_save_db(dflt_scheduler, SVR_SAVE_NEW);
+			sched_save_db(dflt_scheduler, SVR_SAVE_NEW);
 		} else {
 			while ((rc = pbs_db_cursor_next(conn, state, &obj)) == 0) {
 				/* recover sched */
@@ -635,6 +635,7 @@ pbsd_init(int type)
 					}
 					psched->pbs_scheduler_port = psched->sch_attr[SCHED_ATR_sched_port].at_val.at_long;
 					psched->pbs_scheduler_addr = get_hostaddr(psched->sch_attr[SCHED_ATR_SchedHost].at_val.at_str);
+					set_scheduler_flag(SCH_CONFIGURE, psched);
 				}
 				pbs_db_reset_obj(&obj);
 			}
@@ -666,7 +667,7 @@ pbsd_init(int type)
 		svr_save_db(&server, SVR_SAVE_NEW);
 		dflt_scheduler = sched_alloc(PBS_DFLT_SCHED_NAME);
 		set_sched_default(dflt_scheduler, 0);
-		(void)sched_save_db(dflt_scheduler, SVR_SAVE_NEW);
+		sched_save_db(dflt_scheduler, SVR_SAVE_NEW);
 	}
 
 	/* 4. Check License information */

--- a/src/server/run_sched.c
+++ b/src/server/run_sched.c
@@ -612,7 +612,7 @@ set_scheduler_flag(int flag, pbs_sched *psched)
 		 * Note: A) usually SCH_QUIT is sent directly and not via here
 		 *       B) if we ever add a 3rd high prio command, we can lose them
 		 */
-		if (flag == SCH_CONFIGURE || flag == SCH_ATTRS_CONFIGURE || flag == SCH_QUIT) {
+		if (flag == SCH_CONFIGURE || flag == SCH_QUIT) {
 			if (psched->svr_do_sched_high == SCH_QUIT)
 				return; /* keep only SCH_QUIT */
 

--- a/src/tools/pbs_python.c
+++ b/src/tools/pbs_python.c
@@ -322,11 +322,6 @@ action_sched_log(attribute *pattr, void *pobj, int actmode)
 {
 	return 0;
 }
-int
-action_sched_log_events(attribute *pattr, void *pobj, int actmode)
-{
-	return 0;
-}
 
 int
 action_sched_iteration(attribute *pattr, void *pobj, int actmode)

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -516,6 +516,14 @@ class PBSTestSuite(unittest.TestCase):
             self.revert_pbsconf()
             self.revert_schedulers()
             self.revert_moms()
+
+        # turn off opt_backfill_fuzzy to avoid unexpected calendaring behavior
+        # as many tests assume that scheduler will simulate each event
+        a = {'opt_backfill_fuzzy': 'off'}
+        for schedinfo in self.schedulers.values():
+            for schedname in schedinfo.keys():
+                self.server.manager(MGR_CMD_SET, SCHED, a, id=schedname)
+
         self.revert_comms()
         self.log_end_setup()
         self.measurements = []

--- a/test/tests/functional/pbs_sched_attr_updates.py
+++ b/test/tests/functional/pbs_sched_attr_updates.py
@@ -1,0 +1,141 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2020 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of both the OpenPBS software ("OpenPBS")
+# and the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# OpenPBS is free software. You can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# OpenPBS is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# PBS Pro is commercially licensed software that shares a common core with
+# the OpenPBS software.  For a copy of the commercial license terms and
+# conditions, go to: (http://www.pbspro.com/agreement.html) or contact the
+# Altair Legal Department.
+#
+# Altair's dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of OpenPBS and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair's trademarks, including but not limited to "PBS™",
+# "OpenPBS®", "PBS Professional®", and "PBS Pro™" and Altair's logos is
+# subject to Altair's trademark licensing policies.
+
+from tests.functional import *
+
+
+class TestSchedAttrUpdates(TestFunctional):
+    @skipOnCpuSet
+    def test_basic_throttling(self):
+        """
+        Test the behavior of sched's 'attr_update_period' attribute
+        """
+        self.server.manager(MGR_CMD_SET, NODE,
+                            {"resources_available.ncpus": 1},
+                            id=self.mom.shortname)
+
+        jid1 = self.server.submit(Job())
+        jid2 = self.server.submit(Job())
+
+        self.server.expect(JOB, {"job_state": "R"}, id=jid1)
+        self.server.expect(JOB, {"job_state": "Q"}, id=jid2)
+        self.server.expect(JOB, "comment", op=SET, id=jid2)
+
+        self.server.cleanup_jobs()
+
+        a = {"attr_update_period": 45, "scheduling": "False"}
+        self.server.manager(MGR_CMD_SET, SCHED, a, id="default")
+
+        self.server.submit(Job())
+        jid4 = self.server.submit(Job())
+
+        self.scheduler.run_scheduling_cycle()
+
+        # Scheduler should send attr updates in the first cycle
+        # after attr_update_period is set
+        self.server.expect(JOB, "comment", op=SET, id=jid4)
+
+        jid5 = self.server.submit(Job())
+        jid6 = self.server.submit(Job())
+
+        t = time.time()
+        self.scheduler.run_scheduling_cycle()
+
+        # Verify that scheduler didn't send attr updates for new jobs
+        self.server.expect(JOB, "comment", op=UNSET, id=jid5)
+        self.server.expect(JOB, "comment", op=UNSET, id=jid6)
+        self.server.log_match("Type 96 request received", existence=False,
+                              starttime=t, max_attempts=5)
+
+        self.logger.info("Sleep for 45s for the attr_update_period to pass")
+        time.sleep(45)
+        jid7 = self.server.submit(Job())
+        jid8 = self.server.submit(Job())
+
+        t = time.time()
+        self.scheduler.run_scheduling_cycle()
+
+        # Verify that scheduler sent attr updates for all new jobs
+        self.server.expect(JOB, "comment", op=SET, id=jid7)
+        self.server.expect(JOB, "comment", op=SET, id=jid8)
+        self.server.log_match("Type 96 request received", starttime=t)
+
+    @skipOnCpuSet
+    def test_accrue_type(self):
+        """
+        Test that accrue_type updates are sent immediately
+        """
+        self.server.manager(MGR_CMD_SET, NODE,
+                            {"resources_available.ncpus": 1},
+                            id=self.mom.shortname)
+
+        a = {"attr_update_period": 600, "scheduling": "False"}
+        self.server.manager(MGR_CMD_SET, SCHED, a, id="default")
+
+        j = Job()
+        j.set_sleep_time(1000)
+        jid1 = self.server.submit(j)
+        jid2 = self.server.submit(Job())
+
+        self.scheduler.run_scheduling_cycle()
+        self.server.expect(JOB, {"job_state": "R"}, id=jid1)
+        self.server.expect(JOB, {"job_state": "Q"}, id=jid2)
+        self.server.expect(JOB, "comment", op=SET, id=jid2)
+
+        jid3 = self.server.submit(Job())
+        self.scheduler.run_scheduling_cycle()
+        self.server.expect(JOB, "comment", op=UNSET, id=jid3)
+
+        # Now, turn eligible time on and add a limit that'll be crossed
+        # by the user, this will trigger an accrue_type update from sched
+        a = {"eligible_time_enable": "True"}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+        self.server.manager(MGR_CMD_SET, SERVER,
+                            {'max_run_res.ncpus': '[u:PBS_GENERIC=1]'})
+
+        # We should still be within the throttling window
+        # But, because accrue_type needed to be sent out,
+        # sched will send all updates for the jobs
+        jid4 = self.server.submit(Job())
+        self.scheduler.run_scheduling_cycle()
+        self.server.expect(JOB, "comment", op=SET, id=jid4, max_attempts=1)
+        self.server.expect(JOB, {"accrue_type": "1"}, id=jid4, max_attempts=1)
+        self.server.expect(JOB, "comment", op=SET, id=jid3, max_attempts=1)
+        self.server.expect(JOB, {"accrue_type": "1"}, id=jid3, max_attempts=1)
+        self.server.expect(JOB, {"accrue_type": "1"}, id=jid2, max_attempts=1)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Scheduler sends job attribute updates for certain attributes to the server. These updates can become a performance bottleneck, affecting scheduling speed. The most problematic ones are the updates related to “job can’t run”, where scheduler updates the job comment, possibly accrue_type, for each job that’s not run, even if it might run those jobs in the very next cycle. So, throttling such updates  sounds reasonable, and can speed up the scheduler greatly. By reducing the total number of requests sent to the server, it should also help the server be more responsive to other more important requests.

So, adding a sched attribute to do the same. Please see design document for more details.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
- Added new sched attribute "attr_update_period" to control after how long since last the scheduler will send attribute updates to server for "can't run" type updates.
- Refactored the code so that scheduler attributes are not queried every scheduling cycle, they are all cached by sched and updated when one updates them via qmgr.
- Removed sched_config's hidden option 'opt_backfill_fuzzy_time' and enhanced sched attribute opt_backfill_fuzzy to accept time in seconds in addition to existing values "low", "med" etc.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
https://pbspro.atlassian.net/wiki/spaces/PBSPro/pages/1684045848/New+Sched+attribute+to+throttle+job+attribute+updates

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[sched_attr_updates.log](https://github.com/PBSPro/pbspro/files/4526871/sched_attr_updates.log)

(Performance test results will be attached soon)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
