### PR TITLE
Jobs don't accrue eligible time by default

### DIFF
--- a/src/server/array_func.c
+++ b/src/server/array_func.c
@@ -144,6 +144,7 @@ static enum job_atr attrs_to_copy[] = {
 	JOB_ATR_runcount,
 	JOB_ATR_pset,
 	JOB_ATR_eligible_time,
+	JOB_ATR_sample_starttime,
 	JOB_ATR_executable,
 	JOB_ATR_Arglist,
 	JOB_ATR_reserve_ID,
@@ -154,7 +155,7 @@ static enum job_atr attrs_to_copy[] = {
 	JOB_ATR_cred_id,
 #endif
 	JOB_ATR_submit_host,
-	JOB_ATR_LAST		/* This MUST be LAST	*/
+	JOB_ATR_LAST /* This MUST be LAST	*/
 };
 
 /**

--- a/src/server/hook_func.c
+++ b/src/server/hook_func.c
@@ -3565,8 +3565,8 @@ do_runjob_reject_actions(job *pjob, char *hook_name)
 	}
 
 	/* update the eligible time to JOB_INITIAL */
-	if (server.sv_attr[(int)SRV_ATR_EligibleTimeEnable].at_val.at_long == 1 &&
-		server.sv_attr[(int)SRV_ATR_EligibleTimeEnable].at_flags & ATR_VFLAG_SET)
+	if ((server.sv_attr[SRV_ATR_EligibleTimeEnable].at_flags & ATR_VFLAG_SET)
+		&& server.sv_attr[SRV_ATR_EligibleTimeEnable].at_val.at_long == 1)
 		update_eligible_time(JOB_INITIAL, pjob);
 
 	/*

--- a/src/server/hook_func.c
+++ b/src/server/hook_func.c
@@ -3564,6 +3564,10 @@ do_runjob_reject_actions(job *pjob, char *hook_name)
 		}
 	}
 
+	/* update the eligible time to JOB_INITIAL */
+	if (server.sv_attr[(int)SRV_ATR_EligibleTimeEnable].at_val.at_long == 1)
+		update_eligible_time(JOB_INITIAL, pjob);
+
 	/*
 	 * Don't let the values in runjob_reject_attrlist (a_map) linger.
 	 * When resources get deleted and recreated between job runs, the

--- a/src/server/hook_func.c
+++ b/src/server/hook_func.c
@@ -3565,7 +3565,8 @@ do_runjob_reject_actions(job *pjob, char *hook_name)
 	}
 
 	/* update the eligible time to JOB_INITIAL */
-	if (server.sv_attr[(int)SRV_ATR_EligibleTimeEnable].at_val.at_long == 1)
+	if (server.sv_attr[(int)SRV_ATR_EligibleTimeEnable].at_val.at_long == 1 &&
+		server.sv_attr[(int)SRV_ATR_EligibleTimeEnable].at_flags & ATR_VFLAG_SET)
 		update_eligible_time(JOB_INITIAL, pjob);
 
 	/*

--- a/src/server/job_func.c
+++ b/src/server/job_func.c
@@ -425,6 +425,7 @@ job_alloc(void)
 	/* start accruing time from the time job was created */
 	time(&ctm);
 	pj->ji_wattr[(int)JOB_ATR_sample_starttime].at_val.at_long = (long) ctm;
+	pj->ji_wattr[(int)JOB_ATR_eligible_time].at_val.at_long = 0;
 
 	/* if eligible_time_enable is not true, then job does not accrue eligible time */
 	if (server.sv_attr[(int)SRV_ATR_EligibleTimeEnable].at_val.at_long == 1) {

--- a/src/server/job_func.c
+++ b/src/server/job_func.c
@@ -139,6 +139,8 @@
 #include "renew_creds.h"
 #endif
 
+extern int time_now;
+
 /* External functions */
 
 #ifdef WIN32
@@ -340,10 +342,6 @@ job_alloc(void)
 {
 	job	*pj;
 
-#ifndef PBS_MOM
-	time_t 	ctm;
-#endif
-
 	pj = (job *)malloc(sizeof(job));
 	if (pj == NULL) {
 		log_err(errno, "job_alloc", "no memory");
@@ -423,12 +421,12 @@ job_alloc(void)
 
 #ifndef PBS_MOM
 	/* start accruing time from the time job was created */
-	time(&ctm);
-	pj->ji_wattr[(int)JOB_ATR_sample_starttime].at_val.at_long = (long) ctm;
+	pj->ji_wattr[(int)JOB_ATR_sample_starttime].at_val.at_long = (long) time_now;
 	pj->ji_wattr[(int)JOB_ATR_eligible_time].at_val.at_long = 0;
 
 	/* if eligible_time_enable is not true, then job does not accrue eligible time */
-	if (server.sv_attr[(int)SRV_ATR_EligibleTimeEnable].at_val.at_long == 1) {
+	if ((server.sv_attr[SRV_ATR_EligibleTimeEnable].at_flags & ATR_VFLAG_SET) &&
+		server.sv_attr[SRV_ATR_EligibleTimeEnable].at_val.at_long == 1) {
 		int elig_val;
 
 		elig_val = determine_accruetype(pj);

--- a/src/server/job_func.c
+++ b/src/server/job_func.c
@@ -422,21 +422,16 @@ job_alloc(void)
 
 
 #ifndef PBS_MOM
-	/* mark as JOB_INITIAL, set accrue times to zero */
-	pj->ji_wattr[(int)JOB_ATR_accrue_type].at_val.at_long = JOB_INITIAL;
-	pj->ji_wattr[(int)JOB_ATR_eligible_time].at_val.at_long = 0;
 	/* start accruing time from the time job was created */
 	time(&ctm);
-	pj->ji_wattr[(int)JOB_ATR_sample_starttime].at_val.at_long = (long)ctm;
+	pj->ji_wattr[(int)JOB_ATR_sample_starttime].at_val.at_long = (long) ctm;
 
 	/* if eligible_time_enable is not true, then job does not accrue eligible time */
 	if (server.sv_attr[(int)SRV_ATR_EligibleTimeEnable].at_val.at_long == 1) {
-		pj->ji_wattr[(int)JOB_ATR_accrue_type].at_flags |= ATR_VFLAG_SET;
+		int elig_val;
 
-		pj->ji_wattr[(int)JOB_ATR_eligible_time].at_flags |= ATR_VFLAG_SET;
-
-
-		pj->ji_wattr[(int)JOB_ATR_sample_starttime].at_flags |= ATR_VFLAG_SET;
+		elig_val = determine_accruetype(pj);
+		update_eligible_time(elig_val, pj);
 	}
 #endif
 

--- a/src/server/queue_func.c
+++ b/src/server/queue_func.c
@@ -439,7 +439,7 @@ queuestart_action(attribute *pattr, void *pobject, int actmode)
 					oldtype != JOB_ELIGIBLE) {
 
 					newaccruetype = determine_accruetype(pj);
-					(void)update_eligible_time(newaccruetype, pj);
+					update_eligible_time(newaccruetype, pj);
 				}
 
 				pj = (job*)GET_NEXT(pj->ji_jobque);
@@ -502,5 +502,3 @@ action_queue_partition(attribute *pattr, void *pobj, int actmode)
 
 	return PBSE_NONE;
 }
-
-

--- a/src/server/svr_func.c
+++ b/src/server/svr_func.c
@@ -1569,26 +1569,8 @@ eligibletime_action(attribute *pattr, void *pobject, int actmode)
 
 		pj = (job *)GET_NEXT(svr_alljobs);
 		while (pj != NULL) {
-			/*
-			 * try to determine accruetype for
-			 * jobs submitted when eligible_time_enable was 'off'
-			 * if unable to determine now, wait for scheduling cycle
-			 */
-			if ((pj->ji_wattr[(int)JOB_ATR_accrue_type].at_val.at_long == JOB_INITIAL) ||
-				((pj->ji_wattr[(int)JOB_ATR_accrue_type].at_flags & ATR_VFLAG_SET) == 0)) {
-				accruetype = determine_accruetype(pj);
-				if (accruetype == -1)
-					pj->ji_wattr[(int)JOB_ATR_accrue_type].at_val.at_long = JOB_INITIAL;
-				else
-					pj->ji_wattr[(int)JOB_ATR_accrue_type].at_val.at_long = accruetype;
-
-				pj->ji_wattr[(int)JOB_ATR_accrue_type].at_flags |=
-					(ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY);
-				pj->ji_wattr[(int)JOB_ATR_eligible_time].at_flags |=
-					(ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY);
-				pj->ji_wattr[(int)JOB_ATR_sample_starttime].at_flags |=
-					(ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY);
-			}
+			accruetype = determine_accruetype(pj);
+			update_eligible_time(accruetype, pj);
 
 			pj = (job *)GET_NEXT(pj->ji_alljobs);
 		}

--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -4936,7 +4936,7 @@ determine_accruetype(job* pjob)
 		if (pque->qu_attr[(int)QA_ATR_Started].at_val.at_long == 0)
 			return JOB_ELIGIBLE;
 
-	/* New job without any apparent crimes, make it accrue eligible time */
+	/* The job doesn't have any reason to not accrue eligible time (e.g. on hold), so it should accrue it */
 	if (pjob->ji_qs.ji_state == JOB_STATE_TRANSIT &&
 		pjob->ji_qs.ji_substate == JOB_SUBSTATE_TRANSIN)
 		return JOB_ELIGIBLE;

--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -4918,8 +4918,8 @@ determine_accruetype(job* pjob)
 		if ((pjob->ji_qs.ji_substate == JOB_SUBSTATE_DEPNHOLD)
 			&& (temphold & HOLD_s))
 			return JOB_INELIGIBLE;
-		else
-			return JOB_ELIGIBLE;
+
+		return JOB_ELIGIBLE;
 	}
 
 	/* scheduler suspend job ; accrue eligible time */

--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -695,11 +695,8 @@ svr_setjobstate(job *pjob, int newstate, int newsubstate)
 	if (server.sv_attr[SRV_ATR_EligibleTimeEnable].at_val.at_long == 1) {
 		long newaccruetype;
 
-		/* determine accrue type */
 		newaccruetype = determine_accruetype(pjob);
-
-		/* calculate eligible time */
-		(void)update_eligible_time(newaccruetype, pjob);
+		update_eligible_time(newaccruetype, pjob);
 	}
 
 	/* update the job file */
@@ -4884,43 +4881,33 @@ convert_long_to_time(long l)
  * @retval	JOB_INELIGIBLE	-	when job is ineligible to accrue eligible_time
  * @retval	JOB_RUNNING	-	when job is running or provisioning
  * @retval	JOB_EXIT	-	when job is exiting
- * @retval	-1	-	when this function is not able to determine accruetype
+ * @retval	-1	- when accrue type couldn'tbe determined
  */
 long
 determine_accruetype(job* pjob)
 {
 	struct pbs_queue *pque;
-	long	temphold;
-	long newaccruetype = -1;
-
+	long temphold;
 
 	/* have to determine accrue type */
 
 	/* if job is truely running or provisioning */
 	if (pjob->ji_qs.ji_state == JOB_STATE_RUNNING &&
 		(pjob->ji_qs.ji_substate == JOB_SUBSTATE_RUNNING ||
-		pjob->ji_qs.ji_substate == JOB_SUBSTATE_PROVISION)) {
-		newaccruetype = (long)JOB_RUNNING;
-		return newaccruetype;
-	}
+		pjob->ji_qs.ji_substate == JOB_SUBSTATE_PROVISION))
+		return JOB_RUNNING;
 
 	/* if job exit */
-	if (pjob->ji_qs.ji_state == JOB_STATE_EXITING) {
-		newaccruetype = (long)JOB_EXIT;
-		return newaccruetype;
-	}
+	if (pjob->ji_qs.ji_state == JOB_STATE_EXITING)
+		return JOB_EXIT;
 
 	/* handling qsub -a, waiting with substate 30 ; accrue ineligible time */
-	if (pjob->ji_wattr[(int)JOB_ATR_exectime].at_val.at_long) {
-		newaccruetype = (long)JOB_INELIGIBLE;
-		return newaccruetype;
-	}
+	if (pjob->ji_wattr[(int)JOB_ATR_exectime].at_val.at_long)
+		return JOB_INELIGIBLE;
 
 	/* 'user' hold applied ; accrue ineligible time */
-	if (pjob->ji_wattr[(int)JOB_ATR_hold].at_val.at_long & HOLD_u) {
-		newaccruetype = (long)JOB_INELIGIBLE;
-		return newaccruetype;
-	}
+	if (pjob->ji_wattr[(int)JOB_ATR_hold].at_val.at_long & HOLD_u)
+		return JOB_INELIGIBLE;
 
 	/* other than 'user' hold applied */
 	/* accrue type is set to JOB_INELIGIBLE incase a job has dependency */
@@ -4929,36 +4916,32 @@ determine_accruetype(job* pjob)
 	temphold = pjob->ji_wattr[(int)JOB_ATR_hold].at_val.at_long;
 	if (temphold & HOLD_o || temphold & HOLD_bad_password || temphold & HOLD_s) {
 		if ((pjob->ji_qs.ji_substate == JOB_SUBSTATE_DEPNHOLD)
-			&& (temphold & HOLD_s)) {
-			newaccruetype = (long)JOB_INELIGIBLE;
-		} else {
-			newaccruetype = (long)JOB_ELIGIBLE;
-		}
-		return newaccruetype;
+			&& (temphold & HOLD_s))
+			return JOB_INELIGIBLE;
+		else
+			return JOB_ELIGIBLE;
 	}
 
 	/* scheduler suspend job ; accrue eligible time */
-	if (pjob->ji_qs.ji_substate == JOB_SUBSTATE_SCHSUSP) {
-		newaccruetype = (long)JOB_ELIGIBLE;
-		return newaccruetype;
-	}
+	if (pjob->ji_qs.ji_substate == JOB_SUBSTATE_SCHSUSP)
+		return JOB_ELIGIBLE;
 
 	/* qsig suspended job ; accrue eligible time */
-	if (pjob->ji_qs.ji_substate == JOB_SUBSTATE_SUSPEND) {
-		newaccruetype = (long)JOB_ELIGIBLE;
-		return newaccruetype;
-	}
+	if (pjob->ji_qs.ji_substate == JOB_SUBSTATE_SUSPEND)
+		return JOB_ELIGIBLE;
 
 	/* check for stopped queue: routing and execute ; accrue eligible time */
 	pque = find_queuebyname(pjob->ji_qs.ji_queue);
 	if (pque != NULL)
-		if (pque->qu_attr[(int)QA_ATR_Started].at_val.at_long == 0) {
-			newaccruetype = (long)JOB_ELIGIBLE;
-			return newaccruetype;
-		}
+		if (pque->qu_attr[(int)QA_ATR_Started].at_val.at_long == 0)
+			return JOB_ELIGIBLE;
 
-	/* return */
-	return newaccruetype;
+	/* New job without any apparent crimes, make it accrue eligible time */
+	if (pjob->ji_qs.ji_state == JOB_STATE_TRANSIT &&
+		pjob->ji_qs.ji_substate == JOB_SUBSTATE_TRANSIN)
+		return JOB_ELIGIBLE;
+
+	return -1;
 }
 
 /**
@@ -4985,44 +4968,32 @@ update_eligible_time(long newaccruetype, job *pjob)
 	char str[256];
 	long accrued_time;			/* accrued time */
 	long oldaccruetype = pjob->ji_wattr[(int)JOB_ATR_accrue_type].at_val.at_long;
-	long timestamp = (long)time_now; 	/* time since accrual begins */
+	long timestamp = (long) time_now; 	/* time since accrual begins */
+	unsigned int flags = (ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY);
 
 	/* check if updating same accrue type or do nothing */
 	if (newaccruetype == oldaccruetype || newaccruetype == -1)
 		return 1;
 
 	/* time since accrue type last changed  */
-	accrued_time = timestamp - pjob->ji_wattr[(int) JOB_ATR_sample_starttime].at_val.at_long;
+	accrued_time = timestamp - pjob->ji_wattr[JOB_ATR_sample_starttime].at_val.at_long;
 
 	/* time since accrue type last changed is accrued */
 	/* change type to new accrue type,  update start time to mark */
 	/* change of accrue type */
 	switch ((int)oldaccruetype) {
 		case JOB_ELIGIBLE:
-			pjob->ji_wattr[(int)JOB_ATR_eligible_time].at_val.at_long += accrued_time;
-			pjob->ji_wattr[(int)JOB_ATR_accrue_type].at_val.at_long = newaccruetype;
-			pjob->ji_wattr[(int)JOB_ATR_sample_starttime].at_val.at_long = timestamp;
-
-			pjob->ji_wattr[(int)JOB_ATR_sample_starttime].at_flags |=
-				(ATR_VFLAG_MODIFY | ATR_VFLAG_MODCACHE);
-			pjob->ji_wattr[(int)JOB_ATR_accrue_type].at_flags |=
-				(ATR_VFLAG_MODIFY | ATR_VFLAG_MODCACHE);
-			pjob->ji_wattr[(int)JOB_ATR_eligible_time].at_flags |=
-				(ATR_VFLAG_MODIFY | ATR_VFLAG_MODCACHE);
-			break;
+			pjob->ji_wattr[JOB_ATR_eligible_time].at_val.at_long += accrued_time;
 		case JOB_INELIGIBLE:
 		case JOB_RUNNING:
 		case JOB_INITIAL:
 		case JOB_EXIT:
-			pjob->ji_wattr[(int)JOB_ATR_accrue_type].at_val.at_long = newaccruetype;
-			pjob->ji_wattr[(int)JOB_ATR_sample_starttime].at_val.at_long = timestamp;
+			pjob->ji_wattr[JOB_ATR_accrue_type].at_val.at_long = newaccruetype;
+			pjob->ji_wattr[JOB_ATR_sample_starttime].at_val.at_long = timestamp;
 
-			pjob->ji_wattr[(int)JOB_ATR_sample_starttime].at_flags |=
-				(ATR_VFLAG_MODIFY | ATR_VFLAG_MODCACHE);
-			pjob->ji_wattr[(int)JOB_ATR_accrue_type].at_flags |=
-				(ATR_VFLAG_MODIFY | ATR_VFLAG_MODCACHE);
-			pjob->ji_wattr[(int)JOB_ATR_eligible_time].at_flags |=
-				(ATR_VFLAG_MODIFY | ATR_VFLAG_MODCACHE);
+			pjob->ji_wattr[JOB_ATR_accrue_type].at_flags |= flags;
+			pjob->ji_wattr[JOB_ATR_eligible_time].at_flags |= flags;
+			pjob->ji_wattr[JOB_ATR_sample_starttime].at_flags |= flags;
 			break;
 
 		default:
@@ -5031,7 +5002,7 @@ update_eligible_time(long newaccruetype, job *pjob)
 	}  /*switch end*/
 
 	/* Prepare and print log message */
-	strtime = convert_long_to_time(pjob->ji_wattr[(int)JOB_ATR_eligible_time].at_val.at_long);
+	strtime = convert_long_to_time(pjob->ji_wattr[JOB_ATR_eligible_time].at_val.at_long);
 	if (strtime == NULL)
 		strtime = errtime;
 

--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -4984,15 +4984,14 @@ update_eligible_time(long newaccruetype, job *pjob)
 	switch ((int)oldaccruetype) {
 		case JOB_ELIGIBLE:
 			pjob->ji_wattr[JOB_ATR_eligible_time].at_val.at_long += accrued_time;
+			pjob->ji_wattr[JOB_ATR_eligible_time].at_flags |= flags;
 		case JOB_INELIGIBLE:
 		case JOB_RUNNING:
 		case JOB_INITIAL:
 		case JOB_EXIT:
 			pjob->ji_wattr[JOB_ATR_accrue_type].at_val.at_long = newaccruetype;
 			pjob->ji_wattr[JOB_ATR_sample_starttime].at_val.at_long = timestamp;
-
 			pjob->ji_wattr[JOB_ATR_accrue_type].at_flags |= flags;
-			pjob->ji_wattr[JOB_ATR_eligible_time].at_flags |= flags;
 			pjob->ji_wattr[JOB_ATR_sample_starttime].at_flags |= flags;
 			break;
 

--- a/src/server/svr_movejob.c
+++ b/src/server/svr_movejob.c
@@ -280,15 +280,8 @@ local_move(job *jobp, struct batch_request *req)
 	}
 
 	if (server.sv_attr[(int)SRV_ATR_EligibleTimeEnable].at_val.at_long == 1) {
-
 		newtype = determine_accruetype(jobp);
-		if (newtype == -1)
-			/* unable to determine accruetype, set it to NEW */
-			(void)update_eligible_time(JOB_INITIAL, jobp);
-		else
-			/* found suiting accruetype, update to this */
-			(void)update_eligible_time(newtype, jobp);
-
+		update_eligible_time(newtype, jobp);
 	}
 
 

--- a/test/tests/functional/pbs_eligible_time.py
+++ b/test/tests/functional/pbs_eligible_time.py
@@ -199,3 +199,44 @@ class TestEligibleTime(TestFunctional):
 
         self.server.expect(JOB, {'accrue_type': self.accrue['ineligible']},
                            id=jid2)
+
+    def test_default_accrue_type(self):
+        """
+        Test that the default accrue_type for jobs is "eligible time"
+        """
+
+        self.server.manager(MGR_CMD_SET, NODE,
+                            {'resources_available.ncpus': 1},
+                            id=self.mom.shortname)
+        self.server.manager(MGR_CMD_SET, SCHED, {"scheduling": "false"})
+
+        jid1 = self.server.submit(Job())
+
+        # Check that the job's accrue_type is set to eligible time
+        a = {"accrue_type": self.accrue['eligible']}
+        self.server.expect(JOB, a, id=jid1)
+
+    def test_delayed_ineligible(self):
+        """
+        Test that jobs are still correctly marked ineligible by sched
+        even if server thinks that they are eligible
+        """
+
+        self.server.manager(MGR_CMD_SET, NODE,
+                            {'resources_available.ncpus': 2},
+                            id=self.mom.shortname)
+        self.server.manager(MGR_CMD_SET, SCHED, {"scheduling": "false"})
+
+        a = {"max_run_res.ncpus": "[u:PBS_GENERIC=1]"}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+        jid1 = self.server.submit(Job(attrs={"Resource_List.ncpus": 2}))
+
+        # Check that server sets job's accrue_type to eligible time
+        a = {"accrue_type": self.accrue['eligible']}
+        self.server.expect(JOB, a, id=jid1)
+
+        self.scheduler.run_scheduling_cycle()
+
+        # Check that scheduler corrects the accrue_type to ineligible
+        a = {"accrue_type": self.accrue['ineligible']}
+        self.server.expect(JOB, a, id=jid1)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
According to documented behavior, the default accrue_type for jobs should be eligible time, but the code uses initial time instead. This also has a performance implication: usually, the chances of of jobs accruing eligible time are more than ineligible time. Not setting the default to eligible means that the scheduler has to send attribute updates to server for such jobs to update their accrue_type to eligible, which we would save if we corrected the default to eligible time.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Made the default accrue_type eligible time and added a couple of tests.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[testeligible.log](https://github.com/PBSPro/pbspro/files/4567163/testeligible.log)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
