### PR TITLE
resetting of pbs_license_info without unsetting it

### DIFF
--- a/src/server/svr_func.c
+++ b/src/server/svr_func.c
@@ -1021,6 +1021,8 @@ set_license_location(attribute *pattr, void *pobject, int actmode)
 		(server.sv_attr[SRV_ATR_pbs_license_info].at_val.at_str[0] \
 							!= '\0') ) {
 			close_licensing();	/* checkin, close connection */
+			unlicense_socket_licensed_nodes();
+			clear_license_info();
 		} else /* from no license server */
 			init_fl_license_attrs(&licenses);
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Resetting license_info without unsetting.


#### Describe Your Change
While changing the license_info without unsetting the previous license_info all the license attribute on the nodes should be cleared. 


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
