### PR TITLE
if getting new mom addr fails on init job, preserve original mom addr

### DIFF
--- a/src/server/pbsd_init.c
+++ b/src/server/pbsd_init.c
@@ -1720,8 +1720,8 @@ pbsd_init_job(job *pjob, int type)
 					pjob->ji_qs.ji_un.ji_exect.ji_momaddr = new_momaddr;
 					pjob->ji_qs.ji_un.ji_exect.ji_momport = new_momport;
 				} else {
-					log_event(PBSEVENT_DEBUG3, PBS_EVENTCLASS_JOB,
-						LOG_DEBUG, pjob->ji_qs.ji_jobid,
+					log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_JOB,
+						LOG_INFO, pjob->ji_qs.ji_jobid,
 						"Failed to update mom address. Mom address not changed.");
 				}
 			} else {

--- a/src/server/pbsd_init.c
+++ b/src/server/pbsd_init.c
@@ -1488,8 +1488,6 @@ pbsd_init_job(job *pjob, int type)
 {
 	int	 newstate;
 	int	 newsubstate;
-	pbs_net_t new_momaddr;
-	unsigned int new_momport;
 
 	pjob->ji_momhandle = -1;
 	pjob->ji_mom_prot = PROT_INVALID;
@@ -1710,6 +1708,9 @@ pbsd_init_job(job *pjob, int type)
 			(pjob->ji_qs.ji_un.ji_exect.ji_momaddr != 0)) {
 
 			if (pjob->ji_wattr[(int)JOB_ATR_exec_host].at_flags & ATR_VFLAG_SET) {
+				pbs_net_t new_momaddr;
+				unsigned int new_momport;
+
 				new_momaddr =
 					get_addr_of_nodebyname(
 					pjob->ji_wattr[(int)JOB_ATR_exec_host].
@@ -1718,7 +1719,11 @@ pbsd_init_job(job *pjob, int type)
 				if (new_momaddr != 0) {
 					pjob->ji_qs.ji_un.ji_exect.ji_momaddr = new_momaddr;
 					pjob->ji_qs.ji_un.ji_exect.ji_momport = new_momport;
-				} /* else preserve previous mom addr */
+				} else {
+					log_event(PBSEVENT_DEBUG3, PBS_EVENTCLASS_JOB,
+						LOG_DEBUG, pjob->ji_qs.ji_jobid,
+						"Failed to update mom address. Mom address not changed.");
+				}
 			} else {
 				pjob->ji_qs.ji_un.ji_exect.ji_momaddr = 0;
 				pjob->ji_qs.ji_un.ji_exect.ji_momport = 0;

--- a/src/server/pbsd_init.c
+++ b/src/server/pbsd_init.c
@@ -1486,9 +1486,10 @@ reassign_resc(job *pjob)
 static int
 pbsd_init_job(job *pjob, int type)
 {
-	unsigned int d;
 	int	 newstate;
 	int	 newsubstate;
+	pbs_net_t new_momaddr;
+	unsigned int new_momport;
 
 	pjob->ji_momhandle = -1;
 	pjob->ji_mom_prot = PROT_INVALID;
@@ -1709,11 +1710,15 @@ pbsd_init_job(job *pjob, int type)
 			(pjob->ji_qs.ji_un.ji_exect.ji_momaddr != 0)) {
 
 			if (pjob->ji_wattr[(int)JOB_ATR_exec_host].at_flags & ATR_VFLAG_SET) {
-				pjob->ji_qs.ji_un.ji_exect.ji_momaddr =
+				new_momaddr =
 					get_addr_of_nodebyname(
 					pjob->ji_wattr[(int)JOB_ATR_exec_host].
-					at_val.at_str, &d);
-				pjob->ji_qs.ji_un.ji_exect.ji_momport = d;
+					at_val.at_str, &new_momport);
+
+				if (new_momaddr != 0) {
+					pjob->ji_qs.ji_un.ji_exect.ji_momaddr = new_momaddr;
+					pjob->ji_qs.ji_un.ji_exect.ji_momport = new_momport;
+				} /* else preserve previous mom addr */
 			} else {
 				pjob->ji_qs.ji_un.ji_exect.ji_momaddr = 0;
 				pjob->ji_qs.ji_un.ji_exect.ji_momport = 0;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
The jobs can lose the mom addr on job initialization. The reason for the loss is quite rare. In our case, it was (temporary) bad configuration on DNS and we restarted the pbs server during that time. The jobs were initialized and get_addr_of_nodebyname() sometimes failed during the initialization -> mom addr was set to 0 for those jobs. If this happens the jobs can not be recovered. The server is not able to contact the jobs (even after another server restart).


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
I suggest preserving the original mom addr and mom port of jobs if the get_addr_of_nodebyname() fails on job initialization. This can be caused by only a temporary error from the DNS. I think it is too strict and unnecessary to lose such a job. We can try to use the original mom addr and port for those jobs.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
This bug is not easily reproduced and the fix hard to test.
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
