### PR TITLE
pbs commands are failing in failover when secondary server takes over

### DIFF
--- a/src/lib/Libifl/pbsD_connect.c
+++ b/src/lib/Libifl/pbsD_connect.c
@@ -460,7 +460,7 @@ __pbs_connect_extend(char *server, char *extend_data)
 	reply = PBSD_rdrpy(sock);
 	PBSD_FreeReply(reply);
 
-	if (engage_client_auth(sock, server_name, server_port, errbuf, sizeof(errbuf)) != 0) {
+	if (engage_client_auth(sock, server, server_port, errbuf, sizeof(errbuf)) != 0) {
 		if (pbs_errno == 0)
 			pbs_errno = PBSE_PERM;
 		fprintf(stderr, "auth: error returned: %d\n", pbs_errno);
@@ -852,7 +852,7 @@ err:
 	reply = PBSD_rdrpy(sock);
 	PBSD_FreeReply(reply);
 
-	if (engage_client_auth(sock, server_name, server_port, errbuf, sizeof(errbuf)) != 0) {
+	if (engage_client_auth(sock, server, server_port, errbuf, sizeof(errbuf)) != 0) {
 		if (pbs_errno == 0)
 			pbs_errno = PBSE_PERM;
 		fprintf(stderr, "auth: error returned: %d\n", pbs_errno);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
In failover, when the secondary server takes over, PBS commands fail with the following error -

> *pbs_iff: cannot connect to host
> pbs_iff: cannot connect to host
> auth: error returned: -1
> auth: Unable to authenticate connection (xarm-01-s15.pbspro.com:15001)
> qstat: cannot connect to server xarm-02-s15.pbspro.com (errno=-1)*

This is because we do not pass the name of the current active server, which is the secondary server in this case. So the commands try to authenticate with the primary server which is down at that time.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Use the server name of the current active server when calling engage_client_auth

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[after.txt](https://github.com/openpbs/openpbs/files/4679794/after.txt)
[before.txt](https://github.com/openpbs/openpbs/files/4679795/before.txt)
[testinglogs.txt](https://github.com/openpbs/openpbs/files/4679796/testinglogs.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
