### PR TITLE
dependent jobs without job-ids crash server

### DIFF
--- a/src/lib/Libcmds/parse_depend.c
+++ b/src/lib/Libcmds/parse_depend.c
@@ -147,6 +147,10 @@ parse_depend_item(char *depend_list, char **rtn_list, int *rtn_size)
 			if (append_string(rtn_list, deptypes[i], rtn_size))
 				return 1;
 
+			/* It an error if there are no values after ':' */
+			if (*c == '\0')
+				return 1;
+
 		} else {
 
 			if (i < 2) {		/* for "on" and "synccount", number */

--- a/src/lib/Libcmds/parse_depend.c
+++ b/src/lib/Libcmds/parse_depend.c
@@ -147,7 +147,7 @@ parse_depend_item(char *depend_list, char **rtn_list, int *rtn_size)
 			if (append_string(rtn_list, deptypes[i], rtn_size))
 				return 1;
 
-			/* It an error if there are no values after ':' */
+			/* It's an error if there are no values after ':' */
 			if (*c == '\0')
 				return 1;
 

--- a/src/server/accounting.c
+++ b/src/server/accounting.c
@@ -619,15 +619,17 @@ acct_job(job *pjob, int type, char *buf, int len)
 		CLEAR_HEAD(phead);
 		job_attr_def[(int)JOB_ATR_depend].at_encode(&pjob->ji_wattr[(int)JOB_ATR_depend],
 			&phead, job_attr_def[(int)JOB_ATR_depend].at_name, NULL, ATR_ENCODE_CLIENT, &svrattrl_list);
-		nd = sizeof(DEPEND_FMT) + strlen(svrattrl_list->al_value);
-		if (nd > len)
-			if (grow_acct_buf(&pb, &len, nd) == -1)
-				return (pb);
-		(void)snprintf(pb, len, DEPEND_FMT, svrattrl_list->al_value);
-		i = strlen(pb);
-		pb += i;
-		len -= i;
-		free_svrattrl(svrattrl_list);
+		if (svrattrl_list != NULL) {
+			nd = sizeof(DEPEND_FMT) + strlen(svrattrl_list->al_value);
+			if (nd > len)
+				if (grow_acct_buf(&pb, &len, nd) == -1)
+					return (pb);
+			(void)snprintf(pb, len, DEPEND_FMT, svrattrl_list->al_value);
+			i = strlen(pb);
+			pb += i;
+			len -= i;
+			free_svrattrl(svrattrl_list);
+		}
 	}
 
 	if (pjob->ji_wattr[(int)JOB_ATR_array_indices_submitted].at_flags & ATR_VFLAG_SET && ((pjob->ji_qs.ji_state == JOB_STATE_BEGUN) || type == PBS_ACCT_QUEUE)) {

--- a/src/server/req_register.c
+++ b/src/server/req_register.c
@@ -1825,14 +1825,18 @@ build_depend(attribute *pattr, char *value)
 	int			type;
 
 	/*
-	 * Map first subword into dependency type.  If there is just the type
-	 * with no following job id or count, then leave an empty depend
-	 * struct;  set_depend will "remove" any of that kind.
+	 * Map first subword into dependency type. 
 	 */
 
 	if ((nxwrd = strchr(value, (int)':')) != NULL)
 		*nxwrd++ = '\0';
+	else
+		/* dependency can never be without ':<value>' */
+		return (PBSE_BADATVAL);
 
+	if (*nxwrd == '\0')
+		/* dependency can never be without a job-id or a number */
+		return (PBSE_BADATVAL);
 
 	for (pname = dependnames; pname->type != -1; pname++)
 		if (!strcmp(value, pname->name))


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
PBS server crashes if a job is submitted with dependency but without the job-id of parent job it is dependent on. Example, qsub -Wdepend=afterany: job.sh


#### Describe Your Change 
Made a change in libcmds to ensure qsub errors out if a user submits such a job
The server rejects such jobs if the job is sent using a user-written client that uses IFL calls.



#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
Since the check is in clients. I think writing a test for this bug fix isn't that necessary. Please let me know if anyone thinks otherwise.


TEST LOGS - 

```
arung@centos Desktop]$ /opt/pbs/bin/qsub -Wdepend=afterok:3,afterany: -- /bin/sleep 100
qsub: illegal -W value
usage: qsub [-a date_time] [-A account_string] [-c interval]
	[-C directive_prefix] [-e path] [-f ] [-h ] [-I [-X]] [-j oe|eo] [-J X-Y[:Z]]
	[-k keep] [-l resource_list] [-m mail_options] [-M user_list]
	[-N jobname] [-o path] [-p priority] [-P project] [-q queue] [-r y|n]
	[-R o|e|oe] [-S path] [-u user_list] [-W otherattributes=value...]
	[-S path] [-u user_list] [-W otherattributes=value...]
	[-v variable_list] [-V ] [-z] [script | -- command [arg1 ...]]
       qsub --version
[arung@centos Desktop]$ /opt/pbs/bin/qsub -Wdepend=afterok:,afterany: -- /bin/sleep 100
qsub: illegal -W value
usage: qsub [-a date_time] [-A account_string] [-c interval]
	[-C directive_prefix] [-e path] [-f ] [-h ] [-I [-X]] [-j oe|eo] [-J X-Y[:Z]]
	[-k keep] [-l resource_list] [-m mail_options] [-M user_list]
	[-N jobname] [-o path] [-p priority] [-P project] [-q queue] [-r y|n]
	[-R o|e|oe] [-S path] [-u user_list] [-W otherattributes=value...]
	[-S path] [-u user_list] [-W otherattributes=value...]
	[-v variable_list] [-V ] [-z] [script | -- command [arg1 ...]]
       qsub --version
[arung@centos Desktop]$ /opt/pbs/bin/qsub -Wdepend=afterok:: -- /bin/sleep 100
qsub: illegal -W value
usage: qsub [-a date_time] [-A account_string] [-c interval]
	[-C directive_prefix] [-e path] [-f ] [-h ] [-I [-X]] [-j oe|eo] [-J X-Y[:Z]]
	[-k keep] [-l resource_list] [-m mail_options] [-M user_list]
	[-N jobname] [-o path] [-p priority] [-P project] [-q queue] [-r y|n]
	[-R o|e|oe] [-S path] [-u user_list] [-W otherattributes=value...]
	[-S path] [-u user_list] [-W otherattributes=value...]
	[-v variable_list] [-V ] [-z] [script | -- command [arg1 ...]]
       qsub --version
[arung@centos Desktop]$ /opt/pbs/bin/qsub -Wdepend=afterok: -- /bin/sleep 100
qsub: illegal -W value
usage: qsub [-a date_time] [-A account_string] [-c interval]
	[-C directive_prefix] [-e path] [-f ] [-h ] [-I [-X]] [-j oe|eo] [-J X-Y[:Z]]
	[-k keep] [-l resource_list] [-m mail_options] [-M user_list]
	[-N jobname] [-o path] [-p priority] [-P project] [-q queue] [-r y|n]
	[-R o|e|oe] [-S path] [-u user_list] [-W otherattributes=value...]
	[-S path] [-u user_list] [-W otherattributes=value...]
	[-v variable_list] [-V ] [-z] [script | -- command [arg1 ...]]
       qsub --version
[arung@centos Desktop]$ 

```
<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
