### PR TITLE
Windows: mom hook fix

### DIFF
--- a/src/lib/Libwin/passwd.c
+++ b/src/lib/Libwin/passwd.c
@@ -4148,7 +4148,9 @@ wsystem(char *cmdline, HANDLE user_handle)
 	} else {
 		flags = flags|CREATE_UNICODE_ENVIRONMENT;
 		if (!CreateEnvironmentBlock(&user_env, user_handle, FALSE)) {
+			run_exit = GetLastError();
 			log_err(-1, __func__, "failed in CreateEnvironmentBlock");
+			goto end;
 		}
 		rc=CreateProcessAsUser(user_handle, NULL, cmd,
 			NULL, NULL, TRUE, flags,
@@ -4185,6 +4187,7 @@ wsystem(char *cmdline, HANDLE user_handle)
 	if (user_env)
 		DestroyEnvironmentBlock(user_env);
 
+end:
 	return (run_exit);
 }
 

--- a/src/lib/Libwin/passwd.c
+++ b/src/lib/Libwin/passwd.c
@@ -4118,6 +4118,7 @@ wsystem(char *cmdline, HANDLE user_handle)
 	char			*temp_dir = NULL;
 	int			changed_dir = 0;
 	DWORD		stat;
+	LPVOID  user_env = NULL;
 
 	si.cb = sizeof(si);
 	si.lpDesktop = NULL;
@@ -4145,9 +4146,13 @@ wsystem(char *cmdline, HANDLE user_handle)
 			NULL, NULL, TRUE, flags,
 			NULL, NULL, &si, &pi);
 	} else {
+		flags = flags|CREATE_UNICODE_ENVIRONMENT;
+		if (!CreateEnvironmentBlock(&user_env, user_handle, FALSE)) {
+			log_err(-1, __func__, "failed in CreateEnvironmentBlock");
+		}
 		rc=CreateProcessAsUser(user_handle, NULL, cmd,
 			NULL, NULL, TRUE, flags,
-			NULL, NULL, &si, &pi);
+			user_env, NULL, &si, &pi);
 	}
 
 	run_exit = GetLastError();
@@ -4176,6 +4181,9 @@ wsystem(char *cmdline, HANDLE user_handle)
 		CloseHandle(pi.hProcess);
 		CloseHandle(pi.hThread);
 	}
+
+	if (user_env)
+		DestroyEnvironmentBlock(user_env);
 
 	return (run_exit);
 }

--- a/src/resmom/requests.c
+++ b/src/resmom/requests.c
@@ -2834,6 +2834,7 @@ req_cpyfile(struct batch_request *preq)
 	 * the same permissions as TMPDIR
 	 */
 	(void)revert_impersonated_user();
+	SetEnvironmentVariable("USER", NULL);
 
 	if ((dir == STAGE_DIR_IN) && (stage_inout.sandbox_private)) {
 		/* Create PBS_JOBDIR */
@@ -3059,7 +3060,7 @@ req_delfile(struct batch_request *preq)
 
 	(void)revert_impersonated_user();
 	chdir(mom_home);
-
+	SetEnvironmentVariable("USER", NULL);
 }
 
 #else	/* UNIX---------------------------------------------------------------*/

--- a/src/resmom/requests.c
+++ b/src/resmom/requests.c
@@ -277,7 +277,6 @@ fork_to_user(struct batch_request *preq)
 		(void)chdir(lpath);
 	}
 
-	setenv("USER", rqcpf->rq_user, 1);
 	setenv("PBS_EXEC", pbs_conf.pbs_exec_path, 1);
 
 	return (pwdp->pw_userlogin);
@@ -350,7 +349,6 @@ fork_to_user(struct batch_request *preq)
 	else
 		rqcpf = &preq->rq_ind.rq_cpyfile;
 
-	setenv("USER", rqcpf->rq_user, 1);
 	/* create a PBS_EXEC env entry */
 	setenv("PBS_EXEC", pbs_conf.pbs_exec_path, 1);
 
@@ -2834,7 +2832,6 @@ req_cpyfile(struct batch_request *preq)
 	 * the same permissions as TMPDIR
 	 */
 	(void)revert_impersonated_user();
-	SetEnvironmentVariable("USER", NULL);
 
 	if ((dir == STAGE_DIR_IN) && (stage_inout.sandbox_private)) {
 		/* Create PBS_JOBDIR */
@@ -3060,7 +3057,6 @@ req_delfile(struct batch_request *preq)
 
 	(void)revert_impersonated_user();
 	chdir(mom_home);
-	SetEnvironmentVariable("USER", NULL);
 }
 
 #else	/* UNIX---------------------------------------------------------------*/


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
- For mom hook runs as user (pbsuser), the environment of the user always shows service user acc environment under which mom is running
- For mom hook, the getpass.getuser() always shows previous job's user name. Observed this in both for admin and user hook.

These behaviors are noticed only for Windows mom hook.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
- Export the user environment when the hook is running as user
- Inside Windows mom process, we were setting 'USER' env variable at some places in code and didn't reset that.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

[before_fix.txt](https://github.com/openpbs/openpbs/files/4686975/before_fix.txt)
After fix:
[admin_hook_test.txt](https://github.com/openpbs/openpbs/files/4686977/admin_hook_test.txt)
[user_hook_test.txt](https://github.com/openpbs/openpbs/files/4686983/user_hook_test.txt)
[mom_log.txt](https://github.com/openpbs/openpbs/files/4686985/mom_log.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
