### PR TITLE
Job submission from ROOT_USER changed to TST_USR in TestJobPerf testsuite

### DIFF
--- a/test/tests/performance/pbs_jobperf.py
+++ b/test/tests/performance/pbs_jobperf.py
@@ -153,7 +153,7 @@ class TestJobPerf(TestPerformance):
             i = 0
             users = [TEST_USER1, TEST_USER2, TEST_USER3, TEST_USER4,
                      TEST_USER5, TEST_USER6, TEST_USER7, TEST_USER,
-                     TST_USR, ADMIN_USER]
+                     TST_USR, TST_USR1]
             a = {'log_events': config['svr_log_level']}
             self.server.manager(MGR_CMD_SET, SERVER, a)
             a = {'scheduling': 'False'}
@@ -244,7 +244,7 @@ class TestJobPerf(TestPerformance):
             log_start = time.time()
             users = [TEST_USER1, TEST_USER2, TEST_USER3, TEST_USER4,
                      TEST_USER5, TEST_USER6, TEST_USER7, TEST_USER,
-                     TST_USR, ADMIN_USER]
+                     TST_USR, TST_USR1]
             a = {'log_events': self.config['svr_log_level']}
             self.server.manager(MGR_CMD_SET, SERVER, a)
             a = {'job_history_enable': True}
@@ -336,7 +336,7 @@ class TestJobPerf(TestPerformance):
             i = 0
             users = [TEST_USER1, TEST_USER2, TEST_USER3, TEST_USER4,
                      TEST_USER5, TEST_USER6, TEST_USER7, TEST_USER,
-                     TST_USR, ADMIN_USER]
+                     TST_USR, TST_USR1]
             a = {'log_events': config['svr_log_level']}
             self.server.manager(MGR_CMD_SET, SERVER, a)
             a = {'scheduling': 'False'}
@@ -413,7 +413,7 @@ class TestJobPerf(TestPerformance):
             i = 0
             users = [TEST_USER1, TEST_USER2, TEST_USER3, TEST_USER4,
                      TEST_USER5, TEST_USER6, TEST_USER7, TEST_USER,
-                     TST_USR, ADMIN_USER]
+                     TST_USR, TST_USR1]
             a = {'log_events': self.config['svr_log_level']}
             self.server.manager(MGR_CMD_SET, SERVER, a)
             a = {'scheduling': 'False'}
@@ -473,7 +473,7 @@ class TestJobPerf(TestPerformance):
             i = 0
             users = [TEST_USER1, TEST_USER2, TEST_USER3, TEST_USER4,
                      TEST_USER5, TEST_USER6, TEST_USER7, TEST_USER,
-                     TST_USR, ADMIN_USER]
+                     TST_USR, TST_USR1]
             a = {'log_events': config['svr_log_level']}
             self.server.manager(MGR_CMD_SET, SERVER, a)
             a = {'scheduling': 'False'}
@@ -551,7 +551,7 @@ class TestJobPerf(TestPerformance):
         while j < config['No_of_tries']:
             users = [TEST_USER1, TEST_USER2, TEST_USER3, TEST_USER4,
                      TEST_USER5, TEST_USER6, TEST_USER7, TEST_USER,
-                     TST_USR, ADMIN_USER]
+                     TST_USR, TST_USR1]
             a = {'log_events': config['svr_log_level']}
             self.server.manager(MGR_CMD_SET, SERVER, a)
             a = {'scheduling': 'False'}
@@ -611,7 +611,7 @@ class TestJobPerf(TestPerformance):
         while j < self.config['No_of_tries']:
             users = [TEST_USER1, TEST_USER2, TEST_USER3, TEST_USER4,
                      TEST_USER5, TEST_USER6, TEST_USER7, TEST_USER,
-                     TST_USR, ADMIN_USER]
+                     TST_USR, TST_USR1]
             a = {'log_events': self.config['svr_log_level']}
             self.server.manager(MGR_CMD_SET, SERVER, a)
             a = {'scheduling': 'False'}

--- a/test/tests/performance/pbs_jobperf.py
+++ b/test/tests/performance/pbs_jobperf.py
@@ -153,7 +153,7 @@ class TestJobPerf(TestPerformance):
             i = 0
             users = [TEST_USER1, TEST_USER2, TEST_USER3, TEST_USER4,
                      TEST_USER5, TEST_USER6, TEST_USER7, TEST_USER,
-                     ROOT_USER, ADMIN_USER]
+                     TST_USR, ADMIN_USER]
             a = {'log_events': config['svr_log_level']}
             self.server.manager(MGR_CMD_SET, SERVER, a)
             a = {'scheduling': 'False'}
@@ -244,7 +244,7 @@ class TestJobPerf(TestPerformance):
             log_start = time.time()
             users = [TEST_USER1, TEST_USER2, TEST_USER3, TEST_USER4,
                      TEST_USER5, TEST_USER6, TEST_USER7, TEST_USER,
-                     ROOT_USER, ADMIN_USER]
+                     TST_USR, ADMIN_USER]
             a = {'log_events': self.config['svr_log_level']}
             self.server.manager(MGR_CMD_SET, SERVER, a)
             a = {'job_history_enable': True}
@@ -336,7 +336,7 @@ class TestJobPerf(TestPerformance):
             i = 0
             users = [TEST_USER1, TEST_USER2, TEST_USER3, TEST_USER4,
                      TEST_USER5, TEST_USER6, TEST_USER7, TEST_USER,
-                     ROOT_USER, ADMIN_USER]
+                     TST_USR, ADMIN_USER]
             a = {'log_events': config['svr_log_level']}
             self.server.manager(MGR_CMD_SET, SERVER, a)
             a = {'scheduling': 'False'}
@@ -413,7 +413,7 @@ class TestJobPerf(TestPerformance):
             i = 0
             users = [TEST_USER1, TEST_USER2, TEST_USER3, TEST_USER4,
                      TEST_USER5, TEST_USER6, TEST_USER7, TEST_USER,
-                     ROOT_USER, ADMIN_USER]
+                     TST_USR, ADMIN_USER]
             a = {'log_events': self.config['svr_log_level']}
             self.server.manager(MGR_CMD_SET, SERVER, a)
             a = {'scheduling': 'False'}
@@ -473,7 +473,7 @@ class TestJobPerf(TestPerformance):
             i = 0
             users = [TEST_USER1, TEST_USER2, TEST_USER3, TEST_USER4,
                      TEST_USER5, TEST_USER6, TEST_USER7, TEST_USER,
-                     ROOT_USER, ADMIN_USER]
+                     TST_USR, ADMIN_USER]
             a = {'log_events': config['svr_log_level']}
             self.server.manager(MGR_CMD_SET, SERVER, a)
             a = {'scheduling': 'False'}
@@ -551,7 +551,7 @@ class TestJobPerf(TestPerformance):
         while j < config['No_of_tries']:
             users = [TEST_USER1, TEST_USER2, TEST_USER3, TEST_USER4,
                      TEST_USER5, TEST_USER6, TEST_USER7, TEST_USER,
-                     ROOT_USER, ADMIN_USER]
+                     TST_USR, ADMIN_USER]
             a = {'log_events': config['svr_log_level']}
             self.server.manager(MGR_CMD_SET, SERVER, a)
             a = {'scheduling': 'False'}
@@ -611,7 +611,7 @@ class TestJobPerf(TestPerformance):
         while j < self.config['No_of_tries']:
             users = [TEST_USER1, TEST_USER2, TEST_USER3, TEST_USER4,
                      TEST_USER5, TEST_USER6, TEST_USER7, TEST_USER,
-                     ROOT_USER, ADMIN_USER]
+                     TST_USR, ADMIN_USER]
             a = {'log_events': self.config['svr_log_level']}
             self.server.manager(MGR_CMD_SET, SERVER, a)
             a = {'scheduling': 'False'}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Job submitted as a root user fails in TestJobPerf testsuite, if test is run from sudo user


#### Describe Your Change
Replace ROOT_USER to TST_USR and ADMIN_USER to TST_USR1


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[buggy_root.txt](https://github.com/openpbs/openpbs/files/4693420/buggy_root.txt)
[fixed.txt](https://github.com/openpbs/openpbs/files/4693422/fixed.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
