### PR TITLE
server does not cleanup job when jobscript exceeds size

### DIFF
--- a/src/server/req_quejob.c
+++ b/src/server/req_quejob.c
@@ -1480,12 +1480,14 @@ req_jobscript(struct batch_request *preq)
 	/* add the script to the job */
 	size = get_bytes_from_attr(&attr_jobscript_max_size);
 	if (preq->rq_ind.rq_jobfile.rq_size > size){
+		job_purge(pj);
 		req_reject(PBSE_JOBSCRIPTMAXSIZE, 0, preq);
 		return;
 	}
 	temp = realloc(pj->ji_script, pj->ji_qs.ji_un.ji_newt.ji_scriptsz +
 		preq->rq_ind.rq_jobfile.rq_size + 1);
 	if (!temp) {
+		job_purge(pj);
 		req_reject(PBSE_SYSTEM, 0, preq);
 		return;
 	}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
When a user submits a job with a job script that exceeds jobscript_max_size limit, server does not cleanup the job properly. This results into subsequent jobs getting their job scripts attached to the previously rejected job and makes these jobs fail as well.


#### Describe Your Change
This problem only happens when jobs are submitted through qsub daemon process. 
What happens is that inside the server we register a connection handler for qsub clients. In this connection handler, we cleanup jobs if the connection breaks.
This all works fine until qsub is spawned in the background. When a job is submitted with a job script larger than the jobscript_max_size limit, the server rejects the job. But, it does not cleanup the job thinking that it will be cleaned when the connection ends.
Now if the same user modifies the script and submits it after bringing its size below the limit, After receiving the job script, PBS server tries to locate the job. The locate function it calls, checks the socket-id the job is coming from and the username to find out the job structure. The problem is that the job is coming from the same background qsub process and the user is the same user whose previous job was rejected. This makes PBS server locate the wrong job and attach the new jobscript to a previously rejected job.

The solution is simply to cleanup jobs properly when the job is rejected and do not rely on the connection cleanup handler.

resolves: #1711 

#### Link to Design Doc
NA


#### Attach Test and Valgrind Logs/Output
I did not see a recurring benefit of writing a PTL test for this issue. Please let me know if you think otherwise.

[test_jobscript_after.txt](https://github.com/openpbs/openpbs/files/4691197/test_jobscript_after.txt)
[test_jobscript_before.txt](https://github.com/openpbs/openpbs/files/4691198/test_jobscript_before.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
