### PR TITLE
Update Intro Docs with new OpenPBS name

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,5 @@
-### PBS Professional Open Source Project Code of Conduct
+### OpenPBS Open Source Project Code of Conduct
 
 Please see the Contributor's Portal for our **[Code of Conduct](https://pbspro.atlassian.net/wiki/spaces/PBSPro/pages/5537835/Code+of+Conduct)**.
+
+Note: In May 2020, OpenPBS became the new name for the PBS Professional Open Source Project. (PBS Professional will be used to refer to the commercial version; OpenPBS to the Open Source version -- same code, easier naming.) As there are many parts to the project, it will take several weeks to change the name in all places, so you will continue to see references to PBS Pro (as in the above) -- stay tuned.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
-### Contributing to the PBS Professional Open Source Project
+### Contributing to the OpenPBS Open Source Project
 
-We're so happy that you want to contribute to PBS Pro!
+We're so happy that you want to contribute to OpenPBS!
 
 Please see the Contributor's Portal for details, guidelines, and how-to tutorials.  Start at **[Becoming a Contributor to PBS Pro](https://pbspro.atlassian.net/wiki/spaces/DG/pages/20414474/Becoming+a+Contributor+to+PBS+Pro)**.
+
+Note: In May 2020, OpenPBS became the new name for the PBS Professional Open Source Project.  (PBS Professional will be used to refer to the commercial version; OpenPBS to the Open Source version -- same code, easier naming.)  As there are many parts to the project, it will take several weeks to change the name in all places, so you will continue to see references to PBS Pro (as in the above) -- stay tuned. 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
-### PBS Professional Open Source Project
+### OpenPBS Open Source Project
 
 If you are new to this project, please start at http://www.pbspro.org
 
-### What is PBS Professional?
-PBS Professional® software optimizes job scheduling and workload management in high-performance computing (HPC) environments – clusters, clouds, and supercomputers – improving system efficiency and people’s productivity.  Built by HPC people for HPC people, PBS Pro™ is fast, scalable, secure, and resilient, and supports all modern infrastructure, middleware, and applications.
+Note: In May 2020, OpenPBS became the new name for the PBS Professional Open Source Project. (PBS Professional will be used to refer to the commercial version; OpenPBS to the Open Source version -- same code, easier naming.)  As there are many parts to the project, it will take several weeks to change the name in all places, so you will continue to see references to PBS Pro -- stay tuned.
+
+### What is OpenPBS?
+OpenPBS® software optimizes job scheduling and workload management in high-performance computing (HPC) environments – clusters, clouds, and supercomputers – improving system efficiency and people’s productivity.  Built by HPC people for HPC people, OpenPBS is fast, scalable, secure, and resilient, and supports all modern infrastructure, middleware, and applications.
 
 * **Scalability:** supports millions of cores with fast job dispatch and minimal latency; tested beyond 50,000 nodes
 * **Policy-Driven Scheduling:** meets unique site goals and SLAs by balancing job turnaround time and utilization with optimal job placement
@@ -14,7 +16,7 @@ PBS Professional® software optimizes job scheduling and workload management in 
 
 ### Community and Ways to Participate
 
-PBS Professional is a community effort and there are a variety of ways to engage, from helping answer questions to benchmarking to developing new capabilities and tests.  We value being aggressively open and inclusive, but also aggressively respectful and professional.  See our [Code of Conduct](https://pbspro.atlassian.net/wiki/display/PBSPro/Code+of+Conduct).
+OpenPBS is a community effort and there are a variety of ways to engage, from helping answer questions to benchmarking to developing new capabilities and tests.  We value being aggressively open and inclusive, but also aggressively respectful and professional.  See our [Code of Conduct](https://pbspro.atlassian.net/wiki/display/PBSPro/Code+of+Conduct).
 
 The best place to start is by joining the community forum.  You may sign up or view the archives via:
 
@@ -25,17 +27,17 @@ The best place to start is by joining the community forum.  You may sign up or v
 To dive in deeper and learn more about the project and what the community is up to, visit:
 
 * [Contributor’s portal](https://pbspro.atlassian.net/wiki) -- includes roadmaps, processes, how to articles, coding standards, release notes, etc  (Uses Confluence)
-* [Source code](https://github.com/PBSPro/pbspro) -- includes full source code and test framework (Uses Github)
-* [Issue tracking system](https://github.com/PBSPro/pbspro/issues) -- includes bugs and feature requests and status (Uses Github).  Previously, we used [JIRA](https://pbspro.atlassian.net), which contains older issues.
+* [Source code](https://github.com/OpenPBS/openpbs) -- includes full source code and test framework (Uses Github)
+* [Issue tracking system](https://github.com/OpenPBS/openpbs/issues) -- includes bugs and feature requests and status (Uses Github).  Previously, we used [JIRA](https://pbspro.atlassian.net), which contains older issues.
 
-PBS Professional is also integrated in the OpenHPC software stack. The mission of OpenHPC is to provide an integrated collection of HPC-centric components to provide full-featured HPC software stacks. OpenHPC is a Linux Foundation Collaborative Project.  Learn more at:
+OpenPBS is also integrated in the OpenHPC software stack. The mission of OpenHPC is to provide an integrated collection of HPC-centric components to provide full-featured HPC software stacks. OpenHPC is a Linux Foundation Collaborative Project.  Learn more at:
 
 * [OpenHPC.community](http://openhpc.community)
 * [The Linux Foundation](http://thelinuxfoundation.org)
 
 ### Our Vision:  One Scheduler for the whole HPC World
 
-There is a huge opportunity to advance the state of the art in HPC scheduling by bringing the whole HPC world together, marrying public sector innovations with private sector enterprise know-how, and retargeting the effort wasted re-implementing the same old capabilities again and again towards pushing the outside of the envelope.  At the heart of this vision is fostering common standards (at least defacto standards like common software).  To this end, Altair has made a big investment by releasing PBS Pro under an Open Source license (to meet the needs of the public sector), while also continuing to offer PBS Pro under a commercial license (to meet the needs of the private sector).  One defacto standard that can work for the whole HPC community.  See [Bill’s Open Letter to the HPC Community](https://insidehpc.com/2016/05/an-open-letter-to-the-hpc-community/) for more details.
+There is a huge opportunity to advance the state of the art in HPC scheduling by bringing the whole HPC world together, marrying public sector innovations with private sector enterprise know-how, and retargeting the effort wasted re-implementing the same old capabilities again and again towards pushing the outside of the envelope.  At the heart of this vision is fostering common standards (at least defacto standards like common software).  To this end, Altair has made a big investment by releasing the PBS Professional technology as OpenPBS (under an Open Source license to meet the needs of the public sector), while also continuing to offer PBS Professional (under a commercial license to meet the needs of the private sector).  One defacto standard that can work for the whole HPC community.
 
 ### Current Build status
-[![Build Status](https://travis-ci.com/PBSPro/pbspro.svg?branch=master)](https://travis-ci.com/PBSPro/pbspro)
+[![Build Status](https://travis-ci.com/OpenPBS/openpbs.svg?branch=master)](https://travis-ci.com/OpenPBS/openpbs)


### PR DESCRIPTION
#### Describe Bug or Feature
Updating intro docs to reflect the name change (from PBS Pro to OpenPBS).

As the process of renaming everything will take some more time (e.g., to fully move pbspro.org to openpbs.org), more changes will be needed (later).

#### Describe Your Change
Just doc changes (README, CONTRIBUTING, and CODE_OF_CONDUCT), no code changes.