### PR TITLE
Guard find job against freed jobs

### DIFF
--- a/src/server/job_func.c
+++ b/src/server/job_func.c
@@ -1205,6 +1205,13 @@ find_job(char *jobid)
 	if ((AVL_jctx != NULL) && ((pkey = svr_avlkey_create(buf)) != NULL)) {
 		if (avl_find_key(pkey, AVL_jctx) == AVL_IX_OK)
 			pj = (job *) pkey->recptr;
+		if (pj && (pj->ji_qs.ji_jobid[0] == 'X')) {
+			/* found a freed job obj hanging around in the job avl tree */
+			log_errf(PBSE_INTERNAL, __func__, "%s stale job found in job avl tree, deletting it",jobid);
+			avl_delete_key(pkey, AVL_jctx);
+			pj = NULL;
+		}
+
 		free(pkey);
 		return (pj);
 	}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Server segfault when deleting job "found" even though the job ID shows the structure has been freed
```
(gdb) bt

#0  0x0000000000487147 in req_deletejob (preq=0x4043acf0) at /home/pbsbuild/ramdisk/workspace/build/pbspro/src/server/req_delete.c:437

#1  0x00000000004f66dc in process_socket (sock=sock@entry=20) at /home/pbsbuild/ramdisk/workspace/build/pbspro/src/lib/Libnet/net_server.c:504

#2  0x00000000004f6892 in wait_request (waittime=waittime@entry=2, priority_context=<optimized out>)

    at /home/pbsbuild/ramdisk/workspace/build/pbspro/src/lib/Libnet/net_server.c:620

#3  0x0000000000450f38 in main (argc=<optimized out>, argv=<optimized out>)

    at /home/pbsbuild/ramdisk/workspace/build/pbspro/src/server/pbsd_main.c:2133
```
#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
guarded inside `find_job()` by checking the 'X' mark in the first char of freed jobs jobid



#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Pending !



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
