### PR TITLE
Fix pbs.get_local_nodename() returns truncated PBS_MOM_NODE_NAME when it is in URL format

### DIFF
--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -8785,15 +8785,14 @@ main(int argc, char *argv[])
 			LOG_WARNING, msg_daemonname, winlog_buffer);
 	}
 #endif
+
 	/*
-	 * Set mom_host to PBS_MOM_NODE_NAME if it is defined.
-	 * Otherwise, set mom_host with a call to gethostname().
+	 * Query the hostname.
+	 * Set mom_host temporarily with a call to gethostname().
 	 */
-	c = 0;
-	if (pbs_conf.pbs_mom_node_name) {
-		/* Hostname was defined by PBS_MOM_NODE_NAME */
-		(void)strncpy(mom_host, pbs_conf.pbs_mom_node_name, (sizeof(mom_host) - 1));
-		mom_host[(sizeof(mom_host) - 1)] = '\0';
+	c = gethostname(mom_host, (sizeof(mom_host) - 1));
+	if (c != 0) {
+		c = 0;
 		ptr = mom_host;
 		/* First character must be alpha-numeric */
 		if (isalnum((int)*ptr)) {
@@ -8810,20 +8809,30 @@ main(int argc, char *argv[])
 		} else {
 			c = -1;
 		}
-	} else {
-		/* Query the hostname. */
-		c = gethostname(mom_host, (sizeof(mom_host) - 1));
 	}
 	if (c != 0) {
 		log_err(-1, msg_daemonname, "Unable to obtain my host name");
 		return (-1);
 	}
-	(void)strncpy(mom_short_name, mom_host, (sizeof(mom_short_name) - 1));
-	mom_short_name[(sizeof(mom_short_name) - 1)] = '\0';
-	is_mom_host_ip = inet_pton(AF_INET, mom_host, &(check_ip.sin_addr));
-	if (!(is_mom_host_ip > 0))
-		if ((ptr = strchr(mom_short_name, (int)'.')) != NULL)
-			*ptr = '\0';  /* terminate shortname at first dot */
+	/*
+	 * Set mom_short_name to PBS_MOM_NODE_NAME if it is defined.
+	 * Otherwise, set mom_short_name to the return value of
+	 * gethostname(), truncated to first dot.
+	 */
+	if (pbs_conf.pbs_mom_node_name) {
+		/* mom_short_name was specified explicitly using PBS_MOM_NODE_NAME */
+		(void)strncpy(mom_short_name, pbs_conf.pbs_mom_node_name, (sizeof(mom_host) - 1));
+		mom_short_name[(sizeof(mom_host) - 1)] = '\0';
+	} else {
+		/* use gethostname() truncated to first dot, unless it is an ip address*/
+		(void)strncpy(mom_short_name, mom_host, (sizeof(mom_short_name) - 1));
+		mom_short_name[(sizeof(mom_short_name) - 1)] = '\0';
+		is_mom_host_ip = inet_pton(AF_INET, mom_host, &(check_ip.sin_addr));
+		if (is_mom_host_ip <= 0)
+			if ((ptr = strchr(mom_short_name, (int)'.')) != NULL)
+				*ptr = '\0';  /* terminate shortname at first dot */
+	}
+
 	/*
 	 * Now get mom_host, which determines resources_available.host
 	 * and also the interface used to register to pbs_comm if

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -8833,7 +8833,7 @@ main(int argc, char *argv[])
 		(void)strncpy(mom_short_name, pbs_conf.pbs_mom_node_name, (sizeof(mom_short_name) - 1));
 		mom_short_name[(sizeof(mom_short_name) - 1)] = '\0';
 	} else {
-		/* use gethostname(), trucated to first dot */
+		/* use gethostname(), truncated to first dot */
 		(void)strncpy(mom_short_name, mom_host, (sizeof(mom_short_name) - 1));
 		mom_short_name[(sizeof(mom_short_name) - 1)] = '\0';
 		if ((ptr = strchr(mom_short_name, (int)'.')) != NULL)

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -8147,8 +8147,6 @@ main(int argc, char *argv[])
 	char			path_hooks_rescdef[MAXPATHLEN+1];
 	int			sock_bind_rm;
 	int			sock_bind_mom;
-	struct			sockaddr_in check_ip;
-	int			is_mom_host_ip;
 #ifdef	WIN32
 	/* Win32 only */
 	struct arg_param	*p = (struct arg_param *)pv;

--- a/test/tests/functional/pbs_mom_local_nodename.py
+++ b/test/tests/functional/pbs_mom_local_nodename.py
@@ -39,6 +39,7 @@
 
 from tests.functional import *
 from ptl.lib.pbs_testlib import BatchUtils
+import socket
 
 
 class TestMomLocalNodeName(TestFunctional):

--- a/test/tests/functional/pbs_mom_local_nodename.py
+++ b/test/tests/functional/pbs_mom_local_nodename.py
@@ -42,8 +42,16 @@ from ptl.lib.pbs_testlib import BatchUtils
 
 
 class TestMomLocalNodeName(TestFunctional):
+    """
+    This test suite tests that mom sets its short name correctly
+    and that mom.get_local_nodename() returns the correct value
+    """
 
     def test_url_nodename_not_truncated(self):
+        """
+        This test case tests that mom does not truncate the value of
+        PBS_MOM_NODE_NAME when it contains dots
+        """
         self.du.set_pbs_config(confs={'PBS_MOM_NODE_NAME': 'a.b.c.d'})
         # Restart PBS for changes
         self.server.restart()
@@ -63,6 +71,10 @@ pbs.logmsg(pbs.LOG_DEBUG,
         self.mom.log_match("my local nodename is a.b.c.d")
 
     def test_ip_nodename_not_truncated(self):
+        """
+        This test case tests that mom does not truncate the value of
+        PBS_MOM_NODE_NAME when it is an ipaddress
+        """
         ipaddr = socket.gethostbyname(self.mom.hostname)
         self.du.set_pbs_config(confs={'PBS_MOM_NODE_NAME': ipaddr})
         # Restart PBS for changes

--- a/test/tests/functional/pbs_mom_local_nodename.py
+++ b/test/tests/functional/pbs_mom_local_nodename.py
@@ -1,0 +1,89 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2020 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of both the OpenPBS software ("OpenPBS")
+# and the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# OpenPBS is free software. You can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# OpenPBS is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# PBS Pro is commercially licensed software that shares a common core with
+# the OpenPBS software.  For a copy of the commercial license terms and
+# conditions, go to: (http://www.pbspro.com/agreement.html) or contact the
+# Altair Legal Department.
+#
+# Altair's dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of OpenPBS and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair's trademarks, including but not limited to "PBS™",
+# "OpenPBS®", "PBS Professional®", and "PBS Pro™" and Altair's logos is
+# subject to Altair's trademark licensing policies.
+
+from tests.functional import *
+from ptl.lib.pbs_testlib import BatchUtils
+
+
+class TestMomLocalNodeName(TestFunctional):
+
+    def test_url_nodename_not_truncated(self):
+        self.du.set_pbs_config(confs={'PBS_MOM_NODE_NAME': 'a.b.c.d'})
+        # Restart PBS for changes
+        self.server.restart()
+        self.mom.restart()
+        # add hook
+        a = {'event': 'execjob_begin', 'enabled': 'True'}
+        hook_name = "begin"
+        hook_body = """
+import pbs
+pbs.logmsg(pbs.LOG_DEBUG,
+           'my local nodename is %s'
+           % pbs.get_local_nodename())
+"""
+        self.server.create_import_hook(hook_name, a, hook_body)
+        j = Job(TEST_USER)
+        jid = self.server.submit(j)
+        self.mom.log_match("my local nodename is a.b.c.d")
+
+    def test_ip_nodename_not_truncated(self):
+        ipaddr = socket.gethostbyname(self.mom.hostname)
+        self.du.set_pbs_config(confs={'PBS_MOM_NODE_NAME': ipaddr})
+        # Restart PBS for changes
+        self.server.restart()
+        self.mom.restart()
+        # add hook
+        a = {'event': 'execjob_begin', 'enabled': 'True'}
+        hook_name = "begin"
+        hook_body = """
+import pbs
+pbs.logmsg(pbs.LOG_DEBUG,
+           'my local nodename is %s'
+           % pbs.get_local_nodename())
+"""
+        self.server.create_import_hook(hook_name, a, hook_body)
+        j = Job(TEST_USER)
+        jid = self.server.submit(j)
+        self.mom.log_match("my local nodename is %s" % ipaddr)
+
+    def tearDown(self):
+        self.du.unset_pbs_config(confs=['PBS_MOM_NODE_NAME'])
+        self.server.restart()
+        self.mom.restart()
+        TestFunctional.tearDown(self)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
pbs.get_local_nodename() returns truncated PBS_MOM_NODE_NAME when it is in "dotted" format but not an IP address. This is preventing some sites from using URL format mom node names.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Set `mom_short_name` to the value `PBS_MOM_NODE_NAME` in pbs.conf if it is set, regardless of whether it is an IP address. If `PBS_MOM_NODE_NAME` is not set, then use the return value of `gethostname()` but truncated after the first dot.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
https://pbspro.atlassian.net/wiki/spaces/PD/pages/1824423937/Revision+to+PBS+MOM+NODE+NAME+configuration+variable

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
SmokeTest, HookSmokeTests, TestMomLocalNodeName
<img width="1680" alt="Screen Shot 2020-06-15 at 9 31 18 PM" src="https://user-images.githubusercontent.com/6920446/84663394-af818680-af4f-11ea-9b82-be3dfbf0bc15.png">
<img width="701" alt="Screen Shot 2020-06-15 at 9 31 33 PM" src="https://user-images.githubusercontent.com/6920446/84663395-af818680-af4f-11ea-8c81-3eb6caaa6e43.png">


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
