### PR TITLE
Making min_time_since_start as only preempt_sort value

### DIFF
--- a/src/scheduler/parse.c
+++ b/src/scheduler/parse.c
@@ -946,6 +946,7 @@ init_config()
 		sizeof(struct sort_info));
 
 	/* set any defaults other then OFF */
+	conf.preempt_min_wt_used = 1;
 
 	/* for backwards compatibility */
 	conf.update_comments = 1;

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -982,10 +982,7 @@ query_sched_obj(status *policy, struct batch_status *sched, server_info *sinfo)
 				free_string_array(list);
 			}
 		} else if (!strcmp(attrp->name, ATTR_sched_preempt_sort)) {
-			if (strcasecmp(attrp->value, "min_time_since_start") == 0)
-				conf.preempt_min_wt_used = 1;
-			else
-				conf.preempt_min_wt_used = 0;
+			conf.preempt_min_wt_used = 1;
 		} else if (!strcmp(attrp->name, ATTR_job_sort_formula)) {
 			if (sinfo->job_formula != NULL)
 				free(sinfo->job_formula);

--- a/test/tests/functional/pbs_equiv_classes.py
+++ b/test/tests/functional/pbs_equiv_classes.py
@@ -1699,9 +1699,6 @@ else:
              'enabled': 't', 'Priority': 150}
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='expressq')
 
-        a = {'preempt_sort': 'min_time_since_start'}
-        self.server.manager(MGR_CMD_SET, SCHED, a)
-
         (jid1,) = self.submit_jobs(1)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
 
@@ -1759,9 +1756,6 @@ else:
         a = {'queue_type': 'execution', 'started': 'true',
              'enabled': 'true', 'Priority': 150}
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='expressq')
-
-        a = {'preempt_sort': 'min_time_since_start'}
-        self.server.manager(MGR_CMD_SET, SCHED, a)
 
         # Submit 3 jobs with delay of 1 sec
         # Delay of 1 sec will preempt jid3 and then jid2.

--- a/test/tests/functional/pbs_equiv_classes.py
+++ b/test/tests/functional/pbs_equiv_classes.py
@@ -1699,6 +1699,9 @@ else:
              'enabled': 't', 'Priority': 150}
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='expressq')
 
+        a = {'preempt_sort': 'min_time_since_start'}
+        self.server.manager(MGR_CMD_SET, SCHED, a)
+
         (jid1,) = self.submit_jobs(1)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
 
@@ -1756,6 +1759,9 @@ else:
         a = {'queue_type': 'execution', 'started': 'true',
              'enabled': 'true', 'Priority': 150}
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='expressq')
+
+        a = {'preempt_sort': 'min_time_since_start'}	
+        self.server.manager(MGR_CMD_SET, SCHED, a)
 
         # Submit 3 jobs with delay of 1 sec
         # Delay of 1 sec will preempt jid3 and then jid2.

--- a/test/tests/functional/pbs_equiv_classes.py
+++ b/test/tests/functional/pbs_equiv_classes.py
@@ -1760,7 +1760,7 @@ else:
              'enabled': 'true', 'Priority': 150}
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='expressq')
 
-        a = {'preempt_sort': 'min_time_since_start'}	
+        a = {'preempt_sort': 'min_time_since_start'}
         self.server.manager(MGR_CMD_SET, SCHED, a)
 
         # Submit 3 jobs with delay of 1 sec

--- a/test/tests/functional/pbs_preemption.py
+++ b/test/tests/functional/pbs_preemption.py
@@ -357,6 +357,9 @@ exit 1
         a = {ATTR_rescavail + '.ncpus': 2}
         self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
 
+        a = {'preempt_sort': 'min_time_since_start'}	
+        self.server.manager(MGR_CMD_SET, SCHED, a)
+
         jid1, jid2, jid3 = self.submit_jobs()
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
         self.server.expect(JOB, {ATTR_state: 'S'}, id=jid2)

--- a/test/tests/functional/pbs_preemption.py
+++ b/test/tests/functional/pbs_preemption.py
@@ -357,7 +357,7 @@ exit 1
         a = {ATTR_rescavail + '.ncpus': 2}
         self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
 
-        a = {'preempt_sort': 'min_time_since_start'}	
+        a = {'preempt_sort': 'min_time_since_start'}
         self.server.manager(MGR_CMD_SET, SCHED, a)
 
         jid1, jid2, jid3 = self.submit_jobs()

--- a/test/tests/functional/pbs_preemption.py
+++ b/test/tests/functional/pbs_preemption.py
@@ -357,25 +357,9 @@ exit 1
         a = {ATTR_rescavail + '.ncpus': 2}
         self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
 
-        a = {'preempt_sort': 'min_time_since_start'}
-        self.server.manager(MGR_CMD_SET, SCHED, a)
         jid1, jid2, jid3 = self.submit_jobs()
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
         self.server.expect(JOB, {ATTR_state: 'S'}, id=jid2)
-        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid3)
-
-    @skipOnCpuSet
-    def test_preempt_sort_when_unset(self):
-        """
-        This test is for preempt_sort when it is unset
-        """
-        a = {ATTR_rescavail + '.ncpus': 2}
-        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
-
-        self.server.manager(MGR_CMD_UNSET, SCHED, 'preempt_sort')
-        jid1, jid2, jid3 = self.submit_jobs()
-        self.server.expect(JOB, {ATTR_state: 'S'}, id=jid1)
-        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid2)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid3)
 
     @skipOnCpuSet

--- a/test/tests/interfaces/pbs_preempt_params.py
+++ b/test/tests/interfaces/pbs_preempt_params.py
@@ -198,4 +198,5 @@ class TestPreemptParamsQmgr(TestInterfaces):
         self.server.manager(MGR_CMD_SET, SCHED, a, runas=ROOT_USER)
 
         self.server.manager(MGR_CMD_UNSET, SCHED, param, runas=ROOT_USER)
+        self.server.expect(SCHED, a, runas=ROOT_USER)
         self.server.manager(MGR_CMD_LIST, SCHED, a, runas=ROOT_USER)

--- a/test/tests/performance/pbs_preemptperformance.py
+++ b/test/tests/performance/pbs_preemptperformance.py
@@ -197,6 +197,7 @@ class TestPreemptPerformance(TestPerformance):
         self.scheduler.add_resource('qlist')
 
         jid = self.server.submit(j)
+        time.sleep(1)
 
         a = {ATTR_l + '.select': '1:ncpus=1:qlist=list1'}
         for _ in range(3200):
@@ -366,6 +367,7 @@ class TestPreemptPerformance(TestPerformance):
         j = Job(TEST_USER, attrs=a)
         j.set_sleep_time(3000)
         jid = self.server.submit(j)
+        time.sleep(1)
 
         a = {ATTR_l + '.select': '1:ncpus=1'}
         for _ in range(3200):

--- a/test/tests/performance/pbs_preemptperformance.py
+++ b/test/tests/performance/pbs_preemptperformance.py
@@ -189,22 +189,21 @@ class TestPreemptPerformance(TestPerformance):
 
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
 
-        a = {ATTR_l + '.select': '1:ncpus=1:qlist=list1'}
-        for _ in range(3200):
-            j = Job(TEST_USER, attrs=a)
-            j.set_sleep_time(3000)
-            self.server.submit(j)
-
         a = {ATTR_l + '.select': '1:ncpus=1:qlist=list2'}
         j = Job(TEST_USER, attrs=a)
         j.set_sleep_time(3000)
 
         # Add qlist to the resources scheduler checks for
         self.scheduler.add_resource('qlist')
-        self.server.manager(MGR_CMD_UNSET, SCHED, 'preempt_sort',
-                            runas=ROOT_USER)
 
         jid = self.server.submit(j)
+
+        a = {ATTR_l + '.select': '1:ncpus=1:qlist=list1'}
+        for _ in range(3200):
+            j = Job(TEST_USER, attrs=a)
+            j.set_sleep_time(3000)
+            self.server.submit(j)
+
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
 
         self.server.expect(JOB, {'job_state=R': 3201}, interval=20,
@@ -276,12 +275,6 @@ class TestPreemptPerformance(TestPerformance):
 
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
 
-        a = {ATTR_l + '.select': '1:ncpus=1:qlist=list1'}
-        for _ in range(3200):
-            j = Job(TEST_USER, attrs=a)
-            j.set_sleep_time(3000)
-            self.server.submit(j)
-
         a = {ATTR_l + '.select': '1:ncpus=1:qlist=list2'}
         j = Job(TEST_USER, attrs=a)
         j.set_sleep_time(3000)
@@ -292,11 +285,16 @@ class TestPreemptPerformance(TestPerformance):
 
         # Add qlist to the resources scheduler checks for
         self.scheduler.add_resource('qlist')
-        self.server.manager(MGR_CMD_UNSET, SCHED, 'preempt_sort',
-                            runas=ROOT_USER)
 
         jid = self.server.submit(j)
         jid2 = self.server.submit(j2)
+
+        a = {ATTR_l + '.select': '1:ncpus=1:qlist=list1'}
+        for _ in range(3200):
+            j = Job(TEST_USER, attrs=a)
+            j.set_sleep_time(3000)
+            self.server.submit(j)
+
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
 
         self.server.expect(JOB, {'job_state=R': 3202}, interval=20,
@@ -361,21 +359,19 @@ class TestPreemptPerformance(TestPerformance):
         a = {ATTR_rescavail + ".foo": 50, 'scheduling': 'False'}
         self.server.manager(MGR_CMD_SET, SERVER, a)
 
-        a = {ATTR_l + '.select': '1:ncpus=1'}
-        for _ in range(3200):
-            j = Job(TEST_USER, attrs=a)
-            j.set_sleep_time(3000)
-            self.server.submit(j)
-
         # Add foo to the resources scheduler checks for
         self.scheduler.add_resource('foo')
-        self.server.manager(MGR_CMD_UNSET, SCHED, 'preempt_sort',
-                            runas=ROOT_USER)
 
         a = {ATTR_l + '.select': '1:ncpus=1', ATTR_l + '.foo': 25}
         j = Job(TEST_USER, attrs=a)
         j.set_sleep_time(3000)
         jid = self.server.submit(j)
+
+        a = {ATTR_l + '.select': '1:ncpus=1'}
+        for _ in range(3200):
+            j = Job(TEST_USER, attrs=a)
+            j.set_sleep_time(3000)
+            self.server.submit(j)
 
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
         self.server.expect(JOB, {'job_state=R': 3201}, interval=20,


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Currently preempt_sort by default is set to 'min_time_since_start'. Basically between jobs selected for preemption it will choose to preempt jobs with least amount of running time first.  When  unset preempt_sort, the jobs selected for preemption will be sorted with longest running time first. It does not make make sense to select jobs that have longest running time for preemption.

Therefore we propose that only min_time_since_start value will be set for preempt_sort so that scheduler chooses jobs for preemption with least running time first.

The users will not be able to UNSET preempt_sort, on UNSET the value will remain 'min_time_since_start'


#### Describe Your Change
Set conf.preempt_min_wt_used = 1. Code for conf.preempt_min_wt_used = 0 is removed.
Tests for unset preempt_sort are fixed/ removed

#### Link to Design Doc
https://pbspro.atlassian.net/wiki/spaces/PD/pages/1747058710/preempt+sort+attribute+will+only+have+one+value

#### Attach Test and Valgrind Logs/Output
[test_set_unset_preempt_sort.txt](https://github.com/openpbs/openpbs/files/4704175/test_set_unset_preempt_sort.txt)
[test_insufficient_resc_multiple_non_cons.txt](https://github.com/openpbs/openpbs/files/4704177/test_insufficient_resc_multiple_non_cons.txt)
[test_insufficient_resc_non_cons.txt](https://github.com/openpbs/openpbs/files/4704178/test_insufficient_resc_non_cons.txt)
[test_insufficient_server_resc.txt](https://github.com/openpbs/openpbs/files/4704180/test_insufficient_server_resc.txt)
[test_multiple_job_preemption_order.txt](https://github.com/openpbs/openpbs/files/4704183/test_multiple_job_preemption_order.txt)
[test_preempt_sort_when_set.txt](https://github.com/openpbs/openpbs/files/4704185/test_preempt_sort_when_set.txt)
[test_preemption2.txt](https://github.com/openpbs/openpbs/files/4704187/test_preemption2.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
