### PR TITLE
Deleting reservation leaves dangling pointers

### DIFF
--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -7656,11 +7656,14 @@ free_resvNodes(resc_resv *presv)
 		pnode = pbsndlist[i];
 
 		for (prev = NULL, rinfp = pnode->nd_resvp;
-			rinfp; prev = rinfp, rinfp = rinfp->next) {
+			rinfp;) {
 
 
-			if (rinfp->resvp != presv)
+			if (rinfp->resvp != presv) {
+				prev = rinfp;
+				rinfp = rinfp->next;
 				continue;
+			}
 
 			/* garbage collect the pbsnode_list */
 			for (pnl = presv->ri_pbsnode_list, pnl_next = pnl; pnl_next; pnl = pnl_next) {
@@ -7682,12 +7685,15 @@ free_resvNodes(resc_resv *presv)
 
 			DBPRT(("Freeing resvinfo on node %s from reservation %s\n",
 				pnode->nd_name, presv->ri_qs.ri_resvID))
-			if (prev == NULL)
+			if (prev == NULL) {
 				pnode->nd_resvp = rinfp->next;
-			else
+				free(rinfp);
+				rinfp = pnode->nd_resvp;
+			} else {
 				prev->next = rinfp->next;
-			free(rinfp);
-			break;
+				free(rinfp);
+				rinfp = prev->next;
+			}
 		}
 	}
 	presv->ri_vnodect = 0;

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -7655,9 +7655,7 @@ free_resvNodes(resc_resv *presv)
 	for (i = 0; i < svr_totnodes; i++) {
 		pnode = pbsndlist[i];
 
-		for (prev = NULL, rinfp = pnode->nd_resvp;
-			rinfp;) {
-
+		for (prev = NULL, rinfp = pnode->nd_resvp; rinfp;) {
 
 			if (rinfp->resvp != presv) {
 				prev = rinfp;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Deleting a reservation leaves dangling pointers on nodes.

```
==127743== Invalid read of size 1
==127743==    at 0x4C2C9D2: strlen (vg_replace_strmem.c:454)
==127743==    by 0x4AA2CE: encode_resvs (attr_node_func.c:630)
==127743==    by 0x445090: status_nodeattrib (node_func.c:382)
==127743==    by 0x474BC8: status_node.isra.3.part.4 (req_stat.c:682)
==127743==    by 0x475325: status_node (req_stat.c:644)
==127743==    by 0x475325: req_stat_node (req_stat.c:591)
==127743==    by 0x455C8C: dispatch_request (process_request.c:909)
==127743==    by 0x45667A: process_request (process_request.c:590)
==127743==    by 0x4BC2E5: process_socket (net_server.c:521)
==127743==    by 0x4BC41D: wait_request (net_server.c:602)
==127743==    by 0x42B13E: main (pbsd_main.c:1805)
==127743==  Address 0x136b38c8 is 296 bytes inside a block of size 2,832 free'd
==127743==    at 0x4C2ACDD: free (vg_replace_malloc.c:530)
==127743==    by 0x44165A: resv_purge (job_func.c:1854)
==127743==    by 0x4B87F8: dispatch_task (in /opt/pbs/sbin/pbs_server.bin)
==127743==    by 0x4B8A44: default_next_task (in /opt/pbs/sbin/pbs_server.bin)
==127743==    by 0x42AF2F: next_task (pbsd_main.c:2023)
==127743==    by 0x42AF2F: main (pbsd_main.c:1712)
==127743==  Block was alloc'd at
==127743==    at 0x4C29BE3: malloc (vg_replace_malloc.c:299)
==127743==    by 0x44132D: resc_resv_alloc (job_func.c:1627)
==127743==    by 0x46A6D8: req_resvSub (req_quejob.c:2289)
==127743==    by 0x45667A: process_request (process_request.c:590)
==127743==    by 0x4BC2E5: process_socket (net_server.c:521)
==127743==    by 0x4BC4A1: wait_request (net_server.c:637)
==127743==    by 0x42B13E: main (pbsd_main.c:1805)
```

#### Describe Your Change
This problem only happens when more than one chunk of a reservation is confirmed on the same node.
The node maintains a list of reservations chunks confirmed on it. Each node in this list contains a reference to the reservation.
When the reservation is deleted, it was previously cleaning up only one matching node of the linked list. But in reality, these nodes are actually representing each chunk. So some were never cleaned and left dangling pointers.



#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
I don't see a recurring benefit of writing a PTL test for it. Attached are the Valgrind logs of manual testing.

[server_valgrind_before.txt](https://github.com/openpbs/openpbs/files/4704802/server_valgrind_before.txt)
[server_valgrind_after.txt](https://github.com/openpbs/openpbs/files/4704803/server_valgrind_after.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
