### PR TITLE
Fixed some log messages issues in windows mom

### DIFF
--- a/src/lib/Liblog/pbs_log.c
+++ b/src/lib/Liblog/pbs_log.c
@@ -763,8 +763,13 @@ log_err(int errnum, const char *routine, const char *text)
 	if (log_opened == 0)
 		(void)log_open("/dev/console", log_directory);
 
-	if (isatty(2))
-		(void)fprintf(stderr, "%s: %s\n", msg_daemonname, buf);
+	if (isatty(2)) {
+		if (msg_daemonname == NULL) {
+			(void)fprintf(stderr, "%s\n", buf);
+		} else {
+			(void)fprintf(stderr, "%s: %s\n", msg_daemonname, buf);
+		}
+	}
 
 	(void)log_record(PBSEVENT_ERROR | PBSEVENT_FORCE, PBS_EVENTCLASS_SERVER,
 		LOG_ERR, msg_daemonname, buf);

--- a/src/lib/Liblog/pbs_log.c
+++ b/src/lib/Liblog/pbs_log.c
@@ -728,7 +728,7 @@ log_err(int errnum, const char *routine, const char *text)
 		DWORD	err = GetLastError();
 		int		len;
 
-		snprintf(buf, LOG_BUF_SIZE, "errno(%lu):", err);
+		snprintf(buf, LOG_BUF_SIZE, "Err(%lu): ", err);
 		FormatMessage(
 			FORMAT_MESSAGE_ALLOCATE_BUFFER |
 			FORMAT_MESSAGE_FROM_SYSTEM |
@@ -738,15 +738,13 @@ log_err(int errnum, const char *routine, const char *text)
 			(LPTSTR)&lpMsgBuf, 0, NULL);
 		strncat(buf, lpMsgBuf, LOG_BUF_SIZE - (int)strlen(buf) - 1);
 		LocalFree(lpMsgBuf);
-		buf[sizeof(buf) - 1] = '\0';
+		buf[sizeof(buf)-1] = '\0';
 		len = strlen(buf);
-		if (buf[len - 1] == '\n')
+		if (buf[len-1] == '\n')
 			len--;
-		if (buf[len - 1] == '\r')
+		if (buf[len-1] == '.')
 			len--;
-		if (buf[len - 1] == '.')
-			len--;
-		buf[len] = '\0';
+		buf[len-1] = '\0';
 #else
 		buf[0] = '\0';
 #endif
@@ -754,8 +752,9 @@ log_err(int errnum, const char *routine, const char *text)
 		if (((errmsg = pbse_to_txt(errnum)) == NULL) &&
 			((errmsg = strerror(errnum)) == NULL))
 				errmsg = "";
-		(void)snprintf(buf, LOG_BUF_SIZE, "errno(%d):%s", errnum, errmsg);
+		(void)snprintf(buf, LOG_BUF_SIZE, "%s (%d) in ", errmsg, errnum);
 	}
+	(void)strcat(buf, routine);
 	(void)strcat(buf, ", ");
 	i = LOG_BUF_SIZE - (int)strlen(buf) - 2;
 	(void)strncat(buf, text, i);
@@ -764,17 +763,11 @@ log_err(int errnum, const char *routine, const char *text)
 	if (log_opened == 0)
 		(void)log_open("/dev/console", log_directory);
 
-	if (isatty(2)) {
-		if (msg_daemonname == NULL) {
-			(void)fprintf(stderr, "%s\n", buf);
-		} else {
-			(void)fprintf(stderr, "%s;%s\n", msg_daemonname, buf);
-		}
-	}
+	if (isatty(2))
+		(void)fprintf(stderr, "%s: %s\n", msg_daemonname, buf);
 
-	snprintf(log_buffer, sizeof(log_buffer), "%s;%s", routine, buf);
 	(void)log_record(PBSEVENT_ERROR | PBSEVENT_FORCE, PBS_EVENTCLASS_SERVER,
-		LOG_ERR, msg_daemonname, log_buffer);
+		LOG_ERR, msg_daemonname, buf);
 }
 
 /**

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -9468,7 +9468,7 @@ main(int argc, char *argv[])
 	}
 
 	sprintf(log_buffer, "Created window station=%s", winsta_name);
-	log_event(PBSEVENT_SYSTEM | PBSEVENT_FORCE, PBS_EVENTCLASS_SERVER, LOG_NOTICE, msg_daemonname, log_buffer);
+	log_event(PBSEVENT_SYSTEM | PBSEVENT_FORCE, PBS_EVENTCLASS_SERVER, LOG_NOTICE, __func__, log_buffer);
 
 	SetProcessWindowStation(pbs_winsta);
 
@@ -9499,7 +9499,7 @@ main(int argc, char *argv[])
 	}
 	sprintf(log_buffer, "Created desktop %s in window station=%s",
 		desktop_name, winsta_name);
-	log_event(PBSEVENT_SYSTEM | PBSEVENT_FORCE, PBS_EVENTCLASS_SERVER, LOG_NOTICE, msg_daemonname, log_buffer);
+	log_event(PBSEVENT_SYSTEM | PBSEVENT_FORCE, PBS_EVENTCLASS_SERVER, LOG_NOTICE, __func__, log_buffer);
 
 	SetProcessWindowStation(old_winsta);
 

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -9468,7 +9468,7 @@ main(int argc, char *argv[])
 	}
 
 	sprintf(log_buffer, "Created window station=%s", winsta_name);
-	log_err(0, "main", log_buffer);
+	log_event(PBSEVENT_SYSTEM | PBSEVENT_FORCE, PBS_EVENTCLASS_SERVER, LOG_NOTICE, msg_daemonname, log_buffer);
 
 	SetProcessWindowStation(pbs_winsta);
 
@@ -9499,7 +9499,7 @@ main(int argc, char *argv[])
 	}
 	sprintf(log_buffer, "Created desktop %s in window station=%s",
 		desktop_name, winsta_name);
-	log_err(0, "main", log_buffer);
+	log_event(PBSEVENT_SYSTEM | PBSEVENT_FORCE, PBS_EVENTCLASS_SERVER, LOG_NOTICE, msg_daemonname, log_buffer);
 
 	SetProcessWindowStation(old_winsta);
 

--- a/src/resmom/requests.c
+++ b/src/resmom/requests.c
@@ -246,6 +246,8 @@ fork_to_user(struct batch_request *preq)
 	/* path maybe hanging off it. With pbs_mom running under     */
 	/* SERVICE_ACCOUNT, we have to map drives under user session */
 	/* Only the session that mapped the drive can unmap it.      */
+
+	log_buffer[0] = '\0';
 	if ( ((pwdp == NULL) || (pwdp->pw_userlogin == INVALID_HANDLE_VALUE)) \
 		&& \
 		((pwdp = logon_pw(preq->rq_ind.rq_cpyfile.rq_user, cred_buf,
@@ -256,7 +258,7 @@ fork_to_user(struct batch_request *preq)
 	}
 
 	if (strlen(log_buffer) > 0)
-		log_err(0, __func__, log_buffer);
+		log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_JOB, LOG_DEBUG, __func__, log_buffer);
 
 	if (pwdp->pw_userlogin != INVALID_HANDLE_VALUE) {
 		if (!impersonate_user(pwdp->pw_userlogin)) {

--- a/src/resmom_win/start_exec.c
+++ b/src/resmom_win/start_exec.c
@@ -4352,8 +4352,6 @@ start_exec(job *pjob)
 		}
 
 		finish_exec(pjob);
-		log_event(PBSEVENT_JOB, PBS_EVENTCLASS_JOB, LOG_INFO,
-			pjob->ji_qs.ji_jobid, log_buffer);
 	}
 	return;
 }

--- a/src/server/job_recov.c
+++ b/src/server/job_recov.c
@@ -183,7 +183,7 @@ job_save_fs(job *pjob, int updatetype)
 		openflags =  O_WRONLY;
 		fds = open(namebuf1, openflags, pmode);
 		if (fds < 0) {
-			log_err(errno, "job_save", "error on open");
+			log_errf(errno, __func__, "Failed to open %s file", namebuf1);
 			return (-1);
 		}
 #ifdef WIN32

--- a/src/server/req_quejob.c
+++ b/src/server/req_quejob.c
@@ -1819,8 +1819,8 @@ req_commit(struct batch_request *preq)
 	 */
 
 	(void)reply_jobid(preq, pj->ji_qs.ji_jobid, BATCH_REPLY_CHOICE_Commit);
-	start_exec(pj);
 	job_or_resv_save((void *)pj, SAVEJOB_NEW, JOB_OBJECT);
+	start_exec(pj);
 
 	/* The ATR_VFLAG_MODIFY bit for several attributes used to be
 	 * set here. Now we rely on these bits to be set when and where


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Some inappropriate log messages appear during job run or at mom's startup, like:
**Error 1.** 05/29/2020 11:48:55;0001;pbs_mom;Svr;pbs_mom;**No such file or directory (2)** in job_save, error on open
**Error 2.** **(same log comes twice)** 
05/29/2020 11:48:55;0008;pbs_mom;Job;1251.blrlap836-centos7;Started, pid = 7336
   05/29/2020 11:48:55;0008;pbs_mom;Job;1251.blrlap836-centos7;Started, pid = 7336
**Error 3.** 05/29/2020 11:49:01;0001;pbs_mom;Svr;pbs_mom**;No error (0) in fork_to_user**, Type 63 request received from root@172.20.10.3:15001, sock=1
**Error 4 .** C:\Users\bhagatr>qstat
**(null):** Err(122): The data area passed to a system call is too small.get_full_username, failed in LookupAccountName(tryname) for WIN-MOM\bhagatr

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
**Error 1.** This message was coming because we were trying to save a job data through SAVEJOB_QUICK flag but job_id.JB file has not been created yet.
**Error 2.** Some dead code was left in the file.
**Error 3.** Here we were passing log_buffer to the logon_pw() without clearing it, resulting logging some old messages.
**Error 4.** Added a check in log_err(), if msg_daemonname is NULL then will change the error format

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Testing Log: [before_and_after_fix_logs.txt](https://github.com/openpbs/openpbs/files/4724127/before_and_after_fix_logs.txt)

Valgrind log: [valgrind_logs.txt](https://github.com/openpbs/openpbs/files/4723798/valgrind_logs.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
