### PR TITLE
pbs_topologyinfo does not work in Linux Windows Interoperability

### DIFF
--- a/src/cmds/scripts/pbs_topologyinfo.py
+++ b/src/cmds/scripts/pbs_topologyinfo.py
@@ -70,7 +70,7 @@ class Inventory(object):
         """
         counting devices by parsing topo_file
         """
-        temp = topo_file.split(',')
+        temp = topo_file.read().decode('utf-8').split(',')
         for item in temp:
             if item.find('sockets:') != -1:
                 self.nsockets = int(item[8:])  # len('sockets:') = 8
@@ -137,9 +137,10 @@ class Inventory(object):
             self.reset()
             try:
                 with open(pathname, "rb") as topo_file:
-                    temp_buf = topo_file.read().decode('utf-8')
-                    if 'hwloc' not in temp_buf:
-                        self.reportsockets_win(temp_buf)
+                    temp_buf = topo_file.readline().decode('utf-8')
+                    topo_file.seek(0)
+                    if not temp_buf.startswith('<'):
+                        self.reportsockets_win(topo_file)
                     elif ExpatParser:
                         try:
                             p = xml.parsers.expat.ParserCreate()

--- a/src/cmds/scripts/pbs_topologyinfo.py
+++ b/src/cmds/scripts/pbs_topologyinfo.py
@@ -139,6 +139,9 @@ class Inventory(object):
                 with open(pathname, "rb") as topo_file:
                     temp_buf = topo_file.readline().decode('utf-8')
                     topo_file.seek(0)
+                    # Windows topology file are not XML files. So if
+                    # a file does not start with '<', it is a Windows
+                    # topology file
                     if not temp_buf.startswith('<'):
                         self.reportsockets_win(topo_file)
                     elif ExpatParser:

--- a/src/cmds/scripts/pbs_topologyinfo.py
+++ b/src/cmds/scripts/pbs_topologyinfo.py
@@ -70,7 +70,7 @@ class Inventory(object):
         """
         counting devices by parsing topo_file
         """
-        temp = topo_file.read().split(',')
+        temp = topo_file.split(',')
         for item in temp:
             if item.find('sockets:') != -1:
                 self.nsockets = int(item[8:])  # len('sockets:') = 8
@@ -137,9 +137,9 @@ class Inventory(object):
             self.reset()
             try:
                 with open(pathname, "rb") as topo_file:
-
-                    if platform.system() == "Windows":
-                        self.reportsockets_win(topo_file)
+                    temp_buf = topo_file.read().decode('utf-8')
+                    if 'hwloc' not in temp_buf:
+                        self.reportsockets_win(temp_buf)
                     elif ExpatParser:
                         try:
                             p = xml.parsers.expat.ParserCreate()


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
pbs_topologyinfo fails for windows node's topology files because it fails to identify the node's platform correctly as we use platform.system() to identify the platform. Since the server is Linux, we identify the platform as Linux always. 

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Instead of using platform.system(), check if topology data is in xml format by looking for '<'.  XML format is used only for Linux nodes and will not be present in the windows node's topology file.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[topofix.txt](https://github.com/openpbs/openpbs/files/4725315/topofix.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
