### PR TITLE
remove skipcode from SmokeTest.test_jobscript_max_size

### DIFF
--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -1460,9 +1460,6 @@ class SmokeTest(PBSTestSuite):
         Test that if jobscript_max_size attribute is set, users can not
         submit jobs with job script size exceeding the limit.
         """
-        msg = "skipped due to issue: "
-        msg += "server attribute 'jobscript_max_size' not working properly."
-        self.skipTest(msg)
 
         scr = []
         scr += ['echo "This is a very long line, it will exceed 20 bytes"']


### PR DESCRIPTION
#### Describe Bug or Feature
Currently test have skipped code for issue https://github.com/openpbs/openpbs/issues/1711.
issue has been resolved in PR https://github.com/openpbs/openpbs/pull/1772. 
we need to remove skip code from test.

#### Describe Your Change
removed skip code from test.

#### Attach Test and Valgrind Logs/Output
before_fix:
[before_fix.txt](https://github.com/openpbs/openpbs/files/4712559/before_fix.txt)

After_fix:
[after_fix.txt](https://github.com/openpbs/openpbs/files/4712557/after_fix.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
