### PR TITLE
TestJobArray.test_job_array_history_duration failed due to race condition.

### DIFF
--- a/test/tests/functional/pbs_job_array.py
+++ b/test/tests/functional/pbs_job_array.py
@@ -400,7 +400,7 @@ class TestJobArray(TestFunctional):
         self.server.manager(MGR_CMD_SET, SERVER, a)
         j = Job(TEST_USER, attrs={
             ATTR_J: '1-2', 'Resource_List.select': 'ncpus=1'})
-        j.set_sleep_time(5)
+        j.set_sleep_time(15)
         j_id = self.server.submit(j)
         subjid_1 = j.create_subjob_id(j_id, 1)
         subjid_2 = j.create_subjob_id(j_id, 2)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
TestJobArray.test_job_array_history_duration failed due to race condition.
In test we are setting job_history_enable=True and job_history_duration=30. After we submitting array job of 2 sub-jobs of 5 sec. and expecting first sub-job is in R state. 
sometime race condition occurred such that when PTL try to expect first sub-job is in R state till that point sub-job completed and PTL cannot get expected job state due to test got failed. 

#### Describe Your Change
Increase the job sleep time from 5 sec to 15 sec. 

#### Attach Test and Valgrind Logs/Output
before fix:
[before_fix.txt](https://github.com/openpbs/openpbs/files/4716970/before_fix.txt)

After fix:
After fix i ran test multiple times and every time its pass.
[res_1.txt](https://github.com/openpbs/openpbs/files/4716972/res_1.txt)
[res_2.txt](https://github.com/openpbs/openpbs/files/4716973/res_2.txt)
[res_3.txt](https://github.com/openpbs/openpbs/files/4716974/res_3.txt)
[res_4.txt](https://github.com/openpbs/openpbs/files/4716975/res_4.txt)
[res_5.txt](https://github.com/openpbs/openpbs/files/4716976/res_5.txt)
[res_6.txt](https://github.com/openpbs/openpbs/files/4716977/res_6.txt)
[res_7.txt](https://github.com/openpbs/openpbs/files/4716978/res_7.txt)
[res_8.txt](https://github.com/openpbs/openpbs/files/4716979/res_8.txt)
[res_9.txt](https://github.com/openpbs/openpbs/files/4716980/res_9.txt)
[res_10.txt](https://github.com/openpbs/openpbs/files/4716981/res_10.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
