### PR TITLE
Add logs to error path in Libwin-util.c

### DIFF
--- a/src/include/win.h
+++ b/src/include/win.h
@@ -315,7 +315,11 @@ extern int	get_dcinfo(char *net_name, char domain_name[], char domain_ctrl[]);
 extern SID*	create_everyone_sid(void);
 extern HANDLE LogonUserNoPass(char *username);
 extern BOOL impersonate_user(HANDLE hlogintoken);
-extern BOOL revert_impersonated_user();
+
+/* wrap revert_impersonated_user to log in case of error */
+#define revert_impersonated_user() _log_wrap_revert_impersonated_user(__func__, __LINE__)
+extern BOOL _log_wrap_revert_impersonated_user(LPCSTR, INT);
+
 extern HANDLE setuser(char *username);
 extern void setuser_close_handle(HANDLE user_handle);
 extern int setuid(uid_t uid);	/* mimics UNIX call */
@@ -418,7 +422,6 @@ extern char *lpath2short(char *str);	/* static area returned */
 extern void lpath2short_B(char *str);
 extern char *shorten_and_cleanup_path(char *path);
 
-extern void fix_temp_path(char tmp_name[]);
 /* stuff that makes life easier for creating the daemons into a service */
 
 struct arg_param {
@@ -431,7 +434,6 @@ extern char *get_win_rootdir(void);
 extern void ErrorMessage(char *str);
 extern struct arg_param *create_arg_param(void);
 extern void free_arg_param(struct arg_param *p);
-extern void print_arg_param(struct arg_param *p);
 
 /* win_alarm: calls func() after specified # of timeout_secs have expired.
  Specify 0 for timeout_secs to reset alarm */

--- a/src/lib/Libwin/passwd.c
+++ b/src/lib/Libwin/passwd.c
@@ -2589,7 +2589,8 @@ default_local_homedir(char *username, HANDLE usertoken, int ret_profile_path)
 
 		/* The following must be done last */
 		if (became_admin)
-			(void)impersonate_user(userlogin);
+			if (impersonate_user(userlogin) == FALSE)
+				log_errf(-1, __func__, "failed in impersonate_user for user %s", username);
 	}
 
 	return (homestr);

--- a/src/server/job_func.c
+++ b/src/server/job_func.c
@@ -523,8 +523,10 @@ job_free(job *pj)
 			if ((pj->ji_wattr[JOB_ATR_euser].at_val.at_str) &&
 				(pwdp = getpwnam(pj->ji_wattr[JOB_ATR_euser].at_val.at_str))) {
 				if (pwdp->pw_userlogin != INVALID_HANDLE_VALUE) {
-					if (impersonate_user(pwdp->pw_userlogin) == 0)
+					if (impersonate_user(pwdp->pw_userlogin) == 0) {
+						log_joberr(-1, __func__, "impersonate_user() failed", pj->ji_qs.ji_jobid);
 						return;
+					}
 				}
 				/* p+14 is the string after HomeDirectory= */
 				unmap_unc_path(p+14);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
some error paths were not logged in src/lib/Libwin/util.c, making it difficult to debug rare issues on windows nodes.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
1. added logs to error paths
2. wrapped `revert_impersonated_user()` to print error log
3. removed unused functions `print_arg_param()` and `fix_temp_path`

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Pending !

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
