### PR TITLE
Server gives false positive for pbs_ralter cmd

### DIFF
--- a/src/server/req_rescq.c
+++ b/src/server/req_rescq.c
@@ -586,7 +586,7 @@ req_confirmresv(struct batch_request *preq)
 				log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_RESV, LOG_NOTICE, presv->ri_qs.ri_resvID, log_buffer);
 			}
 		} else {
-			if ((presv->rep_sched_count >= presv->req_sched_count) && !is_confirmed) {
+			if (presv->rep_sched_count >= presv->req_sched_count) {
 				/* Clients waiting on an interactive request must be
 				* notified of the failure to confirm
 				*/
@@ -600,7 +600,7 @@ req_confirmresv(struct batch_request *preq)
 						PBSE_NONE, buf);
 					presv->ri_brp = NULL;
 				}
-				if (!is_being_altered) {
+				if (!is_being_altered && !is_confirmed) {
 					log_event(PBS_EVENTCLASS_RESV, PBS_EVENTCLASS_RESV,
 						LOG_INFO, presv->ri_qs.ri_resvID,
 						"Reservation denied");
@@ -826,6 +826,8 @@ req_confirmresv(struct batch_request *preq)
 			req_reject(PBSE_SYSTEM, 0, preq);
 			return;
 		}
+		/* Reservation is not degraded anymore */
+		is_degraded = 0;
 
 	}
 	if (state == RESV_CONFIRMED && partition_name != NULL) {

--- a/test/tests/functional/pbs_ralter.py
+++ b/test/tests/functional/pbs_ralter.py
@@ -1278,26 +1278,35 @@ class TestPbsResvAlter(TestFunctional):
             'resv_nodes'].split(':')[0].split('(')[1]
         resv_node2 = self.server.status(RESV, 'resv_nodes', id=rid2)[0][
             'resv_nodes'].split(':')[0].split('(')[1]
-        if resv_node1 is resv_node2:
+        mtype = 0
+        seq = 0
+        if resv_node1 == resv_node2:
             self.server.manager(MGR_CMD_SET, NODE, {
                                 'state': "offline"}, id=resv_node1)
+            mtype = 1
+            seq = 1
         else:
             self.server.manager(MGR_CMD_SET, NODE, {
                                 'state': "offline"}, id=resv_node1)
             self.server.manager(MGR_CMD_SET, NODE, {
                                 'state': "offline"}, id=resv_node2)
+            mtype = 3
+            seq = 3
+
         self.server.expect(RESV, attrs, id=rid1)
         self.server.expect(RESV, attrs, id=rid2)
         self.alter_a_reservation(rid1, start1, end1, shift, alter_s=True,
-                                 alter_e=True, whichMessage=3, sequence=3)
+                                 alter_e=True, whichMessage=mtype,
+                                 sequence=seq)
         self.alter_a_reservation(rid2, start2, end2, shift, alter_s=True,
-                                 alter_e=True, whichMessage=3, sequence=3)
+                                 alter_e=True, whichMessage=mtype,
+                                 sequence=seq)
         self.alter_a_reservation(rid1, start1, end1, shift, alter_s=True,
-                                 alter_e=True, whichMessage=3, interactive=2,
-                                 sequence=4)
+                                 alter_e=True, whichMessage=mtype,
+                                 interactive=2, sequence=seq+1)
         self.alter_a_reservation(rid2, start2, end2, shift, alter_s=True,
-                                 alter_e=True, whichMessage=3, interactive=2,
-                                 sequence=4)
+                                 alter_e=True, whichMessage=mtype,
+                                 interactive=2, sequence=seq+1)
 
     @skipOnCpuSet
     def test_alter_resv_name(self):


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
There are multiple problems addressed in this PR
- When a confirmed reservation is altered and ralter fails, it gives a false positive to the user stating the changes were confirmed.
- When a degraded reservation is altered, the server does not log a message in PBS accounting logs. 
- The third problem was in a test that expected ralter to fail in a case it shouldn’t.



#### Describe Your Change
- This issue happens when alter is issues with the ‘Interactive’ attribute. The problem happens because the server had a misplaced check of checking for the reservation to be NOT CONFIRMED before replying that it is denied. This check was wrongly placed.
- Second problem was fixed by updating a flag server checks to ensure that it does not log ralter accounting messages for degraded reservations.
- A test was modified to ensure that it accounts for free nodes in the system and expect the reservation ralter to succeed in such cases


#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
[test_resv.txt](https://github.com/openpbs/openpbs/files/4720534/test_resv.txt)
[test_ralter.txt](https://github.com/openpbs/openpbs/files/4720536/test_ralter.txt)
[test_multi_sched.txt](https://github.com/openpbs/openpbs/files/4720537/test_multi_sched.txt)
I added no new tests. Following are the tests from ralter test suite that were failing - 
test_alter_degraded_resv_mom_down, test_conflict_two_advance_resvs, test_conflict_two_standing_resvs

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
