### PR TITLE
[WIP]Added back the closeHandle in get_processowner

### DIFF
--- a/src/lib/Libwin/passwd.c
+++ b/src/lib/Libwin/passwd.c
@@ -1040,7 +1040,7 @@ getusersid2(char *uname,
 
 			/* get the size of the memory buffer needed for the SID */
 			ret = GetTokenInformation(hToken, TokenUser, NULL, 0, &dwBufferSize);
-			if ((ret ==0) && (GetLastError() == ERROR_INSUFFICIENT_BUFFER)) {
+			if ((ret == 0) && (GetLastError() == ERROR_INSUFFICIENT_BUFFER)) {
 
 				pTokenUser = (PTOKEN_USER)malloc(dwBufferSize);
 				if (pTokenUser == NULL) {
@@ -5775,6 +5775,7 @@ get_processowner(DWORD processid, uid_t *puid, char *puname, size_t uname_len, c
 	hProcess = OpenProcess(PROCESS_ALL_ACCESS, FALSE, processid);
 	if ((hProcess == INVALID_HANDLE_VALUE) || (hProcess == NULL)) {
 		log_errf(-1, __func__, "failed in OpenProcess for process: %lu", processid);
+		CloseHandle(hProcess);
 		return NULL;
 	}
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
As part of [#1738 ](https://github.com/openpbs/openpbs/pull/1738) while adding debug log in error path, removed CloseHandle() by mistake from get_processowner() of passwd.c


#### Describe Your Change
Added back the same in error path before returning from the function.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
