### PR TITLE
Fix test_runjob_hook log match failure caused by regular expression

### DIFF
--- a/test/tests/functional/pbs_hooksmoketest.py
+++ b/test/tests/functional/pbs_hooksmoketest.py
@@ -454,19 +454,15 @@ print_attribs(j)"""
         # Verify server logs
         self.logger.info("Verifying logs in server")
         msg_1 = "Server@.*;Hook;%s;started" % \
-                (self.hook_name)
+                (re.escape(self.hook_name))
         msg_2 = "Hook;Server@.*;requestor = Scheduler"
         msg_3 = "Hook;Server@.*;hook_name = %s" % \
-                (self.hook_name)
+                (re.escape(self.hook_name))
         msg_4 = "Hook;Server@.*;exec_vnode = %s" % \
-                (ev)
+                (re.escape(ev))
         # Character escaping '()' as the log_match is regexp
-        msg_4 = msg_4.replace("(", "\(")
-        msg_4 = msg_4.replace(")", "\)")
-        msg_4 = msg_4.replace("[", "\[")
-        msg_4 = msg_4.replace("]", "\]")
         msg_5 = "Server@.*;Hook;%s;finished" % \
-                (self.hook_name)
+                (re.escape(self.hook_name))
         msg = [msg_1, msg_2, msg_3, msg_4, msg_5]
         for i in msg:
             self.server.log_match(i, starttime=now, regexp=True)

--- a/test/tests/functional/pbs_hooksmoketest.py
+++ b/test/tests/functional/pbs_hooksmoketest.py
@@ -463,6 +463,8 @@ print_attribs(j)"""
         # Character escaping '()' as the log_match is regexp
         msg_4 = msg_4.replace("(", "\(")
         msg_4 = msg_4.replace(")", "\)")
+        msg_4 = msg_4.replace("[", "\[")
+        msg_4 = msg_4.replace("]", "\]")
         msg_5 = "Server@.*;Hook;%s;finished" % \
                 (self.hook_name)
         msg = [msg_1, msg_2, msg_3, msg_4, msg_5]


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
test_runjob_hook fails to log match `msg_4` if the exec_vnode name contains a pair of square brackets. Square brackets are used in regular expression to specify a set of allowed characters. They need to be escaped. 

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Escape square brackets using `replace`. 

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
N/A

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[pbi-23-r7p1 build and test.txt](https://github.com/openpbs/openpbs/files/4734719/pbi-23-r7p1.build.and.test.txt)
[pbi-24-s12 build and test.txt](https://github.com/openpbs/openpbs/files/4734717/pbi-24-s12.build.and.test.txt)

[uv-01.txt](https://github.com/openpbs/openpbs/files/4730704/uv-01.txt)
[uv-02-s12.txt](https://github.com/openpbs/openpbs/files/4730705/uv-02-s12.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
