### PR TITLE
Add the ability to tell Shasta ATOM about exclusive

### DIFF
--- a/src/modules/python/pbs_hooks/PBS_cray_atom.PY
+++ b/src/modules/python/pbs_hooks/PBS_cray_atom.PY
@@ -177,13 +177,14 @@ class HookHelper(object):
         log_with_caller(pbs.EVENT_DEBUG4, 'path is %s' % path)
         return path
 
+    @staticmethod
     def is_it_exclusive(job):
         """
         check to see if the job requested exclusive, or if the
         nodes are marked exclusive.  This needs to be passed
         to ATOM.
         """
-        place = job.Resource_List["place"]
+        place = str(job.Resource_List["place"])
         log_with_caller(pbs.EVENT_DEBUG4, "place is %s" % place)
 
         # See if the node sharing value has exclusive
@@ -199,26 +200,9 @@ class HookHelper(object):
         if (sharing == pbs.ND_IGNORE_EXCL):
             return False
 
-        excls = re.findall(r'excl', str(place))
-        totalexcls = len(excls)
-        if totalexcls > 0:
-            if "group" in str(place):
-                # A group is in the place statement, is it excl 
-                output = re.search(r'(?<=group=)[^:$]*', str(place))
-                if output:
-                    groupv = output.group()
-                    log_with_caller(pbs.EVENT_DEBUG4, "The groupv is = %s" % str(groupv))
-                    groups = re.findall(r'excl', groupv)
-                    gcount = len(groups)
-                    if gcount != totalexcls:
-                        # Found excl and it wasn't in group
-                        log_with_caller(pbs.EVENT_DEBUG4, "Found excl not as group - sending true")
-                        return True
-            else:
-                # The 'excl' found is the sharing part of place not the group
-                return True
-
-        if "shared" in str(place):
+        if any(s.startswith('excl') for s in place.split(':')):
+            return True
+        if any(s.startswith('shared') for s in place.split(':')):
             return False
 
         if ((sharing == pbs.ND_DEFAULT_EXCL) or
@@ -228,8 +212,7 @@ class HookHelper(object):
         if (sharing == pbs.ND_DEFAULT_SHARED):
             return False
 
-        pbs.logmsg(pbs.LOG_DEBUG, "It was none of the above cases,"
-                   "return not exclusive")
+        # It was none of the above cases return not exclusive
         return False
 
 def post(url, json=None, **kwargs):

--- a/src/modules/python/pbs_hooks/PBS_cray_atom.PY
+++ b/src/modules/python/pbs_hooks/PBS_cray_atom.PY
@@ -205,8 +205,8 @@ class HookHelper(object):
         if any(s.startswith('shared') for s in place.split(':')):
             return False
 
-        if sharing == pbs.ND_DEFAULT_EXCL or
-            sharing == pbs.ND_DEFAULT_EXCLHOST:
+        if (sharing == pbs.ND_DEFAULT_EXCL or
+            sharing == pbs.ND_DEFAULT_EXCLHOST):
             return True
 
         if sharing == pbs.ND_DEFAULT_SHARED:

--- a/src/modules/python/pbs_hooks/PBS_cray_atom.PY
+++ b/src/modules/python/pbs_hooks/PBS_cray_atom.PY
@@ -62,6 +62,7 @@ if True:
     import pbs
     import pwd
     import copy
+    import re
 
 requests_unixsocket.monkeypatch()
 
@@ -176,6 +177,60 @@ class HookHelper(object):
         log_with_caller(pbs.EVENT_DEBUG4, 'path is %s' % path)
         return path
 
+    def is_it_exclusive(job):
+        """
+        check to see if the job requested exclusive, or if the
+        nodes are marked exclusive.  This needs to be passed
+        to ATOM.
+        """
+        place = job.Resource_List["place"]
+        log_with_caller(pbs.EVENT_DEBUG4, "place is %s" % place)
+
+        # See if the node sharing value has exclusive
+        vn = pbs.server().vnode(pbs.get_local_nodename())
+        sharing = vn.sharing
+        log_with_caller(pbs.EVENT_DEBUG4, "The sharing value is %s type %s" %
+                        (str(sharing), str(type(sharing))))
+
+        # Uses the same logic as the scheduler (is_excl())
+        if ((sharing == pbs.ND_FORCE_EXCL) or (sharing == pbs.ND_FORCE_EXCLHOST)):
+            return True
+
+        if (sharing == pbs.ND_IGNORE_EXCL):
+            return False
+
+        excls = re.findall(r'excl', str(place))
+        totalexcls = len(excls)
+        if totalexcls > 0:
+            if "group" in str(place):
+                # A group is in the place statement, is it excl 
+                output = re.search(r'(?<=group=)[^:$]*', str(place))
+                if output:
+                    groupv = output.group()
+                    log_with_caller(pbs.EVENT_DEBUG4, "The groupv is = %s" % str(groupv))
+                    groups = re.findall(r'excl', groupv)
+                    gcount = len(groups)
+                    if gcount != totalexcls:
+                        # Found excl and it wasn't in group
+                        log_with_caller(pbs.EVENT_DEBUG4, "Found excl not as group - sending true")
+                        return True
+            else:
+                # The 'excl' found is the sharing part of place not the group
+                return True
+
+        if "shared" in str(place):
+            return False
+
+        if ((sharing == pbs.ND_DEFAULT_EXCL) or
+            (sharing == pbs.ND_DEFAULT_EXCLHOST)):
+            return True
+
+        if (sharing == pbs.ND_DEFAULT_SHARED):
+            return False
+
+        pbs.logmsg(pbs.LOG_DEBUG, "It was none of the above cases,"
+                   "return not exclusive")
+        return False
 
 def post(url, json=None, **kwargs):
     """
@@ -338,9 +393,11 @@ def handle_execjob_begin():
     jid = event.job.id
     uid = pwd.getpwnam(event.job.euser).pw_uid
     log_with_caller(pbs.EVENT_DEBUG4, 'UID is %d' % uid)
+    excl = HookHelper.is_it_exclusive(event.job)
     data = {
         'jobid': jid,
-        'uid': uid
+        'uid': uid,
+        'exclusive': excl
     }
     url = HookHelper.build_path(resource='job')
     timeout = HookHelper.get_config()['post_timeout']

--- a/src/modules/python/pbs_hooks/PBS_cray_atom.PY
+++ b/src/modules/python/pbs_hooks/PBS_cray_atom.PY
@@ -194,10 +194,10 @@ class HookHelper(object):
                         (str(sharing), str(type(sharing))))
 
         # Uses the same logic as the scheduler (is_excl())
-        if ((sharing == pbs.ND_FORCE_EXCL) or (sharing == pbs.ND_FORCE_EXCLHOST)):
+        if sharing == pbs.ND_FORCE_EXCL or sharing == pbs.ND_FORCE_EXCLHOST:
             return True
 
-        if (sharing == pbs.ND_IGNORE_EXCL):
+        if sharing == pbs.ND_IGNORE_EXCL:
             return False
 
         if any(s.startswith('excl') for s in place.split(':')):
@@ -205,14 +205,13 @@ class HookHelper(object):
         if any(s.startswith('shared') for s in place.split(':')):
             return False
 
-        if ((sharing == pbs.ND_DEFAULT_EXCL) or
-            (sharing == pbs.ND_DEFAULT_EXCLHOST)):
+        if sharing == pbs.ND_DEFAULT_EXCL or
+            sharing == pbs.ND_DEFAULT_EXCLHOST:
             return True
 
-        if (sharing == pbs.ND_DEFAULT_SHARED):
+        if sharing == pbs.ND_DEFAULT_SHARED:
             return False
 
-        # It was none of the above cases return not exclusive
         return False
 
 def post(url, json=None, **kwargs):


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Cray Shasta's ATOM interface has added an "exclusive" field as part of the ATOM REST interface for POSTing when a job starts.  The "exclusive" field will be set to true if either the job's -lplace= contains some form of "excl" or if the node the job will run on has a sharing value containing "excl".  To understand the outcome of the job/node combinations, please refer to the design.


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
I added logic to the PBS_cray_atom hook to correctly determine the value to pass to ATOM.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
https://pbspro.atlassian.net/wiki/spaces/PD/pages/1086029883/PBS+Design+Changes+for+Shasta

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
