### PR TITLE
Mistakenly removed one close_dir() call during code refactoring

### DIFF
--- a/src/resmom/stage_func.c
+++ b/src/resmom/stage_func.c
@@ -1133,6 +1133,7 @@ stage_file(int dir, int	rmtflag, char *owner, struct rqfpair *pair, int conn, cp
 			rc = copy_file(dir, rmtflag, owner, matched,
 				pair, conn, stage_inout, prmt);
 			if (rc != 0) {
+				(void)closedir(dirp);
 				snprintf(log_buffer, sizeof(log_buffer), "Pattern matched:%s stage%s failed for %s from %s to %s",
 					(rmtflag == 1) ? "remote" : "local", (dir == STAGE_DIR_OUT) ? "out" : "in", owner, source,
 					(dir == STAGE_DIR_OUT) ? pair->fp_rmt : pair->fp_local);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Mistakenly removed one close_dir() call during code refactoring of stage_func. c file through this PR https://github.com/openpbs/openpbs/pull/1740 


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Added a close_dir() call

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
