### PR TITLE
only_explicit_psets not working with -lplace=group

### DIFF
--- a/src/scheduler/node_partition.c
+++ b/src/scheduler/node_partition.c
@@ -899,7 +899,7 @@ find_alloc_np_cache(status *policy, np_cache ***pnpc_arr,
 	if (npc == NULL) {
 		int flags = NP_NO_ADD_NP_ARR;
 
-		if (policy->only_explicit_psets)
+		if (policy->only_explicit_psets == 0)
 			flags |= NP_CREATE_REST;
 
 		/* didn't find node partition cache, need to allocate and create */


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
PBS scheduler does not seem to honor only_explicit_psets setting when jobs are submitted with -lplace=group=<res>.

#### Describe Your Change
There was a mistake in how only_explicit_psets condition was checked.


#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
[test_place.txt](https://github.com/openpbs/openpbs/files/4732874/test_place.txt)

No new test needed. The existing Test_explicit_psets test suite was failing.

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
