### PR TITLE
Fixed resv overlap issue with ghost jobs

### DIFF
--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -4029,7 +4029,7 @@ create_resource_assn_for_node(node_info *ninfo)
 	}
 
 	if (ncpus_res != NULL && ncpus_res->assigned < ncpus_res->avail)
-		set_node_info_state(ninfo, ND_free);
+		remove_node_state(ninfo, ND_jobbusy);
 
 	return 1;
 }


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
It is possible for a job to run on a node with an exclusive reservation if there is a ghost job inside the reservation on that node.

#### Describe Your Change
When we have a ghost job on a node, we recreate the resources_assigned values for that node.  The problem is that we would set the node state to free (to remove job-busy) without looking for any other states like resv-exclusive.  Since the node is then in state free, the other resources would be used to run jobs.


#### Attach Test and Valgrind Logs/Output
A ghost job is created by a narrow race condition where a job ends between when the scheduler queries the nodes and the jobs.  The only reliable way to create this race condition is to use a debugger and put a break point between the queries.  Here is manual testing:
[resv.log](https://github.com/openpbs/openpbs/files/4732976/resv.log)
