### PR TITLE
qmsg to windows job returning false error string

### DIFF
--- a/src/resmom/requests.c
+++ b/src/resmom/requests.c
@@ -798,7 +798,7 @@ message_job(job *pjob, enum job_file jft, char *text)
 		text = pstr;
 	}
 #ifdef	WIN32
-	(void)write(fds, text, len);
+	total_bytes_written = write(fds, text, len);
 	(void)_commit(fds);
 #else
 	for (i = 0; i < 3; i++) {


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug
<!--- Describe the problem, ideally from the customer's viewpoint  -->
qmsg to a windows job works but still returns failure message
qmsg ing a job which is running at windows node works but the qmsg gives out an error message as below. This error message appeared both at linux client as well as windows client. but the same error message wont be returned if qmsg is operating on linux job
```
C:\Users\pbsuser>qmsg -O "output" 3
qmsg: Execution server rejected request 3.server
[root@server ~]# qmsg -O "root out" 3
qmsg: Execution server rejected request 3.server
```

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
updated `total_bytes_written` variable from write funtion in `message_job()`



#### Attach Test Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

[Testing_logs.txt](https://github.com/openpbs/openpbs/files/4736022/Testing_logs.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
