### PR TITLE
Fix for slow qdel due to heavy pbs_loadconf

### DIFF
--- a/src/iff/iff2.c
+++ b/src/iff/iff2.c
@@ -98,8 +98,6 @@ main(int argc, char *argv[], char *envp[])
 	/*the real deal or output pbs_version and exit?*/
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-	pbs_loadconf(0);
-
 	cln_hostaddr = getenv(PBS_IFF_CLIENT_ADDR);
 
 	/* Need to unset LOCALDOMAIN if set, want local host name */
@@ -239,7 +237,7 @@ main(int argc, char *argv[], char *envp[])
 		parentport = ntohs(parentsock_port);
 
 	pbs_errno = 0;
-	err = tcp_send_auth_req(sock, parentport, pwent->pw_name);
+	err = tcp_send_auth_req(sock, parentport, pwent->pw_name, AUTH_RESVPORT_NAME, getenv(PBS_CONF_ENCRYPT_METHOD));
 	if (err != 0 && pbs_errno != PBSE_BADCRED)
 		return 2;
 

--- a/src/include/libpbs.h
+++ b/src/include/libpbs.h
@@ -363,7 +363,7 @@ extern int tcp_pre_process(conn_t *);
 extern char *PBSD_modify_resv(int, char *, struct attropl *, char *);
 extern int PBSD_cred(int, char *, char *, int, char *, long, int, char **);
 
-int tcp_send_auth_req(int, unsigned int, char *);
+extern int tcp_send_auth_req(int, unsigned int, char *, char *, char *);
 
 #ifdef __cplusplus
 }

--- a/src/lib/Libifl/auth.c
+++ b/src/lib/Libifl/auth.c
@@ -369,31 +369,41 @@ is_valid_encrypt_method(char *method)
  *	tcp_send_auth_req - encodes and sends PBS_BATCH_Authenticate request
  *
  * @param[in] sock - socket descriptor
+ * @param[in] port - parent port in pbs_iff (only used in resvport auth) else 0
+ * @param[in] user - authenticating user name
+ * @param[in] auth_method - auth method name
+ * @param[in] encrypt_method - encrypt method name
  *
  * @return	int
  * @retval	0 on success
  * @retval	-1 on error
  */
 int
-tcp_send_auth_req(int sock, unsigned int port, char *user)
+tcp_send_auth_req(int sock, unsigned int port, char *user, char *auth_method, char *encrypt_method)
 {
 	struct batch_reply *reply;
 	int rc;
-	int am_len = strlen(pbs_conf.auth_method);
-	int em_len = strlen(pbs_conf.encrypt_method);
+	int am_len;
+	int em_len = encrypt_method ? strlen(encrypt_method) : 0;
 
+	if (auth_method == NULL || *auth_method == '\0') {
+		/* auth method can't be null or empty string */
+		pbs_errno = PBSE_INTERNAL;
+		return -1;
+	}
+	am_len = strlen(auth_method);
 	set_conn_errno(sock, 0);
 	set_conn_errtxt(sock, NULL);
 
 	if (encode_DIS_ReqHdr(sock, PBS_BATCH_Authenticate, user) ||
 		diswui(sock, am_len) || /* auth method length */
-		diswcs(sock, pbs_conf.auth_method, am_len) || /* auth method */
+		diswcs(sock, auth_method, am_len) || /* auth method */
 		diswui(sock, em_len)) { /* encrypt method length */
 		pbs_errno = PBSE_SYSTEM;
 		return -1;
 	}
 
-	if (em_len > 0 && diswcs(sock, pbs_conf.encrypt_method, em_len)) { /* encrypt method */
+	if (em_len > 0 && diswcs(sock, encrypt_method, em_len)) { /* encrypt method */
 		pbs_errno = PBSE_SYSTEM;
 		return -1;
 	}
@@ -478,6 +488,8 @@ _invoke_pbs_iff(int psock, char *server_name, int server_port, char *ebuf, size_
 	/* for compatibility with 12.0 pbs_iff */
 	(void)snprintf(cmd[1], sizeof(cmd[1]) - 1, "%s -i %s %s %u %d %u", pbs_conf.iff_path, pbs_client_addr, server_name, server_port, psock, psock_port);
 #ifdef WIN32
+	if (pbs_conf.encrypt_method[0] != '\0')
+		SetEnvironmentVariable(PBS_CONF_ENCRYPT_METHOD, pbs_conf.encrypt_method);
 	(void)snprintf(cmd[0], sizeof(cmd[0]) - 1, "%s %s %u %d %u", pbs_conf.iff_path, server_name, server_port, psock, psock_port);
 	for (k = 0; k < 2; k++) {
 		rc = 0;
@@ -508,7 +520,18 @@ _invoke_pbs_iff(int psock, char *server_name, int server_port, char *ebuf, size_
 	}
 
 #else	/* UNIX code here */
-	(void)snprintf(cmd[0], sizeof(cmd[0]) - 1, "%s=%s %s %s %u %d %u", PBS_IFF_CLIENT_ADDR, pbs_client_addr, pbs_conf.iff_path, server_name, server_port, psock, psock_port);
+	if (pbs_conf.encrypt_method[0] != '\0') {
+		snprintf(cmd[0], sizeof(cmd[0]) - 1, "%s=%s %s=%s %s %s %u %d %u",
+				PBS_IFF_CLIENT_ADDR, pbs_client_addr,
+				PBS_CONF_ENCRYPT_METHOD, pbs_conf.encrypt_method,
+				pbs_conf.iff_path, server_name, server_port,
+				psock, psock_port);
+	} else {
+		snprintf(cmd[0], sizeof(cmd[0]) - 1, "%s=%s %s %s %u %d %u",
+				PBS_IFF_CLIENT_ADDR, pbs_client_addr,
+				pbs_conf.iff_path, server_name, server_port,
+				psock, psock_port);
+	}
 
 	for (k = 0; k < 2; k++) {
 		rc = -1;
@@ -772,7 +795,7 @@ engage_client_auth(int fd, char *hostname, int port, char *ebuf, size_t ebufsz)
 			}
 		}
 	} else {
-		if (tcp_send_auth_req(fd, 0, pbs_current_user) != 0) {
+		if (tcp_send_auth_req(fd, 0, pbs_current_user, pbs_conf.auth_method, pbs_conf.encrypt_method) != 0) {
 			snprintf(ebuf, ebufsz, "Failed to send auth request");
 			free_auth_config(config);
 			return -1;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* As part of #1505, I added pbs_loadconf(0) in pbs_iff to get PBS_ENCRYPT_METHOD value from pbs.conf so it can pass that to the server along with PBS_BATCH_Authenticate request. But pbs_loadconf() is heavy function as it does IO + memory allocations + string parsing (aka key=value parsing) + much more stuff, so pbs_iff became slow, which slowdowns qdel sending requests to the server, which results in overall qdel slow.
And this issue is not only limited to qdel but all client commands who do connect/disconnect to the server per jobid...

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* Remove heavy pbs_loadconf() and pass encrypt method via environment variable, like we pass PBS_IFF_CLIENT_ADDR (aka client address)

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
* None

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
* valgrind logs - no new leak detected: [valgrind.txt](https://github.com/openpbs/openpbs/files/4763453/valgrind.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
