### PR TITLE
PBS fails local peering on server with multiple IPs

### DIFF
--- a/src/include/net_connect.h
+++ b/src/include/net_connect.h
@@ -199,6 +199,7 @@ void close_conn(int socket);
 pbs_net_t get_connectaddr(int sock);
 int  get_connecthost(int sock, char *namebuf, int size);
 pbs_net_t get_hostaddr(char *hostname);
+int comp_svraddr(pbs_net_t, char *);
 int  compare_short_hostname(char *shost, char *lhost);
 unsigned int  get_svrport(char *servicename, char *proto, unsigned int df);
 int  init_network(unsigned int port);

--- a/src/lib/Libnet/get_hostaddr.c
+++ b/src/lib/Libnet/get_hostaddr.c
@@ -177,3 +177,55 @@ compare_short_hostname(char *shost, char *lhost)
 	else
 		return 1;	/* no match */
 }
+
+/**
+ * @brief
+ *
+ * comp_svraddr - get internal internet address of the given host
+ *		  check to see if any of the addresses match the given server
+ *		  net address.
+ *
+ *
+ * @param[in] svr_addr - net address of the server
+ * @param[in] hostname - hostname whose internet addr needs to be compared
+ *
+ * @return	int
+ * @retval	0 address found
+ * @retval	1 address not found
+ * @retval	2 failed to find address
+ *
+ */
+int
+comp_svraddr(pbs_net_t svr_addr, char *hostname)
+{
+	struct addrinfo *aip, *pai;
+	struct addrinfo hints;
+	struct sockaddr_in *inp;
+	int		err;
+	pbs_net_t	res;
+
+	if ((hostname == 0) || (*hostname == '\0')) {
+		return (2);
+	}
+
+	memset(&hints, 0, sizeof(struct addrinfo));
+	hints.ai_family = AF_UNSPEC;
+	hints.ai_socktype = SOCK_STREAM;
+	hints.ai_protocol = IPPROTO_TCP;
+	if ((err = getaddrinfo(hostname, NULL, &hints, &pai)) != 0) {
+		return (2);
+	}
+	for (aip = pai; aip != NULL; aip = aip->ai_next) {
+		if (aip->ai_family == AF_INET) {
+			inp = (struct sockaddr_in *) aip->ai_addr;
+			res = ntohl(inp->sin_addr.s_addr);
+			if (res == svr_addr) {
+				freeaddrinfo(pai);
+				return 0;
+			}
+		}
+	}
+	/* no match found */
+	freeaddrinfo(pai);
+	return (1);
+}

--- a/src/lib/Libnet/get_hostaddr.c
+++ b/src/lib/Libnet/get_hostaddr.c
@@ -201,10 +201,9 @@ comp_svraddr(pbs_net_t svr_addr, char *hostname)
 	struct addrinfo *aip, *pai;
 	struct addrinfo hints;
 	struct sockaddr_in *inp;
-	int		err;
 	pbs_net_t	res;
 
-	if ((hostname == 0) || (*hostname == '\0')) {
+	if ((hostname == NULL) || (*hostname == '\0')) {
 		return (2);
 	}
 
@@ -212,7 +211,7 @@ comp_svraddr(pbs_net_t svr_addr, char *hostname)
 	hints.ai_family = AF_UNSPEC;
 	hints.ai_socktype = SOCK_STREAM;
 	hints.ai_protocol = IPPROTO_TCP;
-	if ((err = getaddrinfo(hostname, NULL, &hints, &pai)) != 0) {
+	if (getaddrinfo(hostname, NULL, &hints, &pai) != 0) {
 		return (2);
 	}
 	for (aip = pai; aip != NULL; aip = aip->ai_next) {

--- a/src/server/svr_movejob.c
+++ b/src/server/svr_movejob.c
@@ -160,7 +160,6 @@ extern struct work_task *add_mom_deferred_list(int stream, mominfo_t *minfo, voi
 int
 svr_movejob(job	*jobp, char *destination, struct batch_request *req)
 {
-	pbs_net_t destaddr;
 	unsigned int port = pbs_server_port_dis;
 	char	*toserver;
 
@@ -178,11 +177,14 @@ svr_movejob(job	*jobp, char *destination, struct batch_request *req)
 
 	if ((toserver = strchr(destination, '@')) != NULL) {
 		/* check to see if the part after '@' is this server */
-		destaddr = get_hostaddr(parse_servername(++toserver, &port));
-		if ((destaddr != pbs_server_addr) ||
+		int comp = -1;
+		comp = comp_svraddr(pbs_server_addr, parse_servername(++toserver, &port));
+		if ((comp == 1) ||
 			(port != pbs_server_port_dis)) {
 			return (net_move(jobp, req));	/* not a local dest */
 		}
+		else if (comp == 2)
+			return -1;
 	}
 
 	/* if get to here, it is a local destination */


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
When a local peering complex is configured on a machine that has more than one network interface, PBS server fails to identify that the move-job request issued by the scheduler is for the local server. This makes it try network move which fails because the job already exists in the destination server (which is actually the local server).
This issue only happens when the destination queue in sched_config is configured with a server name that's attached to one of the network interface which does not match PBS_SERVER in pbs.conf.


#### Describe Your Change
Change is to compare all the IP addresses of the destination server to the local pbs server, if any one of them match then the request needs to be honored locally.


#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
This issue happened on the Shasta setup. I was able to reproduce it manually in a container but I couldn't get ptl to work with this setup in a way that the test can run on Shasta as well as on the normal machine.
Since the issue is remote, I have attached manual test logs - 
[test_peer.txt](https://github.com/openpbs/openpbs/files/4749305/test_peer.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
