### PR TITLE
Fix TestSupportLinuxHookEventPhase1_2.test_prologue_attach_order on cpuset mom

### DIFF
--- a/test/tests/functional/pbs_support_linux_hook_event_phase1_2.py
+++ b/test/tests/functional/pbs_support_linux_hook_event_phase1_2.py
@@ -84,7 +84,7 @@ else:
         if self.momA.is_cpuset_mom():
             self.hostA = self.hostA + '[0]'
         if self.momB.is_cpuset_mom():
-            self.hostB = self.hostB + '[1]'
+            self.hostB = self.hostB + '[0]'
 
         # Job script
         test = []


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
TestSupportLinuxHookEventPhase1_2.test_prologue_attach_order test case is failing with Job in Q state.

#### Describe Your Change
In test case, self.hostB is assigned to self.momB[1] node if second mom is cpuset mom. If there is only one vnode on second cpuset mom then this test case would fail.
So changing self.momB[1] -> self.momB[0]


#### Attach Test and Valgrind Logs/Output
[TestSupportLinuxHookEventPhase1_2_logs_after_fix.txt](https://github.com/openpbs/openpbs/files/4750990/TestSupportLinuxHookEventPhase1_2_logs_after_fix.txt)
[TestSupportLinuxHookEventPhase1_2_logs_before_fix.txt](https://github.com/openpbs/openpbs/files/4751002/TestSupportLinuxHookEventPhase1_2_logs_before_fix.txt)