### PR TITLE
Eligible time doesn't get updated after the recent accrue_type change

### DIFF
--- a/src/server/job_func.c
+++ b/src/server/job_func.c
@@ -423,12 +423,14 @@ job_alloc(void)
 
 #ifndef PBS_MOM
 	/* start accruing time from the time job was created */
-	pj->ji_wattr[(int)JOB_ATR_sample_starttime].at_val.at_long = (long) time_now;
-	pj->ji_wattr[(int)JOB_ATR_eligible_time].at_val.at_long = 0;
+	pj->ji_wattr[JOB_ATR_sample_starttime].at_val.at_long = (long) time_now;
+	pj->ji_wattr[JOB_ATR_eligible_time].at_val.at_long = 0;
+	pj->ji_wattr[JOB_ATR_eligible_time].at_flags |= ATR_VFLAG_SET;
+	pj->ji_wattr[JOB_ATR_sample_starttime].at_flags |= ATR_VFLAG_SET;
 
 	/* if eligible_time_enable is not true, then job does not accrue eligible time */
 	if ((server.sv_attr[SRV_ATR_EligibleTimeEnable].at_flags & ATR_VFLAG_SET) &&
-		server.sv_attr[SRV_ATR_EligibleTimeEnable].at_val.at_long == 1) {
+	    server.sv_attr[SRV_ATR_EligibleTimeEnable].at_val.at_long == TRUE) {
 		int elig_val;
 
 		elig_val = determine_accruetype(pj);

--- a/src/server/job_func.c
+++ b/src/server/job_func.c
@@ -424,9 +424,9 @@ job_alloc(void)
 #ifndef PBS_MOM
 	/* start accruing time from the time job was created */
 	pj->ji_wattr[JOB_ATR_sample_starttime].at_val.at_long = (long) time_now;
+	pj->ji_wattr[JOB_ATR_sample_starttime].at_flags |= ATR_VFLAG_SET;
 	pj->ji_wattr[JOB_ATR_eligible_time].at_val.at_long = 0;
 	pj->ji_wattr[JOB_ATR_eligible_time].at_flags |= ATR_VFLAG_SET;
-	pj->ji_wattr[JOB_ATR_sample_starttime].at_flags |= ATR_VFLAG_SET;
 
 	/* if eligible_time_enable is not true, then job does not accrue eligible time */
 	if ((server.sv_attr[SRV_ATR_EligibleTimeEnable].at_flags & ATR_VFLAG_SET) &&

--- a/src/server/stat_job.c
+++ b/src/server/stat_job.c
@@ -79,6 +79,7 @@ extern attribute_def job_attr_def[];
 extern int	     resc_access_perm; /* see encode_resc() in attr_fn_resc.c */
 extern struct server server;
 extern char	     statechars[];
+extern time_t time_now;
 
 /**
  * @brief
@@ -249,7 +250,6 @@ int
 status_job(job *pjob, struct batch_request *preq, svrattrl *pal, pbs_list_head *pstathd, int *bad)
 {
 	struct brp_status *pstat;
-	time_t tm;
 	long oldtime = 0;
 	int old_elig_flags = 0;
 	int old_atyp_flags = 0;
@@ -267,11 +267,10 @@ status_job(job *pjob, struct batch_request *preq, svrattrl *pal, pbs_list_head *
 	}
 
 	/* calc eligible time on the fly and return, don't save. */
-	if (server.sv_attr[SRV_ATR_EligibleTimeEnable].at_val.at_long != 0) {
+	if (server.sv_attr[SRV_ATR_EligibleTimeEnable].at_val.at_long == TRUE) {
 		if (pjob->ji_wattr[JOB_ATR_accrue_type].at_val.at_long == JOB_ELIGIBLE) {
-			time(&tm);
 			oldtime = pjob->ji_wattr[JOB_ATR_eligible_time].at_val.at_long;
-			pjob->ji_wattr[JOB_ATR_eligible_time].at_val.at_long += ((long)tm - pjob->ji_wattr[JOB_ATR_sample_starttime].at_val.at_long);
+			pjob->ji_wattr[JOB_ATR_eligible_time].at_val.at_long += (time_now - pjob->ji_wattr[JOB_ATR_sample_starttime].at_val.at_long);
 			pjob->ji_wattr[JOB_ATR_eligible_time].at_flags |= (ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY);
 
 			/* Note: ATR_VFLAG_MODCACHE must be set because of svr_cached() does */

--- a/src/server/stat_job.c
+++ b/src/server/stat_job.c
@@ -267,12 +267,12 @@ status_job(job *pjob, struct batch_request *preq, svrattrl *pal, pbs_list_head *
 	}
 
 	/* calc eligible time on the fly and return, don't save. */
-	if (server.sv_attr[(int)SRV_ATR_EligibleTimeEnable].at_val.at_long != 0) {
-		if (pjob->ji_wattr[(int)JOB_ATR_accrue_type].at_val.at_long == JOB_ELIGIBLE) {
+	if (server.sv_attr[SRV_ATR_EligibleTimeEnable].at_val.at_long != 0) {
+		if (pjob->ji_wattr[JOB_ATR_accrue_type].at_val.at_long == JOB_ELIGIBLE) {
 			time(&tm);
-			oldtime = pjob->ji_wattr[(int)JOB_ATR_eligible_time].at_val.at_long;
-			pjob->ji_wattr[(int)JOB_ATR_eligible_time].at_val.at_long += ((long)tm - pjob->ji_wattr[(int)JOB_ATR_sample_starttime].at_val.at_long);
-			pjob->ji_wattr[(int)JOB_ATR_eligible_time].at_flags |= ATR_VFLAG_MODCACHE;
+			oldtime = pjob->ji_wattr[JOB_ATR_eligible_time].at_val.at_long;
+			pjob->ji_wattr[JOB_ATR_eligible_time].at_val.at_long += ((long)tm - pjob->ji_wattr[JOB_ATR_sample_starttime].at_val.at_long);
+			pjob->ji_wattr[JOB_ATR_eligible_time].at_flags |= (ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY);
 
 			/* Note: ATR_VFLAG_MODCACHE must be set because of svr_cached() does */
 			/* 	 not correctly check ATR_VFLAG_SET */

--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -4626,7 +4626,7 @@ update_eligible_time(long newaccruetype, job *pjob)
 	char *strtime;
 	static char errtime[] = "00:00:00";
 	char str[256];
-	long accrued_time;			/* accrued time */
+	long accrued_time = 0;			/* accrued time */
 	long oldaccruetype = pjob->ji_wattr[(int)JOB_ATR_accrue_type].at_val.at_long;
 	long timestamp = (long) time_now; 	/* time since accrual begins */
 	unsigned int flags = (ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY);
@@ -4638,27 +4638,17 @@ update_eligible_time(long newaccruetype, job *pjob)
 	/* time since accrue type last changed  */
 	accrued_time = timestamp - pjob->ji_wattr[JOB_ATR_sample_starttime].at_val.at_long;
 
-	/* time since accrue type last changed is accrued */
-	/* change type to new accrue type,  update start time to mark */
-	/* change of accrue type */
-	switch ((int)oldaccruetype) {
-		case JOB_ELIGIBLE:
-			pjob->ji_wattr[JOB_ATR_eligible_time].at_val.at_long += accrued_time;
-			pjob->ji_wattr[JOB_ATR_eligible_time].at_flags |= flags;
-		case JOB_INELIGIBLE:
-		case JOB_RUNNING:
-		case JOB_INITIAL:
-		case JOB_EXIT:
-			pjob->ji_wattr[JOB_ATR_accrue_type].at_val.at_long = newaccruetype;
-			pjob->ji_wattr[JOB_ATR_sample_starttime].at_val.at_long = timestamp;
-			pjob->ji_wattr[JOB_ATR_accrue_type].at_flags |= flags;
-			pjob->ji_wattr[JOB_ATR_sample_starttime].at_flags |= flags;
-			break;
+	if (oldaccruetype == JOB_ELIGIBLE && accrued_time > 0) {
+		pjob->ji_wattr[JOB_ATR_eligible_time].at_val.at_long += accrued_time;
+		pjob->ji_wattr[JOB_ATR_eligible_time].at_flags |= flags;
+	} else
+		pjob->ji_wattr[JOB_ATR_eligible_time].at_flags |= ATR_VFLAG_SET;
 
-		default:
-			break;
-
-	}  /*switch end*/
+	/* change type to new accrue type, update start time to mark change of accrue type */
+	pjob->ji_wattr[JOB_ATR_accrue_type].at_val.at_long = newaccruetype;
+	pjob->ji_wattr[JOB_ATR_accrue_type].at_flags |= flags;
+	pjob->ji_wattr[JOB_ATR_sample_starttime].at_val.at_long = timestamp;
+	pjob->ji_wattr[JOB_ATR_sample_starttime].at_flags |= flags;
 
 	/* Prepare and print log message */
 	strtime = convert_long_to_time(pjob->ji_wattr[JOB_ATR_eligible_time].at_val.at_long);

--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -4641,8 +4641,7 @@ update_eligible_time(long newaccruetype, job *pjob)
 	if (oldaccruetype == JOB_ELIGIBLE && accrued_time > 0) {
 		pjob->ji_wattr[JOB_ATR_eligible_time].at_val.at_long += accrued_time;
 		pjob->ji_wattr[JOB_ATR_eligible_time].at_flags |= flags;
-	} else
-		pjob->ji_wattr[JOB_ATR_eligible_time].at_flags |= ATR_VFLAG_SET;
+	}
 
 	/* change type to new accrue type, update start time to mark change of accrue type */
 	pjob->ji_wattr[JOB_ATR_accrue_type].at_val.at_long = newaccruetype;

--- a/test/tests/functional/pbs_eligible_time.py
+++ b/test/tests/functional/pbs_eligible_time.py
@@ -55,12 +55,13 @@ class TestEligibleTime(TestFunctional):
 
     def test_eligible_time_updated(self):
         """
-        Test that eligible time gets updated when a job has accrue_type eligible
+        Test that eligible time gets updated when a job is eligible
         """
         a = {'resources_available.ncpus': 1}
         self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom.shortname)
 
-        self.server.manager(MGR_CMD_SET, SERVER, {"eligible_time_enable": "True"})
+        self.server.manager(MGR_CMD_SET, SERVER,
+                            {"eligible_time_enable": "True"})
 
         jid1 = self.server.submit(Job())
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)

--- a/test/tests/functional/pbs_eligible_time.py
+++ b/test/tests/functional/pbs_eligible_time.py
@@ -53,6 +53,24 @@ class TestEligibleTime(TestFunctional):
         self.server.manager(MGR_CMD_SET, SERVER, a)
         self.accrue = {'ineligible': 1, 'eligible': 2, 'run': 3, 'exit': 4}
 
+    def test_eligible_time_updated(self):
+        """
+        Test that eligible time gets updated when a job has accrue_type eligible
+        """
+        a = {'resources_available.ncpus': 1}
+        self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom.shortname)
+
+        self.server.manager(MGR_CMD_SET, SERVER, {"eligible_time_enable": "True"})
+
+        jid1 = self.server.submit(Job())
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
+
+        jid2 = self.server.submit(Job())
+        a = {ATTR_state: 'Q', "accrue_type": "2"}
+        self.server.expect(JOB, a, id=jid2)
+
+        self.server.expect(JOB, {"eligible_time": "00:00:00"}, op=NE, id=jid2)
+
     def test_qsub_a(self):
         """
         Test that jobs requsting qsub -a <time> do not accrue


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
After the check-in of #1708 , a bug was introduced which caused eligible time attribute to not be printed on job stats. This happened because I was not setting the ATR_VFLAG_SET to eligible time's attribute flags, which made svrcached() skip it while serving job stats.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Now adding ATR_VFLAG_SET to flags correctly inside update_eligible_time().

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[after_fix.log](https://github.com/openpbs/openpbs/files/4756115/after_fix.log)
[before_fix.log](https://github.com/openpbs/openpbs/files/4756116/before_fix.log)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
