### PR TITLE
Fix issues #1817 and #1818 seen by drtoss

### DIFF
--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -3339,7 +3339,7 @@ class CgroupUtils(object):
             # before calling splitlines
             # should not happen since we pass universal_newlines True
             out_split = stringified_output(out).splitlines()
-            ver = int(re.sub(r'Version=([0-9]+)', r'\1', out_split[0]))
+            ver = int(re.sub(r'Version=\D*(\d+)', r'\1', out_split[0]))
         except Exception:
             # Note we also get here if we can't decode an int version
             return 0
@@ -3835,12 +3835,12 @@ class CgroupUtils(object):
                 # and ncpus_are_cores are both True)
                 pass
             elif needed <= len(cores):
-                    corelist = sorted(cores)
-                    assigned['cpuset.cpus'] += corelist[:needed]
+                corelist = sorted(cores)
+                assigned['cpuset.cpus'] += corelist[:needed]
             else:
-                    pbs.logmsg(pbs.EVENT_DEBUG4, '%s: %d ncpus still needed' %
-                               (caller_name(), len(cores) - needed))
-                    return {}
+                pbs.logmsg(pbs.EVENT_DEBUG4, '%s: %d ncpus still needed' %
+                           (caller_name(), len(cores) - needed))
+                return {}
 
             # Set cpuset.mems to the socketlist for now even though
             # there may not be sufficient memory. Memory gets

--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -138,10 +138,7 @@ else:
     import fcntl
     import pwd
 
-    if sys.version_info[0] < 3:
-        PYTHON2 = True
-    else:
-        PYTHON2 = False
+    PYTHON2 = sys.version_info[0] < 3
 
     try:
         bytearray
@@ -621,29 +618,28 @@ def printjob_info(jobid, include_attributes=False):
         cmd.append('-a')
     cmd.append(jobfile)
     try:
-        err_nonsplit = ''
         pbs.logmsg(pbs.EVENT_DEBUG4, 'Running: %s' % cmd)
         process = subprocess.Popen(cmd, shell=False,
                                    stdout=subprocess.PIPE,
                                    stderr=subprocess.PIPE,
                                    universal_newlines=True)
-        out_nonsplit, err_nonsplit = process.communicate()
+        out, err = process.communicate()
         if process.returncode != 0:
             pbs.logmsg(pbs.EVENT_DEBUG4,
                        'command return code non-zero: %s'
                        % str(process.returncode))
             pbs.logmsg(pbs.EVENT_DEBUG4,
                        'command stderr: %s'
-                       % stringified_output(err_nonsplit))
+                       % stringified_output(err))
     except Exception as exc:
         pbs.logmsg(pbs.EVENT_DEBUG2, 'Error running command: %s' % cmd)
         pbs.logmsg(pbs.EVENT_DEBUG2, 'Exception: %s' % exc)
         return {}
     # if we get a non-str type then convert before calling splitlines
     # should not happen since we pass universal_newlines True
-    out = stringified_output(out_nonsplit).splitlines()
+    out_split = stringified_output(out).splitlines()
     pattern = re.compile(r'^(\w.*):\s*(\S+)')
-    for line in out:
+    for line in out_split:
         result = re.match(pattern, line)
         if not result:
             continue
@@ -1781,7 +1777,7 @@ class NodeUtils(object):
                                        stdout=subprocess.PIPE,
                                        stderr=subprocess.PIPE,
                                        universal_newlines=True)
-            out_nonsplit = process.communicate()[0]
+            out = process.communicate()[0]
         except Exception:
             pbs.logmsg(pbs.EVENT_DEBUG4, 'Failed to execute: %s' %
                        " ".join(cmd))
@@ -1797,7 +1793,7 @@ class NodeUtils(object):
         try:
             # Try parsing the output
             import xml.etree.ElementTree as xmlet
-            root = xmlet.fromstring(stringified_output(out_nonsplit))
+            root = xmlet.fromstring(stringified_output(out))
             pbs.logmsg(pbs.EVENT_DEBUG4, 'root.tag: %s' % root.tag)
             for child in root:
                 if child.tag == 'gpu':
@@ -3067,7 +3063,7 @@ class CgroupUtils(object):
                                            stdout=subprocess.PIPE,
                                            stderr=subprocess.PIPE,
                                            universal_newlines=True)
-                out_nonsplit = process.communicate()[0]
+                out = process.communicate()[0]
                 if (process.returncode == 0):
                     # service is already active -- no need to create it
                     return
@@ -3106,13 +3102,12 @@ class CgroupUtils(object):
                        % (caller_name(), servicefile))
             raise
         try:
-            err_nonsplit = ''
             cmd = ['systemctl', 'start', os.path.basename(servicefile)]
             process = subprocess.Popen(cmd, shell=False,
                                        stdout=subprocess.PIPE,
                                        stderr=subprocess.PIPE,
                                        universal_newlines=True)
-            out_nonsplit, err_nonsplit = process.communicate()
+            out, err = process.communicate()
             if (process.returncode == 0):
                 pbs.logmsg(pbs.EVENT_DEBUG,
                            '%s: Started systemd service with file %s'
@@ -3123,7 +3118,7 @@ class CgroupUtils(object):
                            % (caller_name(), process.returncode))
                 pbs.logmsg(pbs.EVENT_ERROR, '%s: stderr of systemctl was: %s'
                            % (caller_name(),
-                              stringified_output(err_nonsplit)))
+                              stringified_output(err)))
         except Exception:
             pbs.logmsg(pbs.EVENT_DEBUG,
                        '%s: Failed to start systemd service: %s'
@@ -3339,12 +3334,12 @@ class CgroupUtils(object):
                                        stdout=subprocess.PIPE,
                                        stderr=subprocess.PIPE,
                                        universal_newlines=True)
-            out_nonsplit = process.communicate()[0]
+            out = process.communicate()[0]
             # if we get a non-str type then convert
             # before calling splitlines
             # should not happen since we pass universal_newlines True
-            out = stringified_output(out_nonsplit).splitlines()
-            ver = int(re.sub(r'Version=([0-9]+)', r'\1', out[0]))
+            out_split = stringified_output(out).splitlines()
+            ver = int(re.sub(r'Version=([0-9]+)', r'\1', out_split[0]))
         except Exception:
             # Note we also get here if we can't decode an int version
             return 0
@@ -3835,14 +3830,18 @@ class CgroupUtils(object):
             # assigned all of the fully avaiable cores. There still may
             # be cores to assign. When use_hyperthreads is disabled, we
             # assign all the cores here.
-            if needed >= 1:
-                if needed > len(cores):
+            if needed <= 0:
+                # we're done (will always hold if use_hyperthreads
+                # and ncpus_are_cores are both True)
+                pass
+            elif needed <= len(cores):
+                    corelist = sorted(cores)
+                    assigned['cpuset.cpus'] += corelist[:needed]
+            else:
                     pbs.logmsg(pbs.EVENT_DEBUG4, '%s: %d ncpus still needed' %
                                (caller_name(), len(cores) - needed))
                     return {}
-                else:
-                    corelist = sorted(cores)
-                    assigned['cpuset.cpus'] += corelist[:needed]
+
             # Set cpuset.mems to the socketlist for now even though
             # there may not be sufficient memory. Memory gets
             # checked later in this method.
@@ -4657,7 +4656,7 @@ class CgroupUtils(object):
                 except Exception:
                     jobdict = dict()
                     pbs.logmsg(pbs.EVENT_DEBUG2,
-                               '%s: Failed gathering local job data' %
+                               '%s: Failed to gather local job data' %
                                caller_name())
                 # There may not be a .JB file present for this job yet
                 if jobid not in jobdict:
@@ -5251,15 +5250,15 @@ class CgroupUtils(object):
             proc = subprocess.Popen(['dmesg'], shell=False,
                                     stdout=subprocess.PIPE,
                                     universal_newlines=True)
-            out_nonsplit = proc.communicate()[0]
+            out = proc.communicate()[0]
             # if we get a non-str type then convert before calling splitlines
             # should not happen since we pass universal_newlines True
-            out = stringified_output(out_nonsplit).splitlines()
+            out_split = stringified_output(out).splitlines()
         except Exception:
             return ''
-        out.reverse()
+        out_split.reverse()
         # Check to see if the job id is found in dmesg output
-        for line in out:
+        for line in out_split:
             start = line.find('Killed process ')
             if start < 0:
                 start = line.find('Task in /%s' % self.cfg['cgroup_prefix'])

--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -143,7 +143,7 @@ else:
     try:
         bytearray
         BYTEARRAY_EXISTS = True
-    except Exception:
+    except NameError:
         BYTEARRAY_EXISTS = False
 
 # Define some globals that get set in main

--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -3800,8 +3800,9 @@ class CgroupUtils(object):
             if self.cfg['use_hyperthreads'] and self.cfg['ncpus_are_cores']:
                 needed *= node.cpuinfo['hyperthreads_per_core']
             if needed > avail:
-                pbs.logmsg(pbs.EVENT_DEBUG4, '%s: Insufficient ncpus: %s/%s' %
-                           (caller_name(), needed, avail))
+                pbs.logmsg(pbs.EVENT_DEBUG4,
+                           '%s: insufficient ncpus: %s needed, %s available'
+                           % (caller_name(), needed, avail))
                 return {}
             if self.cfg['use_hyperthreads']:
                 # Find cores that are fully available
@@ -3838,8 +3839,10 @@ class CgroupUtils(object):
                 corelist = sorted(cores)
                 assigned['cpuset.cpus'] += corelist[:needed]
             else:
-                pbs.logmsg(pbs.EVENT_DEBUG4, '%s: %d ncpus still needed' %
-                           (caller_name(), len(cores) - needed))
+                pbs.logmsg(pbs.EVENT_DEBUG4,
+                           '%s: in final pass, '
+                           '%d more ncpus needed than available'
+                           % (caller_name(), needed - len(cores)))
                 return {}
 
             # Set cpuset.mems to the socketlist for now even though

--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -86,6 +86,7 @@ rel = list(map(int, (platform.release().split('-')[0].split('.'))))
 pbs.logmsg(pbs.EVENT_DEBUG4,
            'Cgroup hook: detected Linux kernel version %d.%d.%d' %
            (rel[0], rel[1], rel[2]))
+
 supported = False
 if rel[0] > 2:
     supported = True
@@ -95,6 +96,7 @@ elif rel[0] == 2:
     elif rel[1] == 6:
         if rel[2] >= 28:
             supported = True
+
 if not supported:
     pbs.logmsg(pbs.EVENT_DEBUG,
                'Cgroup hook: kernel %s.%s.%s < 2.6.28; not supported'
@@ -135,6 +137,11 @@ else:
         pass
     import fcntl
     import pwd
+
+    if sys.version_info[0] < 3:
+        PYTHON2 = True
+    else:
+        PYTHON2 = False
 
 # Define some globals that get set in main
 PBS_EXEC = ''
@@ -215,6 +222,26 @@ class TimeoutError(ProcessingError):
 # ============================================================================
 
 #
+# FUNCTION stringified_output
+#
+def stringified_output(out):
+    if PYTHON2:
+        if isinstance(out, str):
+            return(out)
+        elif isinstance(out, unicode):
+            return(out.encode('utf-8'))
+        else:
+            return(str(out))
+    else:
+        if isinstance(out, str):
+            return(out)
+        elif isinstance(out, (bytes, bytearray)):
+            return(out.decode('utf-8'))
+        else:
+            return(str(out))
+
+
+#
 # FUNCTION caller_name
 #
 def caller_name():
@@ -238,7 +265,7 @@ def systemd_escape(buf):
     ret = ''
     for i, char in enumerate(buf):
         if i < 1 and char == '.':
-            if (sys.version_info[0] < 3):
+            if PYTHON2:
                 ret += '\\x' + '.'.encode('hex')
             else:
                 ret += '\\x' + b'.'.hex()
@@ -248,7 +275,7 @@ def systemd_escape(buf):
             ret += '-'
         else:
             # Will turn non-ASCII into UTF-8 hex sequence on both Py2/3
-            if (sys.version_info[0] < 3):
+            if PYTHON2:
                 hexval = char.encode('hex')
             else:
                 hexval = char.encode('utf-8').hex()
@@ -376,17 +403,19 @@ def decode_list(data):
     for item in data:
         if isinstance(item, str):
             pass
-        elif (sys.version_info[0] < 3) and isinstance(item, unicode):
-            item = item.encode('utf-8')
-        elif isinstance(item, (bytes, bytearray)):
-            if sys.version_info[0] >= 3:
-                item = str(item, 'utf-8')
-            else:
-                item = str(item)
-        elif isinstance(item, list):
+        if isinstance(item, list):
             item = decode_list(item)
         elif isinstance(item, dict):
             item = decode_dict(item)
+        elif PYTHON2:
+            if isinstance(item, unicode):
+                item = item.encode('utf-8')
+            else:
+                item = str(item)
+        elif isinstance(item, (bytes, bytearray)):
+            item = str(item, 'utf-8')
+        else:
+            item = str(item)
         ret.append(item)
     return ret
 
@@ -400,29 +429,32 @@ def decode_dict(data):
         # first the key
         if isinstance(key, str):
             pass
-        elif (sys.version_info[0] < 3) and isinstance(key, unicode):
-            key = key.encode('utf-8')
-        elif isinstance(key, (bytes, bytearray)):
-            if sys.version_info[0] >= 3:
-                key = str(key, 'utf-8')
+        elif PYTHON2:
+            if isinstance(key, unicode):
+                key = key.encode('utf-8')
             else:
                 key = str(key)
+        elif isinstance(key, (bytes, bytearray)):
+            key = str(key, 'utf-8')
+        else:
+            key = str(key)
 
         # now the value
         if isinstance(value, str):
             pass
-        elif (sys.version_info[0] < 3) and isinstance(value, unicode):
-            value = value.encode('utf-8')
-        elif isinstance(value, (bytes, bytearray)):
-            if sys.version_info[0] >= 3:
-                value = str(value, 'utf-8')
-            else:
-                key = str(value)
-
-        elif isinstance(value, list):
+        if isinstance(value, list):
             value = decode_list(value)
         elif isinstance(value, dict):
             value = decode_dict(value)
+        elif PYTHON2:
+            if isinstance(value, unicode):
+                value = value.encode('utf-8')
+            else:
+                value = str(value)
+        elif isinstance(value, (bytes, bytearray)):
+            value = str(value, 'utf-8')
+        else:
+            value = str(value)
 
         # add stringified (key, value) pair to result
         ret[key] = value
@@ -589,25 +621,29 @@ def printjob_info(jobid, include_attributes=False):
         cmd.append('-a')
     cmd.append(jobfile)
     try:
+        err_nonsplit = ''
         pbs.logmsg(pbs.EVENT_DEBUG4, 'Running: %s' % cmd)
         process = subprocess.Popen(cmd, shell=False,
                                    stdout=subprocess.PIPE,
-                                   stderr=subprocess.PIPE)
-        out, err = process.communicate()
+                                   stderr=subprocess.PIPE,
+                                   universal_newlines=True)
+        out_nonsplit, err_nonsplit = process.communicate()
+        if process.returncode != 0:
+            pbs.logmsg(pbs.EVENT_DEBUG4,
+                       'command return code non-zero: %s'
+                       % str(process.returncode))
+            pbs.logmsg(pbs.EVENT_DEBUG4,
+                       'command stderr: %s'
+                       % stringified_output(err_nonsplit))
     except Exception as exc:
         pbs.logmsg(pbs.EVENT_DEBUG2, 'Error running command: %s' % cmd)
-        pbs.logmsg(pbs.EVENT_DEBUG2, 'Error message: %s' % err)
         pbs.logmsg(pbs.EVENT_DEBUG2, 'Exception: %s' % exc)
-        return info
+        return {}
+    # if we get a non-str type then convert before calling splitlines
+    # should not happen since we pass universal_newlines True
+    out = stringified_output(out_nonsplit).splitlines()
     pattern = re.compile(r'^(\w.*):\s*(\S+)')
-    if (not isinstance(out, str)
-            and isinstance(out, (bytes, bytearray))):
-        if sys.version_info[0] >= 3:
-            out = out.decode('utf-8')
-        else:
-            out = str(out)
-
-    for line in out.splitlines():
+    for line in out:
         result = re.match(pattern, line)
         if not result:
             continue
@@ -1743,8 +1779,9 @@ class NodeUtils(object):
             # Try running the nvidia-smi command
             process = subprocess.Popen(cmd, shell=False,
                                        stdout=subprocess.PIPE,
-                                       stderr=subprocess.PIPE)
-            out, err = process.communicate()
+                                       stderr=subprocess.PIPE,
+                                       universal_newlines=True)
+            out_nonsplit = process.communicate()[0]
         except Exception:
             pbs.logmsg(pbs.EVENT_DEBUG4, 'Failed to execute: %s' %
                        " ".join(cmd))
@@ -1755,10 +1792,12 @@ class NodeUtils(object):
             pbs.logmsg(pbs.EVENT_DEBUG,
                        '%s: nvidia-smi call took %f seconds' %
                        (caller_name(), elapsed_time))
+        # if we get a non-str type then convert before calling xmlet
+        # should not happen since we passed universal_newlines True
         try:
             # Try parsing the output
             import xml.etree.ElementTree as xmlet
-            root = xmlet.fromstring(out)
+            root = xmlet.fromstring(stringified_output(out_nonsplit))
             pbs.logmsg(pbs.EVENT_DEBUG4, 'root.tag: %s' % root.tag)
             for child in root:
                 if child.tag == 'gpu':
@@ -1852,8 +1891,8 @@ class NodeUtils(object):
                     or 'AuthenticAMD' in cpuinfo['cpu'][0]['vendor_id']):
                 if 'ht' in cpuinfo['cpu'][0]['flags']:
                     cpuinfo['hyperthreads_per_core'] = \
-                        (cpuinfo['cpu'][0]['siblings']
-                         / cpuinfo['cpu'][0]['cpu cores'])
+                        int(cpuinfo['cpu'][0]['siblings']
+                            // cpuinfo['cpu'][0]['cpu cores'])
                     # Map hyperthreads to physical cores
                     if cpuinfo['hyperthreads_per_core'] > 1:
                         pbs.logmsg(pbs.EVENT_DEBUG4,
@@ -1888,8 +1927,8 @@ class NodeUtils(object):
         except Exception:
             pbs.logmsg(pbs.EVENT_DEBUG, '%s: Hyperthreading check failed' %
                        caller_name())
-        cpuinfo['physical_cpus'] = cpuinfo['logical_cpus'] / \
-            cpuinfo['hyperthreads_per_core']
+        cpuinfo['physical_cpus'] = int(cpuinfo['logical_cpus']
+                                       // cpuinfo['hyperthreads_per_core'])
         pbs.logmsg(pbs.EVENT_DEBUG4, '%s returning: %s' %
                    (caller_name(), cpuinfo))
         return cpuinfo
@@ -2247,11 +2286,13 @@ class NodeUtils(object):
                     if not self.cfg['use_hyperthreads']:
                         # Do not treat a hyperthread as a core when
                         # use_hyperthreads is false.
-                        threads /= self.cpuinfo['hyperthreads_per_core']
+                        threads = int(threads
+                                      // self.cpuinfo['hyperthreads_per_core'])
                     elif self.cfg['ncpus_are_cores']:
                         # use_hyperthreads and ncpus_are_cores are both true,
                         # advertise only one thread per core
-                        threads /= self.cpuinfo['hyperthreads_per_core']
+                        threads = int(threads
+                                      // self.cpuinfo['hyperthreads_per_core'])
                     if vnodes:
                         # set the value on the host to 0
                         host_resc_avail['ncpus'] = 0
@@ -2699,10 +2740,10 @@ class CgroupUtils(object):
         except NameError:
             basestring = str
         # We want a view/iterator object, not something that creates copied
-        # lists. Unfortunately, iteritems/viewitems() no longer exists in Py3
+        # lists. iteritems/viewitems() no longer exists in Py3
         # since items() itself is now implemented as a view object.
-        dict_iter_object = (config_dict.items() if sys.version_info[0] >= 3
-                            else config_dict.iteritems())
+        dict_iter_object = (config_dict.iteritems() if PYTHON2
+                            else config_dict.items())
         for key_found, value_found in dict_iter_object:
             if isinstance(value_found, dict):
                 # subsection found
@@ -3024,16 +3065,20 @@ class CgroupUtils(object):
                 cmd = ['systemctl', 'is-active', self.cfg['cgroup_prefix']]
                 process = subprocess.Popen(cmd, shell=False,
                                            stdout=subprocess.PIPE,
-                                           stderr=subprocess.PIPE)
-                out, err = process.communicate()
+                                           stderr=subprocess.PIPE,
+                                           universal_newlines=True)
+                out_nonsplit = process.communicate()[0]
                 if (process.returncode == 0):
                     # service is already active -- no need to create it
                     return
                 else:
                     pbs.logmsg(pbs.EVENT_DEBUG,
-                               '%s: systemctl is-active <service> returned %s'
-                               % (caller_name(), cmd.returncode))
+                               '%s: systemctl is-active <svc> return code %s'
+                               % (caller_name(), process.returncode))
             except Exception:
+                pbs.logmsg(pbs.EVENT_DEBUG4,
+                           '%s: Failed to call systemctl is-active'
+                           % caller_name())
                 # was worth a try -- try to create service now
                 # and see if that fails
                 pass
@@ -3061,18 +3106,29 @@ class CgroupUtils(object):
                        % (caller_name(), servicefile))
             raise
         try:
+            err_nonsplit = ''
             cmd = ['systemctl', 'start', os.path.basename(servicefile)]
             process = subprocess.Popen(cmd, shell=False,
                                        stdout=subprocess.PIPE,
-                                       stderr=subprocess.PIPE)
-            out, err = process.communicate()
+                                       stderr=subprocess.PIPE,
+                                       universal_newlines=True)
+            out_nonsplit, err_nonsplit = process.communicate()
+            if (process.returncode == 0):
+                pbs.logmsg(pbs.EVENT_DEBUG,
+                           '%s: Started systemd service with file %s'
+                           % (caller_name(), servicefile))
+            else:
+                pbs.logmsg(pbs.EVENT_ERROR,
+                           '%s: systemctl start <svc> return code %s'
+                           % (caller_name(), process.returncode))
+                pbs.logmsg(pbs.EVENT_ERROR, '%s: stderr of systemctl was: %s'
+                           % (caller_name(),
+                              stringified_output(err_nonsplit)))
         except Exception:
             pbs.logmsg(pbs.EVENT_DEBUG,
-                       '%s: Failed to start systemd service: %s' %
-                       (caller_name(), os.path.basename(servicefile)))
+                       '%s: Failed to start systemd service: %s'
+                       % (caller_name(), os.path.basename(servicefile)))
             raise
-        pbs.logmsg(pbs.EVENT_DEBUG, '%s: Started systemd service with file %s'
-                   % (caller_name(), servicefile))
 
     def create_paths(self):
         """
@@ -3281,9 +3337,14 @@ class CgroupUtils(object):
                                         '--property=Version'],
                                        shell=False,
                                        stdout=subprocess.PIPE,
-                                       stderr=subprocess.PIPE)
-            out, err = process.communicate()
-            ver = int(re.sub(r'Version=([0-9]+)', r'\1', out.splitlines()[0]))
+                                       stderr=subprocess.PIPE,
+                                       universal_newlines=True)
+            out_nonsplit = process.communicate()[0]
+            # if we get a non-str type then convert
+            # before calling splitlines
+            # should not happen since we pass universal_newlines True
+            out = stringified_output(out_nonsplit).splitlines()
+            ver = int(re.sub(r'Version=([0-9]+)', r'\1', out[0]))
         except Exception:
             # Note we also get here if we can't decode an int version
             return 0
@@ -3774,12 +3835,14 @@ class CgroupUtils(object):
             # assigned all of the fully avaiable cores. There still may
             # be cores to assign. When use_hyperthreads is disabled, we
             # assign all the cores here.
-            corelist = sorted(cores)
-            if needed > len(corelist):
-                pbs.logmsg(pbs.EVENT_DEBUG4, '%s: %d ncpus still needed' %
-                           (caller_name(), len(corelist) - needed))
-                return {}
-            assigned['cpuset.cpus'] += corelist[:needed]
+            if needed >= 1:
+                if needed > len(cores):
+                    pbs.logmsg(pbs.EVENT_DEBUG4, '%s: %d ncpus still needed' %
+                               (caller_name(), len(cores) - needed))
+                    return {}
+                else:
+                    corelist = sorted(cores)
+                    assigned['cpuset.cpus'] += corelist[:needed]
             # Set cpuset.mems to the socketlist for now even though
             # there may not be sufficient memory. Memory gets
             # checked later in this method.
@@ -4363,10 +4426,10 @@ class CgroupUtils(object):
                         cput = 0
                 # Calculate cpupercent based on the reported values
                 if walltime > 0:
-                    cpupercent = 100 * cput / walltime
+                    cpupercent = (100.0 * cput) / walltime
                 else:
                     cpupercent = 0
-                resc_used['cpupercent'] = pbs.pbs_int(cpupercent)
+                resc_used['cpupercent'] = pbs.pbs_int(int(cpupercent))
                 pbs.logjobmsg(jobid, '%s: CPU percent: %d' %
                               (caller_name(), cpupercent))
                 # Now update cput
@@ -4502,11 +4565,16 @@ class CgroupUtils(object):
                             'vmem limit (%s) exceeds vmem requested (%s)' %
                             (vmem_limit, vmem_requested))
                 if size_as_int(vmem_limit) > size_as_int(mem_limit):
-                    # This job may utilize swap
+                    # This job may try to utilize swap
                     if size_as_int(vmem_avail) <= size_as_int(mem_avail):
                         # No swap available
-                        raise CgroupLimitError('Job might utilize swap '
-                                               'and no swap space available')
+                        if vmem_requested is not None:
+                            raise CgroupLimitError('Job might utilize swap'
+                                                   ' and no swap on host')
+                        else:
+                            # It got its impossible vmem>mem from a default
+                            # undo that since there is no swap
+                            vmem_limit = mem_limit
             # Assign mem and vmem
             if mem_enabled:
                 if mem_requested is None:
@@ -4589,7 +4657,7 @@ class CgroupUtils(object):
                 except Exception:
                     jobdict = dict()
                     pbs.logmsg(pbs.EVENT_DEBUG2,
-                               '%s: Failed to resyncing local job data' %
+                               '%s: Failed gathering local job data' %
                                caller_name())
                 # There may not be a .JB file present for this job yet
                 if jobid not in jobdict:
@@ -5181,17 +5249,12 @@ class CgroupUtils(object):
         pbs.logmsg(pbs.EVENT_DEBUG4, '%s: Method called' % caller_name())
         try:
             proc = subprocess.Popen(['dmesg'], shell=False,
-                                    stdout=subprocess.PIPE)
-            if (sys.version_info[0] < 3):
-                # string returned is a raw byte array in Py2, we don't care
-                # about what happens to special characters here as long as we
-                # can match the job cgroups-- assume no one is foolish
-                # enough to use non-ASCII in the cgroup prefix ot server name
-                out = proc.communicate()[0].splitlines()
-            else:
-                # Python 3 gets a UTF-8 encoded byte array,
-                # convert to normal Py3 string
-                out = proc.communicate()[0].decode('utf-8').splitlines()
+                                    stdout=subprocess.PIPE,
+                                    universal_newlines=True)
+            out_nonsplit = proc.communicate()[0]
+            # if we get a non-str type then convert before calling splitlines
+            # should not happen since we pass universal_newlines True
+            out = stringified_output(out_nonsplit).splitlines()
         except Exception:
             return ''
         out.reverse()

--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -143,6 +143,12 @@ else:
     else:
         PYTHON2 = False
 
+    try:
+        bytearray
+        BYTEARRAY_EXISTS = True
+    except Exception:
+        BYTEARRAY_EXISTS = False
+
 # Define some globals that get set in main
 PBS_EXEC = ''
 PBS_HOME = ''
@@ -410,12 +416,10 @@ def decode_list(data):
         elif PYTHON2:
             if isinstance(item, unicode):
                 item = item.encode('utf-8')
-            else:
+            elif BYTEARRAY_EXISTS and isinstance(item, bytearray):
                 item = str(item)
         elif isinstance(item, (bytes, bytearray)):
             item = str(item, 'utf-8')
-        else:
-            item = str(item)
         ret.append(item)
     return ret
 
@@ -432,12 +436,10 @@ def decode_dict(data):
         elif PYTHON2:
             if isinstance(key, unicode):
                 key = key.encode('utf-8')
-            else:
+            elif BYTEARRAY_EXISTS and isinstance(key, bytearray):
                 key = str(key)
         elif isinstance(key, (bytes, bytearray)):
             key = str(key, 'utf-8')
-        else:
-            key = str(key)
 
         # now the value
         if isinstance(value, str):
@@ -449,12 +451,10 @@ def decode_dict(data):
         elif PYTHON2:
             if isinstance(value, unicode):
                 value = value.encode('utf-8')
-            else:
+            elif BYTEARRAY_EXISTS and isinstance(key, bytearray):
                 value = str(value)
         elif isinstance(value, (bytes, bytearray)):
             value = str(value, 'utf-8')
-        else:
-            value = str(value)
 
         # add stringified (key, value) pair to result
         ret[key] = value

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -1372,24 +1372,25 @@ if %s e.job.in_ms_mom():
         #
         # Entries for older hooks deleted. I am leaving them as comments should
         # this be used to test old hooks, but DO NOT put them at the top
-        # when testing newer hooks, or you will run into race conditions with
-        # some of the hardcoded test timings
+        # of the list when testing newer hooks, or you will run into
+        # race conditions with some of the hardcoded test timings
         #
-        # Assumes cgroup_prefix is always pbs_jobs,
+        # Add these if needed:
+        # os.path.join(basedir, 'pbs.slice',
+        #             'pbs-%s.slice' % systemd_escape(jobid)),
+        # os.path.join(basedir, 'pbs_jobs.slice',
+        #             'pbs_jobs-%s.slice' % systemd_escape(jobid)),
+        # os.path.join(basedir, 'pbs', jobid),
+        # os.path.join(basedir, 'pbs_jobs', jobid),
+        # os.path.join(basedir, 'pbs.service/jobid', jobid),
+        #
+        #
+        # This cleaned version assumes cgroup_prefix is always pbs_jobs,
         # i.e. cgroup_prefix is not changed
         #
         # Separate test for different "sbp" prefix should use
         # its own script instead; that will not support multi-host jobs
-        jobdirs = [
-                   # os.path.join(basedir, 'pbs.slice',
-                   #             'pbs-%s.slice' % systemd_escape(jobid)),
-                   # os.path.join(basedir, 'pbs_jobs.slice',
-                   #             'pbs_jobs-%s.slice' % systemd_escape(jobid)),
-                   # os.path.join(basedir, 'pbs', jobid),
-                   # os.path.join(basedir, 'pbs_jobs', jobid),
-                   # os.path.join(basedir, 'pbs.service/jobid', jobid),
-                   os.path.join(basedir, 'pbs_jobs.service/jobid', jobid)
-                  ]
+        jobdirs = [os.path.join(basedir, 'pbs_jobs.service/jobid', jobid)]
         for jdir in jobdirs:
             if self.du.isdir(hostname=host, path=jdir, sudo=True):
                 return jdir

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -532,6 +532,10 @@ fi
 #PBS -joe
 sleep 15
 """
+        self.sleep30_job = """#!/bin/bash
+#PBS -joe
+sleep 30
+"""
         self.sleep5_job = """#!/bin/bash
 #PBS -joe
 sleep 5
@@ -560,7 +564,6 @@ cat $PBS_NODEFILE
 sleep 300
 """
         self.cfg0 = """{
-    "cgroup_prefix"         : "pbs",
     "exclude_hosts"         : [],
     "exclude_vntypes"       : [],
     "run_only_on_hosts"     : [],
@@ -591,7 +594,6 @@ sleep 300
 }
 """
         self.cfg1 = """{
-    "cgroup_prefix"         : "pbs",
     "exclude_hosts"         : [%s],
     "exclude_vntypes"       : [%s],
     "run_only_on_hosts"     : [%s],
@@ -691,7 +693,6 @@ sleep 300
 }
 """
         self.cfg3 = """{
-    "cgroup_prefix"         : "pbs",
     "exclude_hosts"         : [],
     "exclude_vntypes"       : [%s],
     "run_only_on_hosts"     : [],
@@ -741,7 +742,6 @@ sleep 300
 }
 """
         self.cfg4 = """{
-    "cgroup_prefix"         : "pbs",
     "exclude_hosts"         : [],
     "exclude_vntypes"       : ["no_cgroups"],
     "run_only_on_hosts"     : [],
@@ -830,7 +830,6 @@ sleep 300
 }
 """
         self.cfg7 = """{
-    "cgroup_prefix"         : "pbs",
     "exclude_hosts"         : [],
     "exclude_vntypes"       : [],
     "run_only_on_hosts"     : [],
@@ -874,7 +873,6 @@ sleep 300
 }
 """
         self.cfg8 = """{
-    "cgroup_prefix"         : "pbs",
     "exclude_hosts"         : [],
     "exclude_vntypes"       : [%s],
     "run_only_on_hosts"     : [],
@@ -925,7 +923,6 @@ sleep 300
 }
 """
         self.cfg9 = """{
-    "cgroup_prefix"         : "pbs",
     "exclude_hosts"         : [],
     "exclude_vntypes"       : [],
     "run_only_on_hosts"     : [],
@@ -969,7 +966,6 @@ sleep 300
 }
 """
         self.cfg10 = """{
-    "cgroup_prefix"         : "pbs",
     "exclude_hosts"         : [],
     "exclude_vntypes"       : ["no_cgroups"],
     "run_only_on_hosts"     : [],
@@ -1024,7 +1020,6 @@ sleep 300
 }
 """
         self.cfg11 = """{
-    "cgroup_prefix"         : "pbs",
     "exclude_hosts"         : [],
     "exclude_vntypes"       : ["no_cgroups"],
     "run_only_on_hosts"     : [],
@@ -1081,7 +1076,6 @@ sleep 300
 }
 """
         self.cfg12 = """{
-    "cgroup_prefix"         : "pbs",
     "exclude_hosts"         : [],
     "exclude_vntypes"       : ["no_cgroups"],
     "run_only_on_hosts"     : [],
@@ -1137,7 +1131,6 @@ sleep 300
 }
 """
         self.cfg13 = """{
-    "cgroup_prefix"         : "pbs",
     "exclude_hosts"         : [],
     "exclude_vntypes"       : ["no_cgroups"],
     "run_only_on_hosts"     : [],
@@ -1300,7 +1293,12 @@ if %s e.job.in_ms_mom():
                  'memsw': None,
                  'cpuacct': None,
                  'devices': None,
-                 'cpu': None}
+                 'cpu': None,
+                 'hugetlb': None,
+                 'perf_event': None,
+                 'freezer': None,
+                 'net_cls': None,
+                 'net_prio': None}
         # Loop through the mounts and collect the ones for cgroups
         fd = self.du.cat(host, '/proc/mounts')
         for line in fd['out']:
@@ -1321,6 +1319,26 @@ if %s e.job.in_ms_mom():
                 paths['devices'] = paths[subsys]
             if 'cpu' in flags:
                 paths['cpu'] = paths[subsys]
+            # Add these to support future unified hierarchy
+            # (everything in one dir)
+            if paths['pids'] is None and 'pids' in flags:
+                paths['pids'] = paths[subsys]
+            if paths['blkio'] is None and 'blkio' in flags:
+                paths['blkio'] = paths[subsys]
+            if paths['systemd'] is None and 'systemd' in flags:
+                paths['systemd'] = paths[subsys]
+            if paths['cpuset'] is None and 'cpuset' in flags:
+                paths['cpuset'] = paths[subsys]
+            if paths['hugetlb'] is None and 'hugetlb' in flags:
+                paths['hugetlb'] = paths[subsys]
+            if paths['perf_event'] is None and 'perf_event' in flags:
+                paths['perf_event'] = paths[subsys]
+            if paths['freezer'] is None and 'freezer' in flags:
+                paths['freezer'] = paths[subsys]
+            if paths['net_cls'] is None and 'net_cls' in flags:
+                paths['net_cls'] = paths[subsys]
+            if paths['net_prio'] is None and 'net_prio' in flags:
+                paths['net_prio'] = paths[subsys]
         return paths
 
     def is_dir(self, cpath, host):
@@ -1350,20 +1368,44 @@ if %s e.job.in_ms_mom():
         Returns path of subsystem for jobid
         """
         basedir = self.paths[subsys]
-        # one of these should exist depending on platform
-        # That last option should never exist, but let us
-        # leave it in there
-        jobdirs = [os.path.join(basedir, 'pbs', jobid),
-                   os.path.join(basedir, 'pbs.service/jobid', jobid),
-                   os.path.join(basedir, 'pbs_jobs.service/jobid', jobid),
-                   os.path.join(basedir, 'pbs.slice',
-                                'pbs-%s.slice' % systemd_escape(jobid)),
-                   os.path.join(basedir, 'pbs',
-                                'pbs-%s.slice' % systemd_escape(jobid))]
+        # One of these should exist depending on platform.
+        #
+        # Entries for older hooks deleted. I am leaving them as comments should
+        # this be used to test old hooks, but DO NOT put them at the top
+        # when testing newer hooks, or you will run into race conditions with
+        # some of the hardcoded test timings
+        #
+        # Assumes cgroup_prefix is always pbs_jobs,
+        # i.e. cgroup_prefix is not changed
+        #
+        # Separate test for different "sbp" prefix should use
+        # its own script instead; that will not support multi-host jobs
+        jobdirs = [
+                   # os.path.join(basedir, 'pbs.slice',
+                   #             'pbs-%s.slice' % systemd_escape(jobid)),
+                   # os.path.join(basedir, 'pbs_jobs.slice',
+                   #             'pbs_jobs-%s.slice' % systemd_escape(jobid)),
+                   # os.path.join(basedir, 'pbs', jobid),
+                   # os.path.join(basedir, 'pbs_jobs', jobid),
+                   # os.path.join(basedir, 'pbs.service/jobid', jobid),
+                   os.path.join(basedir, 'pbs_jobs.service/jobid', jobid)
+                  ]
         for jdir in jobdirs:
-            if self.du.isdir(hostname=host, path=jdir):
+            if self.du.isdir(hostname=host, path=jdir, sudo=True):
                 return jdir
         return None
+
+    def find_main_cpath(self, cdir):
+        cpath = None
+        if os.path.isdir(cdir):
+            cpath = os.path.join(cdir, 'pbs_jobs.service/jobid')
+            if not os.path.isdir(cpath):
+                cpath = os.path.join(cdir, 'pbs.service/jobid')
+            if not os.path.isdir(cpath):
+                cpath = os.path.join(cdir, 'pbs.slice')
+            if not os.path.isdir(cpath):
+                cpath = os.path.join(cdir, 'pbs')
+        return cpath
 
     def load_hook(self, filename, mom_checks=True):
         """
@@ -2497,7 +2539,7 @@ if %s e.job.in_ms_mom():
         a = {'Resource_List.select': '2:ncpus=1:mem=100mb',
              'Resource_List.place': 'scatter', ATTR_N: name}
         j = Job(TEST_USER, attrs=a)
-        j.create_script(self.sleep15_job)
+        j.create_script(self.sleep30_job)
         jid = self.server.submit(j)
         a = {'job_state': 'R'}
         self.server.expect(JOB, a, jid)
@@ -2510,10 +2552,11 @@ if %s e.job.in_ms_mom():
                         'Missing memory subdirectory: %s' % ehjd1)
         ehost2 = tmp_host[1].split('/')[0]
         ehjd2 = self.get_cgroup_job_dir('memory', jid, ehost2)
-        self.assertTrue(self.is_dir(ehjd2, ehost2))
+        self.assertTrue(self.is_dir(ehjd2, ehost2),
+                        'Missing memory subdirectory: %s' % ehjd2)
         # Wait for job to finish and make sure that cgroup directories
         # has been cleaned up by the hook
-        self.server.expect(JOB, 'queue', op=UNSET, offset=15, interval=1,
+        self.server.expect(JOB, 'queue', op=UNSET, offset=30, interval=1,
                            id=jid)
         self.assertFalse(self.is_dir(ehjd1, ehost1),
                          'Directory still present: %s' % ehjd1)
@@ -2627,27 +2670,34 @@ if %s e.job.in_ms_mom():
         self.server.expect(JOB, 'queue', id=jid, op=UNSET,
                            interval=1, offset=1)
         # verify that cgroup files for this job are gone even if
-        # epilogue and periodic events are not disabled
+        # epilogue and periodic events are disabled
         for subsys, path in self.paths.items():
             # only check under subsystems that are enabled
             enabled_subsys = ['cpuacct', 'cpuset', 'memory', 'memsw']
             if (any([x in subsys for x in enabled_subsys])):
                 continue
             if path:
-                # Apparently cgroup_prefix for this test is pbs
-                filename = os.path.join(path, 'pbs', str(jid))
+                filename = os.path.join(path,
+                                        'pbs_jobs.service',
+                                        'jobid', str(jid))
                 self.logger.info('Checking that file %s should not exist'
                                  % filename)
                 self.assertFalse(os.path.isfile(filename))
-                filename = os.path.join(path, 'pbs.slice', 'pbs-%s.slice'
-                                        % systemd_escape(jid))
-                self.logger.info('Checking that file %s should not exist'
-                                 % filename)
-                self.assertFalse(os.path.isfile(filename))
-                filename = os.path.join(path, 'pbs.service', str(jid))
-                self.logger.info('Checking that file %s should not exist'
-                                 % filename)
-                self.assertFalse(os.path.isfile(filename))
+            #   filename = os.path.join(path, 'pbs.service',
+            #                           'jobid', str(jid))
+            #    self.logger.info('Checking that file %s should not exist'
+            #                     % filename)
+            #    self.assertFalse(os.path.isfile(filename))
+            #    filename = os.path.join(path, 'pbs.slice', 'pbs-%s.slice'
+            #                            % systemd_escape(jid))
+            #    self.logger.info('Checking that file %s should not exist'
+            #                     % filename)
+            #    self.assertFalse(os.path.isfile(filename))
+            #    filename = os.path.join(path, 'pbs.slice', 'pbs-%s.slice'
+            #                            % systemd_escape(jid))
+            #    self.logger.info('Checking that file %s should not exist'
+            #                     % filename)
+            #    self.assertFalse(os.path.isfile(filename))
 
     @skipOnCray
     def test_cgroup_assign_resources_mem_only_vnode(self):
@@ -2968,14 +3018,7 @@ if %s e.job.in_ms_mom():
         cpath = None
         if 'memory' in self.paths and self.paths['memory']:
             cdir = self.paths['memory']
-            if os.path.isdir(cdir):
-                cpath = os.path.join(cdir, 'pbs')
-                if not os.path.isdir(cpath):
-                    cpath = os.path.join(cdir, 'pbs.slice')
-                if not os.path.isdir(cpath):
-                    cpath = os.path.join(cdir, 'pbs.service/jobid')
-                if not os.path.isdir(cpath):
-                    cpath = os.path.join(cdir, 'pbs_jobs.service/jobid')
+            cpath = self.find_main_cpath(cdir)
         else:
             self.skipTest(
                 "memory subsystem is not enabled for cgroups")
@@ -2994,14 +3037,7 @@ if %s e.job.in_ms_mom():
         cpath = None
         if 'memory' in self.paths and self.paths['memory']:
             cdir = self.paths['memory']
-            if os.path.isdir(cdir):
-                cpath = os.path.join(cdir, 'pbs')
-                if not os.path.isdir(cpath):
-                    cpath = os.path.join(cdir, 'pbs.slice')
-                if not os.path.isdir(cpath):
-                    cpath = os.path.join(cdir, 'pbs.service/jobid')
-                if not os.path.isdir(cpath):
-                    cpath = os.path.join(cdir, 'pbs_jobs.service/jobid')
+            cpath = self.find_main_cpath(cdir)
         # Verify that memory.use_hierarchy is enabled
         fpath = os.path.join(cpath, "memory.use_hierarchy")
         self.logger.info("looking for file %s" % fpath)
@@ -3610,7 +3646,7 @@ sleep 300
         for m in self.moms.values():
             # add checkpoint script
             m.add_checkpoint_abort_script(body=chk_script)
-            m.add_restart_script(body=restart_script)
+            m.add_restart_script(body=restart_script, abort_time=300)
             self.server.manager(MGR_CMD_SET, NODE, a, id=m.shortname)
 
         # submit multi-node job
@@ -4169,21 +4205,16 @@ sleep 300
                             self.du.run_cmd(cmd=cmd, sudo=True)
                         self.du.rm(hostname=self.hosts_list[0], path=fpath)
         # Remove the jobdir if any under other cgroups
-        cgroup_subsys = ('cpuset', 'memory', 'blkio', 'devices', 'cpuacct',
-                         'pids', 'systemd')
+        cgroup_subsys = ('systemd', 'cpu', 'cpuacct', 'cpuset', 'devices',
+                         'memory', 'hugetlb', 'perf_event', 'freezer',
+                         'blkio', 'pids', 'net_cls', 'net_prio')
         for subsys in cgroup_subsys:
             if subsys in self.paths and self.paths[subsys]:
                 self.logger.info('Looking for orphaned jobdir in %s' % subsys)
                 cdir = self.paths[subsys]
                 if os.path.isdir(cdir):
-                    cpath = os.path.join(cdir, 'pbs')
-                    if not os.path.isdir(cpath):
-                        cpath = os.path.join(cdir, 'pbs.slice')
-                    if not os.path.isdir(cpath):
-                        cpath = os.path.join(cdir, 'pbs.service/jobid')
-                    if not os.path.isdir(cpath):
-                        cpath = os.path.join(cdir, 'pbs_jobs.service/jobid')
-                    if os.path.isdir(cpath):
+                    cpath = self.find_main_cpath(cdir)
+                    if cpath is not None and os.path.isdir(cpath):
                         for jdir in glob.glob(os.path.join(cpath, '*', '')):
                             if not os.path.isdir(jdir):
                                 continue

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -1368,28 +1368,26 @@ if %s e.job.in_ms_mom():
         Returns path of subsystem for jobid
         """
         basedir = self.paths[subsys]
-        # One of these should exist depending on platform.
-        #
-        # Entries for older hooks deleted. I am leaving them as comments should
-        # this be used to test old hooks, but DO NOT put them at the top
-        # of the list when testing newer hooks, or you will run into
-        # race conditions with some of the hardcoded test timings
-        #
-        # Add these if needed:
-        # os.path.join(basedir, 'pbs.slice',
-        #             'pbs-%s.slice' % systemd_escape(jobid)),
-        # os.path.join(basedir, 'pbs_jobs.slice',
-        #             'pbs_jobs-%s.slice' % systemd_escape(jobid)),
-        # os.path.join(basedir, 'pbs', jobid),
-        # os.path.join(basedir, 'pbs_jobs', jobid),
-        # os.path.join(basedir, 'pbs.service/jobid', jobid),
-        #
+        # One of the entries in the following list should exist
         #
         # This cleaned version assumes cgroup_prefix is always pbs_jobs,
-        # i.e. cgroup_prefix is not changed
+        # i.e. that cgroup_prefix is not changed if you use this routine
         #
-        # Separate test for different "sbp" prefix should use
-        # its own script instead; that will not support multi-host jobs
+        # The separate test for a different prefix ("sbp") uses its own
+        # script instead; that script need not support multi-host jobs
+        #
+        # Older possible per job paths (relative to the basedir) looked:
+        # 1) <prefix>.slice/<prefix>-<jobid>.slice
+        #     (and <jobid> needs to be passed through systemd_escape)
+        # 2) <prefix>/<jobid>
+        #
+        # Some older hooks used either depending on the OS platform
+        # which was the reason to support a list in the first place
+        #
+        # If you need to add paths to make the tests support older hooks,
+        # put the least likely paths at the end of the list, to avoid
+        # changing test timings too much.
+        #
         jobdirs = [os.path.join(basedir, 'pbs_jobs.service/jobid', jobid)]
         for jdir in jobdirs:
             if self.du.isdir(hostname=host, path=jdir, sudo=True):

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -1397,16 +1397,16 @@ if %s e.job.in_ms_mom():
         return None
 
     def find_main_cpath(self, cdir):
-        cpath = None
         if os.path.isdir(cdir):
-            cpath = os.path.join(cdir, 'pbs_jobs.service/jobid')
-            if not os.path.isdir(cpath):
-                cpath = os.path.join(cdir, 'pbs.service/jobid')
-            if not os.path.isdir(cpath):
-                cpath = os.path.join(cdir, 'pbs.slice')
-            if not os.path.isdir(cpath):
-                cpath = os.path.join(cdir, 'pbs')
-        return cpath
+            paths = ['pbs_jobs.service/jobid',
+                     'pbs.service/jobid',
+                     'pbs.slice',
+                     'pbs']
+            for p in paths:
+                cpath = os.path.join(cdir, p)
+                if os.path.isdir(cpath):
+                    return cpath
+        return None
 
     def load_hook(self, filename, mom_checks=True):
         """
@@ -2678,27 +2678,16 @@ if %s e.job.in_ms_mom():
             if (any([x in subsys for x in enabled_subsys])):
                 continue
             if path:
+                # Following code only works with recent hooks
+                # and default cgroup_prefix
+                # change the path if testing with older hooks
+                # see comments in get_cgroup_job_dir()
                 filename = os.path.join(path,
                                         'pbs_jobs.service',
                                         'jobid', str(jid))
                 self.logger.info('Checking that file %s should not exist'
                                  % filename)
                 self.assertFalse(os.path.isfile(filename))
-            #   filename = os.path.join(path, 'pbs.service',
-            #                           'jobid', str(jid))
-            #    self.logger.info('Checking that file %s should not exist'
-            #                     % filename)
-            #    self.assertFalse(os.path.isfile(filename))
-            #    filename = os.path.join(path, 'pbs.slice', 'pbs-%s.slice'
-            #                            % systemd_escape(jid))
-            #    self.logger.info('Checking that file %s should not exist'
-            #                     % filename)
-            #    self.assertFalse(os.path.isfile(filename))
-            #    filename = os.path.join(path, 'pbs.slice', 'pbs-%s.slice'
-            #                            % systemd_escape(jid))
-            #    self.logger.info('Checking that file %s should not exist'
-            #                     % filename)
-            #    self.assertFalse(os.path.isfile(filename))
 
     @skipOnCray
     def test_cgroup_assign_resources_mem_only_vnode(self):

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -881,7 +881,7 @@ sleep 300
     "periodic_resc_update"  : true,
     "vnode_per_numa_node"   : false,
     "online_offlined_nodes" : true,
-    "use_hyperthreads"      : false,
+    "use_hyperthreads"      : true,
     "ncpus_are_cores"       : true,
     "cgroup":
     {


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
This is mainly cleanup for two issues seen by drtoss affecting only Python3-based versions of PBSPro/openPBS

1. 
Python 3 "x / y" produces floats even when x and y are integers and y is a divisor of x. This propagates into hyperthreads_per_core and ultimately the variable "needed" that describes how many CPU threads a job needs to assign. When use_hyperthreads and ncpus_are_cores are enabled, the code correctly assigns all cpus and needed becomes 0.0. Unfortunately, instead of adding a guard to see we're done, we're also going to pick the 0.0 CPUs needed from a list of remaining CPUs, using slice syntax, so we get a crash.

2. 
Popen.communicate() _by default_ returns a pair (stdout, stderr) of non-mutable array of bytes ("str" in Python 2, "bytes"  in Python3). 

We cannot use string operations on those, but we have 6 Popen constructors and often we do things like use splitlines(). Since subprocesses are always dangerous, we do have code to catch exceptions, but unfortunately that leads to silent failures. The most prominent one is that on Python 3 PBSPro we will always think a host does not have systemd enabled, but there are others. 

3.
A small corner case for memsw -- if specifying -lselect=1:ncpus=1:mem=X, if memsw is enabled and X is less than the memsw default, vmem will be set to default. If this is larger than X, the job will fail on hosts that have no swap (the hook will detect that you're setting nonsensical limits that the host will not honour).


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

For problem #1, use int(x // y) when you want an integer result. A guard was also inserted to avoid needless work when the amount of needed CPUs goes below 1 (i.e. zero). Also, there is a PTL test that _should_ have caught this, but didn't because the config file neutered the effects of ncpus_are_cores (if use_hyperthreads is False then ncpus_are_cores doesn't do anything, so the current test also doesn't test anything). That test's config file was changed to fully test ncpus_are_cores CPU assignment.

For problem #2, set universal_newlines in the Popen constructor so that the stdout and stderr objects returned are always strings (in both Python 2.x, x>=3, and Python 3). Add a stringified_output() function to nevertheless _convert_ anything we may find to strings (should Python change again, should we get "unicode" objects in a version of Python2, or if we ever have NoneType objects), so that we can safely call string operations. The function should basically do nothing but return the first argument (unchanged, without creating a new object) if we did our job in the calling routine, so the overhead is really small.

Error reporting was also reworked to remove some of the silent failures (especially at DEBUG4). All too often just running a command is seen as "success", so in the relevant cases checks on process.returncode were added to at least _log_ something.

For problem #3, on hosts without swap, leave vmem to mem regardless of the default if vmem_default>mem. Don't apply the default just to make the job fail.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
N/A

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

Problem #1 _should_ have been seen by the test_cgroup_cpuset_ncpus_are_cores PTL test that is already existing, but unfortunately the config file loaded disables hyperthread use, which makes the test fail to fully test ncpus_are_cores functionality.

Problem #2 has been seen on system MoM logs in almost _all_ existing tests: hosts that have a systemd running with a valid systemd version are reported as having systemd version 0 in the MoM logs. Sadly, it is well nigh impossible to design a PTL test for it; a generic PTL test has to guard on logging "failures" on hosts that do not have systemd running, but given these are also in Python would be using almost the exact same code (with the use of Popen) to test whether the system _can_ run the test. It would be possible to add a test if a guard can be found that is _not_ dependent on Python (but e.g. on the name of a host) if you can guarantee that host runs systemd.

An example on a particular host:
[cousein@pbi-33-r7 ~]$ systemctl --version 
systemd 208
+PAM +LIBWRAP +AUDIT +SELINUX +IMA +SYSVINIT +LIBCRYPTSETUP +GCRYPT +ACL +XZ

but the MoM logs for existing PTL tests reveal:
    06/09/2020 13:48:37.102182;0800;pbs_python;Hook;pbs_python;_get_systemd_version: Method called 06/09/2020 13:48:37.161733;0800;pbs_python;Hook;pbs_python;__init__: systemd version seems to be 0

That should have been 208, not 0.

As detailed above, this is hard to test _within_ PTL, since you would need the exact same code that is in the hook to determine whether the host has systemd enabled (here, it was checked _manually_ by logging into the host). Write a bug in the hook and you'll likely write the same one in the PTL test to determine whether the host should be skipped or not.

Problem #3 can be seen in the following MoM log snippet. memsw was enabled, the default was 256MB, and a job was submitted with -lncpus=1:mem=123gb on a host with no configured swap space:

06/10/2020 14:29:08;0800;pbs_python;Hook;pbs_python;get_vmem_on_node: No swap space detected
06/10/2020 14:29:08;0080;pbs_python;Hook;pbs_python;['Traceback (most recent call last):', '  File "<embedded code object>", line 5538, in main', '  File "<embedded code object>", line 968, in invoke_handler', '  File "<embedded code object>", line 1017, in _execjob_begin_handler', '  File "<embedded code object>", line 4504, in configure_job', 'CgroupLimitError: Job might utilize swap and no swap space available']
06/10/2020 14:29:08;0001;pbs_python;Hook;pbs_python;Unexpected error in pbs_cgroups handling execjob_begin event for job 323.tc72 (system hold set): CgroupLimitError ('Job might utilize swap and no swap space available',)
06/10/2020 14:29:08;0008;pbs_mom;Job;323.tc72;Unexpected error in pbs_cgroups handling execjob_begin event for job 323.tc72 (system hold set): CgroupLimitError ('Job might utilize swap and no swap space available',)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
