### PR TITLE
Fixed overlay upgrade issue

### DIFF
--- a/src/cmds/scripts/pbs_habitat.in
+++ b/src/cmds/scripts/pbs_habitat.in
@@ -235,10 +235,6 @@ upgrade_pbs_database() {
 	elif [ -d "${PBS_HOME}/pgsql.forupgrade" ]; then
 		old_inst_dir="${PBS_HOME}/pgsql.forupgrade"
 		old_data_dir="${PBS_HOME}/datastore.forupgrade"
-	else
-		echo "Data service directory from previous PBS installation not found,"
-		echo "Datastore upgrade cannot continue"
-		return 1
 	fi
 
 	# strip the minor version from sys_pgsql_ver if old_pgsql_ver does not have minor version (for comparison).
@@ -283,6 +279,12 @@ upgrade_db() {
 
 	if [ ! -x "${inst_dir}/bin/pg_upgrade" ]; then
 		echo "${inst_dir}/bin/pg_upgrade not found"
+		return 1
+	fi
+
+	if [ -z "${old_inst_dir}" ]; then
+		echo "Data service directory from previous PBS installation not found,"
+		echo "Datastore upgrade cannot continue"
 		return 1
 	fi
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Overlay upgrade failed with following error message.

`
Data service directory from previous PBS installation not found,
Datastore upgrade cannot continue
Failed to upgrade PBS Datastore
`

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Updated pbs_habitat to have old pgsql directory check at proper place.

***Upgrade instructions for openpbs_20.0***

*From release version 20 pbspro rpm has renamed to openpbs, and upgrade to this version requires to follow below instructions instead of 'rpm -U' option.*

- *Remove the old version using 'rpm -e'*
	`example: rpm -e pbspro-server-19.1.3-0.x86_64`
- *Do not remove PBS_HOME and /etc/pbs.conf*
- *Install openpbs version 20 using 'rpm -i'*
	`example: rpm -i openpbs-server-20.0.0-0.x86_64.rpm`
 - *Start the openpbs*

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

[19.1.3_to_20_master.txt](https://github.com/openpbs/openpbs/files/4763208/19.1.3_to_20_master.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
