### PR TITLE
Add env variable LC_all to fix pip installation failure

### DIFF
--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -46,6 +46,9 @@ services:
       - ./logs:/logs
     entrypoint: /src/docker-entrypoint
     env_file: .env
+    environment:
+      - LC_ALL=en_US.utf-8
+      - LANG=en_US.utf-8
     networks:
       ci:
         aliases:


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Pip install was failing in container with the error 
```
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position
```

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Added env variables to container which were causing failure of pip install after adding license header to it.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
[build.txt](https://github.com/openpbs/openpbs/files/4764129/build.txt)
