### PR TITLE
Fix: Python is unable to initialize in windows jobs

### DIFF
--- a/src/resmom_win/win/mom_start.c
+++ b/src/resmom_win/win/mom_start.c
@@ -96,7 +96,7 @@ set_shell(job *pjob, struct passwd *pwdp)
 {
 	char	*cp;
 	int	i;
-	static char	shell[MAX_PATH + 1] = {'\0'};
+	static char	shell[MAX_PATH + 1];
 	char    *temp_dir = NULL;
 	struct array_strings *vstrs;
 
@@ -121,6 +121,7 @@ set_shell(job *pjob, struct passwd *pwdp)
 			}
 		}
 	}
+	shell[sizeof(shell) - 1] = '\0';
 	for (i=0; shell[i] != '\0'; i++) {
 		if (shell[i] == '/')
 			shell[i] = '\\';

--- a/src/resmom_win/win/mom_start.c
+++ b/src/resmom_win/win/mom_start.c
@@ -104,8 +104,10 @@ set_shell(job *pjob, struct passwd *pwdp)
 	 * Find which shell to use, one specified or the login shell
 	 * If we fail to get cmd shell(unlikely), use "cmd.exe" as shell
 	 */
-	if (0 != get_cmd_shell(shell, sizeof(shell)))
+	if (0 != get_cmd_shell(shell, sizeof(shell))) {
 		strncpy(shell, "cmd.exe", sizeof(shell) - 1);
+		shell[sizeof(shell) - 1] = '\0';
+	}
 	if ((pjob->ji_wattr[(int)JOB_ATR_shell].at_flags & ATR_VFLAG_SET) &&
 		(vstrs = pjob->ji_wattr[(int)JOB_ATR_shell].at_val.at_arst)) {
 		for (i = 0; i < vstrs->as_usedptr; ++i) {
@@ -114,14 +116,15 @@ set_shell(job *pjob, struct passwd *pwdp)
 				if (!strncmp(mom_host, cp+1, strlen(cp+1))) {
 					*cp = '\0';	/* host name matches */
 					strncpy(shell, vstrs->as_string[i], sizeof(shell) - 1);
+					shell[sizeof(shell) - 1] = '\0';
 					break;
 				}
 			} else {
 				strncpy(shell, vstrs->as_string[i], sizeof(shell) - 1);	/* wildcard */
+				shell[sizeof(shell) - 1] = '\0';
 			}
 		}
 	}
-	shell[sizeof(shell) - 1] = '\0';
 	for (i=0; shell[i] != '\0'; i++) {
 		if (shell[i] == '/')
 			shell[i] = '\\';

--- a/src/resmom_win/win/mom_start.c
+++ b/src/resmom_win/win/mom_start.c
@@ -105,7 +105,7 @@ set_shell(job *pjob, struct passwd *pwdp)
 	 * If we fail to get cmd shell(unlikely), use "cmd.exe" as shell
 	 */
 	if (0 != get_cmd_shell(shell, sizeof(shell)))
-		(void)snprintf(shell, sizeof(shell) - 1, "cmd.exe");
+		strncpy(shell, "cmd.exe", sizeof(shell) - 1);
 	if ((pjob->ji_wattr[(int)JOB_ATR_shell].at_flags & ATR_VFLAG_SET) &&
 		(vstrs = pjob->ji_wattr[(int)JOB_ATR_shell].at_val.at_arst)) {
 		for (i = 0; i < vstrs->as_usedptr; ++i) {
@@ -113,11 +113,11 @@ set_shell(job *pjob, struct passwd *pwdp)
 			if (cp) {
 				if (!strncmp(mom_host, cp+1, strlen(cp+1))) {
 					*cp = '\0';	/* host name matches */
-					strncpy(shell, vstrs->as_string[i], PBS_CMDLINE_LENGTH - 1);
+					strncpy(shell, vstrs->as_string[i], sizeof(shell) - 1);
 					break;
 				}
 			} else {
-				strncpy(shell, vstrs->as_string[i], PBS_CMDLINE_LENGTH - 1);	/* wildcard */
+				strncpy(shell, vstrs->as_string[i], sizeof(shell) - 1);	/* wildcard */
 			}
 		}
 	}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Python jobs fail to start the interpreter when submitted with a shell (qsub -S) with an error: Fatal Python error: failed to get random numbers to initialize Python


#### Describe Your Change
This error occurs when the environment does not contain the SystemRoot variable. The environ variable was NULLing out because of a buffer overflow.


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[test_logs.txt](https://github.com/openpbs/openpbs/files/4764666/test_logs.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
