### PR TITLE
Fixed reconfirming multinode reservations

### DIFF
--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -1945,7 +1945,7 @@ release_running_resv_nodes(resource_resv *resv, node_info **all_nodes)
 	if (resv == NULL || all_nodes == NULL )
 		return;
 	degraded = resv->resv->resv_state == RESV_RUNNING && resv->resv->resv_substate == RESV_DEGRADED;
-	being_altered = resv->resv->resv_state == RESV_RUNNING && resv->resv->resv_substate == RESV_DEGRADED;
+	being_altered = resv->resv->resv_state == RESV_BEING_ALTERED && resv->resv->resv_substate == RESV_RUNNING;
 	if (degraded || being_altered) {
 		resv_nodes = resv->ninfo_arr;
 		for (i = 0; resv_nodes[i] != NULL; i++) {

--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -971,7 +971,7 @@ check_new_reservations(status *policy, int pbs_sd, resource_resv **resvs, server
 				return -1;
 			}
 
-			adjust_alter_resv_nodes(nresv, nsinfo->nodes);
+			release_running_resv_nodes(nresv, nsinfo->nodes);
 
 			/* Attempt to confirm the reservation. For a standing reservation,
 			 * each occurrence is unrolled and attempted to be confirmed within the
@@ -1429,7 +1429,7 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 					sel = create_select_from_nspec(nresv->nspec_arr);
 					nresv->execselect = parse_selspec(sel);
 					free(sel);
-					adjust_alter_resv_nodes(nresv, nsinfo->nodes);
+					release_running_resv_nodes(nresv, nsinfo->nodes);
 				}
 				release_nodes(nresv);
 			} else if (vnodes_down == 0) {
@@ -1924,33 +1924,33 @@ end_resv_on_nodes(resource_resv *resv, node_info **all_nodes)
 
 /**
  * @brief - adjust resources on nodes belonging to a reservation that is
- *	    being altered.
+ *	    running and is either degraded or being altered.  We need to free
+ * 	    the resources on these nodes so the resources are available for 
+ * 	    check_nodes() to assign back to the reservation.
  *
  * @param[in] resv - reservation to alter nodes for
  * @param[in] all_nodes - array of server's nodes
  *
- * @par - The altering process of a running reservation requires us to keep
- * 	the same nodes for the reservation.  When we call check_nodes(), we
- * 	will attempt to reassign the same nodes to the reservation.  For this
- * 	to be successful, they need to be free.
  */
 
 void
-adjust_alter_resv_nodes(resource_resv *resv, node_info **all_nodes)
+release_running_resv_nodes(resource_resv *resv, node_info **all_nodes)
 {
 	int i = 0;
 	node_info **resv_nodes = NULL;
 	node_info *ninfo = NULL;
+	int degraded;
+	int being_altered;
 
 	if (resv == NULL || all_nodes == NULL )
 		return;
-	if (resv->resv->resv_state == RESV_BEING_ALTERED) {
-		if (resv->resv->resv_substate == RESV_RUNNING) {
-			resv_nodes = resv->ninfo_arr;
-			for (i = 0; resv_nodes[i] != NULL; i++) {
-				ninfo = find_node_by_indrank(all_nodes, resv_nodes[i]->node_ind, resv_nodes[i]->rank);
-				update_node_on_end(ninfo, resv, NULL);
-			}
+	degraded = resv->resv->resv_state == RESV_RUNNING && resv->resv->resv_substate == RESV_DEGRADED;
+	being_altered = resv->resv->resv_state == RESV_RUNNING && resv->resv->resv_substate == RESV_DEGRADED;
+	if (degraded || being_altered) {
+		resv_nodes = resv->ninfo_arr;
+		for (i = 0; resv_nodes[i] != NULL; i++) {
+			ninfo = find_node_by_indrank(all_nodes, resv_nodes[i]->node_ind, resv_nodes[i]->rank);
+			update_node_on_end(ninfo, resv, NULL);
 		}
 	}
 }

--- a/src/scheduler/resv_info.h
+++ b/src/scheduler/resv_info.h
@@ -110,10 +110,10 @@ void release_nodes(resource_resv *resc_resv);
 node_info **create_resv_nodes(nspec **nspec_arr, server_info *sinfo);
 
 /*
- *	adjust_alter_resv_nodes - adjust nodes resources for reservations that
- *				  that are being altered.
+ *	release_running_resv_nodes - adjust nodes resources for reservations that
+ *				  that are being altered or are degraded.
  */
-void adjust_alter_resv_nodes(resource_resv *resv, node_info **all_nodes);
+void release_running_resv_nodes(resource_resv *resv, node_info **all_nodes);
 
 /* Will we try and confirm this reservation in this cycle */
 int will_confirm(resource_resv *resv, time_t server_time);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
The scheduler would fail to reconfirm a multi-node reservation

#### Describe Your Change
In order to reconfirm a running reservation, the scheduler has to remove the currently allocated resources the reservation is using.  This is so when we go to find nodes for the reservation, there are resources free on those nodes.  The scheduler was not removing the resources on the nodes, so the reservation basically conflicted with itself and failed to reconfirm.

The function that removes the resources from a reservation only worked for reservations in state RESV_BEING_ALTERED.  I modified it to also with for reservations in state RESV_DEGRADED.

#### Attach Test and Valgrind Logs/Output
[resv.log](https://github.com/openpbs/openpbs/files/4767732/resv.log)
