### PR TITLE
Fixing test_psets_queue from NodeBuckets suite

### DIFF
--- a/test/tests/functional/pbs_node_buckets.py
+++ b/test/tests/functional/pbs_node_buckets.py
@@ -798,6 +798,7 @@ class TestNodeBuckets(TestFunctional):
              'Resource_List.place': 'scatter:excl'}
         for _ in range(7):
             j = Job(TEST_USER, a)
+            j.set_sleep_time(1000)
             jid = self.server.submit(j)
             self.server.expect(JOB, {'job_state': 'R'}, id=jid)
             self.scheduler.log_match(jid + ';Chunk: ' + chunk, n=10000)
@@ -824,6 +825,7 @@ class TestNodeBuckets(TestFunctional):
         a = {'Resource_List.select': chunk, 'queue': 'workq2',
              'Resource_List.place': 'scatter:excl'}
         j = Job(TEST_USER, a)
+        j.set_sleep_time(1000)
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
         self.scheduler.log_match(jid + ';Chunk: ' + chunk, n=10000)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
In this test qstat was failing because the job had already ended.  'qstat: Unknown Job Id' error was seen. 
Increasing the job time from default 100 seconds to 1000 seconds.

#### Attach Test and Valgrind Logs/Output
[test_psets_queue.txt](https://github.com/openpbs/openpbs/files/4767815/test_psets_queue.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
