### PR TITLE
qsub hangs for 60 secs when job is submitted from python script on windows

### DIFF
--- a/src/cmds/qsub.c
+++ b/src/cmds/qsub.c
@@ -5094,7 +5094,7 @@ again:
 					qsub_exe, fl,
 					h_event, server_out);
 			if (!CreateProcess(NULL, cmd_line, &sa, &sa,
-						TRUE, CREATE_NO_WINDOW, NULL,
+						TRUE, CREATE_NEW_PROCESS_GROUP, NULL,
 						NULL, &si, &pi)) {
 				CloseHandle(h_event);
 				return rc;
@@ -5681,6 +5681,9 @@ main(int argc, char **argv, char **envp) /* qsub */
 	if ((argc == 4 || argc == 5) && (strcasecmp(argv[1], "--daemon") == 0)) {
 		/* set when background qsub is running */
 		is_background = 1;
+		(void)fclose(stdin);
+		(void)fclose(stdout);
+		(void)fclose(stderr);
 		if (argc == 4)
 			do_daemon_stuff(argv[2], argv[3], NULL);
 		else

--- a/src/cmds/qsub.c
+++ b/src/cmds/qsub.c
@@ -5043,6 +5043,7 @@ daemon_submit(char *qsub_exe, int *do_regular_submit)
 	char cmd_line[2 * MAXPATHLEN + 1];
 	int created = 0;
 	HANDLE h_event;
+	int flags = CREATE_DEFAULT_ERROR_MODE | CREATE_NEW_PROCESS_GROUP;
 
 	/* determine pipe name */
 	get_comm_filename(fl);
@@ -5090,12 +5091,13 @@ again:
 
 			/* launch new qsub process, connect 2 server */
 			sa.bInheritHandle = FALSE;
+			si.lpDesktop = NULL;
 			sprintf(cmd_line, "%s --daemon %s %d %s",
 					qsub_exe, fl,
 					h_event, server_out);
 			if (!CreateProcess(NULL, cmd_line, &sa, &sa,
-						TRUE, CREATE_NEW_PROCESS_GROUP, NULL,
-						NULL, &si, &pi)) {
+						TRUE, flags,
+						NULL, NULL, &si, &pi)) {
 				CloseHandle(h_event);
 				return rc;
 			}


### PR DESCRIPTION

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
When a job is submitted from python script on windows it hangs for 60 secs.
Reason: 

- qsub command is executed using subprocess.Popen, followed by proc. communicate() to get error, out of command execution.

- Since Background qsub process is attached to foreground qsub process, proc.communicate() waits for background qsub process to complete which is 60 secs.

#### Describe Your Change
1. To create background qsub process in CreateProcess function change creation flag attribute from CREATE_NO_WINDOW to CREATE_NEW_PROCESS_GROUP.

CREATE_NO_WINDOW : The process is a console application that is being run without a console window. Therefore, the console handle for the application is not set
CREATE_NEW_PROCESS_GROUP: The new process is the root process of a new process group. The process group includes all processes that are descendants of this root process. The process identifier of the new process group is the same as the process identifier, which is returned in the lpProcessInformation parameter.

Microsoft doc link: https://docs.microsoft.com/en-us/windows/win32/procthread/process-creation-flags

2. Close stdin, stdout, stderr of background qsub.


#### Attach Test and Valgrind Logs/Output

[test logs.txt](https://github.com/openpbs/openpbs/files/4768965/test.logs.txt)
[qsub_tracejob_logs.txt](https://github.com/openpbs/openpbs/files/4768967/qsub_tracejob_logs.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
