### PR TITLE
Fix test_runjob_hook log match failure caused by regular expression

### DIFF
--- a/test/tests/functional/pbs_hooksmoketest.py
+++ b/test/tests/functional/pbs_hooksmoketest.py
@@ -454,17 +454,14 @@ print_attribs(j)"""
         # Verify server logs
         self.logger.info("Verifying logs in server")
         msg_1 = "Server@.*;Hook;%s;started" % \
-                (self.hook_name)
+                (re.escape(self.hook_name))
         msg_2 = "Hook;Server@.*;requestor = Scheduler"
         msg_3 = "Hook;Server@.*;hook_name = %s" % \
-                (self.hook_name)
+                (re.escape(self.hook_name))
         msg_4 = "Hook;Server@.*;exec_vnode = %s" % \
-                (ev)
-        # Character escaping '()' as the log_match is regexp
-        msg_4 = msg_4.replace("(", "\(")
-        msg_4 = msg_4.replace(")", "\)")
+                (re.escape(ev))
         msg_5 = "Server@.*;Hook;%s;finished" % \
-                (self.hook_name)
+                (re.escape(self.hook_name))
         msg = [msg_1, msg_2, msg_3, msg_4, msg_5]
         for i in msg:
             self.server.log_match(i, starttime=now, regexp=True)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
This is a cherry pick of https://github.com/openpbs/openpbs/pull/1798
which fixes log match failure in test case test_runjob_hook caused by un-escaped square brackets in regular expression. 

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Escape special characters in `hookname` and `ev` using  `re.escape` 

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
N/A

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

<img width="1678" alt="Screen Shot 2020-06-12 at 4 11 32 PM" src="https://user-images.githubusercontent.com/6920446/84480622-6d461400-acc7-11ea-9138-c2953ecc76d6.png">
<img width="712" alt="Screen Shot 2020-06-12 at 4 11 43 PM" src="https://user-images.githubusercontent.com/6920446/84480626-70410480-acc7-11ea-99ff-2eca4012794e.png">


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
