### PR TITLE
[WIP] create_temp_dir does not honor permissions and group

### DIFF
--- a/test/fw/ptl/utils/pbs_dshutils.py
+++ b/test/fw/ptl/utils/pbs_dshutils.py
@@ -1540,6 +1540,8 @@ class DshUtils(object):
                            runas=runas, level=level)
         if ret['rc'] == 0:
             if gid is not None:
+                if runas is None:
+                    runas = _u
                 rv = self.chgrp(hostname, path, gid=gid, sudo=sudo,
                                 level=level, recursive=recursive, runas=runas,
                                 logerr=logerr)
@@ -2072,8 +2074,7 @@ class DshUtils(object):
             self.run_copy(hostname, src=tmpdir, dest=dirname, runas=asuser,
                           recursive=True, gid=gid, uid=uid,
                           level=level)
-            if mode is not None:
-                self.chmod(hostname, path=dirname, mode=mode, runas=asuser)
+            self.chmod(hostname, path=dirname, mode=mode, runas=asuser)
 
             tmpdir = dirname + tmpdir[4:]
 
@@ -2085,8 +2086,7 @@ class DshUtils(object):
                 self.run_copy(hostname, src=tmpdir, dest=tmpdir, runas=asuser,
                               recursive=True, uid=uid, gid=gid,
                               level=level)
-                if mode is not None:
-                    self.chmod(hostname, path=tmpdir, mode=mode, runas=asuser)
+                self.chmod(hostname, path=tmpdir, mode=mode, runas=asuser)
             else:
                 # copy temp dir created on localhost to remote as current user
                 self.run_copy(hostname, src=tmpdir, dest=tmpdir,
@@ -2102,8 +2102,7 @@ class DshUtils(object):
             # copy the orginal temp as new temp dir
             self.run_copy(hostname, src=tmpdir, dest=tmpdir2, runas=asuser,
                           recursive=True, uid=uid, gid=gid, level=level)
-            if mode is not None:
-                self.chmod(hostname, path=tmpdir2, mode=mode, runas=asuser)
+            self.chmod(hostname, path=tmpdir2, mode=mode, runas=asuser)
             # remove original temp dir
             os.rmdir(tmpdir)
             self.tmpdirlist.append(tmpdir2)

--- a/test/fw/ptl/utils/pbs_dshutils.py
+++ b/test/fw/ptl/utils/pbs_dshutils.py
@@ -2054,6 +2054,8 @@ class DshUtils(object):
         preserve = False
         if mode is not None:
             preserve = True
+        else:
+            mode = 0o755
         # create a temp dir as current user
         tmpdir = tempfile.mkdtemp(suffix, prefix)
         if dirname is not None:

--- a/test/fw/ptl/utils/pbs_dshutils.py
+++ b/test/fw/ptl/utils/pbs_dshutils.py
@@ -2051,12 +2051,6 @@ class DshUtils(object):
                      directory
         :param level: logging level, defaults to INFOCLI2
         """
-        preserve = False
-        if mode is not None:
-            if asuser is None:
-                preserve = True
-            else:
-                preserve = False
         current_user_info = self.get_id_info(self.get_current_user())
         uid = current_user_info['uid']
         gid = current_user_info['gid']
@@ -2071,7 +2065,7 @@ class DshUtils(object):
             self.chmod(path=tmpdir, mode=0o755)
             self.run_copy(hostname, src=tmpdir, dest=dirname, runas=asuser,
                           recursive=True, gid=gid, uid=uid,
-                          preserve_permission=preserve, level=level)
+                          level=level)
             if mode is not None:
                 self.chmod(hostname, path=dirname, mode=mode, runas=asuser)
             else:
@@ -2090,7 +2084,7 @@ class DshUtils(object):
                 # as different user
                 self.run_copy(hostname, src=tmpdir, dest=tmpdir, runas=asuser,
                               recursive=True, uid=uid, gid=gid,
-                              preserve_permission=preserve, level=level)
+                              level=level)
                 if mode is not None:
                     self.chmod(hostname, path=tmpdir, mode=mode, runas=asuser)
                 else:
@@ -2099,7 +2093,7 @@ class DshUtils(object):
                 self.chmod(path=tmpdir, mode=0o755)
                 # copy temp dir created on localhost to remote as current user
                 self.run_copy(hostname, src=tmpdir, dest=tmpdir,
-                              preserve_permission=True, level=level,
+                              level=level, preserve_permission=True,
                               uid=uid, gid=gid)
             # remove local temp dir
             os.rmdir(tmpdir)
@@ -2114,8 +2108,7 @@ class DshUtils(object):
             os.rmdir(tmpdir2)
             # copy the orginal temp as new temp dir
             self.run_copy(hostname, src=tmpdir, dest=tmpdir2, runas=asuser,
-                          recursive=True, uid=uid, gid=gid,
-                          preserve_permission=preserve, level=level)
+                          recursive=True, uid=uid, gid=gid, level=level)
             if mode is not None:
                 self.chmod(hostname, path=tmpdir2, mode=mode, runas=asuser)
             else:

--- a/test/fw/ptl/utils/pbs_dshutils.py
+++ b/test/fw/ptl/utils/pbs_dshutils.py
@@ -2084,7 +2084,7 @@ class DshUtils(object):
             if asuser is not None:
                 # copy temp dir created on local host to remote host
                 # as different user
-                self.run_copy(hostname, src=tmpdir, dest=tmpdir, runas=asuser,
+                self.run_copy(hostname, src=tmpdir, dest=tmpdir,
                               recursive=True, uid=uid, gid=gid,
                               level=level)
                 self.chmod(hostname, path=tmpdir, mode=mode, runas=asuser)

--- a/test/fw/ptl/utils/pbs_dshutils.py
+++ b/test/fw/ptl/utils/pbs_dshutils.py
@@ -2045,10 +2045,13 @@ class DshUtils(object):
         :param dirname: the directory will be created in this directory
         :type dirname: str or None
         :param asuser: Optional username of temp directory owner
+        :type asuser: str
         :param asgroup: Optional group name of temp directory
                     group owner
+        :type asgroup: str
         :param mode: Optional mode bits to assign to the temporary
                      directory
+        :type mode: octal integer
         :param level: logging level, defaults to INFOCLI2
         """
         current_user_info = self.get_id_info(self.get_current_user())
@@ -2076,9 +2079,9 @@ class DshUtils(object):
         # if temp dir to be created on remote host
         if not self.is_localhost(hostname):
             if asuser is not None:
-                # by default mkstemp creates dir with 0700 permission
+                # by default mkstemp creates dir with 0o700 permission
                 # to create dir as different user first change the dir
-                # permission to 0755 so that other user has read permission
+                # permission to 0o755 so that other user has read permission
                 self.chmod(path=tmpdir, mode=0o755)
                 # copy temp dir created on local host to remote host
                 # as different user
@@ -2098,9 +2101,9 @@ class DshUtils(object):
             # remove local temp dir
             os.rmdir(tmpdir)
         if asuser is not None:
-            # by default mkdtemp creates dir with 0700 permission
+            # by default mkdtemp creates dir with 0o700 permission
             # to create dir as different user first change the dir
-            # permission to 0755 so that other user has read permission
+            # permission to 0o755 so that other user has read permission
             self.chmod(path=tmpdir, mode=0o755)
             # since we need to create as differnt user than current user
             # create a temp dir just to get temp dir name with absolute path

--- a/test/fw/ptl/utils/pbs_dshutils.py
+++ b/test/fw/ptl/utils/pbs_dshutils.py
@@ -2051,13 +2051,17 @@ class DshUtils(object):
                      directory
         :param level: logging level, defaults to INFOCLI2
         """
+        preserve = False
+        if mode is not None:
+            preserve = True
         # create a temp dir as current user
         tmpdir = tempfile.mkdtemp(suffix, prefix)
         if dirname is not None:
             dirname = str(dirname)
+            self.chmod(path=tmpdir, mode=mode)
             self.run_copy(hostname, src=tmpdir, dest=dirname, runas=asuser,
                           recursive=True,
-                          preserve_permission=False, level=level, sudo=sudo)
+                          preserve_permission=preserve, level=level)
             tmpdir = dirname + tmpdir[4:]
 
         # if temp dir to be created on remote host
@@ -2065,24 +2069,24 @@ class DshUtils(object):
             if asuser is not None:
                 # by default mkstemp creates dir with 0600 permission
                 # to create dir as different user first change the dir
-                # permission to 0644 so that other user has read permission
-                self.chmod(path=tmpdir, mode=0o755)
+                # permission to 0755 so that other user has read permission
+                self.chmod(path=tmpdir, mode=mode)
                 # copy temp dir created on local host to remote host
                 # as different user
                 self.run_copy(hostname, src=tmpdir, dest=tmpdir, runas=asuser,
                               recursive=True,
-                              preserve_permission=False, level=level)
+                              preserve_permission=preserve, level=level)
             else:
                 # copy temp dir created on localhost to remote as current user
                 self.run_copy(hostname, src=tmpdir, dest=tmpdir,
-                              preserve_permission=False, level=level)
+                              preserve_permission=preserve, level=level)
             # remove local temp dir
             os.rmdir(tmpdir)
         if asuser is not None:
             # by default mkdtemp creates dir with 0600 permission
             # to create dir as different user first change the dir
-            # permission to 0644 so that other user has read permission
-            self.chmod(path=tmpdir, mode=0o755)
+            # permission to 0755 so that other user has read permission
+            self.chmod(path=tmpdir, mode=mode)
             # since we need to create as differnt user than current user
             # create a temp dir just to get temp dir name with absolute path
             tmpdir2 = tempfile.mkdtemp(suffix, prefix, dirname)
@@ -2090,7 +2094,7 @@ class DshUtils(object):
             # copy the orginal temp as new temp dir
             self.run_copy(hostname, src=tmpdir, dest=tmpdir2, runas=asuser,
                           recursive=True,
-                          preserve_permission=False, level=level)
+                          preserve_permission=preserve, level=level)
             # remove original temp dir
             os.rmdir(tmpdir)
             self.tmpdirlist.append(tmpdir2)

--- a/test/fw/ptl/utils/pbs_testusers.py
+++ b/test/fw/ptl/utils/pbs_testusers.py
@@ -57,6 +57,26 @@ class PbsGroup(object):
     :type users: List or None
     """
 
+    @staticmethod
+    def get_group(group):
+        """
+        param: group - groupname
+        type: group - str or int or class object
+        returns PbsGroup class object or None
+        """
+        if isinstance(group, int):
+            for g in PBS_ALL_GROUPS:
+                if g.gid == group:
+                    return g
+        elif isinstance(group, str):
+            for g in PBS_ALL_GROUPS:
+                if g.name == group:
+                    return g
+        elif isinstance(group, PbsGroup):
+            if group in PBS_ALL_GROUPS:
+                return group
+        return None
+
     def __init__(self, name, gid=None, users=None):
         self.name = name
         if gid is not None:
@@ -257,3 +277,5 @@ REQUIRED_USERS = (TEST_USER, TEST_USER1, TEST_USER2, TEST_USER3)
 PBS_ALL_USERS = (PBS_USERS + PBS_OPER_USERS + PBS_MGR_USERS +
                  PBS_DATA_USERS + PBS_ROOT_USERS + PBS_BUILD_USERS +
                  PBS_DAEMON_SERVICE_USERS)
+                 
+PBS_ALL_GROUPS = (PBS_GROUPS + (ROOT_GRP,))

--- a/test/tests/functional/pbs_qsub_direct_write.py
+++ b/test/tests/functional/pbs_qsub_direct_write.py
@@ -100,8 +100,7 @@ class TestQsub_direct_write(TestFunctional):
         j.set_sleep_time(10)
         sub_dir = self.du.create_temp_dir(asuser=TEST_USER5)
         mapping_dir = self.du.create_temp_dir(
-            asuser=TEST_USER2, asgroup=TSTGRP5)
-        self.du.chmod(path=mapping_dir, mode=0o770, runas=TEST_USER2)
+            asuser=TEST_USER2, asgroup=TSTGRP0, mode=0o770)
         self.mom.add_config(
             {'$usecp': self.server.hostname + ':' + sub_dir +
              ' ' + mapping_dir})

--- a/test/tests/functional/pbs_qsub_direct_write.py
+++ b/test/tests/functional/pbs_qsub_direct_write.py
@@ -96,11 +96,12 @@ class TestQsub_direct_write(TestFunctional):
                 (but is a gid that the user is a member of)
         3) not accessible via other permissions
         """
-        j = Job(TEST_USER4, attrs={ATTR_k: 'doe'})
+        j = Job(TEST_USER2, attrs={ATTR_k: 'doe'})
         j.set_sleep_time(10)
         sub_dir = self.du.create_temp_dir(asuser=TEST_USER5)
         mapping_dir = self.du.create_temp_dir(
-            asuser=TEST_USER4, asgroup=TSTGRP5, mode=0o770)
+            asuser=TEST_USER2, asgroup=TSTGRP5)
+        self.du.chmod(path=mapping_dir, mode=0o770, runas=TEST_USER2)
         self.mom.add_config(
             {'$usecp': self.server.hostname + ':' + sub_dir +
              ' ' + mapping_dir})

--- a/test/tests/selftest/pbs_dshutils_tests.py
+++ b/test/tests/selftest/pbs_dshutils_tests.py
@@ -117,8 +117,8 @@ class TestDshUtils(TestSelf):
         self.check_access(tmpdir, user=TEST_USER2, mode=0o755)
 
         # create a directory as a specific user and permissions
-        tmpdir = self.du.create_temp_dir(asuser=TEST_USER2, mode=0o765)
-        self.check_access(tmpdir, mode=0o765, user=TEST_USER2)
+        tmpdir = self.du.create_temp_dir(asuser=TEST_USER2, mode=0o750)
+        self.check_access(tmpdir, mode=0o750, user=TEST_USER2)
 
         # create a directory as a specific user, group and permissions
         tmpdir = self.du.create_temp_dir(asuser=TEST_USER2, mode=0o770,

--- a/test/tests/selftest/pbs_dshutils_tests.py
+++ b/test/tests/selftest/pbs_dshutils_tests.py
@@ -122,5 +122,5 @@ class TestDshUtils(TestSelf):
 
         # create a directory as a specific user, group and permissions
         tmpdir = self.du.create_temp_dir(asuser=TEST_USER2, mode=0o770,
-                                         asgroup=TSTGRP2)
-        self.check_access(tmpdir, mode=0o770, user=TEST_USER2, group=TSTGRP2)
+                                         asgroup=TSTGRP3)
+        self.check_access(tmpdir, mode=0o770, user=TEST_USER2, group=TSTGRP3)

--- a/test/tests/selftest/pbs_dshutils_tests.py
+++ b/test/tests/selftest/pbs_dshutils_tests.py
@@ -105,7 +105,8 @@ class TestDshUtils(TestSelf):
             c = '"import os;s = os.stat(\'' + path + '\');'
             c += 'print((s.st_uid,s.st_gid,s.st_mode))"'
             cmd = [py, '-c', c]
-            ret = self.du.run_cmd(host, cmd, sudo=True)
+            runas = self.du.get_current_user()
+            ret = self.du.run_cmd(host, cmd, sudo=True, runas=runas)
             self.assertEqual(ret['rc'], 0)
             res = ret['out'][0]
             u, g, m = [int(v) for v in

--- a/test/tests/selftest/pbs_dshutils_tests.py
+++ b/test/tests/selftest/pbs_dshutils_tests.py
@@ -90,7 +90,7 @@ class TestDshUtils(TestSelf):
         environ = self.du.parse_pbs_environment()
         self.assertNotIn('pbs_foo', environ, msg)
 
-    def check_access(self, path, mode=0o700, user=None, group=None):
+    def check_access(self, path, mode=0o755, user=None, group=None):
         """
         Helper function to check user, group and mode of given path
         """


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
create_temp_dir creates a temporary directory but does not honor the permission bits given as input.


#### Describe Your Change
Change in #1098 changed the way a temporary directory used to be created. But this change missed checking for mode.

#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
[test.txt](https://github.com/openpbs/openpbs/files/4773746/test.txt)

I'm going to run regression. PR is marked as draft.

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
