### PR TITLE
Fix invalid return value in transport_recv_pkt

### DIFF
--- a/src/lib/Libdis/dis_helpers.c
+++ b/src/lib/Libdis/dis_helpers.c
@@ -508,7 +508,7 @@ transport_recv_pkt(int fd, int *type, void **data_out, size_t *len_out)
 
 	i = transport_recv(fd, (void *)&pkt_magic, PKT_MAGIC_SZ);
 	if (i <= 0)
-		return -1;
+		return i;
 	if (strncmp(pkt_magic, PKT_MAGIC, PKT_MAGIC_SZ) != 0) {
 		if (pkt_magic[0] == DIS_HDR_FSTCHR) {
 			/*


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* due to invalid return value in transport_recv_pkt, If connection to server is close abruptly (by client) (for example closure of connection with sched after sched cycle completes) then server see that as an error instead considering EOF on that connection

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* return correct value in transport_recv_pkt

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
* None

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[before_fix.txt](https://github.com/openpbs/openpbs/files/4774321/before_fix.txt)
[after_fix.txt](https://github.com/openpbs/openpbs/files/4774320/after_fix.txt)

![Screen Shot 2020-06-13 at 2 24 14 PM](https://user-images.githubusercontent.com/17191391/84564739-a17e0b00-ad81-11ea-8220-21cd6392418e.png)
(NOTE: 1 failure is known issue in test cases)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
