### PR TITLE
qmove gives wrong err msg when remote host is unknown

### DIFF
--- a/src/lib/Libnet/get_hostaddr.c
+++ b/src/lib/Libnet/get_hostaddr.c
@@ -212,6 +212,7 @@ comp_svraddr(pbs_net_t svr_addr, char *hostname)
 	hints.ai_socktype = SOCK_STREAM;
 	hints.ai_protocol = IPPROTO_TCP;
 	if (getaddrinfo(hostname, NULL, &hints, &pai) != 0) {
+		pbs_errno = PBSE_BADHOST;
 		return (2);
 	}
 	for (aip = pai; aip != NULL; aip = aip->ai_next) {

--- a/test/tests/functional/pbs_moved_job.py
+++ b/test/tests/functional/pbs_moved_job.py
@@ -128,5 +128,6 @@ class TestMovedJob(TestFunctional):
         jid = self.server.submit(j)
 
         err = "Access from host not allowed, or unknown host " + jid
-        with self.assertRaises(PbsMoveError, msg=err):
+        with self.assertRaises(PbsMoveError) as e:
             self.server.movejob(jid, 'workq@unknownserver')
+        self.assertIn(err, e.exception.msg[0])

--- a/test/tests/functional/pbs_moved_job.py
+++ b/test/tests/functional/pbs_moved_job.py
@@ -114,3 +114,19 @@ class TestMovedJob(TestFunctional):
             qstat = ""
 
         self.assertEqual(qstat, "")
+
+    def test_movejob_to_unknown_host(self):
+        """
+        This test verifies the error message qmove gives when user tries to
+        move a job to an unknown server
+        """
+
+        attr = {'scheduling': 'false'}
+        self.server.manager(MGR_CMD_SET, SERVER, attr)
+
+        j = Job(TEST_USER)
+        jid = self.server.submit(j)
+
+        err = "Access from host not allowed, or unknown host " + jid
+        with self.assertRaises(PbsMoveError, msg=err):
+            self.server.movejob(jid, 'workq@unknownserver')


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Change made in #1814 resulted into PBS server rejecting a move job request when it is not able to resolve the remote host address. But we did not set the right error number while returning from svr_movejob which means the error qmove command gets is ambiguous. 

#### Describe Your Change
This change sets the pbs_errno to PBSE_BADHOST.

#### Link to Design Doc
NA


#### Attach Test and Valgrind Logs/Output
[test_fix.txt](https://github.com/openpbs/openpbs/files/4782513/test_fix.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
