### PR TITLE
test_epilogue_single_node fails on altix because the cgroups hook runs after the test's hook

### DIFF
--- a/test/tests/functional/pbs_resc_used_single_node.py
+++ b/test/tests/functional/pbs_resc_used_single_node.py
@@ -147,7 +147,7 @@ e.job.resources_used["stra"] = '"glad,elated","happy"'
 """
 
         hook_name = "epi"
-        a = {'event': "execjob_epilogue", 'enabled': 'True'}
+        a = {'event': "execjob_epilogue", 'enabled': 'True', 'order': '200'}
         rv = self.server.create_import_hook(
             hook_name,
             a,

--- a/test/tests/functional/pbs_resc_used_single_node.py
+++ b/test/tests/functional/pbs_resc_used_single_node.py
@@ -147,7 +147,7 @@ e.job.resources_used["stra"] = '"glad,elated","happy"'
 """
 
         hook_name = "epi"
-        # the order of this hook must be after the order of cgroups hook (default 100)
+        # this hook must run after the cgroups hook (default order=100)
         # on the same machine
         a = {'event': "execjob_epilogue", 'enabled': 'True', 'order': '200'}
         rv = self.server.create_import_hook(

--- a/test/tests/functional/pbs_resc_used_single_node.py
+++ b/test/tests/functional/pbs_resc_used_single_node.py
@@ -147,6 +147,8 @@ e.job.resources_used["stra"] = '"glad,elated","happy"'
 """
 
         hook_name = "epi"
+        # the order of this hook must be after the order of cgroups hook (default 100)
+        # on the same machine
         a = {'event': "execjob_epilogue", 'enabled': 'True', 'order': '200'}
         rv = self.server.create_import_hook(
             hook_name,


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Test_singleNode_Job_ResourceUsed.test_epilogue_single_node fails on cpuset systems because those systems have the cgroups hook enabled by default.
test_spilogue_single_node fails because it creates an exechost_epilogue hook that sets a bunch of resources_used values and expects to find those values in the qstat of the job.
However because the cgroups hook (order=100) runs after the test's hook, the cgroups hook can overwrite values that the test expects to find.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
The epilogue hook in this test was given a higher order number than the cgroups hook so that the test hook run last. 
#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
N/A

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[pbi-24-s12-altix.txt](https://github.com/openpbs/openpbs/files/4784691/pbi-24-s12-altix.txt)
[pbi-23-r7p1-altix.txt](https://github.com/openpbs/openpbs/files/4784693/pbi-23-r7p1-altix.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
