### PR TITLE
Update to SmokeTest to run on cpuset system

### DIFF
--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -1217,7 +1217,9 @@ class SmokeTest(PBSTestSuite):
 
         vnode_val = self.mom.shortname
         if self.mom.is_cpuset_mom():
-            vnode_val = self.server.status(NODE)[1]['id']
+            nodeinfo = self.server.status(NODE)
+            if len(nodeinfo) > 1:
+                vnode_val = nodeinfo[1]['id']
         attr = {'Resources_available.foo3': '2gb'}
         self.server.manager(MGR_CMD_SET, NODE, attr, id=vnode_val)
         attr = {'Resources_available.foo1': 3}

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -1214,10 +1214,14 @@ class SmokeTest(PBSTestSuite):
         attr = {'Resources_available.foo': True}
         self.server.manager(MGR_CMD_SET, SERVER, attr,
                             id=self.server.shortname)
+
+        vnode_val = self.mom.shortname
+        if self.mom.is_cpuset_mom():
+            vnode_val = self.server.status(NODE)[1]['id']
         attr = {'Resources_available.foo3': '2gb'}
-        self.server.manager(MGR_CMD_SET, NODE, attr, id=self.mom.shortname)
+        self.server.manager(MGR_CMD_SET, NODE, attr, id=vnode_val)
         attr = {'Resources_available.foo1': 3}
-        self.server.manager(MGR_CMD_SET, NODE, attr, id=self.mom.shortname)
+        self.server.manager(MGR_CMD_SET, NODE, attr, id=vnode_val)
 
         now = time.time()
         r = Reservation(TEST_USER)


### PR DESCRIPTION




<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
SmokeTest.test_resource_create_delete fails on cpuset systems.


#### Describe Your Change
On a cpuset system, resources foo3 and foo1 assignment to node was changed to a cpuset vnode instead of to the natural vnode.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
Tests passed on non-cpuset system:
[SmokeTest_noncset_before.txt](https://github.com/openpbs/openpbs/files/4794085/SmokeTest_noncset_before.txt)
[SmokeTest_noncset_after.txt](https://github.com/openpbs/openpbs/files/4794086/SmokeTest_noncset_after.txt)

Tests now pass on a cpuset system:
[SmokeTest_cset_before.txt](https://github.com/openpbs/openpbs/files/4794087/SmokeTest_cset_before.txt)
[SmokeTest_cset_after.txt](https://github.com/openpbs/openpbs/files/4794088/SmokeTest_cset_after.txt)

[SmokeTest_pbi24_before.txt](https://github.com/openpbs/openpbs/files/4794967/SmokeTest_pbi24_before.txt)
[SmokeTest_pbi24_after.txt](https://github.com/openpbs/openpbs/files/4794968/SmokeTest_pbi24_after.txt)

[SmokeTest_pbi23_before.txt](https://github.com/openpbs/openpbs/files/4795079/SmokeTest_pbi23_before.txt)
[SmokeTest_pbi23_after.txt](https://github.com/openpbs/openpbs/files/4795080/SmokeTest_pbi23_after.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
