### PR TITLE
pbs_snapshot obfuscate fails for mom hosts

### DIFF
--- a/test/fw/ptl/utils/pbs_dshutils.py
+++ b/test/fw/ptl/utils/pbs_dshutils.py
@@ -1485,24 +1485,25 @@ class DshUtils(object):
         :param level: Logging level.
         :type level: int
         :returns: A list containing the names of the entries in
-                  the directory
+                  the directory or an empty list in case no files exist
         """
+        retvalerr = []
 
         if path is None:
-            return None
+            return retvalerr
 
         if (self.is_localhost(hostname) and (not sudo) and (runas is None)):
             try:
                 files = os.listdir(path)
             except OSError:
-                return None
+                return retvalerr
         else:
             ret = self.run_cmd(hostname, cmd=['ls', path], sudo=sudo,
                                runas=runas, logerr=False, level=level)
             if ret['rc'] == 0:
                 files = ret['out']
             else:
-                return None
+                return retvalerr
         if fullpath is True:
             return [os.path.join(path, p.strip()) for p in files]
         else:

--- a/test/fw/ptl/utils/pbs_snaputils.py
+++ b/test/fw/ptl/utils/pbs_snaputils.py
@@ -418,6 +418,8 @@ class ObfuscateSnapshot(object):
         attrs_to_obf += acct_extras
 
         acct_path = os.path.join(snap_dir, "server_priv", "accounting")
+        if not os.path.isdir(acct_path):
+            return
         acct_fnames = self.du.listdir(path=acct_path, sudo=sudo_val)
         for acct_fname in acct_fnames:
             acct_fpath = os.path.join(acct_path, acct_fname)

--- a/test/tests/functional/pbs_snapshot_unittest.py
+++ b/test/tests/functional/pbs_snapshot_unittest.py
@@ -952,6 +952,22 @@ pbs.logmsg(pbs.EVENT_DEBUG,"%s")
                     if not fpath.startswith(sched_priv_dir):
                         self.fail("Unexpected file " + fpath + " captured")
 
+    def test_snapshot_mom_obf(self):
+        """
+        Test capturing a snapshot of a system that's only running pbs_mom
+        """
+        # Kill all daemons and start only pbs_mom
+        self.server.pi.initd(op="stop", daemon="all")
+        self.mom.pi.start_mom()
+        self.assertTrue(self.mom.isUp())
+        self.assertFalse(self.server.isUp())
+
+        # Take & verify a snapshot with obfuscate
+        self.take_snapshot(obfuscate=True, with_sudo=True, acct_logs=10)
+
+        # Bring the rest of daemons up otherwise tearDown will error out
+        self.server.pi.initd(op="start", daemon="all")
+
     def tearDown(self):
         # Delete the snapshot directories and tarballs created
         for snap_dir in self.snapdirs:


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
When capturing a mom host with obfuscate, pbs_snapshot errors out as follows:

'Traceback (most recent call last):', ' File "/opt/pbs/unsupported/fw/bin/pbs_snapshot.py", line 388, in <module>', ' outtar = capture_local_snap(with_sudo)', ' File "/opt/pbs/unsupported/fw/bin/pbs_snapshot.py", line 199, in capture_local_snap', ' obj.obfuscate_snapshot(snap_name, map_file, sudo_val)', ' File "/opt/pbs/unsupported/fw/ptl/utils/pbs_snaputils.py", line 502, in obfuscate_snapshot', ' self.obfuscate_acct_logs(snap_dir, sudo_val)
' File "/opt/pbs/unsupported/fw/ptl/utils/pbs_snaputils.py", line 422, in obfuscate_acct_logs', ' for acct_fname in acct_fnames:', "TypeError: 'NoneType' object is not iterable"


This is because there are no accounting logs, and DshUtils.listdir() returns None for this.
#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
- Modified listdir to return an empty list instead when there are no files to list

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[after_fix.log](https://github.com/openpbs/openpbs/files/4795278/after_fix.log)
[before_fix.log](https://github.com/openpbs/openpbs/files/4795279/before_fix.log)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
