### PR TITLE
Fixed pbs_ralter -D to modify walltime

### DIFF
--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -4297,6 +4297,8 @@ start_end_dur_wall(resc_resv *presv)
 					ATR_VFLAG_MODIFY | ATR_VFLAG_MODCACHE;
 				petime->at_val.at_long = pstime->at_val.at_long +
 					pduration->at_val.at_long;
+				atemp.at_val.at_long = pduration->at_val.at_long;
+				rscdef->rs_set(&prsc->rs_value, &atemp, SET);
 			}
 			break;
 
@@ -4307,6 +4309,10 @@ start_end_dur_wall(resc_resv *presv)
 				((petime->at_val.at_long - pstime->at_val.at_long) !=
 					pduration->at_val.at_long))
 				rc = -1;
+			else {
+				atemp.at_val.at_long = pduration->at_val.at_long;
+				rscdef->rs_set(&prsc->rs_value, &atemp, SET);
+			}
 			break;
 
 		case  6:
@@ -4321,6 +4327,8 @@ start_end_dur_wall(resc_resv *presv)
 					ATR_VFLAG_MODIFY | ATR_VFLAG_MODCACHE;
 				pstime->at_val.at_long = petime->at_val.at_long -
 					pduration->at_val.at_long;
+				atemp.at_val.at_long = pduration->at_val.at_long;
+				rscdef->rs_set(&prsc->rs_value, &atemp, SET);
 			}
 			break;
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
When pbs_ralter modifies the duration with the -D option, it does not modify Resource_List.walltime as well

#### Describe Your Change
Pretty much what you'd expect, Resource_List.walltime was not being set.  I set it in all cases where -D was used.

I also had to fix the alter_a_reservation() function in the pbs_ralter.py test plan to work properly with duration

#### Attach Test and Valgrind Logs/Output
[ralter_dur.log](https://github.com/openpbs/openpbs/files/4801694/ralter_dur.log)
