### PR TITLE
pbs_snapshot can error out for incomplete multi-sched

### DIFF
--- a/test/fw/ptl/utils/pbs_snaputils.py
+++ b/test/fw/ptl/utils/pbs_snaputils.py
@@ -1573,10 +1573,11 @@ quit()
                             line.split("=")[1]
 
             for sched_name in sched_details:
+                pbs_sched_priv = None
                 # Capture sched_priv for the scheduler
                 if len(sched_details) == 1:  # For pre-multisched outputs
                     pbs_sched_priv = os.path.join(self.pbs_home, "sched_priv")
-                else:
+                elif "sched_priv" in sched_details[sched_name]:
                     pbs_sched_priv = sched_details[sched_name]["sched_priv"]
                 if sched_name == "default" or len(sched_details) == 1:
                     snap_sched_priv = os.path.join(self.snapdir,
@@ -1589,15 +1590,17 @@ quit()
                     os.makedirs(snap_sched_priv, 0o755)
                     core_dir = os.path.join(self.snapdir, coredirname)
 
-                self.__copy_dir_with_core(pbs_sched_priv,
-                                          snap_sched_priv, core_dir,
-                                          sudo=self.with_sudo)
+                if pbs_sched_priv and os.path.isdir(pbs_sched_priv):
+                    self.__copy_dir_with_core(pbs_sched_priv,
+                                              snap_sched_priv, core_dir,
+                                              sudo=self.with_sudo)
                 if with_sched_logs and self.num_daemon_logs > 0:
+                    pbs_sched_log = None
                     # Capture scheduler logs
                     if len(sched_details) == 1:  # For pre-multisched outputs
                         pbs_sched_log = os.path.join(self.pbs_home,
                                                      "sched_logs")
-                    else:
+                    elif "sched_log" in sched_details[sched_name]:
                         pbs_sched_log = sched_details[sched_name]["sched_log"]
                     if sched_name == "default" or len(sched_details) == 1:
                         snap_sched_log = os.path.join(self.snapdir,
@@ -1607,7 +1610,9 @@ quit()
                         snap_sched_log = os.path.join(self.snapdir, dirname)
                         os.makedirs(snap_sched_log, 0o755)
 
-                    self.__capture_sched_logs(pbs_sched_log, snap_sched_log)
+                    if pbs_sched_log and os.path.isdir(pbs_sched_log):
+                        self.__capture_sched_logs(pbs_sched_log,
+                                                  snap_sched_log)
 
         elif self.sched_info_avail:
             # We don't know about other multi-scheds,


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
For users using older versions of PBS, pbs_snapshot can error out if multi-sched is configured incorrectly. Specifically, if one unsets sched_priv attribute, which doesn't get reset to default in older versions of PBS, then pbs_snapshot can error out as follows:
Traceback (most recent call last):
  File "/opt/ptl/bin/pbs_snapshot", line 388, in <module>
    outtar = capture_local_snap(with_sudo)
  File "/opt/ptl/bin/pbs_snapshot", line 195, in capture_local_snap
    snap_name = snap_utils.capture_all()
  File "/opt/ptl/lib/python3.6/site-packages/ptl/utils/pbs_snaputils.py", line 1892, in capture_all
    self.capture_scheduler(with_sched_logs=True)
  File "/opt/ptl/lib/python3.6/site-packages/ptl/utils/pbs_snaputils.py", line 1580, in capture_scheduler
    pbs_sched_priv = sched_details[sched_name]["sched_priv"]
KeyError: 'sched_priv'


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Made pbs_snapshot more robust to handle situations like these.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
This will need to be code inspected since it's not reproducible in the current version of PBS. I've tested it manually successfully.


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
