### PR TITLE
update requirment decorator on few tests in TestPBSSnapshot.

### DIFF
--- a/test/tests/functional/pbs_snapshot_unittest.py
+++ b/test/tests/functional/pbs_snapshot_unittest.py
@@ -639,7 +639,6 @@ pbs.logmsg(pbs.EVENT_DEBUG,"%s")
         self.assertTrue(rv)
         self.server.log_match(logmsg)
 
-    @requirements(num_moms=2)
     def snapshot_multi_mom_basic(self, obfuscate=False):
         """
         Test capturing data from a multi-mom system
@@ -710,12 +709,14 @@ pbs.logmsg(pbs.EVENT_DEBUG,"%s")
                         "%s snapshot didn't capture all expected"
                         " information" % (host2))
 
+    @requirements(num_moms=2)
     def test_multi_mom_basic(self):
         """
         Test running pbs_snapshot on a multi-mom setup
         """
         self.snapshot_multi_mom_basic()
 
+    @requirements(num_moms=2)
     def test_multi_mom_basic_obfuscate(self):
         """
         Test running pbs_snapshot on a multi-mom setup with obfuscation


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Need to update requirment decorator on following tests in TestPBSSnapshot.
- test_multi_mom_basic
- test_multi_mom_basic_obfuscate

currently requirement decorator is on common function of both tests. need to put on every test.

#### Describe Your Change
added requirement decorator on mentioned tests and removed from common function.

#### Attach Test and Valgrind Logs/Output
[res_with_two_mom_after_fix.txt](https://github.com/openpbs/openpbs/files/4819676/res_with_two_mom_after_fix.txt)
[res_without_mom_after_fix.txt](https://github.com/openpbs/openpbs/files/4819679/res_without_mom_after_fix.txt)
[res_without_mom_before_fix.txt](https://github.com/openpbs/openpbs/files/4819680/res_without_mom_before_fix.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
