### PR TITLE
Fix minor typo in qmgr help

### DIFF
--- a/src/include/qmgr.h
+++ b/src/include/qmgr.h
@@ -325,7 +325,7 @@ void disconnect_from_server();
 "Syntax ... OP value[multiplier]\n" \
 "A multipler can be added to the end of a size in bytes or words.\n" \
 "The multipliers are: tb, gb, mb, kb, b, tw, gw, mw, kw, w.  The second letter\n" \
-"stands for bytes or words.  b or w is the default multiplier.\n" \
+"stands for bytes or words.  b is the default multiplier.\n" \
 "The multipliers are case insensitive i.e. gw is the same as GW.\n" \
 "Examples:\n" \
 "100mb\n" \


### PR DESCRIPTION
Size values have "b" as the default ("b or w is the default multiplier" doesn't make sense).

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Typo in qmgr help.

#### Describe Your Change
Fixed text (removed "or w") to make it clear that "b" is the default multiplier for sizes.

#### Link to Design Doc
N/A

#### Attach Test and Valgrind Logs/Output
N/A



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
