### PR TITLE
Fixing a mem leak in sched

### DIFF
--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -2450,6 +2450,16 @@ next_job(status *policy, server_info *sinfo, int flag)
 static void
 init_sc_attrs(void)
 {
+	static int first_time = 1;
+
+	if (!first_time) {
+		free(sc_attrs.comment);
+		free(sc_attrs.job_sort_formula);
+		free(sc_attrs.partition);
+		free(sc_attrs.sched_log);
+		free(sc_attrs.sched_port);
+		free(sc_attrs.sched_priv);
+	}
 	sc_attrs.attr_update_period = 0;
 	sc_attrs.comment = NULL;
 	sc_attrs.do_not_span_psets = 0;
@@ -2469,6 +2479,8 @@ init_sc_attrs(void)
 	sc_attrs.server_dyn_res_alarm = 0;
 	sc_attrs.throughput_mode = 1;
 	sc_attrs.opt_backfill_fuzzy = BF_DEFAULT;
+
+	first_time = 0;
 }
 
 /**

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -2450,16 +2450,13 @@ next_job(status *policy, server_info *sinfo, int flag)
 static void
 init_sc_attrs(void)
 {
-	static int first_time = 1;
+	free(sc_attrs.comment);
+	free(sc_attrs.job_sort_formula);
+	free(sc_attrs.partition);
+	free(sc_attrs.sched_log);
+	free(sc_attrs.sched_port);
+	free(sc_attrs.sched_priv);
 
-	if (!first_time) {
-		free(sc_attrs.comment);
-		free(sc_attrs.job_sort_formula);
-		free(sc_attrs.partition);
-		free(sc_attrs.sched_log);
-		free(sc_attrs.sched_port);
-		free(sc_attrs.sched_priv);
-	}
 	sc_attrs.attr_update_period = 0;
 	sc_attrs.comment = NULL;
 	sc_attrs.do_not_span_psets = 0;
@@ -2479,8 +2476,6 @@ init_sc_attrs(void)
 	sc_attrs.server_dyn_res_alarm = 0;
 	sc_attrs.throughput_mode = 1;
 	sc_attrs.opt_backfill_fuzzy = BF_DEFAULT;
-
-	first_time = 0;
 }
 
 /**


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
#1689  introduced the following memory leak in sched:

==56924== 12 bytes in 1 blocks are definitely lost in loss record 30 of 3,513
==56924==    at 0x4C30EDB: malloc (vg_replace_malloc.c:309)
==56924==    by 0x434F0F: string_dup (in /opt/pbs/sbin/pbs_sched)
==56924==    by 0x422406: ??? (in /opt/pbs/sbin/pbs_sched)
==56924==    by 0x42398B: set_validate_sched_attrs (in /opt/pbs/sbin/pbs_sched)
==56924==    by 0x4236D6: update_svr_schedobj (in /opt/pbs/sbin/pbs_sched)
==56924==    by 0x41D8C6: main (in /opt/pbs/sbin/pbs_sched)
==56924== 
==56924== 36 bytes in 3 blocks are definitely lost in loss record 307 of 3,513
==56924==    at 0x4C30EDB: malloc (vg_replace_malloc.c:309)
==56924==    by 0x434F0F: string_dup (in /opt/pbs/sbin/pbs_sched)
==56924==    by 0x422406: ??? (in /opt/pbs/sbin/pbs_sched)
==56924==    by 0x42398B: set_validate_sched_attrs (in /opt/pbs/sbin/pbs_sched)
==56924==    by 0x41EA38: schedule (in /opt/pbs/sbin/pbs_sched)
==56924==    by 0x41D936: main (in /opt/pbs/sbin/pbs_sched)

This just fixes that.

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
