### PR TITLE
test_hook_interrupt fails due to not finding the log message

### DIFF
--- a/test/tests/functional/pbs_hook_set_interrupt.py
+++ b/test/tests/functional/pbs_hook_set_interrupt.py
@@ -68,14 +68,14 @@ pbs.logmsg(pbs.LOG_DEBUG, "TestHook Ended")
         st = time.time()
         jid = self.server.submit(j)
 
-        self.server.log_match("TestHook Started", starttime=st, max_attempts=5)
+        self.server.log_match("TestHook Started", starttime=st)
 
         _msg = "Not Running: PBS Error: request rejected"
         _msg += " as filter hook '%s' got an alarm call." % hook_name
         _msg += " Please inform Admin"
         self.server.expect(JOB,
                            {'job_state': 'Q', 'comment': _msg},
-                           id=jid, offset=5, max_attempts=5)
+                           id=jid, offset=5)
 
         self.server.log_match("Hook;catch_hook_alarm;alarm call received",
                               starttime=st)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
test_hook_interrupt searches for "TestHook Started" in the servers log messages, but only searches 5 times before it gives up.  On slow machines or when other hook event may be happening, this may not be enough time.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Removed the max_attempts.  This way the default max_attempts will be used.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

This is a sporadic timing issue, and I could not reproduce the problem.
[hook_interrupt_after.txt](https://github.com/openpbs/openpbs/files/4822353/hook_interrupt_after.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
