### PR TITLE
add_mom_dyn_res does not create the script on remote host as expected

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -14043,8 +14043,7 @@ class MoM(PBSService):
             if dirname is None:
                 dirname = self.pbs_conf['PBS_HOME']
             tmp_file = self.du.create_temp_file(prefix=prefix, suffix=suffix,
-                                                body=script_body,
-                                                hostname=host)
+                                                body=script_body)
 
             res_file = os.path.join(dirname, tmp_file.split(os.path.sep)[-1])
             self.du.run_copy(host, src=tmp_file, dest=res_file, sudo=True,


### PR DESCRIPTION
#### Describe Bug or Feature
While creating a remote mom dynamic resource using the api add_mom_dyn_res, the api creates a temporary file(script) in the local machine and copies it to /tmp directory on the remote host and deletes the temporary file from the local machine. After copy,  add_mom_dyn_res again calls run_copy with the same temporary file which does not exist(as it has been deleted by create_temp_file after copying) and it fails and exits. The script is never copied to remote host's destined directory.

#### Describe Your Change
add_mom_dyn_res calls create_temp_dir with host as parameter which leads to the initial copy operation. Removed the host parameter. With this change, add_mom_dyn_res creates the script in local host and then copies it to the destination of the remote host

#### Link to Design Doc

#### Attach Test and Valgrind Logs/Output

[testsuite_results.txt](https://github.com/openpbs/openpbs/files/4823368/testsuite_results.txt)
[after_fix.txt](https://github.com/openpbs/openpbs/files/4823369/after_fix.txt)
[before_fix.txt](https://github.com/openpbs/openpbs/files/4823371/before_fix.txt)

Note: The test results are obtained after running the initial section of this particular testcase TestMomDynRes.test_mom_dyn_res_permissions i.e. upto [here](https://github.com/openpbs/openpbs/blob/master/test/tests/functional/pbs_mom_dynamic_resource.py#L387). I picked a section because the whole test case does not run fully on remote host due to some more bugs.

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
