### PR TITLE
Modify TestPbsNodeRampDown tests to work on slow machines

### DIFF
--- a/test/tests/functional/pbs_node_rampdown.py
+++ b/test/tests/functional/pbs_node_rampdown.py
@@ -152,19 +152,29 @@ class TestPbsNodeRampDown(TestFunctional):
 
     def check_test_img_size(self):
         """
-        This Function will make sure that 1gb of test.img file is created
-        in 10 seconds
+        This Function will make sure that atleast 1gb of test.img
+        file is created in 10 seconds
         """
-        test_file_path = os.path.join("/home", str(TEST_USER), "test.img")
-        cmd = ['stat', '-c', '%s', test_file_path]
-        for i in range(0, 11):
-            rc = self.du.run_cmd(hosts=self.hostA, cmd=cmd, runas=TEST_USER)
-            test_img_size = int(rc['out'][0])
-            if (test_img_size < 1073741824) and (i > 9):
-                self.fail("Failed to Create 1gb test.img file")
-            elif test_img_size > 1073741824:
-                break
+        fpath = os.path.join(TEST_USER.home, "test.img")
+        cmd = ['stat', '-c', '%s', fpath]
+        count = 10
+        fsize = 0
+        while count > 0:
+        fsize = 0
+        rc = self.du.run_cmd(hosts=self.hostA, cmd=cmd, runas=TEST_USER)
+        if rc['rc'] == 0 and len(rc['out']) == 1:
+        try:
+            fsize = int(rc['out'][0])
+        except:
+            pass
+        # 1073741824 == 1Gb
+        if fsize > 1073741824:
+            break
+        else:
+            count -= 1
             time.sleep(1)
+        if fsize <= 1073741824:
+            self.fail("Failed to create 1gb file at %s" % fpath)
 
     def match_accounting_log(self, atype, jid, exec_host, exec_vnode,
                              mem, ncpus, nodect, place, select):

--- a/test/tests/functional/pbs_node_rampdown.py
+++ b/test/tests/functional/pbs_node_rampdown.py
@@ -160,19 +160,19 @@ class TestPbsNodeRampDown(TestFunctional):
         count = 10
         fsize = 0
         while count > 0:
-        fsize = 0
-        rc = self.du.run_cmd(hosts=self.hostA, cmd=cmd, runas=TEST_USER)
-        if rc['rc'] == 0 and len(rc['out']) == 1:
-        try:
-            fsize = int(rc['out'][0])
-        except:
-            pass
-        # 1073741824 == 1Gb
-        if fsize > 1073741824:
-            break
-        else:
-            count -= 1
-            time.sleep(1)
+            rc = self.du.run_cmd(hosts=self.hostA, cmd=cmd,
+                                 runas=TEST_USER)
+            if rc['rc'] == 0 and len(rc['out']) == 1:
+                try:
+                    fsize = int(rc['out'][0])
+                except:
+                    pass
+            # 1073741824 == 1Gb
+            if fsize > 1073741824:
+                break
+            else:
+                count -= 1
+                time.sleep(1)
         if fsize <= 1073741824:
             self.fail("Failed to create 1gb file at %s" % fpath)
 

--- a/test/tests/functional/pbs_node_rampdown.py
+++ b/test/tests/functional/pbs_node_rampdown.py
@@ -578,10 +578,10 @@ return i\\n return fib(i-1) + fib(i-2)\\n\\nprint(fib(400))\\\")"'
         self.momA.signal("-CONT")
         self.momB.signal("-CONT")
         self.momC.signal("-CONT")
-        TestFunctional.tearDown(self)
         for host in [self.hostA, self.hostB, self.hostC]:
             test_img = os.path.join("/home", "pbsuser", "test.img")
-            self.du.rm(hostname=host, path=test_img, force=True, runas=TEST_USER)
+            self.du.rm(hostname=host, path=test_img, force=True,
+                       runas=TEST_USER)
         TestFunctional.tearDown(self)
 
     def test_release_nodes_on_stageout_true(self):
@@ -601,7 +601,6 @@ return i\\n return fib(i-1) + fib(i-2)\\n\\nprint(fib(400))\\\")"'
         # Inside job1's script contains the
         # directive to release_nodes_on_stageout=true
         jid = self.create_and_submit_job('job1')
-
 
         self.server.expect(JOB, {'job_state': 'R',
                                  'release_nodes_on_stageout': 'True',

--- a/test/tests/functional/pbs_node_rampdown.py
+++ b/test/tests/functional/pbs_node_rampdown.py
@@ -150,16 +150,15 @@ class TestPbsNodeRampDown(TestFunctional):
             return False
         return True
 
-    def check_test_img_size(self):
+    def check_stageout_file_size(self):
         """
-        This Function will make sure that atleast 1gb of test.img
-        file is created in 10 seconds
+        This Function will check that atleast 1gb of test.img
+        file which is to be stagedout is created in 10 seconds
         """
         fpath = os.path.join(TEST_USER.home, "test.img")
         cmd = ['stat', '-c', '%s', fpath]
-        count = 10
         fsize = 0
-        while count > 0:
+        for i in range(0, 11):
             rc = self.du.run_cmd(hosts=self.hostA, cmd=cmd,
                                  runas=TEST_USER)
             if rc['rc'] == 0 and len(rc['out']) == 1:
@@ -171,7 +170,6 @@ class TestPbsNodeRampDown(TestFunctional):
             if fsize > 1073741824:
                 break
             else:
-                count -= 1
                 time.sleep(1)
         if fsize <= 1073741824:
             self.fail("Failed to create 1gb file at %s" % fpath)
@@ -659,7 +657,7 @@ return i\\n return fib(i-1) + fib(i-2)\\n\\nprint(fib(400))\\\")"'
         # Deleting the job will trigger the stageout process
         # at which time sister nodes are automatically released
         # due to release_nodes_stageout=true set
-        self.check_test_img_size()
+        self.check_stageout_file_size()
         self.server.delete(jid)
 
         # Verify remaining job resources.
@@ -756,7 +754,7 @@ return i\\n return fib(i-1) + fib(i-2)\\n\\nprint(fib(400))\\\")"'
 
         # Deleting a job should not trigger automatic
         # release of nodes due to release_nodes_stagout=False
-        self.check_test_img_size()
+        self.check_stageout_file_size()
         self.server.delete(jid)
 
         # Verify no change in remaining job resources.
@@ -837,7 +835,7 @@ return i\\n return fib(i-1) + fib(i-2)\\n\\nprint(fib(400))\\\")"'
 
         self.match_vnode_status([self.n0, self.n8, self.n9, self.n10], 'free')
 
-        self.check_test_img_size()
+        self.check_stageout_file_size()
         self.server.delete(jid)
 
         # Verify no change in remaining job resources.
@@ -930,7 +928,7 @@ return i\\n return fib(i-1) + fib(i-2)\\n\\nprint(fib(400))\\\")"'
 
         # This triggers the lengthy stageout process
         # Wait for the Job to create test.img file
-        self.check_test_img_size()
+        self.check_stageout_file_size()
         self.server.delete(jid)
 
         self.server.expect(JOB, {'job_state': 'E',
@@ -1026,7 +1024,7 @@ return i\\n return fib(i-1) + fib(i-2)\\n\\nprint(fib(400))\\\")"'
 
         # This triggers long stageout process
         # Wait for the Job to create test.img file
-        self.check_test_img_size()
+        self.check_stageout_file_size()
         self.server.delete(jid)
 
         # Verify no change in remaining job resources.
@@ -1132,7 +1130,7 @@ pbs.event().job.release_nodes_on_stageout=True
         # at which time sister nodes are automatically released
         # due to release_nodes_stageout=true set
         # Wait for the Job to create test.img file
-        self.check_test_img_size()
+        self.check_stageout_file_size()
         self.server.delete(jid)
 
         # Verify remaining job resources.
@@ -1242,7 +1240,7 @@ pbs.event().job.release_nodes_on_stageout=False
         # Deleting a job should not trigger automatic
         # release of nodes due to release_nodes_stagout=False
         # Wait for the Job to create test.img file
-        self.check_test_img_size()
+        self.check_stageout_file_size()
         self.server.delete(jid)
 
         # Verify no change in remaining job resources.
@@ -1352,7 +1350,7 @@ pbs.event().job.release_nodes_on_stageout=True
         # at which time sister nodes are automatically released
         # due to release_nodes_stageout=true set
         # Wait for the Job to create test.img file
-        self.check_test_img_size()
+        self.check_stageout_file_size()
         self.server.delete(jid)
 
         # Verify remaining job resources.
@@ -1464,7 +1462,7 @@ pbs.event().job.release_nodes_on_stageout=False
         # Deleting a job should not trigger automatic
         # release of nodes due to release_nodes_stagout=False
         # Wait for the Job to create test.img file
-        self.check_test_img_size()
+        self.check_stageout_file_size()
         self.server.delete(jid)
 
         # Verify no change in remaining job resources.
@@ -4448,7 +4446,7 @@ pbs.event().job.release_nodes_on_stageout=False
                                   6, 2, self.job1_place, newsel_esc)
 
         # Terminate the job
-        self.check_test_img_size()
+        self.check_stageout_file_size()
         self.server.delete(jid)
 
         # Verify remaining job resources.

--- a/test/tests/functional/pbs_node_rampdown.py
+++ b/test/tests/functional/pbs_node_rampdown.py
@@ -150,6 +150,18 @@ class TestPbsNodeRampDown(TestFunctional):
             return False
         return True
 
+    def check_test_img_size(self):
+        """
+        This Function will make sure that 1gb of test.img file is created
+        in 10 seconds
+        """
+        test_file_path = os.path.join("/home", str(TEST_USER), "test.img")
+        for i in range(0,11):
+            test_img_size = os.stat(test_file_path).st_size
+            if (test_img_size < 1073741824) and (i > 9):
+                self.fail("Failed to Create 1gb test.img file")
+            time.sleep(1)
+
     def match_accounting_log(self, atype, jid, exec_host, exec_vnode,
                              mem, ncpus, nodect, place, select):
         """
@@ -633,7 +645,7 @@ return i\\n return fib(i-1) + fib(i-2)\\n\\nprint(fib(400))\\\")"'
         # Deleting the job will trigger the stageout process
         # at which time sister nodes are automatically released
         # due to release_nodes_stageout=true set
-        time.sleep(3)
+        self.check_test_img_size()
         self.server.delete(jid)
 
         # Verify remaining job resources.
@@ -730,7 +742,7 @@ return i\\n return fib(i-1) + fib(i-2)\\n\\nprint(fib(400))\\\")"'
 
         # Deleting a job should not trigger automatic
         # release of nodes due to release_nodes_stagout=False
-        time.sleep(3)
+        self.check_test_img_size()
         self.server.delete(jid)
 
         # Verify no change in remaining job resources.
@@ -811,7 +823,7 @@ return i\\n return fib(i-1) + fib(i-2)\\n\\nprint(fib(400))\\\")"'
 
         self.match_vnode_status([self.n0, self.n8, self.n9, self.n10], 'free')
 
-        time.sleep(3)
+        self.check_test_img_size()
         self.server.delete(jid)
 
         # Verify no change in remaining job resources.
@@ -904,7 +916,7 @@ return i\\n return fib(i-1) + fib(i-2)\\n\\nprint(fib(400))\\\")"'
 
         # This triggers the lengthy stageout process
         # Wait for the Job to create test.img file
-        time.sleep(3)
+        self.check_test_img_size()
         self.server.delete(jid)
 
         self.server.expect(JOB, {'job_state': 'E',
@@ -1000,7 +1012,7 @@ return i\\n return fib(i-1) + fib(i-2)\\n\\nprint(fib(400))\\\")"'
 
         # This triggers long stageout process
         # Wait for the Job to create test.img file
-        time.sleep(3)
+        self.check_test_img_size()
         self.server.delete(jid)
 
         # Verify no change in remaining job resources.
@@ -1106,7 +1118,7 @@ pbs.event().job.release_nodes_on_stageout=True
         # at which time sister nodes are automatically released
         # due to release_nodes_stageout=true set
         # Wait for the Job to create test.img file
-        time.sleep(3)
+        self.check_test_img_size()
         self.server.delete(jid)
 
         # Verify remaining job resources.
@@ -1216,7 +1228,7 @@ pbs.event().job.release_nodes_on_stageout=False
         # Deleting a job should not trigger automatic
         # release of nodes due to release_nodes_stagout=False
         # Wait for the Job to create test.img file
-        time.sleep(3)
+        self.check_test_img_size()
         self.server.delete(jid)
 
         # Verify no change in remaining job resources.
@@ -1326,7 +1338,7 @@ pbs.event().job.release_nodes_on_stageout=True
         # at which time sister nodes are automatically released
         # due to release_nodes_stageout=true set
         # Wait for the Job to create test.img file
-        time.sleep(3)
+        self.check_test_img_size()
         self.server.delete(jid)
 
         # Verify remaining job resources.
@@ -1438,7 +1450,7 @@ pbs.event().job.release_nodes_on_stageout=False
         # Deleting a job should not trigger automatic
         # release of nodes due to release_nodes_stagout=False
         # Wait for the Job to create test.img file
-        time.sleep(3)
+        self.check_test_img_size()
         self.server.delete(jid)
 
         # Verify no change in remaining job resources.
@@ -4422,7 +4434,7 @@ pbs.event().job.release_nodes_on_stageout=False
                                   6, 2, self.job1_place, newsel_esc)
 
         # Terminate the job
-        time.sleep(3)
+        self.check_test_img_size()
         self.server.delete(jid)
 
         # Verify remaining job resources.

--- a/test/tests/functional/pbs_node_rampdown.py
+++ b/test/tests/functional/pbs_node_rampdown.py
@@ -156,10 +156,14 @@ class TestPbsNodeRampDown(TestFunctional):
         in 10 seconds
         """
         test_file_path = os.path.join("/home", str(TEST_USER), "test.img")
-        for i in range(0,11):
-            test_img_size = os.stat(test_file_path).st_size
+        cmd = ['stat', '-c', '%s', test_file_path]
+        for i in range(0, 11):
+            rc = self.du.run_cmd(hosts=self.hostA, cmd=cmd, runas=TEST_USER)
+            test_img_size = int(rc['out'][0])
             if (test_img_size < 1073741824) and (i > 9):
                 self.fail("Failed to Create 1gb test.img file")
+            elif test_img_size > 1073741824:
+                break
             time.sleep(1)
 
     def match_accounting_log(self, atype, jid, exec_host, exec_vnode,

--- a/test/tests/functional/pbs_node_rampdown.py
+++ b/test/tests/functional/pbs_node_rampdown.py
@@ -158,7 +158,7 @@ class TestPbsNodeRampDown(TestFunctional):
         fpath = os.path.join(TEST_USER.home, "test.img")
         cmd = ['stat', '-c', '%s', fpath]
         fsize = 0
-        for i in range(0, 11):
+        for i in range(11):
             rc = self.du.run_cmd(hosts=self.hostA, cmd=cmd,
                                  runas=TEST_USER)
             if rc['rc'] == 0 and len(rc['out']) == 1:


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Few of the TestPbsNodeRampDown tests were failing on slow machines with error "no data for job".
In these tests, Job is creating a 1Gb file to lengthen stageout process but on slow machines this would create only few 100Mbs file and when Job is deleted in test, stageout process would be done in 1 second due to which test fails in further Log matches. 

#### Describe Your Change
Increased File size which Job is creating from 1gb to 2gb also changed Fibnoacci series to create 400 series instead of 50 in Job script.
Added a sleep of 3 seconds before we delete a job which triggers stageout process in tests to create a large sized file.


#### Attach Test and Valgrind Logs/Output
![TH3_results](https://user-images.githubusercontent.com/33057352/85540264-6955b280-b634-11ea-96b0-ef3337936c06.PNG)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
