### PR TITLE
Fix premature end of message when encryption enabled

### DIFF
--- a/src/lib/Libdis/dis_helpers.c
+++ b/src/lib/Libdis/dis_helpers.c
@@ -380,7 +380,7 @@ parse_pkt(void *pkt, size_t pkt_len, int *type, void **data_out, size_t *len_out
 	*type = *((unsigned char *)pos);
 	pos++;
 	*len_out = ntohl(*((int *)pos));
-	if (*len_out != (pkt_len - 1 - sizeof(int))) {
+	if (*len_out != (pkt_len - PKT_MAGIC_SZ - 1 - sizeof(int))) {
 		*type = 0;
 		*data_out = NULL;
 		*len_out = 0;
@@ -388,7 +388,7 @@ parse_pkt(void *pkt, size_t pkt_len, int *type, void **data_out, size_t *len_out
 	}
 	pos += sizeof(int);
 	*data_out = malloc(*len_out);
-	if (data_out == NULL) {
+	if (*data_out == NULL) {
 		*type = 0;
 		*len_out = 0;
 		return -1;


### PR DESCRIPTION
#### Describe Bug or Feature
* commands are failing with "premature end of message" when encryption enabled in PBS, due to an invalid check for pkt len while parsing encrypted pkt.

#### Describe Your Change
* Fixed invalid check in parse_pkt.

#### Link to Design Doc
* None

#### Attach Test and Valgrind Logs/Output
[before.txt](https://github.com/openpbs/openpbs/files/4824704/before.txt)
[after.txt](https://github.com/openpbs/openpbs/files/4824702/after.txt)