### PR TITLE
test_node_jobs_restart timing issue

### DIFF
--- a/test/tests/functional/pbs_node_jobs_restart.py
+++ b/test/tests/functional/pbs_node_jobs_restart.py
@@ -59,6 +59,7 @@ class TestNodeJobsRestart(TestFunctional):
         svr_nodes = self.server.status(NODE, id=job_nodes[0])
         msg = 'Job ' + jid + ' not in node ' + job_nodes[0] + '\'s jobs line'
         self.assertTrue(jid in svr_nodes[0]['jobs'], msg)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
 
         self.server.restart()
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
The test fails because the job doesn't really start before the server gets restarted.  There is a timing issue with test_node_jobs_restart, where if the restart happens before the job is in substate 42, it won't behave correctly for what the test is trying to test.  

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
I added a check to make sure the job was running before the test does the restart.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[restart_before.txt](https://github.com/openpbs/openpbs/files/4827692/restart_before.txt)
[restart_after.txt](https://github.com/openpbs/openpbs/files/4827691/restart_after.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
