### PR TITLE
Fixed memory leak in scheduler HUP

### DIFF
--- a/src/scheduler/config.h
+++ b/src/scheduler/config.h
@@ -102,7 +102,6 @@
 #define PARSE_BY_QUEUE "by_queue"
 #define PARSE_FAIR_SHARE "fair_share"
 #define PARSE_HALF_LIFE "half_life"
-#define PARSE_SYNC_TIME "sync_time"
 #define PARSE_UNKNOWN_SHARES "unknown_shares"
 #define PARSE_LOG_FILTER "log_filter"
 #define PARSE_DEDICATED_PREFIX "dedicated_prefix"

--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -1171,7 +1171,6 @@ struct config
 	time_t nonprime_spill;			/* vice versa for prime_spill */
 	fairshare_head *fairshare;		/* fairshare tree */
 	time_t decay_time;			/*  time in seconds for the decay period*/
-	time_t sync_time;			/* time between syncing usage to disk */
 	struct t prime[HIGH_DAY][HIGH_PRIME];	/* prime time start and prime time end*/
 	int holidays[MAX_HOLIDAY_SIZE];		/* holidays in Julian date */
 	int holiday_year;			/* the year the holidays are for */

--- a/src/scheduler/parse.c
+++ b/src/scheduler/parse.c
@@ -321,10 +321,6 @@ parse_config(char *fname)
 					if (!type.is_time)
 						error = 1;
 				}
-				else if (!strcmp(config_name, PARSE_SYNC_TIME)) {
-					obsolete[0] = PARSE_SYNC_TIME;
-					obsolete[1] = "nothing - syncs happen automatically";
-				}
 				else if (!strcmp(config_name, PARSE_UNKNOWN_SHARES))
 					conf.unknown_shares = num;
 				else if (!strcmp(config_name, PARSE_FAIRSHARE_DECAY_FACTOR)) {

--- a/src/scheduler/parse.c
+++ b/src/scheduler/parse.c
@@ -899,6 +899,15 @@ init_config()
 		free_string_array(conf.res_to_check);
 	if (conf.dyn_res_to_get != NULL)
 		free_string_array(conf.dyn_res_to_get);
+	
+	if (conf.dynamic_res[0].res != NULL) {
+		int i;
+		for (i = 0; conf.dynamic_res[i].res != NULL; i++) {
+			free(conf.dynamic_res[i].res);
+			free(conf.dynamic_res[i].command_line);
+			free(conf.dynamic_res[i].script_name);
+		}
+	}
 
 	/* default everyone OFF */
 	memset(&conf, 0, sizeof(struct config));
@@ -934,7 +943,6 @@ init_config()
 	conf.update_comments = 1;
 
 	conf.decay_time = 86400;	/* default decay time period is 24 hours */
-	conf.sync_time = 86400;
 
 	if ((conf.fairshare_res = string_dup("cput")) == NULL)
 		return 0;

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -10920,7 +10920,6 @@ class Scheduler(PBSService):
                             "fairshare_enforce_no_shares",
                             "strict_ordering",
                             "resource_unset_infinite",
-                            "sync_time",
                             "unknown_shares",
                             "dedicated_prefix",
                             "load_balancing",


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Memory leak when the scheduler is HUP'd

#### Describe Your Change
The scheduler dups some strings when it parsing server_dyn_res.  It does not free these strings on HUP.

#### Attach Test and Valgrind Logs/Output
BEFORE:
[bmann@mars scheduler]$ grep parse_config valgrind-before.log 
==814486==    by 0x44A932: parse_config (parse.c:611)
==814486==    by 0x44A932: parse_config (parse.c:611)
==814486==    by 0x44A9AA: parse_config (parse.c:620)
==814486==    by 0x44A9BA: parse_config (parse.c:621)
==814486==    by 0x44A9AA: parse_config (parse.c:620)
==814486==    by 0x44A9BA: parse_config (parse.c:621)


AFTER:
[bmann@mars scheduler]$ sudo valgrind --leak-check=full --track-origins=yes --log-file=valgrind.log ./pbs_sched -N
[bmann@mars scheduler]$ grep parse_config valgrind.log 
