### PR TITLE
Fixed test_stale_degraded failure due to nodes not being free when reservation is submitted

### DIFF
--- a/test/tests/functional/pbs_conf_resv_stale_vnode.py
+++ b/test/tests/functional/pbs_conf_resv_stale_vnode.py
@@ -105,6 +105,8 @@ class TestResvStaleVnode(TestFunctional):
         Test that a reservation goes into the degraded state
         when one of its vnodes go stale
         """
+        self.server.expect(NODE, {'state': 'free'}, id='vn[0]')
+        self.server.expect(NODE, {'state': 'free'}, id='vnode[0]')
         now = int(time.time())
         a = {'Resource_List.select': '3:ncpus=1',
              'Resource_List.place': 'vscatter',

--- a/test/tests/functional/pbs_conf_resv_stale_vnode.py
+++ b/test/tests/functional/pbs_conf_resv_stale_vnode.py
@@ -105,8 +105,7 @@ class TestResvStaleVnode(TestFunctional):
         Test that a reservation goes into the degraded state
         when one of its vnodes go stale
         """
-        self.server.expect(NODE, {'state': 'free'}, id='vn[0]')
-        self.server.expect(NODE, {'state': 'free'}, id='vnode[0]')
+        self.server.expect(NODE, {'state=free': 3})
         now = int(time.time())
         a = {'Resource_List.select': '3:ncpus=1',
              'Resource_List.place': 'vscatter',


### PR DESCRIPTION

#### Describe Bug or Feature
test_stale_degraded fails due to nodes not being free when reservation is submitted.
Test is failing  because at the time of reservation submission , node was in initializing state so reservation got denied and deleted immediately .
Race condition in test script 

#### Describe Your Change
In test, before reservation submission confirm node state in free state.


#### Attach Test and Valgrind Logs/Output
[Test_stale_degraded_before_fix.txt](https://github.com/openpbs/openpbs/files/4833845/Test_stale_degraded_before_fix.txt)

[Test_stale_degraded_after_fix.txt](https://github.com/openpbs/openpbs/files/4833892/Test_stale_degraded_after_fix.txt)
