### PR TITLE
Scheduler fails to consider requeued/suspended jobs as ghost jobs

### DIFF
--- a/src/scheduler/constant.h
+++ b/src/scheduler/constant.h
@@ -356,6 +356,7 @@ enum misc_constants
 	IGNORE_DISABLED_EVENTS = 1,
 	FORCE,
 	SET_RESRESV_INDEX = 4,
+	DETECT_GHOST_JOBS = 8,
 	ALL_MASK = 0xffffffff
 };
 

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -1876,6 +1876,15 @@ collect_jobs_on_nodes(node_info **ninfo_arr, resource_resv **resresv_arr, int si
 
 	for (i = 0; ninfo_arr[i] != NULL; i++) {
 		if (ninfo_arr[i]->jobs != NULL) {
+			/* If there are no running jobs in the list and node reports a running job,
+			 * mark that the node has ghost job
+			 */
+			if (size == 0) {
+				ninfo_arr[i]->has_ghost_job = 1;
+				log_eventf(PBSEVENT_DEBUG2, PBS_EVENTCLASS_NODE, LOG_DEBUG, ninfo_arr[i]->name,
+					    "Jobs reported running on node no longer exists or are not in running state");
+			}
+
 			for (j = 0, k = 0; ninfo_arr[i]->jobs[j] != NULL && k < size; j++) {
 				/* jobs are in the format of node_name/sub_node.  We don't care about
 				 * the subnode... we just want to populate the jobs on our node

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -1847,6 +1847,7 @@ collect_resvs_on_nodes(node_info **ninfo_arr, resource_resv **resresv_arr, int s
  * @param[in]	ninfo	-	the nodes to collect for
  * @param[in]	resresv_arr	-	the array of jobs to consider
  * @param[in]	size	-	the size (in number of pointers) of the job arrays
+ * @param[in]   flag	-	flag to indicate whether to do ghost job detection
  *
  * @retval	1	: upon success
  * @retval	2	: if a job reported on nodes was not found in the job arrays
@@ -1854,7 +1855,7 @@ collect_resvs_on_nodes(node_info **ninfo_arr, resource_resv **resresv_arr, int s
  *
  */
 int
-collect_jobs_on_nodes(node_info **ninfo_arr, resource_resv **resresv_arr, int size)
+collect_jobs_on_nodes(node_info **ninfo_arr, resource_resv **resresv_arr, int size, int flag)
 {
 	char *ptr;		/* used to find the '/' in the jobs array */
 	resource_resv *job;	/* find the job from the jobs array */
@@ -1870,7 +1871,10 @@ collect_jobs_on_nodes(node_info **ninfo_arr, resource_resv **resresv_arr, int si
 	for (i = 0; ninfo_arr[i] != NULL; i++) {
 		if ((ninfo_arr[i]->job_arr =
 			malloc((size + 1) * sizeof(resource_resv *))) == NULL)
+		{
+			log_err(errno, __func__, MEM_ERR_MSG);
 			return 0;
+		}
 		ninfo_arr[i]->job_arr[0] = NULL;
 	}
 
@@ -1879,10 +1883,10 @@ collect_jobs_on_nodes(node_info **ninfo_arr, resource_resv **resresv_arr, int si
 			/* If there are no running jobs in the list and node reports a running job,
 			 * mark that the node has ghost job
 			 */
-			if (size == 0) {
+			if (size == 0 && flag == DETECT_GHOST_JOBS) {
 				ninfo_arr[i]->has_ghost_job = 1;
-				log_eventf(PBSEVENT_DEBUG2, PBS_EVENTCLASS_NODE, LOG_DEBUG, ninfo_arr[i]->name,
-					    "Jobs reported running on node no longer exists or are not in running state");
+				log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_NODE, LOG_DEBUG, ninfo_arr[i]->name,
+					  "Jobs reported running on node no longer exists or are not in running state");
 			}
 
 			for (j = 0, k = 0; ninfo_arr[i]->jobs[j] != NULL && k < size; j++) {
@@ -1923,7 +1927,7 @@ collect_jobs_on_nodes(node_info **ninfo_arr, resource_resv **resresv_arr, int si
 						/* make the job array searchable with find_resource_resv */
 						ninfo_arr[i]->job_arr[k] = NULL;
 					}
-				} else {
+				} else if (flag == DETECT_GHOST_JOBS) {
 					/* Race Condition occurred: nodes were queried when a job existed.
 					 * Jobs were queried when the job no longer existed.  Make note
 					 * of it on the job so the node's resources_assigned values can be

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -1517,7 +1517,7 @@ dup_nodes(node_info **onodes, server_info *nsinfo, unsigned int flags)
 	if (onodes == NULL || nsinfo == NULL)
 		return NULL;
 
-	num_nodes = thread_node_ct_left = count_array((void **) onodes);
+	num_nodes = thread_node_ct_left = count_array(onodes);
 
 	if ((nnodes = (node_info **) malloc((num_nodes + 1) * sizeof(node_info *))) == NULL) {
 		log_err(errno, __func__, MEM_ERR_MSG);

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -1847,7 +1847,7 @@ collect_resvs_on_nodes(node_info **ninfo_arr, resource_resv **resresv_arr, int s
  * @param[in]	ninfo	-	the nodes to collect for
  * @param[in]	resresv_arr	-	the array of jobs to consider
  * @param[in]	size	-	the size (in number of pointers) of the job arrays
- * @param[in]   flag	-	flag to indicate whether to do ghost job detection
+ * @param[in]	flags	-	to indicate whether to do ghost job detection
  *
  * @retval	1	: upon success
  * @retval	2	: if a job reported on nodes was not found in the job arrays
@@ -1855,7 +1855,7 @@ collect_resvs_on_nodes(node_info **ninfo_arr, resource_resv **resresv_arr, int s
  *
  */
 int
-collect_jobs_on_nodes(node_info **ninfo_arr, resource_resv **resresv_arr, int size, int flag)
+collect_jobs_on_nodes(node_info **ninfo_arr, resource_resv **resresv_arr, int size, enum misc_constants flags)
 {
 	char *ptr;		/* used to find the '/' in the jobs array */
 	resource_resv *job;	/* find the job from the jobs array */
@@ -1883,7 +1883,7 @@ collect_jobs_on_nodes(node_info **ninfo_arr, resource_resv **resresv_arr, int si
 			/* If there are no running jobs in the list and node reports a running job,
 			 * mark that the node has ghost job
 			 */
-			if (size == 0 && flag == DETECT_GHOST_JOBS) {
+			if (size == 0 && flags == DETECT_GHOST_JOBS) {
 				ninfo_arr[i]->has_ghost_job = 1;
 				log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_NODE, LOG_DEBUG, ninfo_arr[i]->name,
 					  "Jobs reported running on node no longer exists or are not in running state");
@@ -1927,7 +1927,7 @@ collect_jobs_on_nodes(node_info **ninfo_arr, resource_resv **resresv_arr, int si
 						/* make the job array searchable with find_resource_resv */
 						ninfo_arr[i]->job_arr[k] = NULL;
 					}
-				} else if (flag == DETECT_GHOST_JOBS) {
+				} else if (flags == DETECT_GHOST_JOBS) {
 					/* Race Condition occurred: nodes were queried when a job existed.
 					 * Jobs were queried when the job no longer existed.  Make note
 					 * of it on the job so the node's resources_assigned values can be

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -1855,7 +1855,7 @@ collect_resvs_on_nodes(node_info **ninfo_arr, resource_resv **resresv_arr, int s
  *
  */
 int
-collect_jobs_on_nodes(node_info **ninfo_arr, resource_resv **resresv_arr, int size, enum misc_constants flags)
+collect_jobs_on_nodes(node_info **ninfo_arr, resource_resv **resresv_arr, int size, int flags)
 {
 	char *ptr;		/* used to find the '/' in the jobs array */
 	resource_resv *job;	/* find the job from the jobs array */
@@ -1883,7 +1883,7 @@ collect_jobs_on_nodes(node_info **ninfo_arr, resource_resv **resresv_arr, int si
 			/* If there are no running jobs in the list and node reports a running job,
 			 * mark that the node has ghost job
 			 */
-			if (size == 0 && flags == DETECT_GHOST_JOBS) {
+			if (size == 0 && (flags & DETECT_GHOST_JOBS)) {
 				ninfo_arr[i]->has_ghost_job = 1;
 				log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_NODE, LOG_DEBUG, ninfo_arr[i]->name,
 					  "Jobs reported running on node no longer exists or are not in running state");
@@ -1927,7 +1927,7 @@ collect_jobs_on_nodes(node_info **ninfo_arr, resource_resv **resresv_arr, int si
 						/* make the job array searchable with find_resource_resv */
 						ninfo_arr[i]->job_arr[k] = NULL;
 					}
-				} else if (flags == DETECT_GHOST_JOBS) {
+				} else if (flags & DETECT_GHOST_JOBS) {
 					/* Race Condition occurred: nodes were queried when a job existed.
 					 * Jobs were queried when the job no longer existed.  Make note
 					 * of it on the job so the node's resources_assigned values can be

--- a/src/scheduler/node_info.h
+++ b/src/scheduler/node_info.h
@@ -46,9 +46,6 @@ extern "C" {
 #include "data_types.h"
 #include <pbs_ifl.h>
 
-#define  DONT_DETECT_GHOST_JOBS	    0
-#define  DETECT_GHOST_JOBS	    1
-
 void query_node_info_chunk(th_data_query_ninfo *data);
 
 /*
@@ -148,7 +145,7 @@ int set_node_type(node_info *ninfo, char *ntype);
  *      collect_jobs_on_nodes - collect all the jobs in the job array on the
  *                              nodes
  */
-int collect_jobs_on_nodes(node_info **ninfo_arr, resource_resv **resresv_arr, int size, int flag);
+int collect_jobs_on_nodes(node_info **ninfo_arr, resource_resv **resresv_arr, int size, enum misc_constants flags);
 
 /*
  *      collect_resvs_on_nodes - collect all the running resvs in the resv array

--- a/src/scheduler/node_info.h
+++ b/src/scheduler/node_info.h
@@ -46,6 +46,9 @@ extern "C" {
 #include "data_types.h"
 #include <pbs_ifl.h>
 
+#define  DONT_DETECT_GHOST_JOBS	    0
+#define  DETECT_GHOST_JOBS	    1
+
 void query_node_info_chunk(th_data_query_ninfo *data);
 
 /*
@@ -145,7 +148,7 @@ int set_node_type(node_info *ninfo, char *ntype);
  *      collect_jobs_on_nodes - collect all the jobs in the job array on the
  *                              nodes
  */
-int collect_jobs_on_nodes(node_info **ninfo_arr, resource_resv **resresv_arr, int size);
+int collect_jobs_on_nodes(node_info **ninfo_arr, resource_resv **resresv_arr, int size, int flag);
 
 /*
  *      collect_resvs_on_nodes - collect all the running resvs in the resv array

--- a/src/scheduler/node_info.h
+++ b/src/scheduler/node_info.h
@@ -145,7 +145,7 @@ int set_node_type(node_info *ninfo, char *ntype);
  *      collect_jobs_on_nodes - collect all the jobs in the job array on the
  *                              nodes
  */
-int collect_jobs_on_nodes(node_info **ninfo_arr, resource_resv **resresv_arr, int size, enum misc_constants flags);
+int collect_jobs_on_nodes(node_info **ninfo_arr, resource_resv **resresv_arr, int size, int flags);
 
 /*
  *      collect_resvs_on_nodes - collect all the running resvs in the resv array

--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -191,6 +191,7 @@ query_reservations(server_info *sinfo, struct batch_status *resvs)
 		int ignore_resv = 0;
 		clear_schd_error(err);
 		struct attrl	*attrp = NULL;
+		resource_resv **jobs_in_reservations;
 		/* Check if this reservation belongs to this scheduler */
 		for (attrp = cur_resv->attribs; attrp != NULL; attrp = attrp->next) {
 			if (strcmp(attrp->name, ATTR_partition) == 0) {
@@ -352,7 +353,12 @@ query_reservations(server_info *sinfo, struct batch_status *resvs)
 						}
 					}
 				}
-				collect_jobs_on_nodes(resresv->resv->resv_nodes, resresv->resv->resv_queue->jobs, j);
+				jobs_in_reservations = resource_resv_filter(resresv->resv->resv_queue->jobs,
+									    count_array((void **)resresv->resv->resv_queue->jobs),
+									    check_running_job_in_reservation, NULL, 0);
+				collect_jobs_on_nodes(resresv->resv->resv_nodes, jobs_in_reservations,
+					              count_array((void **)jobs_in_reservations));
+				free(jobs_in_reservations);
 
 				/* Sort the nodes to ensure correct job placement. */
 				qsort(resresv->resv->resv_nodes,

--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -354,10 +354,10 @@ query_reservations(server_info *sinfo, struct batch_status *resvs)
 					}
 				}
 				jobs_in_reservations = resource_resv_filter(resresv->resv->resv_queue->jobs,
-									    count_array((void **)resresv->resv->resv_queue->jobs),
+									    count_array(resresv->resv->resv_queue->jobs),
 									    check_running_job_in_reservation, NULL, 0);
 				collect_jobs_on_nodes(resresv->resv->resv_nodes, jobs_in_reservations,
-					              count_array((void **)jobs_in_reservations), NO_FLAGS);
+					              count_array(jobs_in_reservations), NO_FLAGS);
 				free(jobs_in_reservations);
 
 				/* Sort the nodes to ensure correct job placement. */

--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -357,7 +357,7 @@ query_reservations(server_info *sinfo, struct batch_status *resvs)
 									    count_array((void **)resresv->resv->resv_queue->jobs),
 									    check_running_job_in_reservation, NULL, 0);
 				collect_jobs_on_nodes(resresv->resv->resv_nodes, jobs_in_reservations,
-					              count_array((void **)jobs_in_reservations));
+					              count_array((void **)jobs_in_reservations), DONT_DETECT_GHOST_JOBS);
 				free(jobs_in_reservations);
 
 				/* Sort the nodes to ensure correct job placement. */

--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -357,7 +357,7 @@ query_reservations(server_info *sinfo, struct batch_status *resvs)
 									    count_array((void **)resresv->resv->resv_queue->jobs),
 									    check_running_job_in_reservation, NULL, 0);
 				collect_jobs_on_nodes(resresv->resv->resv_nodes, jobs_in_reservations,
-					              count_array((void **)jobs_in_reservations), DONT_DETECT_GHOST_JOBS);
+					              count_array((void **)jobs_in_reservations), NO_FLAGS);
 				free(jobs_in_reservations);
 
 				/* Sort the nodes to ensure correct job placement. */

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -71,7 +71,8 @@
  * 	check_exit_job()
  * 	check_run_resv()
  * 	check_susp_job()
- * 	check_job_not_in_reservation()
+ * 	check_running_job_not_in_reservation()
+ * 	check_running_job_in_reservation()
  * 	check_resv_running_on_node()
  * 	dup_server_info()
  * 	dup_resource_list()
@@ -186,9 +187,8 @@ query_server(status *pol, int pbs_sd)
 	counts *cts;			/* used to count running per user/grp */
 	int num_express_queues = 0;	/* number of express queues */
 	int i;
-	int size;
 	char *errmsg;
-	resource_resv **jobs_not_in_reservations;
+	resource_resv **jobs_alive;
 	status *policy;
 
 	if (pol == NULL)
@@ -355,9 +355,9 @@ query_server(status *pol, int pbs_sd)
 		return NULL;
 	}
 
-	jobs_not_in_reservations = resource_resv_filter(sinfo->jobs,
+	jobs_alive = resource_resv_filter(sinfo->jobs,
 		sinfo->sc.total,
-		check_job_not_in_reservation, NULL, 0);
+		check_jobs_running, NULL, 0);
 
 	if (sinfo->has_soft_limit || sinfo->has_hard_limit) {
 		counts *allcts;
@@ -398,17 +398,15 @@ query_server(status *pol, int pbs_sd)
 	policy->equiv_class_resdef = create_resresv_sets_resdef(policy, sinfo);
 	sinfo->equiv_classes = create_resresv_sets(policy, sinfo);
 
-	size = sinfo->sc.running + sinfo->sc.exiting + sinfo->sc.suspended
-		+ sinfo->sc.userbusy;
 	/* To avoid duplicate accounting of jobs on nodes, we are only interested in
 	 * jobs that are bound to the server nodes and not those bound to reservation
 	 * nodes, which are accounted for by collect_jobs_on_nodes in
 	 * query_reservation, hence the use of the filtered list of jobs
 	 */
-	collect_jobs_on_nodes(sinfo->nodes, jobs_not_in_reservations, size);
+	collect_jobs_on_nodes(sinfo->nodes, jobs_alive, count_array((void **)jobs_alive));
 
-	/* Now that the job_arr is created, garbage collect the jobs in resv list */
-	free(jobs_not_in_reservations);
+	/* Now that the job_arr is created, garbage collect the jobs */
+	free(jobs_alive);
 
 	collect_resvs_on_nodes(sinfo->nodes, sinfo->resvs, sinfo->num_resvs);
 
@@ -2063,13 +2061,34 @@ check_susp_job(resource_resv *job, void *arg)
  * @param[in]	arg	-	argument (not used here)
  *
  * @return	int
- * @retval	1	: if job is not in reservation passed in arg
- * @retval	0	:  if job is there in reservation passed in arg
+ * @retval	1	: if job is running
+ * @retval	0	: if job is not running
  */
 int
-check_job_not_in_reservation(resource_resv *job, void *arg)
+check_jobs_running(resource_resv *job, void *arg)
 {
-	if (job->is_job && job->job != NULL && job->job->resv == NULL)
+	if (job->is_job && (job->job->is_running || job->job->is_exiting || job->job->is_suspended || job->job->is_userbusy))
+		return 1;
+
+	return 0;
+}
+
+/**
+ * @brief
+ * 		helper function for resource_resv_filter()
+ *
+ * @param[in]	job	-	resource reservation job.
+ * @param[in]	arg	-	argument (not used here)
+ *
+ * @return	int
+ * @retval	1	: if job is running and in reservation passed in arg
+ * @retval	0	: if job is not running or not in reservation passed in arg
+ */
+int
+check_running_job_in_reservation(resource_resv *job, void *arg)
+{
+	if (job->is_job && job->job != NULL && job->job->resv != NULL &&
+	    (job->job->is_running || job->job->is_exiting || job->job->is_suspended || job->job->is_userbusy))
 		return 1;
 
 	return 0;

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -401,7 +401,7 @@ query_server(status *pol, int pbs_sd)
 	 * nodes, which are accounted for by collect_jobs_on_nodes in
 	 * query_reservation, hence the use of the filtered list of jobs
 	 */
-	collect_jobs_on_nodes(sinfo->nodes, jobs_alive, count_array((void **)jobs_alive), DETECT_GHOST_JOBS);
+	collect_jobs_on_nodes(sinfo->nodes, jobs_alive, count_array(jobs_alive), DETECT_GHOST_JOBS);
 
 	/* Now that the job_arr is created, garbage collect the jobs */
 	free(jobs_alive);

--- a/src/scheduler/server_info.h
+++ b/src/scheduler/server_info.h
@@ -166,10 +166,10 @@ int check_susp_job(resource_resv *job, void *arg);
 
 /*
  *
- *	check_jobs_running - function used by job_filter to filter out
+ *	check_job_running - function used by job_filter to filter out
  *			   jobs that are running
  */
-int check_jobs_running(resource_resv *job, void *arg);
+int check_job_running(resource_resv *job, void *arg);
 
 /*
  *

--- a/src/scheduler/server_info.h
+++ b/src/scheduler/server_info.h
@@ -166,10 +166,17 @@ int check_susp_job(resource_resv *job, void *arg);
 
 /*
  *
- *	check_job_not_in_reservation - function used by job_filter to filter out
- *			   jobs that are in a reservation
+ *	check_jobs_running - function used by job_filter to filter out
+ *			   jobs that are running
  */
-int check_job_not_in_reservation(resource_resv *job, void *arg);
+int check_jobs_running(resource_resv *job, void *arg);
+
+/*
+ *
+ *	check_running_job_in_reservation - function used by job_filter to filter out
+ *			   jobs that are not in a reservation
+ */
+int check_running_job_in_reservation(resource_resv *job, void *arg);
 
 /*
  *


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Sometimes in a scheduling cycle if a job moves its state from running to suspended (or requeued) between the time scheduler queries nodes to the time it queries jobs, these jobs are often missed as ghost jobs. 

#### Describe Your Change
To check the jobs list node reports against the jobs which are queried by the scheduler, pass in only the list of jobs that are actually running (includes exiting, suspended and user busy jobs as well).



#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
[test_before_fix.txt](https://github.com/openpbs/openpbs/files/4833946/test_before_fix.txt)
[test_after_fix.txt](https://github.com/openpbs/openpbs/files/4833947/test_after_fix.txt)

Since this is timing issue, I have posted the results of a manual test I did using a debugger.


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
