### PR TITLE
qrun subjob fails

### DIFF
--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -3897,8 +3897,11 @@ set_preempt_prio(resource_resv *job, queue_info *qinfo, server_info *sinfo)
 	jinfo->preempt = 0;
 	jinfo->preempt_status = 0;
 
-	if (job == sinfo->qrun_job)
-		jinfo->preempt_status |= PREEMPT_TO_BIT(PREEMPT_QRUN);
+	if (sinfo->qrun_job != NULL) {
+		if (job == sinfo->qrun_job ||
+		    (job->job->is_subjob && (strcmp(job->job->array_id, sinfo->qrun_job->name) == 0)))
+			jinfo->preempt_status |= PREEMPT_TO_BIT(PREEMPT_QRUN);
+	}
 
 	if (sc_attrs.preempt_queue_prio != SCHD_INFINITY &&
 		qinfo->priority >= sc_attrs.preempt_queue_prio)

--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -3899,7 +3899,7 @@ set_preempt_prio(resource_resv *job, queue_info *qinfo, server_info *sinfo)
 
 	if (sinfo->qrun_job != NULL) {
 		if (job == sinfo->qrun_job ||
-		    (job->job->is_subjob && (strcmp(job->job->array_id, sinfo->qrun_job->name) == 0)))
+		    (jinfo->is_subjob && (strcmp(jinfo->array_id, sinfo->qrun_job->name) == 0)))
 			jinfo->preempt_status |= PREEMPT_TO_BIT(PREEMPT_QRUN);
 	}
 

--- a/test/tests/functional/pbs_qrun.py
+++ b/test/tests/functional/pbs_qrun.py
@@ -142,3 +142,20 @@ class TestQrun(TestFunctional):
                 os.waitpid(pid, 0)
                 self.logger.info("Runjob hung. Child process exit.")
                 self.fail("Qrun didn't start another sched cycle")
+
+    @skipOnCpuSet
+    def test_qrun_subjob(self):
+        """
+        This test tests if PBS is able to qrun an array subjob
+        """
+        a = {'resources_available.ncpus': 1}
+        self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom.shortname)
+        jid = self.server.submit(Job())
+        self.server.expect(JOB, {'job_state': 'R'}, jid)
+        j = Job(TEST_USER, {ATTR_J: '1-5'})
+        arr_jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'Q'}, arr_jid)
+        subj2 = j.create_subjob_id(arr_jid, 2)
+        self.server.runjob(jobid=subj2)
+        self.server.expect(JOB, {'job_state': 'R'}, subj2)
+        self.server.expect(JOB, {'job_state': 'S'}, jid)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Qrun of a subjob fails

#### Describe Your Change
Changes made in #1188 caused scheduler to lower down the preemption priority of the subjob given with qrun command.
This causes scheduler to reject preemption because we don't preempt when the job being run lowers down its preemption priority.
Change is to make sure that in case of qrun, we check the preemption priority of its array parent instead of the subjob.


#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
[test.txt](https://github.com/openpbs/openpbs/files/4834604/test.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
