### PR TITLE
Reservation jobs might run on non reservation nodes

### DIFF
--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -246,7 +246,8 @@ query_reservations(server_info *sinfo, struct batch_status *resvs, int pbs_sd)
 				queue_info *qinfo = find_queue_info(sinfo->queues, resresv->resv->queuename);
 				if (qinfo != NULL) {
 				    clear_schd_error(err);
-				    set_schd_error_codes(err, NEVER_RUN, NO_TOTAL_NODES);
+				    set_schd_error_arg(err, SPECMSG, "Reservation is in invalid state");
+				    set_schd_error_codes(err, NEVER_RUN, ERR_SPECIAL);
 				    update_jobs_cant_run(pbs_sd, qinfo->jobs, NULL, err, START_WITH_JOB);
 				}
 			}

--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -133,15 +133,15 @@ stat_resvs(int pbs_sd)
  *  reservation retains its currently allocated resources, such that no other
  *  requests make use of the same resources.
  *
+ * @param[in] pbs_sd - connection to the pbs server
  * @param[in] sinfo  - the server to query from
  * @param[in] resvs  - batch status of the stat'ed reservations
- * @param[in] pbs_sd - connection to the pbs server
  *
  * @return    An array of reservations
  *
  */
 resource_resv **
-query_reservations(server_info *sinfo, struct batch_status *resvs, int pbs_sd)
+query_reservations(int pbs_sd, server_info *sinfo, struct batch_status *resvs)
 {
 	/* the current reservation in the list */
 	struct batch_status *cur_resv;
@@ -246,7 +246,7 @@ query_reservations(server_info *sinfo, struct batch_status *resvs, int pbs_sd)
 				queue_info *qinfo = find_queue_info(sinfo->queues, resresv->resv->queuename);
 				if (qinfo != NULL) {
 				    clear_schd_error(err);
-				    set_schd_error_arg(err, SPECMSG, "Reservation is in invalid state");
+				    set_schd_error_arg(err, SPECMSG, "Reservation is in an invalid state");
 				    set_schd_error_codes(err, NEVER_RUN, ERR_SPECIAL);
 				    update_jobs_cant_run(pbs_sd, qinfo->jobs, NULL, err, START_WITH_JOB);
 				}

--- a/src/scheduler/resv_info.h
+++ b/src/scheduler/resv_info.h
@@ -55,7 +55,7 @@ struct batch_status *stat_resvs(int pbs_sd);
 /*
  *	query_reservations - query the reservations from the server
  */
-resource_resv **query_reservations(server_info *sinfo, struct batch_status *resvs);
+resource_resv **query_reservations(server_info *sinfo, struct batch_status *resvsi, int pbs_sd);
 
 /*
  *	query_resv_info - convert the servers batch_statys structure into a

--- a/src/scheduler/resv_info.h
+++ b/src/scheduler/resv_info.h
@@ -55,7 +55,7 @@ struct batch_status *stat_resvs(int pbs_sd);
 /*
  *	query_reservations - query the reservations from the server
  */
-resource_resv **query_reservations(server_info *sinfo, struct batch_status *resvsi, int pbs_sd);
+resource_resv **query_reservations(int pbs_sd, server_info *sinfo, struct batch_status *resvs);
 
 /*
  *	query_resv_info - convert the servers batch_statys structure into a

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -313,7 +313,7 @@ query_server(status *pol, int pbs_sd)
 	}
 
 	/* get reservations, if any - NOTE: will set sinfo -> num_resvs */
-	sinfo->resvs = query_reservations(sinfo, bs_resvs, pbs_sd);
+	sinfo->resvs = query_reservations(pbs_sd, sinfo, bs_resvs);
 	pbs_statfree(bs_resvs);
 
 	if (create_server_arrays(sinfo) == 0) { /* bad stuff happened */

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -313,7 +313,7 @@ query_server(status *pol, int pbs_sd)
 	}
 
 	/* get reservations, if any - NOTE: will set sinfo -> num_resvs */
-	sinfo->resvs = query_reservations(sinfo, bs_resvs);
+	sinfo->resvs = query_reservations(sinfo, bs_resvs, pbs_sd);
 	pbs_statfree(bs_resvs);
 
 	if (create_server_arrays(sinfo) == 0) { /* bad stuff happened */

--- a/test/tests/functional/pbs_maintenance_reservations.py
+++ b/test/tests/functional/pbs_maintenance_reservations.py
@@ -639,3 +639,58 @@ class TestMaintenanceReservations(TestFunctional):
         time.sleep(30)
 
         self.server.expect(JOB, {'job_state': 'Q'}, id=jid1)
+
+    @requirements(num_moms=2)
+    def test_maintenance_degrade_reservation_jobs_dont_run(self):
+        """
+        Test if the reservation is degraded by overlapping
+        maintenance reservation the jobs inside that degraded reservations do
+        not run when the reservation starts running.
+        Two moms (-p "servers=M1,moms=M1:M2") are needed for this test.
+        """
+        if len(self.moms) != 2:
+            cmt = "need 2 mom hosts: -p servers=<m1>,moms=<m1>:<m2>"
+            self.skip_test(reason=cmt)
+
+        now = int(time.time())
+
+        self.server.manager(MGR_CMD_SET, SERVER,
+                            {'managers': '%s@*' % TEST_USER})
+
+        a1 = {'reserve_start': now + 30,
+              'reserve_end': now + 1200}
+        start = now + 30
+        r1 = Reservation(TEST_USER, attrs=a1)
+        rid = self.server.submit(r1)
+        rid1 = rid.split('.')[0]
+
+        exp_attr = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
+        self.server.expect(RESV, exp_attr, id=rid1)
+        self.server.status(RESV, 'resv_nodes', id=rid1)
+        resv_node_list = self.server.reservations[rid].get_vnodes()
+        resv_node = resv_node_list[0]
+
+        jid = self.server.submit(Job(attrs={ATTR_q: rid1}))
+
+        a2 = {'reserve_start': now + 35,
+              'reserve_end': now + 1000}
+        h2 = [resv_node]
+        r2 = Reservation(TEST_USER, attrs=a2, hosts=h2)
+        rid2 = self.server.submit(r2)
+
+        exp_attr = {'reserve_state': (MATCH_RE, 'RESV_DEGRADED|10'),
+                    'reserve_substate': 12}
+        self.server.expect(RESV, exp_attr, id=rid1)
+        resv_state = {'reserve_state': (MATCH_RE, 'RESV_RUNNING|5')}
+        self.logger.info('Sleeping until reservation starts')
+        offset = start - int(time.time())
+        self.server.expect(RESV, resv_state, id=rid,
+                           offset=offset)
+        self.server.expect(RESV, resv_state, id=rid2,
+                           offset=offset)
+
+        self.logger.info('wait 5 seconds to make sure scheduler looks at job')
+        time.sleep(5)
+        a = {'comment': 'Can Never Run: Not enough total nodes available',
+             'job_state': 'Q'}
+        self.server.expect(JOB, a, id=jid)

--- a/test/tests/functional/pbs_maintenance_reservations.py
+++ b/test/tests/functional/pbs_maintenance_reservations.py
@@ -640,7 +640,6 @@ class TestMaintenanceReservations(TestFunctional):
 
         self.server.expect(JOB, {'job_state': 'Q'}, id=jid1)
 
-    @requirements(num_moms=2)
     def test_maintenance_degrade_reservation_jobs_dont_run(self):
         """
         Test if the reservation is degraded by overlapping
@@ -648,6 +647,7 @@ class TestMaintenanceReservations(TestFunctional):
         not run when the reservation starts running.
         Two moms (-p "servers=M1,moms=M1:M2") are needed for this test.
         """
+
         if len(self.moms) != 2:
             cmt = "need 2 mom hosts: -p servers=<m1>,moms=<m1>:<m2>"
             self.skip_test(reason=cmt)
@@ -691,6 +691,6 @@ class TestMaintenanceReservations(TestFunctional):
 
         self.logger.info('wait 5 seconds to make sure scheduler looks at job')
         time.sleep(5)
-        a = {'comment': 'Can Never Run: Not enough total nodes available',
+        a = {'comment': 'Can Never Run: Reservation is in invalid state',
              'job_state': 'Q'}
         self.server.expect(JOB, a, id=jid)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Sometimes when a degraded reservation starts running and when it has no nodes associated to it, the jobs in these reservations might run on any available nodes.
This issue can happen only when all the reservation's nodes are taken away from reservation before it could start. Maintenance reservations can cause this issue when it completely takes over the nodes from and existing confirmed reservation, leaving the confirmed reservation with no nodes at all.

#### Describe Your Change

The scheduler already detects and ignores any running reservation that does not have any reserved nodes in them. But it does not mark the jobs in the reservation queues as can-not-run. This makes the scheduler consider those queued jobs as any other normal queued job and makes the job run on nodes that are not part of the reservation.
After this change, when the scheduler ignores the reservations, it will also mark all the jobs in the associated queue as can-never-run.

#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
[test.txt](https://github.com/openpbs/openpbs/files/4848949/test.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
