### PR TITLE
Increase the order of epilogue hook in test_epilogue_single_node

### DIFF
--- a/test/tests/functional/pbs_resc_used_single_node.py
+++ b/test/tests/functional/pbs_resc_used_single_node.py
@@ -147,9 +147,9 @@ e.job.resources_used["stra"] = '"glad,elated","happy"'
 """
 
         hook_name = "epi"
-        # this hook must run after the cgroups hook (default order=100)
-        # on the same machine
-        a = {'event': "execjob_epilogue", 'enabled': 'True', 'order': '200'}
+        # this hook must run last on the same machine, and after the
+        # cgroups hook (default order=100)
+        a = {'event': "execjob_epilogue", 'enabled': 'True', 'order': '1000'}
         rv = self.server.create_import_hook(
             hook_name,
             a,


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Test_singleNode_Job_ResourceUsed.test_epilogue_single_node failed to verify job attributes on x70.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Increase the order of the epilogue hook in the test to max value of 1000, to make sure it is the last hook run on the machine. 

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
N/A

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

[x69_test_epilogue_single_node.txt](https://github.com/openpbs/openpbs/files/4851587/x69_test_epilogue_single_node.txt)
[x70_test_epilogue_single_node.txt](https://github.com/openpbs/openpbs/files/4851588/x70_test_epilogue_single_node.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
