### PR TITLE
Refactored count_array() to take generic void *

### DIFF
--- a/src/scheduler/buckets.c
+++ b/src/scheduler/buckets.c
@@ -222,7 +222,7 @@ dup_node_bucket_array(node_bucket **old, server_info *nsinfo) {
 	if (old == NULL)
 		return NULL;
 
-	new = malloc((count_array((void**) old) + 1) * sizeof(node_bucket *));
+	new = malloc((count_array(old) + 1) * sizeof(node_bucket *));
 	if (new == NULL) {
 		log_err(errno, __func__, MEM_ERR_MSG);
 		return NULL;
@@ -403,7 +403,7 @@ create_node_buckets(status *policy, node_info **nodes, queue_info **queues, unsi
 	if (policy == NULL || nodes == NULL)
 		return NULL;
 
-	node_ct = count_array((void**) nodes);
+	node_ct = count_array(nodes);
 
 	buckets = calloc((node_ct + 1), sizeof(node_bucket *));
 	if (buckets == NULL) {
@@ -962,8 +962,8 @@ find_correct_buckets(status *policy, node_bucket **buckets, resource_resv *resre
 	} else
 		clear_schd_error(failerr);
 
-	bucket_ct = count_array((void **) buckets);
-	chunk_ct = count_array((void **) resresv->select->chunks);
+	bucket_ct = count_array(buckets);
+	chunk_ct = count_array(resresv->select->chunks);
 
 	cb_map = calloc((chunk_ct + 1), sizeof(chunk_map *));
 	if (cb_map == NULL) {

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -1585,7 +1585,7 @@ run_update_resresv(status *policy, int pbs_sd, server_info *sinfo,
 			}
 #endif
 
-			num_nspec = count_array((void **) ns);
+			num_nspec = count_array(ns);
 			if (num_nspec > 1)
 				qsort(ns, num_nspec, sizeof(nspec *), cmp_nspec);
 
@@ -2304,7 +2304,7 @@ next_job(status *policy, server_info *sinfo, int flag)
 		if (policy->round_robin) {
 			last_queue = 0;
 			last_queue_index = 0;
-			queue_list_size = count_array((void **)sinfo->queue_list);
+			queue_list_size = count_array(sinfo->queue_list);
 
 		}
 		else if (policy->by_queue)
@@ -2370,7 +2370,7 @@ next_job(status *policy, server_info *sinfo, int flag)
 		i = last_queue_index;
 		while((rjob == NULL) && (i < queue_list_size)) {
 			/* Calculating number of queues at this priority level */
-			queue_index_size = count_array((void **) sinfo->queue_list[i]);
+			queue_index_size = count_array(sinfo->queue_list[i]);
 			for (j = last_queue; j < queue_index_size; j++) {
 				ind = find_runnable_resresv_ind(sinfo->queue_list[i][j]->jobs, 0);
 				if(ind != -1)

--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -1017,7 +1017,7 @@ query_jobs(status *policy, int pbs_sd, queue_info *qinfo, resource_resv **pjobs,
 	num_new_jobs = num_jobs;
 
 	/* if there are previous jobs, count those too */
-	num_prev_jobs = count_array((void **) pjobs);
+	num_prev_jobs = count_array(pjobs);
 	num_jobs += num_prev_jobs;
 
 
@@ -2375,7 +2375,7 @@ dup_resresv_set_array(resresv_set **osets, server_info *nsinfo)
 	if (osets == NULL || nsinfo == NULL)
 		return NULL;
 
-	len = count_array((void **) osets);
+	len = count_array(osets);
 
 	rsets = malloc((len + 1) * sizeof(resresv_set *));
 	if (rsets == NULL) {
@@ -2534,7 +2534,7 @@ create_resresv_sets_resdef(status *policy, server_info *sinfo) {
 	for (cur_res = limres; cur_res != NULL; cur_res = cur_res->next)
 		limres_ct++;
 
-	def_ct = count_array((void **) policy->resdef_to_check);
+	def_ct = count_array(policy->resdef_to_check);
 	/* 6 for ctime, walltime, max_walltime, min_walltime, preempt_targets (maybe), and NULL*/
 	defs = malloc((def_ct + limres_ct + 6) * sizeof(resdef *));
 
@@ -2729,7 +2729,7 @@ create_resresv_sets(status *policy, server_info *sinfo)
 
 	resresvs = sinfo->jobs;
 
-	len = count_array((void **) resresvs);
+	len = count_array(resresvs);
 	rsets = malloc((len + 1) * sizeof(resresv_set *));
 	if (rsets == NULL) {
 		log_err(errno, __func__, MEM_ERR_MSG);
@@ -2760,7 +2760,7 @@ create_resresv_sets(status *policy, server_info *sinfo)
 	tmp_rset_arr = realloc(rsets,(j + 1) * sizeof(resresv_set *));
 	if (tmp_rset_arr != NULL)
 		rsets = tmp_rset_arr;
-	rset_len = count_array((void **)rsets);
+	rset_len = count_array(rsets);
 	if (rset_len > 0) {
 		log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_SCHED, LOG_DEBUG, __func__,
 			"Number of job equivalence classes: %d", rset_len);
@@ -3383,7 +3383,7 @@ find_jobs_to_preempt(status *policy, resource_resv *hjob, server_info *sinfo, in
 	if (sc_attrs.preempt_targets_enable) {
 		if (preempt_targets_req != NULL) {
 			prjobs = resource_resv_filter(nsinfo->running_jobs,
-				count_array((void **) nsinfo->running_jobs),
+				count_array(nsinfo->running_jobs),
 				preempt_job_set_filter,
 				(void *) preempt_targets_list, NO_FLAGS);
 			free_string_array(preempt_targets_list);
@@ -3392,7 +3392,7 @@ find_jobs_to_preempt(status *policy, resource_resv *hjob, server_info *sinfo, in
 
 	if (prjobs != NULL) {
 		rjobs = prjobs;
-		rjobs_count = count_array((void **)prjobs);
+		rjobs_count = count_array(prjobs);
 		if (rjobs_count > 0) {
 			log_eventf(PBSEVENT_DEBUG2, PBS_EVENTCLASS_JOB, LOG_DEBUG, nhjob->name,
 				"Limited running jobs used for preemption from %d to %d", nsinfo->sc.running, rjobs_count);
@@ -3792,9 +3792,9 @@ select_index_to_preempt(status *policy, resource_resv *hjob,
 					 */
 					if (rdtc_non_consumable == NULL) {
 						long max_resdefs = 0;
-						if (policy != NULL) {
-							max_resdefs = count_array( (void **) policy->resdef_to_check);
-						}
+						if (policy != NULL)
+							max_resdefs = count_array(policy->resdef_to_check);
+
 						if (max_resdefs > 0)    {
 							rdtc_non_consumable = (resdef **) calloc(sizeof(resdef *),(size_t) max_resdefs + 1);
 							if (rdtc_non_consumable != NULL) {
@@ -5379,7 +5379,7 @@ resource_resv **filter_preemptable_jobs(resource_resv **arr, resource_resv *job,
 	if ((arr == NULL) || (job == NULL) || (err == NULL))
 		return NULL;
 
-	arr_length = count_array((void **)arr);
+	arr_length = count_array(arr);
 
 	switch (err->error_code) {
 		/* list of resources we care about */
@@ -5523,7 +5523,7 @@ void associate_dependent_jobs(server_info *sinfo) {
 			job_arr = parse_runone_job_list(sinfo->jobs[i]->job->depend_job_str);
 			if (job_arr != NULL) {
 				int j;
-				int len = count_array((void **)job_arr);
+				int len = count_array(job_arr);
 				sinfo->jobs[i]->job->dependent_jobs = calloc((len + 1), sizeof(resource_resv *));
 				sinfo->jobs[i]->job->dependent_jobs[len] = NULL;
 				for (j = 0; job_arr[j] != NULL; j++) {

--- a/src/scheduler/misc.c
+++ b/src/scheduler/misc.c
@@ -183,7 +183,7 @@ add_str_to_array(char ***str_arr, char *str)
 	if (*str_arr == NULL)
 		cnt = 0;
 	else
-		cnt = count_array((void **) *str_arr);
+		cnt = count_array(*str_arr);
 
 	tmp_arr = realloc(*str_arr, (cnt+2)*sizeof(char*));
 	if (tmp_arr == NULL)
@@ -409,7 +409,7 @@ filter_array(void **ptrarr, int (*filter_func)(void*, void*),
 	if (ptrarr == NULL || filter_func == NULL)
 		return NULL;
 
-	size = count_array((void **) ptrarr);
+	size = count_array(ptrarr);
 
 	if ((new_arr = (void **) malloc((size + 1) * sizeof(void *))) == NULL) {
 		log_err(errno, __func__, "Error allocating memory");
@@ -453,7 +453,7 @@ dup_string_array(char **ostrs)
 	int i;
 
 	if (ostrs != NULL) {
-		i = count_array((void **) ostrs);
+		i = count_array(ostrs);
 
 		if ((nstrs = (char **)malloc((i + 1) * sizeof(char *))) == NULL) {
 			log_err(errno, __func__, MEM_ERR_MSG);
@@ -513,7 +513,7 @@ enum match_string_array_ret match_string_array(char **strarr1, char **strarr2)
 	if (strarr1 == NULL || strarr2 == NULL)
 		return SA_NO_MATCH;
 
-	strarr2_len = count_array((void **)strarr2);
+	strarr2_len = count_array(strarr2);
 
 	for (i = 0; strarr1[i] != NULL; i++) {
 		if (is_string_in_arr(strarr2, strarr1[i]))
@@ -802,20 +802,23 @@ is_num(char *str)
  *		count_array - count the number of elements in a NULL terminated array
  *		      of pointers
  *
- * @param[in]	arr	-	the array to count
+ * @param[in]	arr	the array to count
  *
  * @return	number of elements in the array
  *
  */
 int
-count_array(void **arr)
+count_array(void *arr)
 {
 	int i;
+	void **ptr_arr;
 
 	if (arr == NULL)
 		return 0;
 
-	for (i = 0; arr[i] != NULL; i++)
+	ptr_arr = (void **) arr;
+
+	for (i = 0; ptr_arr[i] != NULL; i++)
 		;
 
 	return i;

--- a/src/scheduler/misc.h
+++ b/src/scheduler/misc.h
@@ -158,7 +158,7 @@ int is_num(char *str);
  *	count_array - count the number of elements in a NULL terminated array
  *		      of pointers
  */
-int count_array(void **arr);
+int count_array(void *arr);
 
 /*
  *	dup_array - make a shallow copy of elements in a NULL terminated array of pointers.

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -846,7 +846,7 @@ free_nodes(node_info **ninfo_arr)
 	if (ninfo_arr == NULL)
 		return;
 
-	num_nodes = count_array((void **) ninfo_arr);
+	num_nodes = count_array(ninfo_arr);
 
 	tid = *((int *) pthread_getspecific(th_id_key));
 	if (tid != 0 || num_threads <= 1) {
@@ -1330,7 +1330,7 @@ node_filter(node_info **nodes, int size,
 	int i, j;
 
 	if (size < 0)
-		size = count_array((void **) nodes);
+		size = count_array(nodes);
 
 	if ((new_nodes = (node_info **) malloc((size + 1) * sizeof(node_info *))) == NULL) {
 		log_err(errno, __func__, MEM_ERR_MSG);
@@ -1946,7 +1946,7 @@ collect_jobs_on_nodes(node_info **ninfo_arr, resource_resv **resresv_arr, int si
 	}
 
 	susp_jobs = resource_resv_filter(resresv_arr,
-		count_array((void **) resresv_arr), check_susp_job, NULL, 0);
+		count_array(resresv_arr), check_susp_job, NULL, 0);
 	if (susp_jobs == NULL)
 		return 0;
 
@@ -2604,7 +2604,7 @@ eval_selspec(status *policy, selspec *spec, place *placespec,
 
 	if (resresv->server->has_multi_vnode) {
 		/* Worst case is that split all chunks onto all nodes */
-		tot_nodes = count_array((void **)ninfo_arr);
+		tot_nodes = count_array(ninfo_arr);
 		num_nspecs = tot_nodes * spec->total_chunks;
 	}
 	else
@@ -2636,7 +2636,7 @@ eval_selspec(status *policy, selspec *spec, place *placespec,
 			free_nspecs(*nspec_arr);
 			*nspec_arr = NULL;
 		} else if (resresv->server->has_multi_vnode) {
-			tmp = realloc(*nspec_arr, (count_array((void **)*nspec_arr) + 1) * sizeof(nspec *));
+			tmp = realloc(*nspec_arr, (count_array(*nspec_arr) + 1) * sizeof(nspec *));
 			if (tmp != NULL)
 				*nspec_arr = tmp;
 		}
@@ -2723,7 +2723,7 @@ eval_selspec(status *policy, selspec *spec, place *placespec,
 		free_nspecs(*nspec_arr);
 		*nspec_arr = NULL;
 	} else if (resresv->server->has_multi_vnode) {
-		tmp = realloc(*nspec_arr, (count_array((void **)*nspec_arr) + 1) * sizeof(nspec *));
+		tmp = realloc(*nspec_arr, (count_array(*nspec_arr) + 1) * sizeof(nspec *));
 		if (tmp != NULL)
 			*nspec_arr = tmp;
 	}
@@ -3220,7 +3220,7 @@ eval_complex_selspec(status *policy, selspec *spec, node_info **ninfo_arr, place
 		return eval_simple_selspec(policy, spec->chunks[0], ninfo_arr, pl, resresv,
 			flags, resresv->server->flt_lic, nspec_arr, err);
 
-	tot_nodes = count_array((void **) ninfo_arr);
+	tot_nodes = count_array(ninfo_arr);
 
 	nsa = *nspec_arr;
 
@@ -5051,7 +5051,7 @@ create_node_array_from_nspec(nspec **nspec_arr)
 	if (nspec_arr == NULL)
 		return NULL;
 
-	count = count_array((void **) nspec_arr);
+	count = count_array(nspec_arr);
 
 	if ((ninfo_arr = calloc(count + 1, sizeof(node_info *))) == NULL) {
 		log_err(errno, __func__, MEM_ERR_MSG);
@@ -5118,7 +5118,7 @@ reorder_nodes(node_info **nodes, resource_resv *resresv)
 	if (resresv == NULL && conf.provision_policy == AVOID_PROVISION)
 		return NULL;
 
-	nsize = count_array((void **) nodes);
+	nsize = count_array(nodes);
 
 	if ((node_array_size < nsize + 1) || node_array == NULL) {
 		tmparr = realloc(node_array, sizeof(node_info *) * (nsize + 1));
@@ -5832,7 +5832,7 @@ create_node_array_from_str(node_info **nodes, char **strnodes)
 	if (nodes == NULL || strnodes == NULL)
 		return NULL;
 
-	cnt = count_array((void **)strnodes);
+	cnt = count_array(strnodes);
 
 	if ((ninfo_arr = malloc((cnt+1) * sizeof(node_info *))) == NULL) {
 		log_err(errno, __func__, MEM_ERR_MSG);
@@ -6249,7 +6249,7 @@ check_node_array_eligibility(node_info **ninfo_arr, resource_resv *resresv, plac
 		return;
 
 	if (num_nodes == -1)
-		num_nodes = count_array((void **) ninfo_arr);
+		num_nodes = count_array(ninfo_arr);
 
 	tid = *((int *) pthread_getspecific(th_id_key));
 	if (tid != 0 || num_threads <= 1) {

--- a/src/scheduler/node_partition.c
+++ b/src/scheduler/node_partition.c
@@ -289,7 +289,7 @@ copy_node_partition_ptr_array(node_partition **onp_arr, node_partition **new_nps
 	if (onp_arr == NULL || new_nps == NULL)
 		return NULL;
 
-	cnt = count_array((void **)onp_arr);
+	cnt = count_array(onp_arr);
 	if ((nnp_arr = malloc((cnt + 1) * sizeof(node_partition *))) == NULL) {
 		log_err(errno, __func__, MEM_ERR_MSG);
 		return NULL;
@@ -414,7 +414,7 @@ create_node_partitions(status *policy, node_info **nodes, char **resnames, unsig
 	if (nodes[0] != NULL && nodes[0]->server != NULL)
 		queues = nodes[0]->server->queues;
 
-	num_nodes = count_array((void **) nodes);
+	num_nodes = count_array(nodes);
 
 	if ((np_arr = (node_partition **)
 		malloc((num_nodes + 1) * sizeof(node_partition *))) == NULL) {
@@ -593,7 +593,7 @@ create_node_partitions(status *policy, node_info **nodes, char **resnames, unsig
 		/* if multiple resource values are present, tot_nodes may be incorrect.
 		 * recalculating tot_nodes for each node partition.
 		 */
-		np_arr[np_i]->tot_nodes = count_array((void **) np_arr[np_i]->ninfo_arr);
+		np_arr[np_i]->tot_nodes = count_array(np_arr[np_i]->ninfo_arr);
 		np_arr[np_i]->bkts = create_node_buckets(policy, np_arr[np_i]->ninfo_arr, queues, NO_PRINT_BUCKETS);
 		node_partition_update(policy, np_arr[np_i]);
 	}
@@ -958,7 +958,7 @@ add_np_cache(np_cache ***npc_arr, np_cache *npc)
 
 	cur_cache = *npc_arr;
 
-	ct = count_array((void **) cur_cache);
+	ct = count_array(cur_cache);
 
 	/* ct+2: 1 for new element 1 for NULL ptr */
 	new_cache = realloc(cur_cache, (ct+2) * sizeof(np_cache *));
@@ -1155,7 +1155,7 @@ create_specific_nodepart(status *policy, char *name, node_info **nodes, int flag
 	if (np == NULL)
 		return NULL;
 
-	cnt = count_array((void **) nodes);
+	cnt = count_array(nodes);
 
 	np->name = string_dup(name);
 	np->def = NULL;

--- a/src/scheduler/queue_info.c
+++ b/src/scheduler/queue_info.c
@@ -219,7 +219,7 @@ query_queues(status *policy, int pbs_sd, server_info *sinfo)
 				qinfo->nodes = node_filter(sinfo->nodes, sinfo->num_nodes,
 					node_queue_cmp, (void *) qinfo->name, 0);
 
-				qinfo->num_nodes = count_array((void **) qinfo->nodes);
+				qinfo->num_nodes = count_array(qinfo->nodes);
 
 			}
 

--- a/src/scheduler/resource.c
+++ b/src/scheduler/resource.c
@@ -379,7 +379,7 @@ dup_resdef_array(resdef **odef_arr)
 	if (odef_arr == NULL)
 		return NULL;
 
-	ct = count_array((void **) odef_arr);
+	ct = count_array(odef_arr);
 
 	ndef_arr = malloc((ct + 1) * sizeof(resdef*));
 	if (ndef_arr == NULL) {
@@ -436,9 +436,9 @@ add_resdef_to_array(resdef ***resdef_arr, resdef *def)
 	if (resdef_arr == NULL || def == NULL)
 		return -1;
 
-	cnt = count_array((void **) *resdef_arr);
+	cnt = count_array(*resdef_arr);
 
-	tmp_arr = (resdef**) realloc(*resdef_arr, (cnt+2)*sizeof(resdef*));
+	tmp_arr = (resdef **) realloc(*resdef_arr, (cnt + 2) * sizeof(resdef*));
 	if (tmp_arr == NULL)
 		return -1;
 
@@ -470,8 +470,8 @@ copy_resdef_array(resdef **deflist)
 	if (deflist == NULL)
 		return NULL;
 
-	cnt = count_array((void **)deflist);
-	new_deflist = malloc((cnt+1) * sizeof(resdef*));
+	cnt = count_array(deflist);
+	new_deflist = malloc((cnt + 1) * sizeof(resdef*));
 	if (new_deflist == NULL) {
 		log_err(errno, __func__, MEM_ERR_MSG);
 		return NULL;

--- a/src/scheduler/resource.c
+++ b/src/scheduler/resource.c
@@ -806,7 +806,7 @@ resstr_to_resdef(char **resstr)
 	if (resstr == NULL)
 		return NULL;
 
-	cnt = count_array((void **) resstr);
+	cnt = count_array(resstr);
 	if ((tmparr = malloc((cnt + 1) * sizeof(resdef *))) == NULL) {
 		log_err(errno, __func__, MEM_ERR_MSG);
 		return NULL;

--- a/src/scheduler/resource_resv.c
+++ b/src/scheduler/resource_resv.c
@@ -276,7 +276,7 @@ free_resource_resv_array(resource_resv **resresv_arr)
 	if (resresv_arr == NULL)
 		return;
 
-	num_jobs = count_array((void **) resresv_arr);
+	num_jobs = count_array(resresv_arr);
 
 	tid = *((int *) pthread_getspecific(th_id_key));
 	if (tid != 0 || num_threads <= 1) {
@@ -514,7 +514,7 @@ dup_resource_resv_array(resource_resv **oresresv_arr,
 	if (oresresv_arr == NULL || nsinfo == NULL)
 		return NULL;
 
-	num_resresv = thread_job_ct_left = count_array((void **) oresresv_arr);
+	num_resresv = thread_job_ct_left = count_array(oresresv_arr);
 
 	if ((nresresv_arr = malloc((num_resresv + 1) * sizeof(resource_resv *))) == NULL) {
 		log_err(errno, __func__, MEM_ERR_MSG);
@@ -1929,7 +1929,7 @@ add_resresv_to_array(resource_resv **resresv_arr,
 		return new_arr;
 	}
 
-	size = count_array((void **) resresv_arr);
+	size = count_array(resresv_arr);
 
 	/* realloc for 1 more ptr (2 == 1 for new and 1 for NULL) */
 	new_arr = realloc(resresv_arr, ((size+2) * sizeof(resource_resv *)));
@@ -2167,7 +2167,7 @@ dup_chunk_array(chunk **old_chunk_arr)
 	if (old_chunk_arr == NULL)
 		return NULL;
 
-	ct = count_array((void **) old_chunk_arr);
+	ct = count_array(old_chunk_arr);
 
 	if ((new_chunk_arr = calloc(ct + 1, sizeof(chunk *))) == NULL) {
 		log_err(errno, __func__, MEM_ERR_MSG);

--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -356,7 +356,7 @@ query_reservations(server_info *sinfo, struct batch_status *resvs)
 
 				/* Sort the nodes to ensure correct job placement. */
 				qsort(resresv->resv->resv_nodes,
-					count_array((void **) resresv->resv->resv_nodes),
+					count_array(resresv->resv->resv_nodes),
 					sizeof(node_info *), multi_node_sort);
 			}
 		}

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -446,7 +446,7 @@ query_server(status *pol, int pbs_sd)
 
 	if (sinfo->buckets != NULL) {
 		int ct;
-		ct = count_array((void **) sinfo->buckets);
+		ct = count_array(sinfo->buckets);
 		qsort(sinfo->buckets, ct, sizeof(node_bucket *), multi_bkt_sort);
 	}
 
@@ -1654,7 +1654,7 @@ update_server_on_run(status *policy, server_info *sinfo,
 				int num_resv_nodes;
 
 				resv_nodes = resresv->job->resv->resv->resv_nodes;
-				num_resv_nodes = count_array((void **) resv_nodes);
+				num_resv_nodes = count_array(resv_nodes);
 				qsort(resv_nodes, num_resv_nodes, sizeof(node_info *),
 					multi_node_sort);
 			} else {
@@ -1662,7 +1662,7 @@ update_server_on_run(status *policy, server_info *sinfo,
 					multi_node_sort);
 
 				if (sinfo->nodes != sinfo->unassoc_nodes) {
-					num_unassoc = count_array((void **) sinfo->unassoc_nodes);
+					num_unassoc = count_array(sinfo->unassoc_nodes);
 					qsort(sinfo->unassoc_nodes, num_unassoc, sizeof(node_info *),
 						multi_node_sort);
 				}
@@ -3652,7 +3652,7 @@ add_queue_to_list(queue_info **** qlhead, queue_info * qinfo)
 	    return 0;
 
 	list_head = *qlhead;
-	queue_list_size = count_array((void **)list_head);
+	queue_list_size = count_array(list_head);
 
 	temp_list = find_queue_list_by_priority(list_head, qinfo->priority);
 	if (temp_list == NULL) {
@@ -3719,7 +3719,7 @@ struct queue_info **append_to_queue_list(queue_info ***list, queue_info *add)
 
 	if ((list == NULL) || (add == NULL))
 		return NULL;
-	count = count_array((void **)*list);
+	count = count_array(*list);
 
 	/* count contains number of elements in list (excluding NULL). we add 2 to add the NULL
 	 * back in, plus our new element.
@@ -3927,8 +3927,8 @@ dup_unordered_nodes(node_info **old_unordered_nodes, node_info **nnodes)
 	if (old_unordered_nodes == NULL || nnodes == NULL)
 		return NULL;
 
-	ct1 = count_array((void **) nnodes);
-	ct2 = count_array((void **) old_unordered_nodes);
+	ct1 = count_array(nnodes);
+	ct2 = count_array(old_unordered_nodes);
 
 	if(ct1 != ct2)
 		return NULL;
@@ -3962,7 +3962,7 @@ add_ptr_to_array(void *ptr_arr, void *ptr)
 	void **arr;
 	int cnt;
 
-	cnt = count_array((void **)ptr_arr);
+	cnt = count_array(ptr_arr);
 
 	if (cnt == 0) {
 		arr = malloc(sizeof(void *) * 2);

--- a/src/scheduler/simulate.c
+++ b/src/scheduler/simulate.c
@@ -870,7 +870,7 @@ create_events(server_info *sinfo)
 	 * the timed events are in the front of the array.
 	 * Once the first non-timed event is reached, we're done
 	 */
-	all_resresv_len = count_array((void **)sinfo->all_resresv);
+	all_resresv_len = count_array(sinfo->all_resresv);
 	all_resresv_copy = malloc((all_resresv_len + 1) * sizeof(resource_resv *));
 	if (all_resresv_copy == NULL)
 		return 0;
@@ -880,7 +880,7 @@ create_events(server_info *sinfo)
 	all = all_resresv_copy;
 
 	/* sort the all resersv list so all the timed events are in the front */
-	qsort(all, count_array((void **)all), sizeof(resource_resv *), cmp_events);
+	qsort(all, count_array(all), sizeof(resource_resv *), cmp_events);
 
 	for (i = 0; all[i] != NULL && is_timed(all[i]); i++) {
 		/* only add a run event for a job or reservation if they're

--- a/src/scheduler/sort.c
+++ b/src/scheduler/sort.c
@@ -1286,27 +1286,25 @@ sort_jobs(status *policy, server_info *sinfo)
 		}
 		/** Sort on entire complex **/
 		else if (!policy->by_queue && !policy->round_robin) {
-			qsort(sinfo->jobs, count_array((void **)sinfo->jobs),
-				sizeof(resource_resv *), cmp_sort);
+			qsort(sinfo->jobs, count_array(sinfo->jobs), sizeof(resource_resv *), cmp_sort);
 		}
 	}
 	else if (policy->by_queue) {
 		for (i = 0; i < sinfo->num_queues; i++) {
-			qsort(sinfo->queues[i]->jobs, count_array((void **)sinfo->queues[i]->jobs),
-				sizeof(resource_resv *), cmp_sort);
+			qsort(sinfo->queues[i]->jobs, count_array(sinfo->queues[i]->jobs), sizeof(resource_resv *), cmp_sort);
 		}
-		qsort(sinfo->jobs, count_array((void **)sinfo->jobs), sizeof(resource_resv*), cmp_sort);
+		qsort(sinfo->jobs, count_array(sinfo->jobs), sizeof(resource_resv*), cmp_sort);
 	}
 	else if (policy->round_robin) {
 		if (sinfo -> queue_list != NULL) {
-			int queue_list_size = count_array((void **)sinfo->queue_list);
+			int queue_list_size = count_array(sinfo->queue_list);
 			int i,j;
 			for (i = 0; i < queue_list_size; i++)
 			{
-				int queue_index_size = count_array((void **)sinfo->queue_list[i]);
+				int queue_index_size = count_array(sinfo->queue_list[i]);
 				for (j = 0; j < queue_index_size; j++)
 				{
-				    qsort(sinfo->queue_list[i][j]->jobs, count_array((void **)sinfo->queue_list[i][j]->jobs),
+				    qsort(sinfo->queue_list[i][j]->jobs, count_array(sinfo->queue_list[i][j]->jobs),
 					    sizeof(resource_resv *), cmp_sort);
 				}
 			}
@@ -1314,5 +1312,5 @@ sort_jobs(status *policy, server_info *sinfo)
 		}
 	}
 	else
-		qsort(sinfo->jobs, count_array((void **)sinfo->jobs), sizeof(resource_resv*), cmp_sort);
+		qsort(sinfo->jobs, count_array(sinfo->jobs), sizeof(resource_resv*), cmp_sort);
 }


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
The scheduler uses NULL terminated pointer arrays for all of its data structures.  A long time ago a utility function was written to count these arrays called count_array().  It took a void ** so the array could be counted.  This is unfortunately not a generic pointer, so all the scheduler arrays had to be cast to a void ** to use this function or a compiler warning was emitted.

#### Describe Your Change
I refactored count_array() to take a void * which is a generic pointer.  You can pass any pointer to a void * without causing a compiler warning.  Inside of count_array(), I cast the void * to a void ** so it could be counted

#### Attach Test and Valgrind Logs/Output
Since this is an internal only refactor, there should be no change to the scheduler at all.  The Travis smoke test smoke test should be sufficient to test.