### PR TITLE
Fix for perf degradation due to unnecessary heavy memset

### DIFF
--- a/src/lib/Libdis/dis_helpers.c
+++ b/src/lib/Libdis/dis_helpers.c
@@ -743,7 +743,7 @@ dis_clear_buf(pbs_dis_buf_t *tp)
 	tp->tdis_lead = 0;
 	tp->tdis_trail = 0;
 	tp->tdis_eod = 0;
-	memset(tp->tdis_thebuf, '\0', tp->tdis_bufsize);
+	tp->tdis_thebuf[0] = '\0';
 }
 
 /**


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* Performance is degraded compared to release 19 due to unnecessary heavy memset

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* Remove unnecessary heavy memset

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
* None

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
##### Test steps: (thanks @agrawalravi90 for this steps)
1. Install pbs
2. kill running mom `kill -9 $(pidof pbs_mom)`
3. run `pbs_mom -m` as root to start mock mom
4. `pbs_config --vnodify -N 100 -a resources_available.ncpus=500` (to create 100 vnodes with 500 ncpus each)
5. submit 50k jobs (`for i in $(seq 1 1 50000); do qsub -koe -- /bin/date; done;` as pbsroot user)
6. start only one sched cycle (`qmgr -c "s s scheduling=1" && qmgr -c "s s scheduling=0"`)
7. wait for jobs to finish
8. run `pbs_loganalyzer -a <path to accounting log>`
9. capture `duration`, `job_end_rate`, `job_run_rate` and `job_submit_rate` from output of pbs_loganalyzer

##### Perf results of above steps
||Try1|Try2|Try3|Avg.|
|-|-|-|-|-|
|19.2<br>+ mock mom<br>cherry pick|duration: 0:06:42<br>job_end_rate: 240.38/s<br>job_run_rate: 240.38/s<br>submit_rate: 260.42/s|duration: 0:06:46<br>job_end_rate: 241.55/s<br>job_run_rate: 241.55/s<br>submit_rate: 253.81/s|duration: 0:06:44<br>job_end_rate: 242.72/s<br>job_run_rate: 242.72/s<br>submit_rate: 255.10/s|duration: 0:06:44<br>job_end_rate: 241.55/s<br>job_run_rate: 241.55/s<br>submit_rate: 256.44/s|
|Before fix|duration: 0:14:17<br>job_end_rate: 78.86/s<br>job_run_rate: 78.86/s<br>submit_rate: 228.31/s|duration: 0:13:39<br>job_end_rate: 81.17/s<br>job_run_rate: 81.17/s<br>submit_rate: 251.26/s|duration: 0:13:57<br>job_end_rate: 79.74/s<br>job_run_rate: 79.74/s<br>submit_rate: 241.55/s|duration: 0:13:58<br>job_end_rate: 79.92/s<br>job_run_rate: 79.92/s<br>submit_rate: 243.37/s|
|Before LibAuth<br>+ mock mom<br>cherry-pick|duration: 0:04:52<br>job_end_rate: 666.67/s<br>job_run_rate: 666.67/s<br>submit_rate: 232.56/s|duration: 0:04:47<br>job_end_rate: 657.89/s<br>job_run_rate: 657.89/s<br>submit_rate: 239.23/s|duration: 0:04:32<br>job_end_rate: 657.89/s<br>job_run_rate: 657.89/s<br>submit_rate: 257.73/s|duration: 0:04:66<br>job_end_rate: 660.81/s<br>job_run_rate: 660.81/s<br>submit_rate: 243.17/s|
|After fix|duration: 0:04:42<br>job_end_rate: 694.44/s<br>job_run_rate: 694.44/s<br>submit_rate: 242.72/s|duration: 0:04:34<br>job_end_rate: 684.93/s<br>job_run_rate: 684.93/s<br>submit_rate: 252.53/s|duration: 0:04:33<br>job_end_rate: 694.44/s<br>job_run_rate: 694.44/s<br>submit_rate: 253.81/s|duration: 0:04:36<br>job_end_rate: 691.27/s<br>job_run_rate: 691.27/s<br>submit_rate: 249.67/s|




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
