### PR TITLE
skip TestProvisioningJob_Enh suite on cray as it is not meant for cray

### DIFF
--- a/test/tests/functional/pbs_provisioning_enhancement.py
+++ b/test/tests/functional/pbs_provisioning_enhancement.py
@@ -78,6 +78,8 @@ e.reject()
 
     def setUp(self):
 
+        if self.du.get_platform().startswith('cray'):
+            self.skipTest("Test suite only meant to run on non-Cray")
         if len(self.moms) < 2:
             self.skipTest("Provide at least 2 moms while invoking test")
 


### PR DESCRIPTION
#### Describe Bug or Feature
All test from TestProvisioningJob_Enh is throwing error while execution on  Cray as below 

ptl.lib.pbs_testlib.PbsManagerError: rc=32, rv=False, msg=["qmgr obj=fake_prov_hook svr=default: Another hook 'PBS_xeon_phi_provision' already has event 'provision', only one 'provision' hook allowed", 'qmgr: hook error returned from server']


#### Describe Your Change
The above error which we observed is expected on Cray machine , since only one 'provision' hook allowed one time and cray machine has default PBS_xeon_phi_provision pbshook with event provision  so not allowed to add another hook with event provision .
Also this test suite is specifically written for non-cray platform to test provisioning enhancement and to test provisioning enhancement on Cray test is written under TestBasilQuery.

So , Added  skip code to skip execution on cray in setUp.

#### Attach Test and Valgrind Logs/Output
[TestProvisioningJob_Enh_after_fix.txt](https://github.com/openpbs/openpbs/files/4864321/TestProvisioningJob_Enh_after_fix.txt)
[TestProvisioningJob_Enh_before_fix.txt](https://github.com/openpbs/openpbs/files/4864322/TestProvisioningJob_Enh_before_fix.txt)



