### PR TITLE
Check if enough numa vnodes before running TestPbsCpuset

### DIFF
--- a/test/tests/functional/pbs_cpuset.py
+++ b/test/tests/functional/pbs_cpuset.py
@@ -87,6 +87,11 @@ time.sleep(20)
         The released numa node can be used in another job.
         """
 
+        # Check that there are at least a natural vnode + 2 numa vnodes
+        nodeinfo = self.server.status(NODE)
+        if len(nodeinfo) < 3:
+            self.skipTest("Not enough vnodes to run the test.")
+
         # instantiate execjob_launch hook
         hook_event = "execjob_launch"
         hook_name = "launch"


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
TestPbsCpuset.test_reliable_job_startup_on_cpuset fails on systems that have less than the needed 2 numa vnodes.

#### Describe Your Change
Added a check if there are enough needed numa vnodes on the system. Otherwise the test will skip.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
[TestPbsCpuset_before.txt](https://github.com/openpbs/openpbs/files/4866100/TestPbsCpuset_before.txt)
[TestPbsCpuset_after.txt](https://github.com/openpbs/openpbs/files/4866103/TestPbsCpuset_after.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
