### PR TITLE
Added performance data to json file

### DIFF
--- a/test/tests/performance/pbs_qstat_performance.py
+++ b/test/tests/performance/pbs_qstat_performance.py
@@ -108,6 +108,19 @@ class TestQstatPerformance(TestPerformance):
             return -1
         self.logger.info("Without E option :" + without_E_option['err'][0])
         self.logger.info("With E option    :" + with_E_option['err'][0])
+        self.perf_test_result(
+            float(
+                without_E_option['err'][0]),
+            "elapse_time qstat " +
+            query,
+            "sec")
+        self.perf_test_result(
+            float(
+                with_E_option['err'][0]),
+            "elapse_time qstat " +
+            query +
+            " -E",
+            "sec")
         self.assertTrue(
             (without_E_option['err'][0] >= with_E_option['err'][0]),
             "Qstat command with option : " + query + " Failed")

--- a/test/tests/performance/pbs_qstat_performance.py
+++ b/test/tests/performance/pbs_qstat_performance.py
@@ -110,11 +110,9 @@ class TestQstatPerformance(TestPerformance):
         self.logger.info("With E option    :" + with_E_option['err'][0])
         measure = "elapse_time qstat" + query.split("`")[0]
         self.perf_test_result(float(without_E_option['err'][0]),
-                              measure,
-                              "sec")
+                              measure, "sec")
         self.perf_test_result(float(with_E_option['err'][0]),
-                              measure + "-E",
-                              "sec")
+                              measure + "-E", "sec")
         self.assertTrue(
             (without_E_option['err'][0] >= with_E_option['err'][0]),
             "Qstat command with option : " + query + " Failed")

--- a/test/tests/performance/pbs_qstat_performance.py
+++ b/test/tests/performance/pbs_qstat_performance.py
@@ -108,19 +108,13 @@ class TestQstatPerformance(TestPerformance):
             return -1
         self.logger.info("Without E option :" + without_E_option['err'][0])
         self.logger.info("With E option    :" + with_E_option['err'][0])
-        self.perf_test_result(
-            float(
-                without_E_option['err'][0]),
-            "elapse_time qstat " +
-            query,
-            "sec")
-        self.perf_test_result(
-            float(
-                with_E_option['err'][0]),
-            "elapse_time qstat " +
-            query +
-            " -E",
-            "sec")
+        measure = "elapse_time qstat" + query.split("`")[0]
+        self.perf_test_result(float(without_E_option['err'][0]),
+                              measure,
+                              "sec")
+        self.perf_test_result(float(with_E_option['err'][0]),
+                              measure + "-E",
+                              "sec")
         self.assertTrue(
             (without_E_option['err'][0] >= with_E_option['err'][0]),
             "Qstat command with option : " + query + " Failed")

--- a/test/tests/performance/pbs_runjobwait_perf.py
+++ b/test/tests/performance/pbs_runjobwait_perf.py
@@ -90,7 +90,7 @@ class TestRunjobWaitPerf(TestPerformance):
         Test performance of job_run_wait=none
         """
         t = self.common_test("none")
-        self.perf_test_result(t, "time_taken_rw_none", "sec")
+        self.perf_test_result(t, "time_taken_run_wait_none", "sec")
 
     @timeout(7200)
     def test_rw_runjobhook(self):
@@ -106,7 +106,7 @@ pbs.event().accept()
         hk_attrs = {'event': 'runjob', 'enabled': 'True'}
         self.server.create_import_hook('rj', hk_attrs, hook_txt)
         t = self.common_test("runjob_hook")
-        self.perf_test_result(t, "time_taken_rw_runjobhook", "sec")
+        self.perf_test_result(t, "time_taken_run_wait_runjobhook", "sec")
 
     @timeout(7200)
     def test_rw_execjobhook(self):
@@ -114,7 +114,7 @@ pbs.event().accept()
         Test performance of job_run_wait=execjob_hook
         """
         t = self.common_test("execjob_hook")
-        self.perf_test_result(t, "time_taken_rw_execjobhook", "sec")
+        self.perf_test_result(t, "time_taken_run_wait_execjobhook", "sec")
 
     @timeout(14400)
     def test_rw_runjobhook_nohook(self):
@@ -128,9 +128,10 @@ pbs.event().accept()
         # the time taken by none mode, as without a runjob hook, the
         # scheduler should assume none mode even if job_run_wait=runjob_hook
         self.assertLess(t_rj / t_none, 1.5)
-        self.perf_test_result(t_rj, "time_taken_rw_runjobhook_nohook", "sec")
-        self.perf_test_result(t_none, "time_taken_rw_none", "sec")
         self.perf_test_result(
-            (t_rj - t_none),
-            "time_diff_rw_none_rw_runjobhook_nohook",
+            t_rj, "time_taken_run_wait_runjobhook_nohook", "sec")
+        self.perf_test_result(t_none, "time_taken_run_wait_none", "sec")
+        self.perf_test_result(
+            (t_none - t_rj),
+            "time_diff_run_wait_none_and_run_wait_runjobhook_nohook",
             "sec")

--- a/test/tests/performance/pbs_runjobwait_perf.py
+++ b/test/tests/performance/pbs_runjobwait_perf.py
@@ -133,5 +133,4 @@ pbs.event().accept()
         self.perf_test_result(t_none, "time_taken_run_wait_none", "sec")
         self.perf_test_result(
             (t_none - t_rj),
-            "time_diff_run_wait_none_and_run_wait_runjobhook_nohook",
-            "sec")
+            "time_diff_run_wait_none_and_run_wait_runjobhook_nohook", "sec")

--- a/test/tests/performance/pbs_runjobwait_perf.py
+++ b/test/tests/performance/pbs_runjobwait_perf.py
@@ -89,7 +89,8 @@ class TestRunjobWaitPerf(TestPerformance):
         """
         Test performance of job_run_wait=none
         """
-        self.common_test("none")
+        t = self.common_test("none")
+        self.perf_test_result(t, "time_taken_rw_none", "sec")
 
     @timeout(7200)
     def test_rw_runjobhook(self):
@@ -104,14 +105,16 @@ pbs.event().accept()
 """
         hk_attrs = {'event': 'runjob', 'enabled': 'True'}
         self.server.create_import_hook('rj', hk_attrs, hook_txt)
-        self.common_test("runjob_hook")
+        t = self.common_test("runjob_hook")
+        self.perf_test_result(t, "time_taken_rw_runjobhook", "sec")
 
     @timeout(7200)
     def test_rw_execjobhook(self):
         """
         Test performance of job_run_wait=execjob_hook
         """
-        self.common_test("execjob_hook")
+        t = self.common_test("execjob_hook")
+        self.perf_test_result(t, "time_taken_rw_execjobhook", "sec")
 
     @timeout(14400)
     def test_rw_runjobhook_nohook(self):
@@ -125,3 +128,9 @@ pbs.event().accept()
         # the time taken by none mode, as without a runjob hook, the
         # scheduler should assume none mode even if job_run_wait=runjob_hook
         self.assertLess(t_rj / t_none, 1.5)
+        self.perf_test_result(t_rj, "time_taken_rw_runjobhook_nohook", "sec")
+        self.perf_test_result(t_none, "time_taken_rw_none", "sec")
+        self.perf_test_result(
+            (t_rj - t_none),
+            "time_diff_rw_none_rw_runjobhook_nohook",
+            "sec")

--- a/test/tests/performance/test_dependency_perf.py
+++ b/test/tests/performance/test_dependency_perf.py
@@ -84,7 +84,5 @@ class TestDependencyPerformance(TestPerformance):
         self.logger.info('Time taken to delete all jobs %f' % (t2-t1))
         self.logger.info('#' * 80)
         self.check_depend_delete_msg(j_arr[4999], j_arr[5000])
-        self.perf_test_result(
-            (t2 - t1),
-            "time_taken_delete_all_dependent_jobs",
-            "sec")
+        self.perf_test_result((t2 - t1),
+                              "time_taken_delete_all_dependent_jobs", "sec")

--- a/test/tests/performance/test_dependency_perf.py
+++ b/test/tests/performance/test_dependency_perf.py
@@ -83,3 +83,4 @@ class TestDependencyPerformance(TestPerformance):
         self.logger.info('Time taken to delete all jobs %f' % (t2-t1))
         self.logger.info('#' * 80)
         self.check_depend_delete_msg(j_arr[4999], j_arr[5000])
+        self.perf_test_result((t2 - t1), "time_taken_delete_all_jobs", "sec")

--- a/test/tests/performance/test_dependency_perf.py
+++ b/test/tests/performance/test_dependency_perf.py
@@ -45,6 +45,7 @@ class TestDependencyPerformance(TestPerformance):
     """
     Test the performance of job dependency feature
     """
+
     def check_depend_delete_msg(self, pjid, cjid):
         """
         helper function to check ia message that the dependent job (cjid)
@@ -83,4 +84,7 @@ class TestDependencyPerformance(TestPerformance):
         self.logger.info('Time taken to delete all jobs %f' % (t2-t1))
         self.logger.info('#' * 80)
         self.check_depend_delete_msg(j_arr[4999], j_arr[5000])
-        self.perf_test_result((t2 - t1), "time_taken_delete_all_jobs", "sec")
+        self.perf_test_result(
+            (t2 - t1),
+            "time_taken_delete_all_dependent_jobs",
+            "sec")


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Outputs of some performance tests are not stored in json file
#### Describe Your Change
storing performance tests output in json file.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output

[json_dependency.txt](https://github.com/openpbs/openpbs/files/4885194/json_dependency.txt)
[json_qstat.txt](https://github.com/openpbs/openpbs/files/4885197/json_qstat.txt)
[run_job_json.txt](https://github.com/openpbs/openpbs/files/4885199/run_job_json.txt)





<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
