### PR TITLE
TestAcctLog.test_queue_record fails due to race condition

### DIFF
--- a/test/tests/functional/pbs_acct_log.py
+++ b/test/tests/functional/pbs_acct_log.py
@@ -202,6 +202,8 @@ class TestAcctLog(TestFunctional):
 
         r = Reservation()
         rid1 = self.server.submit(r)
+        a = {'reserve_state': (MATCH_RE, "RESV_CONFIRMED|2")}
+        self.server.expect(RESV, a, id=rid1)
         j3 = Job(TEST_USER, {ATTR_queue: rid1.split('.')[0]})
         jid3 = self.server.submit(j3)
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
TestAcctLog.test_queue_record fails due to race condition on a slow machine:

"Traceback (most recent call last):
File ""/home/pbsroot/TEST/tmp/tests/functional/pbs_acct_log.py"", line 203, in test_queue_record
jid3 = self.server.submit(j3)
ptl.lib.pbs_testlib.PbsSubmitError: rc=173, rv=None, msg=['qsub: Queue is not enabled']

Test submits a Reservation and then a Job is submitted to that reservation's queue but Reservation is not yet confirmed by Scheduler.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Need to check if Reservation is confirmed and then submit the job.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[test_queue_record_afterfix.txt](https://github.com/openpbs/openpbs/files/4878693/test_queue_record_afterfix.txt)
[test_queue_record_beforefix.txt](https://github.com/openpbs/openpbs/files/4878694/test_queue_record_beforefix.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
