### PR TITLE
Automate scenario of TPP

### DIFF
--- a/test/tests/functional/pbs_test_tpp.py
+++ b/test/tests/functional/pbs_test_tpp.py
@@ -1016,31 +1016,50 @@ class TestTPP(TestFunctional):
         self.momB = self.moms.values()[1]
         self.hostA = self.momA.shortname
         self.hostB = self.momB.shortname
+
         self.comm.signal("-KILL")
         for mom in self.moms.values():
             self.server.expect(NODE, {'state': 'state-unknown,down'},
                                id=mom.shortname)
-        self.logger.info("starting pbs_comm through command line")
+
         pbs_comm_path = os.path.join(self.pbs_conf['PBS_EXEC'], "sbin",
                                      "pbs_comm")
-        cmd = "sudo -u root %s -N" % pbs_comm_path
-        process = subprocess.Popen(cmd, shell=True)
+        sudo_path = os.path.join(os.sep, "bin", "sudo")
+        cmd = [sudo_path, "-u", "root", pbs_comm_path, "-N"]
+        self.logger.info("Start pbs_comm through command line")
+        msg = "Not able to start pbs_comm through command line"
+        try:
+            process = subprocess.Popen(cmd)
+        except Exception as e:
+            self.logger.error("Error running command " + str(cmd))
+            self.skip_test(msg)
+
         for mom in self.moms.values():
             self.server.expect(NODE, {'state': 'free'},
                                id=mom.shortname)
+
         jid = self.submit_job(job=True, job_script=True, sleep=30)
+
         rid = self.submit_resv()
         resv_jid = self.submit_job(rid=rid, resv_job=True, job_script=True,
                                    sleep=30)
+
         resv_attrib = {'reserve_state': (MATCH_RE, 'RESV_RUNNING|5')}
         self.server.expect(RESV, resv_attrib, rid, offset=10)
+
         for job_id in [jid, resv_jid]:
             self.server.expect(JOB, {'job_state': 'R'}, id=job_id)
-        self.logger.info("kill pbs_comm running in foreground")
-        subprocess.check_call(["sudo", "kill", str(process.pid)])
-        os.waitpid(process.pid, 0)
-        self.logger.info("starting pbs_comm through init script")
+
+        self.logger.info("kill running pbs_comm that was just started")
+        try:
+            cmd = [sudo_path, "kill", str(process.pid)]
+            subprocess.check_call(["sudo", "kill", str(process.pid)])
+        except subprocess.CalledProcessError as e:
+            self.skip_test("Not able to kill pbs_comm. Error: '%s'" % e)
+
+        self.logger.info("start pbs_comm through init script")
         self.comm.start()
+
         self.server.expect(RESV, resv_attrib, rid)
         for job_id in [jid, resv_jid]:
             self.server.expect(JOB, 'queue', id=jid, op=UNSET, offset=30)

--- a/test/tests/functional/pbs_test_tpp.py
+++ b/test/tests/functional/pbs_test_tpp.py
@@ -39,7 +39,6 @@
 
 from tests.functional import *
 import socket
-import subprocess
 
 
 @tags('comm')

--- a/test/tests/functional/pbs_test_tpp.py
+++ b/test/tests/functional/pbs_test_tpp.py
@@ -1012,12 +1012,10 @@ class TestTPP(TestFunctional):
         Node 1 : Server, Sched, Mom, Comm
         Node 2 : Mom
         """
-        """
         self.momA = self.moms.values()[0]
         self.momB = self.moms.values()[1]
         self.hostA = self.momA.shortname
         self.hostB = self.momB.shortname
-        """
 
         self.comm.signal("-KILL")
         for mom in self.moms.values():
@@ -1027,13 +1025,13 @@ class TestTPP(TestFunctional):
         pbs_comm_path = os.path.join(self.pbs_conf['PBS_EXEC'], "sbin",
                                      "pbs_comm")
         sudo_path = self.du.which(hostname=self.mom.hostname,
-                                         exe="sudo")
+                                  exe="sudo")
 
         cmd = [sudo_path, "-u", "root", pbs_comm_path, "-N &"]
 
         self.logger.info("Starting pbs_comm through command line")
         msg = "Not able to start pbs_comm through command line"
-        ret= self.du.run_cmd(self.server.shortname, cmd, as_script=True)
+        ret = self.du.run_cmd(self.server.shortname, cmd, as_script=True)
         self.assertTrue(ret['rc'] == 0 and len(ret['err']) == 0, msg)
 
         for mom in self.moms.values():

--- a/test/tests/functional/pbs_test_tpp.py
+++ b/test/tests/functional/pbs_test_tpp.py
@@ -808,6 +808,10 @@ class TestTPP(TestFunctional):
         Node 4 : Mom (self.hostD)
         Node 5 : Comm (self.hostE)
         """
+        self.common_setup()
+        hostA_ip = socket.gethostbyname(self.hostA)
+        comm_val = self.hostA + ":17001"
+        a = {'PBS_COMM_ROUTERS': comm_val}
         self.set_pbs_conf(host_name=self.hostC, conf_param=a)
         comm_val = hostA_ip + ":17001" + "," + self.hostC
         a = {'PBS_COMM_ROUTERS': comm_val}

--- a/test/tests/functional/pbs_test_tpp.py
+++ b/test/tests/functional/pbs_test_tpp.py
@@ -412,9 +412,9 @@ class TestTPP(TestFunctional):
             self.momB = self.moms.values()[1]
             self.hostB = self.momB.shortname
             self.momC = self.moms.values()[2]
-            self.hostC = self.momC.shortname
+            self.hostD = self.momC.shortname
             self.comm2 = self.comms.values()[1]
-            self.hostD = self.comm2.shortname
+            self.hostC = self.comm2.shortname
             self.comm3 = self.comms.values()[2]
             self.hostE = self.comm3.shortname
             nodes = [
@@ -443,6 +443,31 @@ class TestTPP(TestFunctional):
                 self.hostC,
                 self.hostD,
                 self.hostE]
+        elif len(self.moms.values()) == 4 and len(self.comms.values()) == 5:
+            self.hostA = self.server.shortname
+            self.momB = self.moms.values()[0]
+            self.hostB = self.momB.shortname
+            self.momC = self.moms.values()[1]
+            self.hostC = self.momC.shortname
+            self.momD = self.moms.values()[2]
+            self.hostD = self.momD.shortname
+            self.momE = self.moms.values()[3]
+            self.hostE = self.momE.shortname
+            self.comm2 = self.comms.values()[1]
+            self.hostF = self.comm2.shortname
+            self.comm3 = self.comms.values()[2]
+            self.hostG = self.comm3.shortname
+            self.comm4 = self.comms.values()[3]
+            self.hostH = self.comm4.shortname
+            self.comm5 = self.comms.values()[4]
+            self.hostI = self.comm5.shortname
+            nodes = [
+                self.hostA,
+                self.hostB,
+                self.hostC,
+                self.hostD,
+                self.hostE, self.hostF, self.hostG, self.hostH,
+                self.hostI]
         self.node_list.extend(nodes)
 
     @requirements(num_moms=2, num_comms=2)
@@ -699,8 +724,8 @@ class TestTPP(TestFunctional):
         Configuration:
         Node 1 : Server, Sched, Mom, Comm (self.hostA)
         Node 2 : Mom (self.hostB)
-        Node 3 : Comm (self.hostD)
-        Node 4 : Mom (self.hostC)
+        Node 3 : Comm (self.hostC)
+        Node 4 : Mom (self.hostD)
         Node 5 : Comm (self.hostE)
         """
         self.common_setup()
@@ -738,8 +763,8 @@ class TestTPP(TestFunctional):
         Configuration:
         Node 1 : Server, Sched, Mom, Comm (self.hostA)
         Node 2 : Mom (self.hostB)
-        Node 3 : Comm (self.hostD)
-        Node 4 : Mom (self.hostC)
+        Node 3 : Comm (self.hostC)
+        Node 4 : Mom (self.hostD)
         Node 5 : Comm (self.hostE)
         """
         self.common_setup()
@@ -779,14 +804,10 @@ class TestTPP(TestFunctional):
         Configuration:
         Node 1 : Server, Sched, Mom, Comm (self.hostA)
         Node 2 : Mom (self.hostB)
-        Node 3 : Comm (self.hostD)
-        Node 4 : Mom (self.hostC)
+        Node 3 : Comm (self.hostC)
+        Node 4 : Mom (self.hostD)
         Node 5 : Comm (self.hostE)
         """
-        self.common_setup()
-        hostA_ip = socket.gethostbyname(self.hostA)
-        comm_val = self.hostA + ":17001"
-        a = {'PBS_COMM_ROUTERS': self.hostA}
         self.set_pbs_conf(host_name=self.hostC, conf_param=a)
         comm_val = hostA_ip + ":17001" + "," + self.hostC
         a = {'PBS_COMM_ROUTERS': comm_val}
@@ -820,8 +841,8 @@ class TestTPP(TestFunctional):
         Configuration:
         Node 1 : Server, Sched, Mom, Comm (self.hostA)
         Node 2 : Mom (self.hostB)
-        Node 3 : Comm (self.hostD)
-        Node 4 : Mom (self.hostC)
+        Node 3 : Comm (self.hostC)
+        Node 4 : Mom (self.hostD)
         Node 5 : Comm (self.hostE)
         """
         self.common_setup()
@@ -1003,6 +1024,74 @@ class TestTPP(TestFunctional):
         c = {'PBS_LEAF_ROUTERS': self.hostA}
         self.set_pbs_conf(host_name=self.server.shortname, conf_param=c)
         self.common_steps_for_mom_pool_tests()
+
+    @requirements(num_moms=4, no_mom_on_server=True, num_comms=5)
+    def test_comm_failover_with_isolated_mom_pools(self):
+        """
+        Test comm failover with isolated mom pools
+        Configuration:
+        Node 1 : Server, Sched, Comm (self.hostA)
+        Node 2 : Mom (self.hostB)
+        Node 3 : Comm (self.hostF)
+        Node 4 : Mom (self.hostC)
+        Node 5 : Comm (self.hostG)
+        Node 6 : Mom (self.hostD)
+        Node 7 : Comm (self.hostH)
+        Node 8 : Mom (self.hostE)
+        Node 9 : Comm (self.hostI)
+        """
+        self.common_setup(no_mom_on_comm=True)
+        a = {'PBS_COMM_ROUTERS': self.hostA}
+        comm_hosts = [self.hostF, self.hostG, self.hostH, self.hostI]
+        for host in comm_hosts:
+            self.set_pbs_conf(host_name=host, conf_param=a)
+        mom_hosts = [self.hostB, self.hostC, self.hostD, self.hostE]
+        for hosts in mom_hosts:
+            if hosts == self.hostB:
+                leaf_val = self.hostF + "," + self.hostG
+            if hosts == self.hostC:
+                leaf_val = self.hostG + "," + self.hostF
+            if hosts == self.hostD:
+                leaf_val = self.hostH + "," + self.hostI
+            if hosts == self.hostE:
+                leaf_val = self.hostI + "," + self.hostH
+            b = {'PBS_LEAF_ROUTERS': leaf_val}
+            self.set_pbs_conf(host_name=host, conf_param=b)
+        vnode_val = "vnode=" + self.hostB + ":ncpus=1+vnode="
+        vnode_val += self.hostC + ":ncpus=1"
+        set_attr = {ATTR_l + '.select': vnode_val,
+                    ATTR_l + '.place': 'scatter', ATTR_k: 'oe'}
+        jid = self.submit_job(set_attr=set_attr, job=True,
+                              job_script=True, sleep=30)
+        exp_attr = {'job_state': 'R'}
+        self.server.expect(JOB, exp_attr, id=jid)
+        self.comm2.stop('-KILL')
+        hosts = [self.hostB, self.hostC]
+        for mom in hosts:
+            self.server.expect(NODE, {'state': 'free'}, id=mom)
+        self.server.expect(JOB, exp_attr, id=jid)
+        self.comm2.start()
+        self.server.expect(JOB, 'queue', id=jid, op=UNSET, offset=30)
+
+        vnode_val = "vnode=" + self.hostD + ":ncpus=1+vnode="
+        vnode_val += self.hostE + ":ncpus=1"
+        resv_set_attr = {ATTR_l + '.select': vnode_val,
+                         ATTR_l + '.place': 'scatter',
+                         'reserve_start': time.time() + 10,
+                         'reserve_end': time.time() + 120}
+        rid = self.submit_resv(resv_set_attr)
+        jid = self.submit_job(rid=rid, resv_job=True, sleep=30)
+        resv_exp_attrib = {'reserve_state': (MATCH_RE, 'RESV_RUNNING|5')}
+        self.server.expect(RESV, resv_exp_attrib, rid, offset=10)
+        self.server.expect(JOB, exp_attr, id=jid)
+        self.comm4.stop('-KILL')
+        hosts = [self.hostD, self.hostE]
+        for mom in hosts:
+            self.server.expect(NODE, {'state': 'free'}, id=mom)
+        self.server.expect(RESV, resv_exp_attrib, rid)
+        self.server.expect(JOB, exp_attr, id=jid)
+        self.comm4.start()
+        self.server.expect(JOB, 'queue', id=jid, op=UNSET, offset=30)
 
     @requirements(num_moms=2)
     def test_comm_instantiation_on_cmdline(self):

--- a/test/tests/functional/pbs_test_tpp.py
+++ b/test/tests/functional/pbs_test_tpp.py
@@ -1050,14 +1050,14 @@ class TestTPP(TestFunctional):
         for host in comm_hosts:
             self.set_pbs_conf(host_name=host, conf_param=a)
         mom_hosts = [self.hostB, self.hostC, self.hostD, self.hostE]
-        for hosts in mom_hosts:
+        for host in mom_hosts:
             if hosts == self.hostB:
                 leaf_val = self.hostF + "," + self.hostG
-            if hosts == self.hostC:
+            elif hosts == self.hostC:
                 leaf_val = self.hostG + "," + self.hostF
-            if hosts == self.hostD:
+            elif hosts == self.hostD:
                 leaf_val = self.hostH + "," + self.hostI
-            if hosts == self.hostE:
+            elif hosts == self.hostE:
                 leaf_val = self.hostI + "," + self.hostH
             b = {'PBS_LEAF_ROUTERS': leaf_val}
             self.set_pbs_conf(host_name=host, conf_param=b)

--- a/test/tests/functional/pbs_test_tpp.py
+++ b/test/tests/functional/pbs_test_tpp.py
@@ -1026,7 +1026,7 @@ class TestTPP(TestFunctional):
                                      "pbs_comm")
         sudo_path = os.path.join(os.sep, "bin", "sudo")
         cmd = [sudo_path, "-u", "root", pbs_comm_path, "-N"]
-        self.logger.info("Start pbs_comm through command line")
+        self.logger.info("Starting pbs_comm through command line")
         msg = "Not able to start pbs_comm through command line"
         try:
             process = subprocess.Popen(cmd)
@@ -1050,14 +1050,14 @@ class TestTPP(TestFunctional):
         for job_id in [jid, resv_jid]:
             self.server.expect(JOB, {'job_state': 'R'}, id=job_id)
 
-        self.logger.info("kill running pbs_comm that was just started")
+        self.logger.info("Killing pbs_comm that was just started")
         try:
             cmd = [sudo_path, "kill", str(process.pid)]
             subprocess.check_call(["sudo", "kill", str(process.pid)])
         except subprocess.CalledProcessError as e:
             self.skip_test("Not able to kill pbs_comm. Error: '%s'" % e)
 
-        self.logger.info("start pbs_comm through init script")
+        self.logger.info("Starting pbs_comm through init script")
         self.comm.start()
 
         self.server.expect(RESV, resv_attrib, rid)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Automate scenario of TPP

- Test comm failover with isolated mom pools

- Also I have made changes to function "common_setup". When tests that require 3 moms and comms are run, in the common_setup the host names are set inapprpriately due to which the wrong value(mom name) is getting set in PBS_LEAF_ROUTERS instead of the comm name. I have changed the function accordingly.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output

- [Execution_logs_tpp_new.txt](https://github.com/openpbs/openpbs/files/4884948/Execution_logs_tpp_new.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
