### PR TITLE
test fails because cput isn't accruing on cpuset system with cgroups enabled

### DIFF
--- a/test/tests/functional/pbs_soft_walltime.py
+++ b/test/tests/functional/pbs_soft_walltime.py
@@ -950,7 +950,8 @@ done
         self.server.alterjob(jid, {'Resource_List.soft_walltime': 300})
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
 
-        # verify that job is deleted when cput limit is reached
+        self.logger.info("Sleep 10 secs waiting for cput to cause the"
+            " job to be deleted")
         time.sleep(10)
         self.server.expect(JOB, 'queue', op=UNSET, id=jid)
 

--- a/test/tests/functional/pbs_soft_walltime.py
+++ b/test/tests/functional/pbs_soft_walltime.py
@@ -951,7 +951,7 @@ done
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
 
         self.logger.info("Sleep 10 secs waiting for cput to cause the"
-            " job to be deleted")
+                         " job to be deleted")
         time.sleep(10)
         self.server.expect(JOB, 'queue', op=UNSET, id=jid)
 

--- a/test/tests/functional/pbs_soft_walltime.py
+++ b/test/tests/functional/pbs_soft_walltime.py
@@ -79,7 +79,7 @@ class TestSoftWalltime(TestFunctional):
         if self.mom.is_cpuset_mom():
             # reset the freq value
             attrs = {'freq': 120}
-            rv = self.server.manager(MGR_CMD_SET, HOOK, attrs, "pbs_cgroups")
+            self.server.manager(MGR_CMD_SET, HOOK, attrs, "pbs_cgroups")
         TestFunctional.tearDown(self)
 
     def stat_job(self, job):
@@ -940,7 +940,7 @@ done
         # purpose of this test.
         if self.mom.is_cpuset_mom():
             attrs = {'freq': 1}
-            rv = self.server.manager(MGR_CMD_SET, HOOK, attrs, "pbs_cgroups")
+            self.server.manager(MGR_CMD_SET, HOOK, attrs, "pbs_cgroups")
             # cause the change to take effect now
             self.mom.restart()
 

--- a/test/tests/functional/pbs_soft_walltime.py
+++ b/test/tests/functional/pbs_soft_walltime.py
@@ -75,6 +75,13 @@ class TestSoftWalltime(TestFunctional):
         # Delete operators if added
         self.server.manager(MGR_CMD_UNSET, SERVER, 'operators')
 
+    def tearDown(self):
+        if self.mom.is_cpuset_mom():
+            # reset the freq value
+            attrs = {'freq': 120}
+            rv = self.server.manager(MGR_CMD_SET, HOOK, attrs, "pbs_cgroups")
+        TestFunctional.tearDown(self)
+
     def stat_job(self, job):
         """
         stat a job for its estimated.start_time and soft_walltime or walltime
@@ -928,13 +935,12 @@ do
     dd if=/dev/zero of=/dev/null;
 done
 """
-	# If it is a cpuset mom, the cgroups hook relies on the periodic hook
+        # If it is a cpuset mom, the cgroups hook relies on the periodic hook
         # to update cput, so make the periodic hook run more often for the
         # purpose of this test.
         if self.mom.is_cpuset_mom():
-            attrs = {'freq':1}            
+            attrs = {'freq': 1}
             rv = self.server.manager(MGR_CMD_SET, HOOK, attrs, "pbs_cgroups")
-            self.assertEqual(rv,0)
             # cause the change to take effect now
             self.mom.restart()
 
@@ -945,15 +951,8 @@ done
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
 
         # verify that job is deleted when cput limit is reached
-        self.logger.info("Sleep for 10 waiting for cput to cause job to be deleted")
         time.sleep(10)
         self.server.expect(JOB, 'queue', op=UNSET, id=jid)
-
-        if self.mom.is_cpuset_mom():
-            # reset the freq value
-            attrs = {'freq':120}            
-            rv = self.server.manager(MGR_CMD_SET, HOOK, attrs, "pbs_cgroups")
-            self.assertEqual(rv,0)
 
     def test_soft_walltime_resv(self):
         """


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
The test is testing whether a job is killed because it's cput goes above the limit set.  The job should be killed once it is noticed that the job's cput goes above 5sec.  However, on a machine where cgroups is enabled, then we rely on the cgroups periodic hook to provide the updated cput.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
I cause the cgroups exechost_periodic hook to run more frequently so the cput can be updated by the cgroups hook.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[cput_before.txt](https://github.com/openpbs/openpbs/files/4886724/cput_before.txt)
[cput_after.txt](https://github.com/openpbs/openpbs/files/4886725/cput_after.txt)

[cput_after2.txt](https://github.com/openpbs/openpbs/files/4887077/cput_after2.txt)
[cput_after3.txt](https://github.com/openpbs/openpbs/files/4887397/cput_after3.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
