### PR TITLE
Fix accounting log match and race conditions in TestPbsReliableJobStartup

### DIFF
--- a/test/tests/functional/pbs_reliable_job_startup.py
+++ b/test/tests/functional/pbs_reliable_job_startup.py
@@ -151,41 +151,42 @@ class TestPbsReliableJobStartup(TestFunctional):
         """
 
         if atype == 'e':
-            self.mom.log_match("Job;%s;Obit sent" % (jid,), n=100,
-                               max_attempts=5, interval=5)
+            self.mom.log_match("Job;%s;Obit sent" % (jid,), n="ALL",
+                               max_attempts=5, interval=5,
+                               starttime=self.stime)
 
         self.server.accounting_match(
             msg=".*%s;%s.*exec_host=%s" % (atype, jid, exec_host),
-            regexp=True, n=20, max_attempts=3)
+            regexp=True, n="ALL", max_attempts=3, starttime=self.stime)
 
         self.server.accounting_match(
             msg=".*%s;%s.*exec_vnode=%s" % (atype, jid, exec_vnode),
-            regexp=True, n=20, max_attempts=3)
+            regexp=True, n="ALL", max_attempts=3, starttime=self.stime)
 
         self.server.accounting_match(
             msg=".*%s;%s.*Resource_List\.mem=%s" % (atype, jid,  mem),
-            regexp=True, n=20, max_attempts=3)
+            regexp=True, n="ALL", max_attempts=3, starttime=self.stime)
 
         self.server.accounting_match(
             msg=".*%s;%s.*Resource_List\.ncpus=%d" % (atype, jid, ncpus),
-            regexp=True, n=20, max_attempts=3)
+            regexp=True, n="ALL", max_attempts=3, starttime=self.stime)
 
         self.server.accounting_match(
             msg=".*%s;%s.*Resource_List\.nodect=%d" % (atype, jid, nodect),
-            regexp=True, n=20, max_attempts=3)
+            regexp=True, n="ALL", max_attempts=3, starttime=self.stime)
 
         self.server.accounting_match(
             msg=".*%s;%s.*Resource_List\.place=%s" % (atype, jid, place),
-            regexp=True, n=20, max_attempts=3)
+            regexp=True, n="ALL", max_attempts=3, starttime=self.stime)
 
         self.server.accounting_match(
             msg=".*%s;%s.*Resource_List\.select=%s" % (atype, jid, select),
-            regexp=True, n=20, max_attempts=3)
+            regexp=True, n="ALL", max_attempts=3, starttime=self.stime)
 
         if (atype != 'c') and (atype != 'S') and (atype != 's'):
             self.server.accounting_match(
                 msg=".*%s;%s.*resources_used\." % (atype, jid),
-                regexp=True, n=20, max_attempts=3)
+                regexp=True, n="ALL", max_attempts=3, starttime=self.stime)
 
     def match_vnode_status(self, vnode_list, state, jobs=None, ncpus=None,
                            mem=None):
@@ -1184,6 +1185,7 @@ if e.job.in_ms_mom():
         e.job.rerun()
         e.reject("unsuccessful at LAUNCH")
 """
+        self.stime= time.time()
 
     def tearDown(self):
         self.momA.signal("-CONT")
@@ -1456,10 +1458,10 @@ if e.job.in_ms_mom():
                                   self.job1_sel_esc)
 
         self.momA.log_match("Job;%s;task.+started, hostname" % (jid,),
-                            n=10, max_attempts=60, interval=2, regexp=True)
+                            n=10, max_attempts=60, interval=5, regexp=True)
 
         self.momA.log_match("Job;%s;copy file request received" % (jid,),
-                            n=10, max_attempts=10, interval=2)
+                            n=10, max_attempts=60, interval=5)
 
         # validate output
         expected_out = """/var/spool/pbs/aux/%s
@@ -1797,12 +1799,11 @@ pbs_tmrsh %s hostname
                                   "6gb", 8, 3,
                                   self.job1_place,
                                   self.job1_sel_esc)
-
         self.momA.log_match("Job;%s;task.+started, hostname" % (jid,),
-                            n=10, max_attempts=60, interval=2, regexp=True)
+                            n=10, max_attempts=60, interval=5, regexp=True)
 
         self.momA.log_match("Job;%s;copy file request received" % (jid,),
-                            n=10, max_attempts=10, interval=2)
+                            n=10, max_attempts=60, interval=5)
 
         # validate output
         expected_out = """/var/spool/pbs/aux/%s
@@ -2163,12 +2164,12 @@ if not e.job.in_ms_mom() and (localnode == '%s'):
                                   "6gb", 8, 3,
                                   self.job1_place,
                                   self.job1_sel_esc)
-
+        
         self.momA.log_match("Job;%s;task.+started, hostname" % (jid,),
-                            n=10, max_attempts=60, interval=2, regexp=True)
+                            n=10, max_attempts=60, interval=5, regexp=True)
 
         self.momA.log_match("Job;%s;copy file request received" % (jid,),
-                            n=10, max_attempts=10, interval=2)
+                            n=10, max_attempts=60, interval=5)
 
         # validate output
         expected_out = """/var/spool/pbs/aux/%s
@@ -2407,12 +2408,11 @@ pbs_tmrsh %s hostname
                                   "6gb", 8, 3,
                                   self.job1_place,
                                   self.job1v2_sel_esc)
-
         self.momA.log_match("Job;%s;task.+started, hostname" % (jid,),
-                            n=10, max_attempts=60, interval=2, regexp=True)
+                            n=10, max_attempts=60, interval=5, regexp=True)
 
         self.momA.log_match("Job;%s;copy file request received" % (jid,),
-                            n=10, max_attempts=10, interval=2)
+                            n=10, max_attempts=60, interval=5)
 
         # validate output
         expected_out = """/var/spool/pbs/aux/%s
@@ -2641,12 +2641,12 @@ pbs_tmrsh %s hostname
                                   "6gb", 8, 3,
                                   self.job1_place,
                                   self.job1v3_sel_esc)
-
+        
         self.momA.log_match("Job;%s;task.+started, hostname" % (jid,),
-                            n=10, max_attempts=60, interval=2, regexp=True)
+                            n=10, max_attempts=60, interval=5, regexp=True)
 
         self.momA.log_match("Job;%s;copy file request received" % (jid,),
-                            n=10, max_attempts=10, interval=2)
+                            n=10, max_attempts=60, interval=5)
 
         # validate output
         expected_out = """/var/spool/pbs/aux/%s
@@ -2903,12 +2903,11 @@ pbs_tmrsh %s hostname
                                   "6gb", 8, 3,
                                   self.job1_place,
                                   self.job1v4_sel_esc)
-
         self.momA.log_match("Job;%s;task.+started, hostname" % (jid,),
-                            n=10, max_attempts=60, interval=2, regexp=True)
+                            n=10, max_attempts=60, interval=5, regexp=True)
 
         self.momA.log_match("Job;%s;copy file request received" % (jid,),
-                            n=10, max_attempts=10, interval=2)
+                            n=10, max_attempts=60, interval=5)
 
         # validate output
         expected_out = """/var/spool/pbs/aux/%s
@@ -3085,7 +3084,7 @@ if not e.job.in_ms_mom() and (localnode == '%s'):
             regexp=True, n=10, existence=False, max_attempts=10)
 
         self.server.expect(JOB, {'job_state': 'H'},
-                           id=jid, interval=1, max_attempts=15)
+                           id=jid, interval=1, max_attempts=30)
 
         # turn off begin hook, leaving prologue hook in place
         self.server.manager(MGR_CMD_SET, HOOK, {'enabled': 'false'}, 'begin')
@@ -3315,12 +3314,11 @@ if not e.job.in_ms_mom() and (localnode == '%s'):
                                   "6gb", 8, 3,
                                   self.job1_place,
                                   self.job1v5_sel_esc)
-
         self.momA.log_match("Job;%s;task.+started, hostname" % (jid,),
-                            n=10, max_attempts=60, interval=2, regexp=True)
+                            n=10, max_attempts=60, interval=5, regexp=True)
 
         self.momA.log_match("Job;%s;copy file request received" % (jid,),
-                            n=10, max_attempts=10, interval=2)
+                            n=10, max_attempts=60, interval=5)
 
         # validate output
         expected_out = """/var/spool/pbs/aux/%s
@@ -3591,10 +3589,10 @@ pbs_tmrsh %s hostname
                             n=10, max_attempts=30, interval=2, regexp=True)
 
         self.momA.log_match("Job;%s;task.+started, hostname" % (jid,),
-                            n=10, max_attempts=60, interval=2, regexp=True)
+                            n=10, max_attempts=60, interval=5, regexp=True)
 
         self.momA.log_match("Job;%s;copy file request received" % (jid,),
-                            n=10, max_attempts=10, interval=2)
+                            n=10, max_attempts=60, interval=5)
 
         # validate output
         expected_out = """/var/spool/pbs/aux/%s
@@ -4418,12 +4416,11 @@ if e.job.in_ms_mom():
                                   "7gb", 9, 4,
                                   self.job1_place,
                                   self.job1v6_sel_esc)
-
         self.momA.log_match("Job;%s;task.+started, hostname" % (jid,),
-                            n=10, max_attempts=60, interval=2, regexp=True)
+                            n=10, max_attempts=60, interval=5, regexp=True)
 
         self.momA.log_match("Job;%s;copy file request received" % (jid,),
-                            n=10, max_attempts=10, interval=2)
+                            n=10, max_attempts=60, interval=5)
 
         # validate output
         expected_out = """/var/spool/pbs/aux/%s
@@ -5114,12 +5111,11 @@ if not e.job.in_ms_mom() and (localnode == '%s'):
                                   "6gb", 8, 3,
                                   self.job1_place,
                                   self.job1v2_sel_esc)
-
         self.momA.log_match("Job;%s;task.+started, hostname" % (jid,),
-                            n=10, max_attempts=60, interval=2, regexp=True)
+                            n=10, max_attempts=60, interval=5, regexp=True)
 
         self.momA.log_match("Job;%s;copy file request received" % (jid,),
-                            n=10, max_attempts=10, interval=2)
+                            n=10, max_attempts=60, interval=5)
 
         # validate output
         expected_out = """/var/spool/pbs/aux/%s
@@ -5201,12 +5197,11 @@ pbs_tmrsh %s hostname
                                   "6gb", 8, 3,
                                   self.job1_place,
                                   self.job1v2_sel_esc)
-
         self.momA.log_match("Job;%s;task.+started, hostname" % (jid,),
-                            n=10, max_attempts=60, interval=2, regexp=True)
+                            n=10, max_attempts=60, interval=5, regexp=True)
 
         self.momA.log_match("Job;%s;copy file request received" % (jid,),
-                            n=10, max_attempts=10, interval=2)
+                            n=10, max_attempts=60, interval=5)
 
         # validate output
         expected_out = """/var/spool/pbs/aux/%s
@@ -5411,7 +5406,7 @@ pbs_tmrsh %s hostname
             idx_values[idx] = d
             sub_jobs[idx] = sjid
             self.server.expect(JOB, {'job_state': 'R',
-                                     'substate': 41,
+                                     'substate': 42,
                                      'tolerate_node_failures': 'job_start',
                                      'Resource_List.mem': '3gb',
                                      'Resource_List.ncpus': 3,
@@ -5632,12 +5627,11 @@ pbs_tmrsh %s hostname
                                   "6gb", 8, 3,
                                   self.job1_place,
                                   self.job1v4_sel_esc)
-
         self.momA.log_match("Job;%s;task.+started, hostname" % (jid,),
-                            n=10, max_attempts=60, interval=2, regexp=True)
+                            n=10, max_attempts=60, interval=5, regexp=True)
 
         self.momA.log_match("Job;%s;copy file request received" % (jid,),
-                            n=10, max_attempts=10, interval=2)
+                            n=10, max_attempts=60, interval=5)
 
         # validate output
         expected_out = """/var/spool/pbs/aux/%s

--- a/test/tests/functional/pbs_reliable_job_startup.py
+++ b/test/tests/functional/pbs_reliable_job_startup.py
@@ -1185,7 +1185,7 @@ if e.job.in_ms_mom():
         e.job.rerun()
         e.reject("unsuccessful at LAUNCH")
 """
-        self.stime= time.time()
+        self.stime = time.time()
 
     def tearDown(self):
         self.momA.signal("-CONT")
@@ -1458,10 +1458,10 @@ if e.job.in_ms_mom():
                                   self.job1_sel_esc)
 
         self.momA.log_match("Job;%s;task.+started, hostname" % (jid,),
-                            n=10, max_attempts=60, interval=5, regexp=True)
+                            n=10, interval=5, regexp=True)
 
         self.momA.log_match("Job;%s;copy file request received" % (jid,),
-                            n=10, max_attempts=60, interval=5)
+                            n=10, interval=5)
 
         # validate output
         expected_out = """/var/spool/pbs/aux/%s
@@ -1800,10 +1800,10 @@ pbs_tmrsh %s hostname
                                   self.job1_place,
                                   self.job1_sel_esc)
         self.momA.log_match("Job;%s;task.+started, hostname" % (jid,),
-                            n=10, max_attempts=60, interval=5, regexp=True)
+                            n=10, interval=5, regexp=True)
 
         self.momA.log_match("Job;%s;copy file request received" % (jid,),
-                            n=10, max_attempts=60, interval=5)
+                            n=10, interval=5)
 
         # validate output
         expected_out = """/var/spool/pbs/aux/%s
@@ -2164,12 +2164,11 @@ if not e.job.in_ms_mom() and (localnode == '%s'):
                                   "6gb", 8, 3,
                                   self.job1_place,
                                   self.job1_sel_esc)
-        
         self.momA.log_match("Job;%s;task.+started, hostname" % (jid,),
-                            n=10, max_attempts=60, interval=5, regexp=True)
+                            n=10, interval=5, regexp=True)
 
         self.momA.log_match("Job;%s;copy file request received" % (jid,),
-                            n=10, max_attempts=60, interval=5)
+                            n=10, interval=5)
 
         # validate output
         expected_out = """/var/spool/pbs/aux/%s
@@ -2409,10 +2408,10 @@ pbs_tmrsh %s hostname
                                   self.job1_place,
                                   self.job1v2_sel_esc)
         self.momA.log_match("Job;%s;task.+started, hostname" % (jid,),
-                            n=10, max_attempts=60, interval=5, regexp=True)
+                            n=10, interval=5, regexp=True)
 
         self.momA.log_match("Job;%s;copy file request received" % (jid,),
-                            n=10, max_attempts=60, interval=5)
+                            n=10, interval=5)
 
         # validate output
         expected_out = """/var/spool/pbs/aux/%s
@@ -2641,12 +2640,11 @@ pbs_tmrsh %s hostname
                                   "6gb", 8, 3,
                                   self.job1_place,
                                   self.job1v3_sel_esc)
-        
         self.momA.log_match("Job;%s;task.+started, hostname" % (jid,),
-                            n=10, max_attempts=60, interval=5, regexp=True)
+                            n=10, interval=5, regexp=True)
 
         self.momA.log_match("Job;%s;copy file request received" % (jid,),
-                            n=10, max_attempts=60, interval=5)
+                            n=10, interval=5)
 
         # validate output
         expected_out = """/var/spool/pbs/aux/%s
@@ -2904,10 +2902,10 @@ pbs_tmrsh %s hostname
                                   self.job1_place,
                                   self.job1v4_sel_esc)
         self.momA.log_match("Job;%s;task.+started, hostname" % (jid,),
-                            n=10, max_attempts=60, interval=5, regexp=True)
+                            n=10, interval=5, regexp=True)
 
         self.momA.log_match("Job;%s;copy file request received" % (jid,),
-                            n=10, max_attempts=60, interval=5)
+                            n=10, interval=5)
 
         # validate output
         expected_out = """/var/spool/pbs/aux/%s
@@ -3315,10 +3313,10 @@ if not e.job.in_ms_mom() and (localnode == '%s'):
                                   self.job1_place,
                                   self.job1v5_sel_esc)
         self.momA.log_match("Job;%s;task.+started, hostname" % (jid,),
-                            n=10, max_attempts=60, interval=5, regexp=True)
+                            n=10, interval=5, regexp=True)
 
         self.momA.log_match("Job;%s;copy file request received" % (jid,),
-                            n=10, max_attempts=60, interval=5)
+                            n=10, interval=5)
 
         # validate output
         expected_out = """/var/spool/pbs/aux/%s
@@ -3589,10 +3587,10 @@ pbs_tmrsh %s hostname
                             n=10, max_attempts=30, interval=2, regexp=True)
 
         self.momA.log_match("Job;%s;task.+started, hostname" % (jid,),
-                            n=10, max_attempts=60, interval=5, regexp=True)
+                            n=10, interval=5, regexp=True)
 
         self.momA.log_match("Job;%s;copy file request received" % (jid,),
-                            n=10, max_attempts=60, interval=5)
+                            n=10, interval=5)
 
         # validate output
         expected_out = """/var/spool/pbs/aux/%s
@@ -4417,10 +4415,10 @@ if e.job.in_ms_mom():
                                   self.job1_place,
                                   self.job1v6_sel_esc)
         self.momA.log_match("Job;%s;task.+started, hostname" % (jid,),
-                            n=10, max_attempts=60, interval=5, regexp=True)
+                            n=10, interval=5, regexp=True)
 
         self.momA.log_match("Job;%s;copy file request received" % (jid,),
-                            n=10, max_attempts=60, interval=5)
+                            n=10, interval=5)
 
         # validate output
         expected_out = """/var/spool/pbs/aux/%s
@@ -5112,10 +5110,10 @@ if not e.job.in_ms_mom() and (localnode == '%s'):
                                   self.job1_place,
                                   self.job1v2_sel_esc)
         self.momA.log_match("Job;%s;task.+started, hostname" % (jid,),
-                            n=10, max_attempts=60, interval=5, regexp=True)
+                            n=10, interval=5, regexp=True)
 
         self.momA.log_match("Job;%s;copy file request received" % (jid,),
-                            n=10, max_attempts=60, interval=5)
+                            n=10, interval=5)
 
         # validate output
         expected_out = """/var/spool/pbs/aux/%s
@@ -5198,10 +5196,10 @@ pbs_tmrsh %s hostname
                                   self.job1_place,
                                   self.job1v2_sel_esc)
         self.momA.log_match("Job;%s;task.+started, hostname" % (jid,),
-                            n=10, max_attempts=60, interval=5, regexp=True)
+                            n=10, interval=5, regexp=True)
 
         self.momA.log_match("Job;%s;copy file request received" % (jid,),
-                            n=10, max_attempts=60, interval=5)
+                            n=10, interval=5)
 
         # validate output
         expected_out = """/var/spool/pbs/aux/%s
@@ -5628,10 +5626,10 @@ pbs_tmrsh %s hostname
                                   self.job1_place,
                                   self.job1v4_sel_esc)
         self.momA.log_match("Job;%s;task.+started, hostname" % (jid,),
-                            n=10, max_attempts=60, interval=5, regexp=True)
+                            n=10, interval=5, regexp=True)
 
         self.momA.log_match("Job;%s;copy file request received" % (jid,),
-                            n=10, max_attempts=60, interval=5)
+                            n=10, interval=5)
 
         # validate output
         expected_out = """/var/spool/pbs/aux/%s


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Few of the tests of TestPbsReliableJobStartup are failing due to below reasons:
1. Accounting Log match
2. Race condition while searching log in mom logs
3.  Incorrcet Job state

Test was searching for accounting logs with specific number of lines which internally runs tail on specified accounting logs file resulting in command execution failure on our machines.
In few tests, we are checking for "Job;<jobid>;task.+started, hostname" log in mom logs. This message is appearing 4 minutes after hook execution. This is because job script has 3 "Fib 37" series to run after which "pbsdsh -n 0 -- hostname -s" is called.
**Job Script:**
echo 'pbsdsh -n 1 fib 37'
pbsdsh -n 1 – fib 37
echo 'pbsdsh -n 2 fib 37'
pbsdsh -n 2 – fib 37
echo 'fib 37'
fib 37
echo 'HOSTNAME TESTS'
echo 'pbsdsh -n 0 hostname'
pbsdsh -n 0 --  hostname -s   


#### Describe Your Change
- Replaced number of lines in accounting log match with "ALL" where it will search in entire file.
- Increased max attempts and interval in mom log match
- Changed Substate of Job from 41-> 42


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
![TH3_Reliablejob_test_results](https://user-images.githubusercontent.com/33057352/87010312-004d6d80-c1e4-11ea-8172-9bcc75c5c6ac.PNG)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
