### PR TITLE
TestPbsAccumulateRescUsed doesn't show accumulation of resources if r…

### DIFF
--- a/test/tests/functional/pbs_accumulate_resc_used.py
+++ b/test/tests/functional/pbs_accumulate_resc_used.py
@@ -335,10 +335,10 @@ else:
         will be enabled and will overwrite the cput value set in the prologue
         hook
         """
-        has_cpuset = 0
+        has_cpuset = False
         for mom in self.moms.values():
             if mom.is_cpuset_mom():
-                has_cpuset = 1
+                has_cpuset = True
 
         self.logger.info("test_prologue")
         hook_body = """
@@ -414,7 +414,7 @@ else:
             'resources_used.vmem': '35gb',
             'resources_used.ncpus': '3'}
 
-        if has_cpuset is 0:
+        if not has_cpuset:
             a['resources_used.cput'] = '00:00:35'
 
         self.server.expect(JOB, a, extend='x', offset=10,
@@ -471,7 +471,7 @@ else:
         self.server.accounting_match(
             "E;%s;.*%s.*" % (jid, acctlog_match), regexp=True, n=100)
 
-        if has_cpuset is 0:
+        if not has_cpuset:
             acctlog_match = 'resources_used.cput=00:00:35'
             self.server.accounting_match(
                 "E;%s;.*%s.*" % (jid, acctlog_match), regexp=True, n=100)
@@ -859,10 +859,10 @@ j.resources_used["stra2"] = '"glad"'
         will be enabled and will overwrite the cput value set in the prologue
         hook
         """
-        has_cpuset = 0
+        has_cpuset = False
         for mom in self.moms.values():
             if mom.is_cpuset_mom():
-                has_cpuset = 1
+                has_cpuset = True
 
         # Create a prologue hook
         hook_body = """
@@ -922,7 +922,7 @@ else:
              'resources_used.stra': "\"glad,elated\",\"happy\"",
              'resources_used.foo_str4': "eight",
              'job_state': 'F'}
-        if has_cpuset is 0:
+        if not has_cpuset:
             a['resources_used.cput'] = '00:00:35'
         self.server.expect(JOB, a, extend='x',
                            offset=5, id=jid, interval=1, attrop=PTL_AND)
@@ -1148,10 +1148,10 @@ else:
         will be enabled and will overwrite the cput value set in the prologue
         hook
         """
-        has_cpuset = 0
+        has_cpuset = False
         for mom in self.moms.values():
             if mom.is_cpuset_mom():
-                has_cpuset = 1
+                has_cpuset = True
 
         hook_body = """
 import pbs
@@ -1213,10 +1213,9 @@ e.job.resources_used["cput"] = 10
             'resources_used.foo_f': '0.6',
             'job_state': 'F'}
 
-        if has_cpuset is 0:
+        if not has_cpuset:
             b['resources_used.cput'] = '30'
-        self.server.expect(JOB, b, attrop=PTL_AND, extend='x', id=jid,
-                           offset=5, max_attempts=60, interval=1)
+        self.server.expect(JOB, b, extend='x', id=jid, offset=5, interval=1)
 
         # Submit another job
         j1 = Job(TEST_USER)

--- a/test/tests/functional/pbs_accumulate_resc_used.py
+++ b/test/tests/functional/pbs_accumulate_resc_used.py
@@ -331,8 +331,9 @@ else:
         """
         Test accumulatinon of resources of a multinode job from an
         exechost_prologue hook.
-        On cpuset systems don't check for cput because the pbs_cgroups hook will
-        be enabled and will overwrite the cput value set in the prologue hook
+        On cpuset systems don't check for cput because the pbs_cgroups hook
+        will be enabled and will overwrite the cput value set in the prologue
+        hook
         """
         has_cpuset = 0
         for mom in self.moms.values():
@@ -854,8 +855,9 @@ j.resources_used["stra2"] = '"glad"'
         """
         Test that resource accumulation will not get
         impacted if server is restarted during job execution
-        On cpuset systems don't check for cput because the pbs_cgroups hook will
-        be enabled and will overwrite the cput value set in the prologue hook
+        On cpuset systems don't check for cput because the pbs_cgroups hook
+        will be enabled and will overwrite the cput value set in the prologue
+        hook
         """
         has_cpuset = 0
         for mom in self.moms.values():
@@ -1142,8 +1144,9 @@ else:
         Test that epilogue and prologue changing same
         and different resources. Values of same resource
         would get overwriteen by the last hook.
-        On cpuset systems don't check for cput because the pbs_cgroups hook will
-        be enabled and will overwrite the cput value set in the prologue hook
+        On cpuset systems don't check for cput because the pbs_cgroups hook
+        will be enabled and will overwrite the cput value set in the prologue
+        hook
         """
         has_cpuset = 0
         for mom in self.moms.values():

--- a/test/tests/functional/pbs_accumulate_resc_used.py
+++ b/test/tests/functional/pbs_accumulate_resc_used.py
@@ -331,7 +331,7 @@ else:
         """
         Test accumulatinon of resources of a multinode job from an
         exechost_prologue hook.
-	On cpuset systems don't check for cput because the pbs_cgroups hook will
+        On cpuset systems don't check for cput because the pbs_cgroups hook will
         be enabled and will overwrite the cput value set in the prologue hook
         """
         has_cpuset = 0
@@ -416,8 +416,8 @@ else:
         if has_cpuset is 0:
             a['resources_used.cput'] = '00:00:35'
 
-        self.server.expect(JOB, a,
-            extend='x', offset=10, attrop=PTL_AND, id=jid)
+        self.server.expect(JOB, a, extend='x', offset=10,
+                           attrop=PTL_AND, id=jid)
 
         foo_str_dict_in = {"eight": 8, "seven": 7, "nine": 9}
         qstat = self.server.status(
@@ -854,6 +854,8 @@ j.resources_used["stra2"] = '"glad"'
         """
         Test that resource accumulation will not get
         impacted if server is restarted during job execution
+        On cpuset systems don't check for cput because the pbs_cgroups hook will
+        be enabled and will overwrite the cput value set in the prologue hook
         """
         has_cpuset = 0
         for mom in self.moms.values():
@@ -1140,6 +1142,8 @@ else:
         Test that epilogue and prologue changing same
         and different resources. Values of same resource
         would get overwriteen by the last hook.
+        On cpuset systems don't check for cput because the pbs_cgroups hook will
+        be enabled and will overwrite the cput value set in the prologue hook
         """
         has_cpuset = 0
         for mom in self.moms.values():
@@ -1209,7 +1213,7 @@ e.job.resources_used["cput"] = 10
         if has_cpuset is 0:
             b['resources_used.cput'] = '30'
         self.server.expect(JOB, b, attrop=PTL_AND, extend='x', id=jid,
-            offset=5, max_attempts=60, interval=1)
+                           offset=5, max_attempts=60, interval=1)
 
         # Submit another job
         j1 = Job(TEST_USER)


### PR DESCRIPTION
…emote mom is cpusetmom

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
The problem with the tests is that the tests look for a specific value of cput.  On cpuset machines where the cgroups hook is enabled cput is something the cgroups hook polls for and sets.  Thus anything set in a hook that runs before the cgroups hook  will be overwritten by the cgroups hook.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
To fix this I ordered the tests epilogue hook to run after the cgroups hook.
And for the other tests, I changed the test to not compare cput on cpuset systems.  
This shouldn't be a problem since the test wasn't testing the accumulation of cput, but rather testing that it and other values are set.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[accum_before.txt](https://github.com/openpbs/openpbs/files/4900595/accum_before.txt)
[accum_resc_after.txt](https://github.com/openpbs/openpbs/files/4900596/accum_resc_after.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
