### PR TITLE
Added performance data to json file

### DIFF
--- a/test/tests/performance/pbs_qstat_performance.py
+++ b/test/tests/performance/pbs_qstat_performance.py
@@ -108,6 +108,11 @@ class TestQstatPerformance(TestPerformance):
             return -1
         self.logger.info("Without E option :" + without_E_option['err'][0])
         self.logger.info("With E option    :" + with_E_option['err'][0])
+        measure = "elapse_time qstat" + query.split("`")[0]
+        self.perf_test_result(float(without_E_option['err'][0]),
+                              measure, "sec")
+        self.perf_test_result(float(with_E_option['err'][0]),
+                              measure + "-E", "sec")
         self.assertTrue(
             (without_E_option['err'][0] >= with_E_option['err'][0]),
             "Qstat command with option : " + query + " Failed")

--- a/test/tests/performance/test_dependency_perf.py
+++ b/test/tests/performance/test_dependency_perf.py
@@ -45,6 +45,7 @@ class TestDependencyPerformance(TestPerformance):
     """
     Test the performance of job dependency feature
     """
+
     def check_depend_delete_msg(self, pjid, cjid):
         """
         helper function to check ia message that the dependent job (cjid)
@@ -83,3 +84,5 @@ class TestDependencyPerformance(TestPerformance):
         self.logger.info('Time taken to delete all jobs %f' % (t2-t1))
         self.logger.info('#' * 80)
         self.check_depend_delete_msg(j_arr[4999], j_arr[5000])
+        self.perf_test_result((t2 - t1),
+                              "time_taken_delete_all_dependent_jobs", "sec")


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->
It is cherry-pick of https://github.com/openpbs/openpbs/pull/1881
#### Describe Bug or Feature
Outputs of some performance tests are not stored in json file

#### Describe Your Change
storing performance tests output in json file

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

[qstat.txt](https://github.com/openpbs/openpbs/files/4901995/qstat.txt)

[dependency.txt](https://github.com/openpbs/openpbs/files/4901974/dependency.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
