### PR TITLE
Tolerate network delays while enabling pbs_cgroups hook under cpuset …

### DIFF
--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -1487,8 +1487,9 @@ class PBSTestSuite(unittest.TestCase):
                 # a high max_attempts is needed to tolerate delay receiving
                 # hook-related files, due to temporary network interruptions
                 mom.log_match('pbs_cgroups.CF;copy hook-related '
-                              'file request received', max_attempts=240,
-                              starttime=just_before_enable_cgroup_cset-1)
+                              'file request received', max_attempts=120,
+                              starttime=just_before_enable_cgroup_cset-1,
+                              interval=1)
                 # Make sure that the MoM will generate per-NUMA node vnodes
                 # when the natural node is created below
                 # HUP may not be enough if exechost_startup is delayed

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -1484,9 +1484,11 @@ class PBSTestSuite(unittest.TestCase):
                 time.sleep(4)
                 just_before_enable_cgroup_cset = time.time()
                 mom.enable_cgroup_cset()
+                # a high max_attempts is needed to tolerate delay receiving
+                # hook-related files, due to temporary network interruptions
                 mom.log_match('pbs_cgroups.CF;copy hook-related '
-                              'file request received',
-                              starttime=just_before_enable_cgroup_cset)
+                              'file request received', max_attempts=240,
+                              starttime=just_before_enable_cgroup_cset-1)
                 # Make sure that the MoM will generate per-NUMA node vnodes
                 # when the natural node is created below
                 # HUP may not be enough if exechost_startup is delayed


### PR DESCRIPTION
…systems

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* Observed that when running tests on UV-like systems where pbs_cgroups hook is enabled with vnode_per_numa=true at start up, a temporary network interruptions could delay mom receiving the config file (i.e. pbs_cgroups.CF) file by up to 2 minutes.
* server_Logs get:
07/09/2020 13:20:41.940729;0001;pbs_mom;Svr;pbs_mom ;im_eof, Premature end of message from addr 10.8.7.182:15001 on stream 1
07/09/2020 13:20:41.940820;0002;pbs_mom;Svr;im_eof;Server closed connection.
07/09/2020 13:20:41.940919;0c06;pbs_mom;TPP;leaf_pkt_handler(Thread 0);Data to sd=1 which is deleted
07/09/2020 13:20:41.941197;0c06;pbs_mom;TPP;leaf_pkt_handler(Thread 0);Data to sd=1 which is deleted
...
/09/2020 13:20:47.075654;0002;pbs_mom;Svr;pbs_mom;HELLO sent to server at pbi-36-s15-altix:15001
07/09/2020 13:20:47.076083;0002;pbs_mom;Svr;pbs_mom;ReplyHello from server at 10.8.7.182:15001
07/09/2020 13:22:30.621614;0100;pbs_mom;Req;;Type 85 request received from root@10.8.7.182:15001, sock=4  <-- delay before receiving hook-related CF
~                    


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* Tolerate network delays while mom is starting up by setting max_attempts to high value (240), which should cover up to 2 minutes delay, when looking for "pbs_cgroups.CF" message.
* Also, the starttime of matching log message is set to the time just before pbs_cgroups hook is enabled. Sometimes, there's a timing condition where log message matching is already too late by 1 second. Put a fix for that.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

* [ptl.FAIL.txt](https://github.com/openpbs/openpbs/files/4914318/ptl.FAIL.txt)
* [ptl.PASS.txt](https://github.com/openpbs/openpbs/files/4914321/ptl.PASS.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
