### PR TITLE
Fixed issue where resources_assigned wasn't correct after resv reconfirm

### DIFF
--- a/test/tests/functional/pbs_reservations.py
+++ b/test/tests/functional/pbs_reservations.py
@@ -163,6 +163,11 @@ class TestReservations(TestFunctional):
         self.assertEquals(set(self.server.reservations[rid].get_vnodes()),
                           {resv_node_list[1], other_node},
                           "Node not replaced correctly")
+        if run:
+            a = {'resources_assigned.ncpus': 0}
+            self.server.expect(NODE, a, id=resv_node)
+            a = {'resources_assigned.ncpus=1': 2}
+            self.server.expect(NODE, a)
 
     def degraded_resv_failed_reconfirm(self, start, end, rrule=None,
                                        run=False, resume=False):


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
After a degraded running reservation was reconfirmed, the resources_assigned values on the unavailable nodes were left unchanged, and the new nodes values were not incremented.  Once the reservation ended, since the reservation was no longer on the original node, they would never be decremented.  Also, since the values on the new node were never incremented, the new node could be oversubscribed.

#### Describe Your Change
In req_confirmresv(), the function free_resvNodes() was being called.  This only removes the resv structure from the nodes, not the resources.  A call to set_resc_assigned() was needed to decrement the resources prior to setting the new resv_nodes, and a call to increment the resources after resv_nodes was set.

#### Attach Test and Valgrind Logs/Output
[resv.log](https://github.com/openpbs/openpbs/files/4915063/resv.log)
