### PR TITLE
Sched memleak in corner cases

### DIFF
--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -410,7 +410,7 @@ query_reservations(int pbs_sd, server_info *sinfo, struct batch_status *resvs)
 			char *rrule = NULL;
 			char *tz = NULL;
 			struct tm* loc_time;
-			char start_time[18];
+			char start_time[128];
 			int count = 0;
 			int occr_count; /* occurrences count as reported by execvnodes_seq */
 			int occr_idx = 1; /* the occurrence index of a standing reservation */
@@ -551,18 +551,8 @@ query_reservations(int pbs_sd, server_info *sinfo, struct batch_status *resvs)
 				resresv_arr[idx] = NULL;
 
 				loc_time = localtime(&resresv_ocr->start);
+				strftime(start_time, sizeof(start_time), "%Y%m%d-%H:%M:%S", loc_time);
 
-				if (loc_time == NULL ||
-					strftime(start_time, sizeof(start_time), "%Y%m%d-%H:%M:%S",
-					loc_time) == 0) {
-					free_resource_resv_array(resresv_arr);
-					free_resource_resv(resresv);
-					free_execvnode_seq(tofree);
-					free(execvnodes_seq);
-					free(execvnode_ptr);
-					free_schd_error(err);
-					return NULL;
-				}
 				log_eventf(PBSEVENT_DEBUG2, PBS_EVENTCLASS_RESV, LOG_DEBUG, resresv->name,
 					"Occurrence %d/%d,%s", occr_idx, count, start_time);
 			}

--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -467,6 +467,7 @@ query_reservations(int pbs_sd, server_info *sinfo, struct batch_status *resvs)
 				sizeof(resource_resv *) * (sinfo->num_resvs + 1))) == NULL) {
 				log_err(errno, __func__, MEM_ERR_MSG);
 				free_resource_resv_array(resresv_arr);
+				free_resource_resv(resresv);
 				free_execvnode_seq(tofree);
 				free(execvnodes_seq);
 				free(execvnode_ptr);
@@ -501,6 +502,7 @@ query_reservations(int pbs_sd, server_info *sinfo, struct batch_status *resvs)
 					if (resresv_ocr == NULL) {
 						log_err(errno, __func__, "Error duplicating resource reservation");
 						free_resource_resv_array(resresv_arr);
+						free_resource_resv(resresv);
 						free_execvnode_seq(tofree);
 						free(execvnodes_seq);
 						free(execvnode_ptr);
@@ -554,6 +556,7 @@ query_reservations(int pbs_sd, server_info *sinfo, struct batch_status *resvs)
 					strftime(start_time, sizeof(start_time), "%Y%m%d-%H:%M:%S",
 					loc_time) == 0) {
 					free_resource_resv_array(resresv_arr);
+					free_resource_resv(resresv);
 					free_execvnode_seq(tofree);
 					free(execvnodes_seq);
 					free(execvnode_ptr);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
While querying reservations, scheduler may leak resource resv structure in some corner cases


#### Describe Your Change
Added free 


#### Link to Design Doc
NA


#### Attach Test and Valgrind Logs/Output
This was not reproducible, I could only reproduce this using valgrind and gdb. - 
```
[root:/workspace/PBS/public/pbspro] # psg valg
5 S root      94985      1  0  80   0 - 40256 poll_s 15:14 ?        00:00:01 valgrind --vgdb=yes --vgdb-error=0 /opt/pbs/sbin/pbs_sched
0 S root      95442   5208  0  80   0 - 28163 pipe_w 15:20 pts/1    00:00:00 grep --color=auto valg
[root:/workspace/PBS/public/pbspro] # kill 94985
[root:/workspace/PBS/public/pbspro] # ==94985== 
==94985== HEAP SUMMARY:
==94985==     in use at exit: 777,519 bytes in 4,051 blocks
==94985==   total heap usage: 10,862 allocs, 6,963 frees, 2,306,716 bytes allocated
==94985== 
==94985== LEAK SUMMARY:
==94985==    definitely lost: 0 bytes in 0 blocks
==94985==    indirectly lost: 0 bytes in 0 blocks
==94985==      possibly lost: 13,448 bytes in 23 blocks
==94985==    still reachable: 764,071 bytes in 4,028 blocks
==94985==         suppressed: 0 bytes in 0 blocks
==94985== Rerun with --leak-check=full to see details of leaked memory
==94985== 
==94985== For counts of detected and suppressed errors, rerun with: -v
==94985== Use --track-origins=yes to see where uninitialised values come from
==94985== ERROR SUMMARY: 840 errors from 161 contexts (suppressed: 0 from 0)

[root:/workspace/PBS/public/pbspro] # grep "Error duplicating resource" /var/spool/pbs/sched_logs/20200713 
07/13/2020 15:19:03.793879;0001;pbs_sched;Svr;pbs_sched;Resource temporarily unavailable (11) in query_reservations, Error duplicating resource reservation
07/13/2020 15:19:37.176796;0001;pbs_sched;Svr;pbs_sched;No such file or directory (2) in query_reservations, Error duplicating resource reservation
[root:/workspace/PBS/public/pbspro] # 

```



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
