### PR TITLE
Fix ralter -D not changing end time and doubling resources

### DIFF
--- a/src/server/req_modify.c
+++ b/src/server/req_modify.c
@@ -391,9 +391,9 @@ req_modifyjob(struct batch_request *preq)
 		svr_evaljobstate(pjob, &newstate, &newsubstate, 0);
 		(void)svr_setjobstate(pjob, newstate, newsubstate);
 	}
-	
+
 	job_save_db(pjob); /* we must save the updates anyway, if any */
-	
+
 	log_eventf(PBSEVENT_JOB, PBS_EVENTCLASS_JOB, LOG_INFO, pjob->ji_qs.ji_jobid, msg_manager, msg_jobmod, preq->rq_user, preq->rq_host);
 
 	/* if a resource limit changed for a running job, send to MOM */
@@ -638,7 +638,7 @@ modify_job_attr(job *pjob, svrattrl *plist, int perm, int *bad)
 		if (newattr[i].at_flags & ATR_VFLAG_MODIFY) {
 			if ((job_attr_def[i].at_flags & ATR_DFLAG_NOSAVM))
 				continue;
-				
+
 			if (job_attr_def[i].at_action) {
 				rc = job_attr_def[i].at_action(&newattr[i],
 					pjob, ATR_ACTION_ALTER);
@@ -699,9 +699,9 @@ modify_job_attr(job *pjob, svrattrl *plist, int perm, int *bad)
 }
 
 /**
- * @brief determine if one schedselect is made up of fewer or equal number of 
+ * @brief determine if one schedselect is made up of fewer or equal number of
  *		the same chunk types with possibly some chunk types removed.
- * 
+ *
  * @return int
  * @retval 1 fewer or equal chunks
  * @retval 0 more chunks or different chunks

--- a/src/server/req_rescq.c
+++ b/src/server/req_rescq.c
@@ -792,7 +792,7 @@ req_confirmresv(struct batch_request *preq)
 	 * in this case, the reservation had already been confirmed and added to
 	 * the task list before
 	 */
-	if (!is_degraded && (is_being_altered != RESV_END_TIME_MODIFIED) &&
+	if (!is_degraded && (!is_being_altered || is_being_altered & RESV_START_TIME_MODIFIED) &&
 		(rc = gen_task_Time4resv(presv)) != 0) {
 		free(next_execvnode);
 		req_reject(rc, 0, preq);

--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -4221,6 +4221,10 @@ start_end_dur_wall(resc_resv *presv)
 				(petime->at_val.at_long <= pstime->at_val.at_long))
 				rc = -1;
 			else {
+				if (pstate == RESV_BEING_ALTERED) {
+					presv->ri_alter.ra_flags |= RESV_DURATION_MODIFIED;
+					presv->ri_alter.ra_duration = pduration->at_val.at_long;
+				}
 				atemp.at_val.at_long = (petime->at_val.at_long -
 					pstime->at_val.at_long);
 				pddef->at_set(pduration, &atemp, SET);
@@ -4234,6 +4238,10 @@ start_end_dur_wall(resc_resv *presv)
 				(pduration->at_val.at_long <= 0))
 				rc = -1;
 			else {
+				if (pstate == RESV_BEING_ALTERED) {
+					presv->ri_alter.ra_flags |= RESV_END_TIME_MODIFIED;
+					presv->ri_alter.ra_etime = petime->at_val.at_long;
+				}
 				petime->at_flags |= ATR_SET_MOD_MCACHE;
 				petime->at_val.at_long = pstime->at_val.at_long +
 					pduration->at_val.at_long;
@@ -4263,6 +4271,10 @@ start_end_dur_wall(resc_resv *presv)
 				rc = -1;
 			}
 			else {
+				if (pstate == RESV_BEING_ALTERED) {
+					presv->ri_alter.ra_flags |= RESV_START_TIME_MODIFIED;
+					presv->ri_alter.ra_stime = pstime->at_val.at_long;
+				}
 				pstime->at_flags |= ATR_SET_MOD_MCACHE;
 				pstime->at_val.at_long = petime->at_val.at_long -
 					pduration->at_val.at_long;
@@ -4276,6 +4288,11 @@ start_end_dur_wall(resc_resv *presv)
 				(prsc->rs_value.at_val.at_long <= 0))
 				rc = -1;
 			else {
+				if (pstate == RESV_BEING_ALTERED) {
+					presv->ri_alter.ra_flags |= RESV_END_TIME_MODIFIED | RESV_DURATION_MODIFIED;
+					presv->ri_alter.ra_etime = petime->at_val.at_long;
+					presv->ri_alter.ra_duration = pduration->at_val.at_long;
+				}
 				petime->at_flags |= ATR_SET_MOD_MCACHE;
 				petime->at_val.at_long = pstime->at_val.at_long +
 					prsc->rs_value.at_val.at_long;
@@ -4291,6 +4308,10 @@ start_end_dur_wall(resc_resv *presv)
 				rc = -1;
 			}
 			else {
+				if (pstate == RESV_BEING_ALTERED) {
+					presv->ri_alter.ra_flags |= RESV_START_TIME_MODIFIED;
+					presv->ri_alter.ra_stime = pstime->at_val.at_long;
+				}
 				pstime->at_flags |= ATR_SET_MOD_MCACHE;
 				pstime->at_val.at_long = petime->at_val.at_long -
 					prsc->rs_value.at_val.at_long;
@@ -4306,6 +4327,10 @@ start_end_dur_wall(resc_resv *presv)
 					prsc->rs_value.at_val.at_long))
 				rc = -1;
 			else {
+				if (pstate == RESV_BEING_ALTERED) {
+					presv->ri_alter.ra_flags |= RESV_DURATION_MODIFIED;
+					presv->ri_alter.ra_duration = pduration->at_val.at_long;
+				}
 				pduration->at_flags |= ATR_SET_MOD_MCACHE;
 				pduration->at_val.at_long = prsc->rs_value.at_val.at_long;
 			}
@@ -4317,6 +4342,10 @@ start_end_dur_wall(resc_resv *presv)
 				(pduration->at_val.at_long <= 0))
 				rc = -1;
 			else {
+				if (pstate == RESV_BEING_ALTERED) {
+					presv->ri_alter.ra_flags |= RESV_END_TIME_MODIFIED;
+					presv->ri_alter.ra_etime = petime->at_val.at_long;
+				}
 				petime->at_flags |= ATR_SET_MOD_MCACHE;
 				petime->at_val.at_long = pstime->at_val.at_long +
 					presv->ri_qs.ri_duration;

--- a/test/tests/functional/pbs_ralter.py
+++ b/test/tests/functional/pbs_ralter.py
@@ -1725,6 +1725,8 @@ class TestPbsResvAlter(TestFunctional):
         new_duration = int(time.time()) - int(t_start) - 1
         attr = {'reserve_duration': new_duration}
         self.server.alterresv(rid, attr)
+        msg = "Resv;" + rid + ";Reservation alter confirmed"
+        self.server.log_match(msg, id=rid)
         rid = rid.split('.')[0]
         self.server.log_match(rid + ";deleted at request of pbs_server",
                               id=rid, interval=2)

--- a/test/tests/functional/pbs_ralter.py
+++ b/test/tests/functional/pbs_ralter.py
@@ -333,11 +333,11 @@ class TestPbsResvAlter(TestFunctional):
                 new_duration_conv = a_duration
 
             if not alter_s and not alter_e:
-                new_end = start + a_duration + shift
+                new_end = start + new_duration_conv + shift
             elif alter_s and not alter_e:
-                new_end = new_start + a_duration
+                new_end = new_start + new_duration_conv
             elif not alter_s and alter_e:
-                new_start = new_end - a_duration
+                new_start = new_end - new_duration_conv
             # else new_start and new_end have already been calculated
         else:
             new_duration_conv = new_end - new_start
@@ -2259,10 +2259,7 @@ class TestPbsResvAlter(TestFunctional):
         self.server.expect(RESV,
                            {'reserve_state': (MATCH_RE, 'RESV_RUNNING|5')},
                            offset=sleepdur)
-
-        self.server.alterresv(rid, {ATTR_resv_duration: '10:00'})
-        self.server.expect(RESV,
-                           {'reserve_state': (MATCH_RE, 'RESV_RUNNING|5')},
-                           id=rid, max_attempts=5)
+        self.alter_a_reservation(rid, start, end, a_duration=600,
+                                 confirm=False)
         self.server.expect(NODE, {'resources_assigned.ncpus': 4},
                            max_attempts=1, id=resv_node)

--- a/test/tests/functional/pbs_ralter.py
+++ b/test/tests/functional/pbs_ralter.py
@@ -369,26 +369,23 @@ class TestPbsResvAlter(TestFunctional):
 
             if check_log:
                 msg = "Resv;" + r + ";Attempting to modify reservation "
-                if alter_s:
+                if start != new_start:
                     msg += "start="
                     msg += time.strftime(self.fmt,
                                          time.localtime(int(new_start)))
+                    msg += " "
 
-                if alter_e:
-                    if alter_s:
-                        msg += " "
-                        acct_msg += " "
+                if end != new_end:
                     msg += "end="
                     msg += time.strftime(self.fmt,
                                          time.localtime(int(new_end)))
-                    acct_msg += "end="
-                    acct_msg += str(new_end)
+                    msg += " "
 
                 if select:
-                    if alter_s or alter_e:
-                        msg += " "
-                    msg += "select=" + select
+                    msg += "select=" + select + " "
 
+                # strip the last space
+                msg = msg[:-1]
                 self.server.log_match(msg, interval=2, max_attempts=30)
 
             if whichMessage == 1:
@@ -1624,6 +1621,12 @@ class TestPbsResvAlter(TestFunctional):
         self.assertEqual(t_start, temp_start)
         self.assertEqual(t_duration, new_duration2)
 
+        sleepdur = (temp_end + shift / 2) - time.time()
+        self.logger.info('Sleeping until reservation would have ended')
+        self.server.expect(RESV,
+                           {'reserve_state': (MATCH_RE, 'RESV_RUNNING|5')},
+                           id=rid, max_attempts=5, offset=sleepdur)
+
     @skipOnCpuSet
     def test_adv_resv_dur_and_endtime_before_start(self):
         """
@@ -1722,8 +1725,6 @@ class TestPbsResvAlter(TestFunctional):
         new_duration = int(time.time()) - int(t_start) - 1
         attr = {'reserve_duration': new_duration}
         self.server.alterresv(rid, attr)
-        self.server.log_match(rid + ";Reservation alter denied",
-                              id=rid, interval=2)
         rid = rid.split('.')[0]
         self.server.log_match(rid + ";deleted at request of pbs_server",
                               id=rid, interval=2)
@@ -2234,3 +2235,32 @@ class TestPbsResvAlter(TestFunctional):
         a = {'Resource_List.select': '8:ncpus=1', 'Resource_List.ncpus': 8,
              'Resource_List.nodect': 8}
         self.server.expect(RESV, a, id=rid)
+
+    def test_resv_resc_assigned(self):
+        """
+        Test that when an ralter -D is issued, the resources on the node
+        are still correct
+        """
+
+        offset = 60
+        dur = 60
+        select = "4:ncpus=1"
+
+        rid, start, end = \
+            self.submit_and_confirm_reservation(offset, dur, select=select)
+
+        self.server.status(RESV, 'resv_nodes', id=rid)
+        resv_node = self.server.reservations[rid].get_vnodes()[0]
+
+        sleepdur = start - time.time()
+        self.logger.info('Sleeping until reservation starts')
+        self.server.expect(RESV,
+                           {'reserve_state': (MATCH_RE, 'RESV_RUNNING|5')},
+                           offset=sleepdur)
+
+        self.server.alterresv(rid, {ATTR_resv_duration: '10:00'})
+        self.server.expect(RESV,
+                           {'reserve_state': (MATCH_RE, 'RESV_RUNNING|5')},
+                           id=rid, max_attempts=5)
+        self.server.expect(NODE, {'resources_assigned.ncpus': 4},
+                           max_attempts=1, id=resv_node)


### PR DESCRIPTION
### Describe Bug or Feature
If pbs_ralter -D would change the end time to a later time, the reservation would still end at the original time.
Also, if pbs_ralter -D would change the end time, the server would double the resources used on the nodes.

#### Describe Your Change
When we calculate the new end time, add end time to the modified flags.
When generating a Time4resv task, instead of checking if we are not altering only the End time, we check if we are altering the start time.


#### Attach Test and Valgrind Logs/Output
[after-fix3.txt](https://github.com/openpbs/openpbs/files/4921057/after-fix3.txt)
[beforefix_small.txt](https://github.com/openpbs/openpbs/files/4921058/beforefix_small.txt)
