### PR TITLE
except() should first trigger a scheduling cycle and then verify the value

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -8330,6 +8330,10 @@ class Server(PBSService):
                             str(offset))
             time.sleep(offset)
 
+        if trigger_sched_cycle and attempt == 0:
+            self.manager(MGR_CMD_SET,
+                         SERVER, {'scheduling': 'True'}, sudo=True)
+
         if attrib is None:
             attrib = {}
 

--- a/test/tests/functional/pbs_Rrecord_resources_used.py
+++ b/test/tests/functional/pbs_Rrecord_resources_used.py
@@ -272,9 +272,12 @@ class Test_Rrecord_with_resources_used(TestFunctional):
             id=jid3s1, regexp=True)
 
         # Verify that the jobs are in 'Q' state.
-        self.server.expect(JOB, {ATTR_state: 'Q'}, jid1)
-        self.server.expect(JOB, {ATTR_state: 'Q'}, jid2)
-        self.server.expect(JOB, {ATTR_state: 'Q'}, jid3s1)
+        self.server.expect(JOB, {ATTR_state: 'Q'}, jid1,
+                           trigger_sched_cycle=False)
+        self.server.expect(JOB, {ATTR_state: 'Q'}, jid2,
+                           trigger_sched_cycle=False)
+        self.server.expect(JOB, {ATTR_state: 'Q'}, jid3s1,
+                           trigger_sched_cycle=False)
 
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
 

--- a/test/tests/functional/pbs_acct_log.py
+++ b/test/tests/functional/pbs_acct_log.py
@@ -146,7 +146,8 @@ class TestAcctLog(TestFunctional):
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
 
         self.server.rerunjob(jid)
-        self.server.expect(JOB, {'job_state': 'Q'}, id=jid)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid,
+                           trigger_sched_cycle=False)
 
         # Make sure the accounting log hasn't been truncated
         acctlog_match = 'resources_used.foo_str=' + hstr

--- a/test/tests/functional/pbs_accumulate_resc_used.py
+++ b/test/tests/functional/pbs_accumulate_resc_used.py
@@ -1045,13 +1045,13 @@ for jj in e.job_list.keys():
         self.server.manager(MGR_CMD_SET, SERVER,
                             {'scheduling': 'False'})
         self.server.rerunjob(jobid=jid1, runas=ROOT_USER)
-        self.server.expect(JOB,
-                           {'job_state': 'Q'}, id=jid1)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid1,
+                           trigger_sched_cycle=False)
 
         # Verify that foo_f is unset
         self.server.expect(JOB,
                            'Resource_List.foo_f',
-                           op=UNSET, id=jid1)
+                           op=UNSET, id=jid1, trigger_sched_cycle=False)
 
         # turn the scheduling on
         self.server.manager(MGR_CMD_SET, SERVER,

--- a/test/tests/functional/pbs_admin_suspend.py
+++ b/test/tests/functional/pbs_admin_suspend.py
@@ -549,12 +549,15 @@ class TestAdminSuspend(TestFunctional):
         a = {'resources_available.ncpus': 4, 'resources_available.mem': '4gb'}
         self.server.create_vnodes('vn', a, 3, self.mom, usenatvnode=True)
 
-        j = Job(TEST_USER)
-        j.set_attributes({'Resource_List.select': '3:ncpus=1',
-                          'Resource_List.place': 'vscatter'})
-        jid1 = self.server.submit(j)
-        jid2 = self.server.submit(j)
-        jid3 = self.server.submit(j)
+        ja = {'Resource_List.select': '3:ncpus=1',
+              'Resource_List.place': 'vscatter'}
+        j1 = Job(TEST_USER, ja)
+        jid1 = self.server.submit(j1)
+        j2 = Job(TEST_USER, ja)
+        jid2 = self.server.submit(j2)
+        j3 = Job(TEST_USER, ja)
+        jid3 = self.server.submit(j3)
+
         self.server.expect(JOB, {'job_state=R': 3, 'substate=42': 3})
         self.server.expect(NODE, {'state=free': 3})
 
@@ -584,7 +587,8 @@ class TestAdminSuspend(TestFunctional):
 
         # resume the remaining job
         self.server.sigjob(jid2, 'admin-resume', runas=ROOT_USER)
-        self.server.expect(NODE, {'state=free': 3})
+        self.server.expect(NODE, {'state=free': 2})
+        self.server.expect(NODE, {'state=job-busy': 1})
         self.server.expect(JOB, {'job_state=R': 4})
 
     @skipOnCpuSet

--- a/test/tests/functional/pbs_eligible_time.py
+++ b/test/tests/functional/pbs_eligible_time.py
@@ -86,14 +86,17 @@ class TestEligibleTime(TestFunctional):
 
         J1 = Job(TEST_USER, attrs={ATTR_a: s})
         jid = self.server.submit(J1)
-        self.server.expect(JOB, {ATTR_state: 'W'}, id=jid)
+        self.server.expect(JOB, {ATTR_state: 'W'}, id=jid,
+                           trigger_sched_cycle=False)
 
         self.logger.info("Sleeping 120s till job is out of 'W' state")
         time.sleep(120)
-        self.server.expect(JOB, {ATTR_state: 'Q'}, id=jid)
+        self.server.expect(JOB, {ATTR_state: 'Q'}, id=jid,
+                           trigger_sched_cycle=False)
         # eligible_time should really be 0, but just incase there is some
         # lag on some slow systems, add a little leeway.
-        self.server.expect(JOB, {'eligible_time': 10}, op=LT)
+        self.server.expect(JOB, {'eligible_time': 10}, op=LT,
+                           trigger_sched_cycle=False)
 
     @skipOnCpuSet
     def test_job_array(self):

--- a/test/tests/functional/pbs_equiv_classes.py
+++ b/test/tests/functional/pbs_equiv_classes.py
@@ -2161,8 +2161,10 @@ else:
 
         # Turn on scheduling
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
-        self.server.expect(JOB, {'job_state': 'S'}, id=jid1)
-        self.server.expect(JOB, {'job_state': 'R'}, id=jidh)
+        self.server.expect(JOB, {'job_state': 'S'}, id=jid1,
+                           trigger_sched_cycle=False)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jidh,
+                           trigger_sched_cycle=False)
 
         # make sure that the second job ran in the same cycle as the high
         # priority job

--- a/test/tests/functional/pbs_hook_execjob_end.py
+++ b/test/tests/functional/pbs_hook_execjob_end.py
@@ -413,15 +413,18 @@ class TestPbsExecjobEnd(TestFunctional):
 
         # check for the job's state after the node_fail_requeue time hits
         self.logger.info("Waiting for 30s so that node_fail_requeue time hits")
-        self.server.expect(JOB, {ATTR_state: 'Q'}, id=jid, offset=30)
+        self.server.expect(JOB, {ATTR_state: 'Q'}, id=jid, offset=30,
+                           trigger_sched_cycle=False)
 
         host.start()
         self.logger.info(
             "Successfully started mom process on %s" %
             host.shortname)
-        self.server.expect(NODE, {'state': 'free'}, id=host.shortname)
+        self.server.expect(NODE, {'state': 'free'}, id=host.shortname,
+                           trigger_sched_cycle=False)
 
-        self.server.expect(JOB, {ATTR_state: 'Q'}, id=jid)
+        self.server.expect(JOB, {ATTR_state: 'Q'}, id=jid,
+                           trigger_sched_cycle=False)
         # run job
         try:
             # qrun will fail as it is discarding the job
@@ -436,7 +439,8 @@ class TestPbsExecjobEnd(TestFunctional):
                                starttime=now, interval=2)
             time.sleep(5)
             self.server.runjob(jid)
-            self.server.expect(JOB, {'job_state': 'R'}, jid)
+            self.server.expect(JOB, {'job_state': 'R'}, jid,
+                               trigger_sched_cycle=False)
             now = time.time()
             self.mom.log_match(
                 "starting hook event EXECJOB_END",

--- a/test/tests/functional/pbs_hooksmoketest.py
+++ b/test/tests/functional/pbs_hooksmoketest.py
@@ -262,7 +262,8 @@ else:
         j1 = Job(TEST_USER, a)
         j1.create_script(self.script)
         jid1 = self.server.submit(j1, submit_dir=submit_dir)
-        self.server.expect(JOB, {'job_state': 'Q'}, id=jid1)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid1,
+                           trigger_sched_cycle=False)
         # As a user submit a job without requesting walltime
         # Job is denied with the message
         _msg = "qsub: No walltime specified. Master does not approve! ;o)"
@@ -444,7 +445,8 @@ print_attribs(j)"""
         j1 = Job(TEST_USER7)
         j1.create_script(self.script)
         jid1 = self.server.submit(j1, submit_dir=submit_dir)
-        self.server.expect(JOB, {'job_state': 'Q'}, id=jid1)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid1,
+                           trigger_sched_cycle=False)
         # qrun job j1
         self.server.runjob(jid1)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid1)

--- a/test/tests/functional/pbs_job_array.py
+++ b/test/tests/functional/pbs_job_array.py
@@ -536,9 +536,11 @@ class TestJobArray(TestFunctional):
         a = {'scheduling': 'false'}
         self.server.manager(MGR_CMD_SET, SERVER, a)
         self.server.rerunjob(subjid_1)
-        self.server.expect(JOB, {'job_state': 'Q'}, subjid_1)
+        self.server.expect(JOB, {'job_state': 'Q'}, subjid_1,
+                           trigger_sched_cycle=False)
         self.kill_and_restart_svr()
-        self.server.expect(JOB, {'job_state': 'Q'}, subjid_1)
+        self.server.expect(JOB, {'job_state': 'Q'}, subjid_1,
+                           trigger_sched_cycle=False)
         a = {'scheduling': 'true'}
         self.server.manager(MGR_CMD_SET, SERVER, a)
         a = {'job_state': 'R'}

--- a/test/tests/functional/pbs_job_routing.py
+++ b/test/tests/functional/pbs_job_routing.py
@@ -132,7 +132,7 @@ class TestJobRouting(TestFunctional):
         jid = self.server.submit(job)
 
         self.server.expect(JOB, {ATTR_state + '=Q': 4}, count=True,
-                           id=jid, extend='t')
+                           id=jid, extend='t', trigger_sched_cycle=False)
 
         # Start scheduling cycle. This will move all 3 subjobs to R state.
         # And parent job state to B state.

--- a/test/tests/functional/pbs_multi_sched.py
+++ b/test/tests/functional/pbs_multi_sched.py
@@ -308,7 +308,7 @@ class TestMultipleSchedulers(TestFunctional):
         self.server.manager(MGR_CMD_SET, SCHED,
                             {'scheduling': 'True'}, id="sc5")
         self.server.expect(SCHED, {'state': 'scheduling'},
-                           id='sc5', max_attempts=10)
+                           id='sc5')
 
     @skipOnCpuSet
     def test_resource_sched_reconfigure(self):
@@ -616,10 +616,12 @@ class TestMultipleSchedulers(TestFunctional):
                             {'scheduling': 'False'}, id="default")
         j = Job(TEST_USER1, attrs={'Resource_List.select': '1:ncpus=1'})
         jid1 = self.server.submit(j)
-        self.server.expect(JOB, {'job_state': 'Q'}, id=jid1)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid1,
+                           trigger_sched_cycle=False)
         j = Job(TEST_USER1, attrs={'Resource_List.select': '1:ncpus=2'})
         jid2 = self.server.submit(j)
-        self.server.expect(JOB, {'job_state': 'Q'}, id=jid2)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid2,
+                           trigger_sched_cycle=False)
         self.server.manager(MGR_CMD_SET, SCHED,
                             {'scheduling': 'True'}, id="default")
         self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
@@ -628,11 +630,13 @@ class TestMultipleSchedulers(TestFunctional):
         j = Job(TEST_USER1, attrs={ATTR_queue: 'wq3',
                                    'Resource_List.select': '1:ncpus=1'})
         jid3 = self.server.submit(j)
-        self.server.expect(JOB, {'job_state': 'Q'}, id=jid3)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid3,
+                           trigger_sched_cycle=False)
         j = Job(TEST_USER1, attrs={ATTR_queue: 'wq3',
                                    'Resource_List.select': '1:ncpus=2'})
         jid4 = self.server.submit(j)
-        self.server.expect(JOB, {'job_state': 'Q'}, id=jid4)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid4,
+                           trigger_sched_cycle=False)
         self.server.manager(MGR_CMD_SET, SCHED,
                             {'scheduling': 'True'}, id="sc3")
         self.server.expect(JOB, {'job_state': 'R'}, id=jid4)
@@ -1900,7 +1904,8 @@ class TestMultipleSchedulers(TestFunctional):
              'Resource_List.walltime': 600}
         j = Job(TEST_USER, attrs=a)
         jid = self.server.submit(j)
-        self.server.expect(JOB, {'job_state': 'Q'}, id=jid)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid,
+                           trigger_sched_cycle=False)
 
         # Now turn this job into a reservation and notice that it runs inside
         # a reservation running on vnode[2] which is part of sc3
@@ -1938,7 +1943,7 @@ class TestMultipleSchedulers(TestFunctional):
         r = Reservation(TEST_USER, a)
         rid = self.server.submit(r)
         a = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
-        self.server.expect(RESV, a, rid)
+        self.server.expect(RESV, a, rid, trigger_sched_cycle=False)
 
         # Submit a standing reservation such that it consumes one partition
         # and an occurrence finishes before the advance reservation starts.

--- a/test/tests/functional/pbs_qsub_remove_files.py
+++ b/test/tests/functional/pbs_qsub_remove_files.py
@@ -169,7 +169,7 @@ class TestQsub_remove_files(TestFunctional):
         directory when default_qsub_arguments is set to -Roe.
         """
         j = Job(TEST_USER)
-        j.set_sleep_time(5)
+        j.set_sleep_time(10)
         self.server.manager(MGR_CMD_SET, SERVER, {
                             'default_qsub_arguments': '-Roe'})
         sub_dir = self.du.create_temp_dir(asuser=TEST_USER)
@@ -204,11 +204,13 @@ class TestQsub_remove_files(TestFunctional):
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
         j = Job(TEST_USER)
         jid = self.server.submit(j)
-        self.server.expect(JOB, {'job_state': 'Q'}, id=jid)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid,
+                           trigger_sched_cycle=False)
         attribs = {ATTR_R: 'oe'}
         try:
             self.server.alterjob(jid, attribs)
-            self.server.expect(JOB, attribs, id=jid)
+            self.server.expect(JOB, attribs, id=jid,
+                               trigger_sched_cycle=False)
         except PbsAlterError as e:
             print(str(e))
 

--- a/test/tests/functional/pbs_test_qorder.py
+++ b/test/tests/functional/pbs_test_qorder.py
@@ -72,7 +72,7 @@ class Test_qorder(TestFunctional):
         self.server.manager(MGR_CMD_SET, SERVER, a)
 
         a = {'server_state': 'Scheduling'}
-        self.server.expect(SERVER, a, op=NE)
+        self.server.expect(SERVER, a, op=NE, trigger_sched_cycle=False)
 
         jid2 = jid2.split('.')[0]
         cycle = self.scheduler.cycles(start=self.server.ctime, lastN=1)
@@ -112,7 +112,7 @@ class Test_qorder(TestFunctional):
         self.server.manager(MGR_CMD_SET, SERVER, a)
 
         a = {'server_state': 'Scheduling'}
-        self.server.expect(SERVER, a, op=NE)
+        self.server.expect(SERVER, a, op=NE, trigger_sched_cycle=False)
 
         jid2 = jid2.split('.')[0]
         cycle = self.scheduler.cycles(start=self.server.ctime, lastN=1)

--- a/test/tests/interfaces/pbs_sched_interface_test.py
+++ b/test/tests/interfaces/pbs_sched_interface_test.py
@@ -277,12 +277,14 @@ class TestSchedulerInterface(TestInterfaces):
         self.server.manager(MGR_CMD_SET, SCHED,
                             {'scheduling': 'False'},
                             runas=ROOT_USER)
-        self.server.expect(SERVER, {'scheduling': 'False'})
+        self.server.expect(SERVER, {'scheduling': 'False'},
+                           trigger_sched_cycle=False)
         self.server.manager(MGR_CMD_SET, SERVER,
                             {'scheduling': 'True'},
                             runas=ROOT_USER)
         self.server.expect(SCHED, {'scheduling': 'True'},
-                           id='default', max_attempts=10)
+                           id='default', max_attempts=10,
+                           trigger_sched_cycle=False)
         self.server.manager(MGR_CMD_SET, SCHED,
                             {'scheduler_iteration': 300},
                             runas=ROOT_USER)

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -187,9 +187,11 @@ class SmokeTest(PBSTestSuite):
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
         j = Job(TEST_USER)
         jid = self.server.submit(j)
-        self.server.expect(JOB, {'job_state': 'Q'}, id=jid)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid,
+                           trigger_sched_cycle=False)
         self.server.alterjob(jid, {'comment': 'job comment altered'})
-        self.server.expect(JOB, {'comment': 'job comment altered'}, id=jid)
+        self.server.expect(JOB, {'comment': 'job comment altered'}, id=jid,
+                           trigger_sched_cycle=False)
 
     def test_sigjob(self):
         """

--- a/test/tests/selftest/pbs_testparams_decorator.py
+++ b/test/tests/selftest/pbs_testparams_decorator.py
@@ -68,4 +68,5 @@ class Test_TestparamsDecorator(TestSelf):
         if scheduling:
             self.server.expect(JOB, {'job_state=R': num_jobs})
         else:
-            self.server.expect(JOB, {'job_state=Q': num_jobs})
+            self.server.expect(JOB, {'job_state=Q': num_jobs},
+                               trigger_sched_cycle=False)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Updating expect() such that it first triggers a scheduling cycle and then looks for the value. Currently in PTL we look for an attribute value and then trigger a scheduling cycle if the expected value is not found. This can cause an error if the attribute itself is not present. For example if a job is in Q state, then expect(exec_host=x) will fail since exec_host is not present yet.  Therefore we must trigger a scheduling cycle first in expect() and then look for the value


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
