### PR TITLE
Initial Ubuntu 20.04 support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -187,7 +187,6 @@ AC_CHECK_HEADERS([ \
 	sys/statfs.h \
 	sys/stat.h \
 	sys/statvfs.h \
-	sys/sysctl.h \
 	sys/sysinfo.h \
 	sys/sysmacros.h \
 	sys/time.h \

--- a/m4/with_python.m4
+++ b/m4/with_python.m4
@@ -51,15 +51,19 @@ AC_DEFUN([PBS_AC_WITH_PYTHON],
     [PYTHON_CONFIG="python3-config"]
   )
   AM_PATH_PYTHON([3.5])
-  AS_IF([test "$PYTHON_VERSION" != "3.5" -a "$PYTHON_VERSION" != "3.6" -a "$PYTHON_VERSION" != "3.7"],
-    AC_MSG_ERROR([Python must be version 3.5, 3.6 or 3.7]))
-  [PYTHON_INCLUDES=`$PYTHON_CONFIG --includes`]
+  AS_IF([test "$PYTHON_VERSION" != "3.5" \
+          -a "$PYTHON_VERSION" != "3.6" \
+          -a "$PYTHON_VERSION" != "3.7" \
+          -a "$PYTHON_VERSION" != "3.8" ],
+    AC_MSG_ERROR([Python must be version 3.5, 3.6, 3.7 or 3.8]))
+  AS_IF([test "$PYTHON_VERSION" == "3.8"], [_extra_arg="--embed"], [_extra_arg=""])
+  [PYTHON_INCLUDES=`$PYTHON_CONFIG --includes ${_extra_arg}`]
   AC_SUBST(PYTHON_INCLUDES)
-  [PYTHON_CFLAGS=`$PYTHON_CONFIG --cflags`]
+  [PYTHON_CFLAGS=`$PYTHON_CONFIG --cflags ${_extra_arg}`]
   AC_SUBST(PYTHON_CFLAGS)
-  [PYTHON_LDFLAGS=`$PYTHON_CONFIG --ldflags`]
+  [PYTHON_LDFLAGS=`$PYTHON_CONFIG --ldflags ${_extra_arg}`]
   AC_SUBST(PYTHON_LDFLAGS)
-  [PYTHON_LIBS=`$PYTHON_CONFIG --libs`]
+  [PYTHON_LIBS=`$PYTHON_CONFIG --libs ${_extra_arg}`]
   AC_SUBST(PYTHON_LIBS)
   AC_DEFINE([PYTHON], [], [Defined when Python is available])
   AC_DEFINE_UNQUOTED([PYTHON_BIN_PATH], ["$PYTHON"], [Python executable path])

--- a/m4/with_swig.m4
+++ b/m4/with_swig.m4
@@ -56,5 +56,9 @@ AC_DEFUN([PBS_AC_WITH_SWIG],
     AC_DEFINE([SWIG], [], [Defined when swig is available]),
     AC_MSG_RESULT([not found])
     AC_MSG_WARN([swig command not found.]))
+  AS_IF([test "x`ls -d ${swig_dir}/share/swig/* 2>/dev/null`" == "x" ],
+          [swig_py_inc="-I`ls -d ${swig_dir}/share/swig*` -I`ls -d ${swig_dir}/share/swig*/python`"],
+          [swig_py_inc="-I`ls -d ${swig_dir}/share/swig/*` -I`ls -d ${swig_dir}/share/swig/*/python`"])
   AC_SUBST([swig_dir])
+  AC_SUBST([swig_py_inc])
 ])

--- a/src/lib/Libpython/Makefile.am
+++ b/src/lib/Libpython/Makefile.am
@@ -88,7 +88,6 @@ pbs_ifl_wrap.c: $(top_srcdir)/src/lib/Libifl/pbs_ifl_wrap.c
 	echo '#include "pbs_ifl.h"' >> pbs_ifl.i ; \
 	echo '%}' >> pbs_ifl.i ; \
 	echo '%include "pbs_ifl.h"' >> pbs_ifl.i ; \
-	@swig_dir@/bin/swig -I`ls -d @swig_dir@/share/swig/*` \
-		-I`ls -d @swig_dir@/share/swig/*/python` \
+	@swig_dir@/bin/swig @swig_py_inc@ \
 		-I$(top_srcdir)/src/include \
 		-python pbs_ifl.i

--- a/src/lib/Libpython/common_python_utils.c
+++ b/src/lib/Libpython/common_python_utils.c
@@ -72,7 +72,7 @@ void
 pbs_python_write_object_to_log(PyObject *obj, char *pre, int severity)
 {
 	PyObject *py_tmp_str = NULL;
-	char *obj_str = NULL;
+	const char *obj_str = NULL;
 
 	if (!(py_tmp_str = PyObject_Str(obj))) { goto ERROR_EXIT; }
 	if (!(obj_str = PyUnicode_AsUTF8(py_tmp_str))) { goto ERROR_EXIT; }
@@ -432,7 +432,7 @@ pbs_python_object_get_attr_integral_value(PyObject *obj, const char *key)
 char *
 pbs_python_object_str(PyObject *obj)
 {
-	char *str = NULL;
+	const char *str = NULL;
 	PyObject *py_str;
 	static char *ret_str = NULL;
 	char  	*tmp_str = NULL;

--- a/src/lib/Libpython/pbs_python_external.c
+++ b/src/lib/Libpython/pbs_python_external.c
@@ -698,7 +698,7 @@ pbs_python_run_code_in_namespace(struct python_interpreter_data *interp_data,
 	PyObject *ptraceback;
 	PyObject *pobjStr;
 	PyObject *retval;
-	char      *pStr;
+	const char      *pStr;
 	int rc=0;
 	pid_t orig_pid;
 

--- a/src/lib/Libpython/pbs_python_svr_size_type.c
+++ b/src/lib/Libpython/pbs_python_svr_size_type.c
@@ -124,7 +124,7 @@ extern PyObject * PPSVR_Size_FromSizeValue(struct size_value);
 static int
 _pps_check_for_negative_number(PyObject *il) {
 	PyObject *str_value = NULL;
-	char *c_value;
+	const char *c_value;
 	int rc = 0;
 
 	if (!(str_value = PyObject_Str(il))) {
@@ -247,7 +247,7 @@ _pps_size_from_string(PyObject *self, PyObject *from)
 
 	PPSVR_Size_Object *working_copy = (PPSVR_Size_Object *) self;
 	if (PyUnicode_Check(from)) {
-		if ((to_size(PyUnicode_AsUTF8(from), &working_copy->sz_value) != 0)) {
+		if ((to_size((char *)PyUnicode_AsUTF8(from), &working_copy->sz_value) != 0)) {
 			snprintf(log_buffer, LOG_BUF_SIZE-1, "%s: bad value for _size",
 				pbs_python_object_str(from));
 			PyErr_SetString(PyExc_TypeError, log_buffer);

--- a/src/resmom/catch_child.c
+++ b/src/resmom/catch_child.c
@@ -467,7 +467,7 @@ json_dumps(PyObject *py_val, char *msg, size_t msg_len)
 	PyObject	*py_func_dumps = NULL;
 	PyObject	*py_value = NULL;
 	PyObject	*py_result = NULL;
-	char		*tmp_str = NULL;
+	const char	*tmp_str = NULL;
 	char		*ret_string = NULL;
 	int		slen;
 

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -149,7 +149,7 @@ schedinit(int nthreads)
 	struct tm *tmptr;
 
 #ifdef PYTHON
-	char *errstr;
+	const char *errstr;
 	PyObject *module;
 	PyObject *obj;
 	PyObject *dict;

--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -4296,7 +4296,7 @@ formula_evaluate(char *formula, resource_resv *resresv, resource_req *resreq)
 	int globals_size = 1024;  /* initial size... will grow if needed */
 	resource_req *req;
 	sch_resource_t ans = 0;
-	char *str;
+	const char *str;
 	int i;
 	char *formula_buf;
 	int formula_buf_len;

--- a/src/server/vnparse.c
+++ b/src/server/vnparse.c
@@ -258,9 +258,7 @@ vn_parse_stream(FILE *fp, callfunc_t callback)
 		for (vnp = vnid; *vnp && legal_vnode_char(*vnp, 1); vnp++)
 			;
 		if (*vnp) {
-			sprintf(log_buffer,
-				"invalid character in vnode name \"%s\"", vnid);
-			log_err(PBSE_SYSTEM, __func__, log_buffer);
+			log_errf(PBSE_SYSTEM, __func__, "invalid character in vnode name \"%s\"", vnid);
 			vnl_free(vnlp);
 			return NULL;
 		}
@@ -270,9 +268,7 @@ vn_parse_stream(FILE *fp, callfunc_t callback)
 		 * is defined as string of length 64.
 		 */
 		if (strlen(vnid) > PBS_MAXHOSTNAME) {
-			sprintf(log_buffer,
-				"Node name \"%s\" is too big", vnid);
-			log_err(PBSE_SYSTEM, __func__, log_buffer);
+			log_errf(PBSE_SYSTEM, __func__, "Node name \"%s\" is too big", vnid);
 			return NULL;
 		}
 		/* <ATTRNAME> <ATTRDELIM> */


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* Initial Ubuntu 20.04 support (Fixes #1887)
* NOTE: As of now we need to pass few extra CFLAGS (as below) for successful compilation, but those will be fixed in subsequent PRs
  CFLAGS="-g -O2 -Wall -Werror -Wno-unused-result **-Wno-array-bounds -Wno-stringop-overflow -Wno-format-truncation -Wno-format-overflow**"

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* Specific to Ubuntu 20.04:
  * Removed check for `sys/sysctl.h` as PBS no longer uses it. Also use of `sys/sysctl.h` is deprecated as of GNU Lib C v2.30 ([link](https://lwn.net/Articles/795127), search for sysctl on the page)
  * Changed Python m4 to add support for Python v3.8 as Ubuntu 20.04 has default Python v3.8
  * From Py3.7 `PyUnicode_AsUTF8` return type is `const char *` ([doclink](https://docs.python.org/3.7/c-api/unicode.html#c.PyUnicode_AsUTF8)), so changed variables (who were storing return value of `PyUnicode_AsUTF8`) type to `const char *` in PBS code
* Not Ubuntu 20.04 specific:
  * Fixed swig m4 to point to correct include directory

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
* None

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
* [u20.txt](https://github.com/openpbs/openpbs/files/4918390/u20.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
