### PR TITLE
Running job in a resv causes future resvs to go unconfirmed

### DIFF
--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -2079,8 +2079,8 @@ check_job_running(resource_resv *job, void *arg)
  * @param[in]	arg	-	argument (not used here)
  *
  * @return	int
- * @retval	1	: if job is running and in reservation passed in arg
- * @retval	0	: if job is not running or not in reservation passed in arg
+ * @retval	1	: if job is running and in a reservation
+ * @retval	0	: if job is not running or not in a reservation
  */
 int
 check_running_job_in_reservation(resource_resv *job, void *arg)
@@ -2100,8 +2100,8 @@ check_running_job_in_reservation(resource_resv *job, void *arg)
  * @param[in]	arg	-	argument (not used here)
  *
  * @return	int
- * @retval	1	: if job is running and not in reservation passed in arg
- * @retval	0	: if job is not running or in reservation passed in arg
+ * @retval	1	: if job is running and not in a reservation
+ * @retval	0	: if job is not running or in a reservation
  */
 int
 check_running_job_not_in_reservation(resource_resv *job, void *arg)

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -355,7 +355,7 @@ query_server(status *pol, int pbs_sd)
 		return NULL;
 	}
 
-	jobs_alive = resource_resv_filter(sinfo->jobs, sinfo->sc.total, check_job_running, NULL, 0);
+	jobs_alive = resource_resv_filter(sinfo->jobs, sinfo->sc.total, check_running_job_not_in_reservation, NULL, 0);
 
 	if (sinfo->has_soft_limit || sinfo->has_hard_limit) {
 		counts *allcts;
@@ -2086,6 +2086,27 @@ int
 check_running_job_in_reservation(resource_resv *job, void *arg)
 {
 	if (job->is_job && job->job != NULL && job->job->resv != NULL &&
+		(check_job_running(job, arg) == 1))
+		return 1;
+
+	return 0;
+}
+
+/**
+ * @brief
+ * 		helper function for resource_resv_filter()
+ *
+ * @param[in]	job	-	resource reservation job.
+ * @param[in]	arg	-	argument (not used here)
+ *
+ * @return	int
+ * @retval	1	: if job is running and not in reservation passed in arg
+ * @retval	0	: if job is not running or in reservation passed in arg
+ */
+int
+check_running_job_not_in_reservation(resource_resv *job, void *arg)
+{
+	if (job->is_job && job->job != NULL && job->job->resv == NULL &&
 		(check_job_running(job, arg) == 1))
 		return 1;
 

--- a/src/scheduler/server_info.h
+++ b/src/scheduler/server_info.h
@@ -174,9 +174,16 @@ int check_job_running(resource_resv *job, void *arg);
 /*
  *
  *	check_running_job_in_reservation - function used by job_filter to filter out
- *			   jobs that are not in a reservation
+ *			   jobs that are in a reservation
  */
 int check_running_job_in_reservation(resource_resv *job, void *arg);
+
+/*
+ *
+ *	check_running_job_not_in_reservation - function used by job_filter to filter out
+ *			   jobs that are not in a reservation
+ */
+int check_running_job_not_in_reservation(resource_resv *job, void *arg);
 
 /*
  *


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Scheduler failed to confirm future reservations when it sees the node having a running job inside a running reservation.

#### Describe Your Change
The issue was that when the ghost job issue was addressed, scheduler started considering all running jobs to assign them to nodes. In reality, it only needs to see non-reservation running jobs to assign them to nodes because all reservation jobs resources are already accounted for by the reservation.


#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
Existing tests - test_resv_excl_with_jobs & test_future_resv_with_non_excl_jobs were failing.
[test.txt](https://github.com/openpbs/openpbs/files/4921341/test.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
