### PR TITLE
Increased default max_attempts to 180

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -249,7 +249,7 @@ class PtlConfig(object):
             'PTL_SUDO_CMD': 'sudo -H',
             'PTL_RSH_CMD': 'ssh',
             'PTL_CP_CMD': 'scp -p',
-            'PTL_MAX_ATTEMPTS': 100,
+            'PTL_MAX_ATTEMPTS': 180,
             'PTL_ATTEMPT_INTERVAL': 0.5,
             'PTL_UPDATE_ATTRIBUTES': True,
         }

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -249,7 +249,7 @@ class PtlConfig(object):
             'PTL_SUDO_CMD': 'sudo -H',
             'PTL_RSH_CMD': 'ssh',
             'PTL_CP_CMD': 'scp -p',
-            'PTL_MAX_ATTEMPTS': 60,
+            'PTL_MAX_ATTEMPTS': 100,
             'PTL_ATTEMPT_INTERVAL': 0.5,
             'PTL_UPDATE_ATTRIBUTES': True,
         }


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
On cpuset machines 60 attempts is not sufficient in some cases

#### Describe Your Change
It has been observed that sometimes it takes longer for a test job to reach a particular state when it is run on a cgroups enabled system (cpuset system) due to the many hook events involved with the cgroups hook.  To help the tests actually pass increasing max_attempts to 180.

The change is made to default value of MAX_ATTEMPTS in ptl configuration options. 

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
