### PR TITLE
Fix decode_DIS_svrattrl memory leak and supress couple others

### DIFF
--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -1641,8 +1641,13 @@ mgr_sched_set(struct batch_request *preq)
 	/* if the unsetlist has attributes, call server_unset to remove them separately */
 	ulist = (svrattrl *)GET_NEXT(unsetlist);
 	if (ulist) {
-		mgr_unset_attr(psched->sch_attr, sched_attr_idx, sched_attr_def, SCHED_ATR_LAST, ulist,
+		rc = mgr_unset_attr(psched->sch_attr, sched_attr_idx, sched_attr_def, SCHED_ATR_LAST, ulist,
 			preq->rq_perm, &bad_attr, (void *)psched, PARENT_TYPE_SCHED, INDIRECT_RES_CHECK);
+		if (rc != 0) {
+			reply_badattr(rc, bad_attr, ulist, preq);
+			return;
+		}
+		free_attrlist(&unsetlist); /* since this is not part of plist anymore, we must free separately */
 	}
 
 	plist = (svrattrl *)GET_NEXT(preq->rq_ind.rq_manager.rq_attr);
@@ -1788,8 +1793,13 @@ mgr_queue_set(struct batch_request *preq)
 		/* if the unsetlist has attributes, call server_unset to remove them separately */
 		ulist = (svrattrl *)GET_NEXT(unsetlist);
 		if (ulist) {
-			mgr_unset_attr(pque->qu_attr, que_attr_idx, que_attr_def, QA_ATR_LAST, ulist,
+			rc = mgr_unset_attr(pque->qu_attr, que_attr_idx, que_attr_def, QA_ATR_LAST, ulist,
 				preq->rq_perm, &bad, (void *)pque, PARENT_TYPE_QUE_ALL, INDIRECT_RES_CHECK);
+			if (rc != 0) {
+				reply_badattr(rc, bad, ulist, preq);
+				return;
+			}
+			free_attrlist(&unsetlist); /* since this is not part of plist anymore, we must free separately */	
 		}
 
 		plist = (svrattrl *)GET_NEXT(preq->rq_ind.rq_manager.rq_attr);
@@ -1923,28 +1933,27 @@ mgr_node_set(struct batch_request *preq)
 {
 	extern char *msg_queue_not_in_partition;
 	extern char *msg_partition_not_in_queue;
-	int		bad = 0;
-	char		hostname[PBS_MAXHOSTNAME+1];
-	int		numnodes = 1;	/* number of vnodes to be operated on */
+	int bad = 0;
+	char hostname[PBS_MAXHOSTNAME + 1];
+	int numnodes = 1; /* number of vnodes to be operated on */
 	svrattrl *tmp;
 	svrattrl *plist;
-	svrattrl *ulist;
 	pbs_list_head unsetlist;
-	char		*nodename;
-	mominfo_t	*pmom = NULL;
-	mom_svrinfo_t	*psvrmom = NULL;
-	struct pbsnode  *pnode;
-	int		rc;
-
-	int		i, len;
-	int		problem_cnt = 0;
-	int		momidx;
-	char		*problem_names = NULL;
-	struct pbsnode  **problem_nodes = NULL;
-	static char	*warnmsg = NULL;
-	struct pbsnode  **warn_nodes = NULL;
-	int		warn_idx = 0;
-	int		replied = 0;	/* boolean */
+	pbs_list_head setlist;
+	char *nodename;
+	mominfo_t *pmom = NULL;
+	mom_svrinfo_t *psvrmom = NULL;
+	struct pbsnode *pnode;
+	int rc;
+	int i, j, len;
+	int problem_cnt = 0;
+	int momidx;
+	char *problem_names = NULL;
+	struct pbsnode **problem_nodes = NULL;
+	static char *warnmsg = NULL;
+	struct pbsnode **warn_nodes = NULL;
+	int warn_idx = 0;
+	int replied = 0; /* boolean */
 
 	nodename = preq->rq_ind.rq_manager.rq_objname;
 
@@ -2005,17 +2014,19 @@ mgr_node_set(struct batch_request *preq)
 		return;
 	}
 
+	CLEAR_HEAD(setlist);
 	CLEAR_HEAD(unsetlist);
 	plist = (svrattrl *)GET_NEXT(preq->rq_ind.rq_manager.rq_attr);
 	while (plist) {
-		if (plist->al_atopl.value == NULL || plist->al_atopl.value[0] == '\0') {
-			tmp = (struct svrattrl *)GET_NEXT(plist->al_link);
-			delete_link(&plist->al_link);
+		tmp = (struct svrattrl *)GET_NEXT(plist->al_link);
+		
+		delete_link(&plist->al_link);
+		if (plist->al_atopl.value == NULL || plist->al_atopl.value[0] == '\0')
 			append_link(&unsetlist, &plist->al_link, plist);
-			plist = tmp;
-			continue;
-		}
-		plist = (struct svrattrl *)GET_NEXT(plist->al_link);
+		else
+			append_link(&setlist, &plist->al_link, plist);
+
+		plist = tmp;
 	}
 
 	/* set writtable attributes of node (nodes if numnodes > 1) */
@@ -2042,68 +2053,67 @@ mgr_node_set(struct batch_request *preq)
 	i = 0;
 	while (pnode) {
 		if ((pnode->nd_state & INUSE_DELETED) == 0) {
-			/* if the unsetlist has attributes, call server_unset to remove them separately */
-			ulist = (svrattrl *)GET_NEXT(unsetlist);
-			if (ulist) {
-				mgr_unset_attr(pnode->nd_attr, node_attr_idx, node_attr_def, ND_ATR_LAST, ulist,
-					preq->rq_perm, &bad, (void *)pnode, PARENT_TYPE_NODE, INDIRECT_RES_CHECK);
-			}
-
-			plist = (svrattrl *)GET_NEXT(preq->rq_ind.rq_manager.rq_attr);
-			rc = mgr_set_attr(pnode->nd_attr, node_attr_idx, node_attr_def, ND_ATR_LAST,
-				plist,
-				preq->rq_perm | ATR_PERM_ALLOW_INDIRECT,
-				&bad, (void *)pnode, ATR_ACTION_ALTER);
-			if (rc != 0) {
-
-				if (numnodes > 1) {
-					if (problem_nodes) {
-						/*we have an array in which to save*/
-						problem_nodes[ problem_cnt ] = pnode;
-						++problem_cnt;
-					}
-				} else {/*In the specific node case, reply w/ error and return*/
-					switch (rc) {
-						case PBSE_INTERNAL:
-						case PBSE_SYSTEM:
-							req_reject(rc, bad, preq);
-							break;
-
-						case PBSE_NOATTR:
-						case PBSE_ATTRRO:
-						case PBSE_MUTUALEX:
-						case PBSE_BADNDATVAL:
-							reply_badattr(rc, bad, plist, preq);
-							break;
-						case PBSE_QUE_NOT_IN_PARTITION:
-							(void)snprintf(log_buffer, LOG_BUF_SIZE, msg_queue_not_in_partition,
-								pnode->nd_attr[ND_ATR_Queue].at_val.at_str);
-							log_err(-1, __func__, log_buffer);
-							reply_text(preq, PBSE_QUE_NOT_IN_PARTITION, log_buffer);
-							break;
-						case PBSE_PARTITION_NOT_IN_QUE:
-							(void)snprintf(log_buffer, LOG_BUF_SIZE, msg_partition_not_in_queue,
-								pnode->nd_attr[ND_ATR_partition].at_val.at_str);
-							log_err(-1, __func__, log_buffer);
-							reply_text(preq, PBSE_PARTITION_NOT_IN_QUE, log_buffer);
-							break;
-
-						default:
-							req_reject(rc, 0, preq);
-					}
-					free(warn_nodes);
-					return;
+			for (j = 0; j < 2; j++) {
+				rc = 0;
+				if (j == 0) {
+					plist = (svrattrl *)GET_NEXT(unsetlist);
+					rc = mgr_unset_attr(pnode->nd_attr, node_attr_idx, node_attr_def, ND_ATR_LAST, plist,
+							preq->rq_perm, &bad, (void *)pnode, PARENT_TYPE_NODE, INDIRECT_RES_CHECK);
+				} else {
+					plist = (svrattrl *)GET_NEXT(setlist);
+					rc = mgr_set_attr(pnode->nd_attr, node_attr_idx, node_attr_def, ND_ATR_LAST, plist,
+						preq->rq_perm | ATR_PERM_ALLOW_INDIRECT, &bad, (void *)pnode, ATR_ACTION_ALTER);
 				}
+				if (rc != 0) {
+					if (numnodes > 1) {
+						if (problem_nodes) {
+							/*we have an array in which to save*/
+							if (problem_nodes[problem_cnt - 1] != pnode) {
+								/* and this node was not saved already */
+								problem_nodes[ problem_cnt ] = pnode;
+								++problem_cnt;
+							}
+						}
+					} else {/*In the specific node case, reply w/ error and return*/
+						switch (rc) {
+							case PBSE_INTERNAL:
+							case PBSE_SYSTEM:
+								req_reject(rc, bad, preq);
+								break;
 
-			} else {/*modifications succeed for this node*/
+							case PBSE_NOATTR:
+							case PBSE_ATTRRO:
+							case PBSE_MUTUALEX:
+							case PBSE_BADNDATVAL:
+								reply_badattr(rc, bad, NULL, preq);
+								break;
+							case PBSE_QUE_NOT_IN_PARTITION:
+								(void)snprintf(log_buffer, LOG_BUF_SIZE, msg_queue_not_in_partition,
+									pnode->nd_attr[ND_ATR_Queue].at_val.at_str);
+								log_err(-1, __func__, log_buffer);
+								reply_text(preq, PBSE_QUE_NOT_IN_PARTITION, log_buffer);
+								break;
+							case PBSE_PARTITION_NOT_IN_QUE:
+								(void)snprintf(log_buffer, LOG_BUF_SIZE, msg_partition_not_in_queue,
+									pnode->nd_attr[ND_ATR_partition].at_val.at_str);
+								log_err(-1, __func__, log_buffer);
+								reply_text(preq, PBSE_PARTITION_NOT_IN_QUE, log_buffer);
+								break;
 
-				warnings_update(WARN_ngrp, warn_nodes, &warn_idx, pnode);
+							default:
+								req_reject(rc, 0, preq);
+						}
+						free(warn_nodes);
+						return;
+					}
+				} else {/*modifications succeed for this node*/
+					warnings_update(WARN_ngrp, warn_nodes, &warn_idx, pnode);
 
-				if ((pnode->nd_nsnfree == 0) && (pnode->nd_state == 0))
-					set_vnode_state(pnode, INUSE_JOB, Nd_State_Or);
+					if ((pnode->nd_nsnfree == 0) && (pnode->nd_state == 0))
+						set_vnode_state(pnode, INUSE_JOB, Nd_State_Or);
 
-				mgr_log_attr(msg_man_set, plist,
-					PBS_EVENTCLASS_NODE, pnode->nd_name, NULL);
+					mgr_log_attr(msg_man_set, plist, PBS_EVENTCLASS_NODE, pnode->nd_name, NULL);
+				}
 			}
 		}
 		if (numnodes == 1)
@@ -2143,6 +2153,9 @@ mgr_node_set(struct batch_request *preq)
 			pnode = pbsndlist[i];	/* next vnode in array */
 		}
 	} /*bottom of the while()*/
+
+	free_attrlist(&unsetlist);
+	free_attrlist(&setlist);
 
 	warnmsg = warn_msg_build(WARN_ngrp, warn_nodes, warn_idx);
 

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -1396,6 +1396,7 @@ mgr_server_set(struct batch_request *preq, conn_t *conn)
 				    preq->rq_perm, &bad_attr, (void *) &server, PARENT_TYPE_SERVER, INDIRECT_RES_CHECK);
 		if (rc != 0) {
 			reply_badattr(rc, bad_attr, ulist, preq);
+			free_attrlist(&unsetlist);
 			return;
 		}
 		free_attrlist(&unsetlist); /* since this is not part of plist anymore, we must free separately */
@@ -1645,6 +1646,7 @@ mgr_sched_set(struct batch_request *preq)
 			preq->rq_perm, &bad_attr, (void *)psched, PARENT_TYPE_SCHED, INDIRECT_RES_CHECK);
 		if (rc != 0) {
 			reply_badattr(rc, bad_attr, ulist, preq);
+			free_attrlist(&unsetlist);
 			return;
 		}
 		free_attrlist(&unsetlist); /* since this is not part of plist anymore, we must free separately */
@@ -1797,6 +1799,7 @@ mgr_queue_set(struct batch_request *preq)
 				preq->rq_perm, &bad, (void *)pque, PARENT_TYPE_QUE_ALL, INDIRECT_RES_CHECK);
 			if (rc != 0) {
 				reply_badattr(rc, bad, ulist, preq);
+				free_attrlist(&unsetlist);
 				return;
 			}
 			free_attrlist(&unsetlist); /* since this is not part of plist anymore, we must free separately */	
@@ -2085,7 +2088,8 @@ mgr_node_set(struct batch_request *preq)
 							case PBSE_ATTRRO:
 							case PBSE_MUTUALEX:
 							case PBSE_BADNDATVAL:
-								reply_badattr(rc, bad, NULL, preq);
+							case PBSE_UNKRESC:
+								reply_badattr(rc, bad, plist, preq);
 								break;
 							case PBSE_QUE_NOT_IN_PARTITION:
 								(void)snprintf(log_buffer, LOG_BUF_SIZE, msg_queue_not_in_partition,
@@ -2104,6 +2108,8 @@ mgr_node_set(struct batch_request *preq)
 								req_reject(rc, 0, preq);
 						}
 						free(warn_nodes);
+						free_attrlist(&unsetlist);
+						free_attrlist(&setlist);
 						return;
 					}
 				} else {/*modifications succeed for this node*/
@@ -2396,6 +2402,7 @@ mgr_node_unset(struct batch_request *preq)
 						case PBSE_ATTRRO:
 						case PBSE_MUTUALEX:
 						case PBSE_BADNDATVAL:
+						case PBSE_UNKRESC:
 							reply_badattr(rc, bad, plist, preq);
 							break;
 

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -671,3 +671,29 @@
    fun:work
    ...
 }
+{
+   From PBS - Suppress uninitialized job fs structure in mom
+   Memcheck:Param
+   write(buf)
+   ...
+   fun:job_save_fs
+   ...
+}
+{
+   From PBS - Suppress hook allocated buffer
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:hook_alloc
+   fun:hook_recov
+   ...
+}
+{
+   From PBS - Suppress hook allocated buffer
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:hook_alloc
+   fun:mgr_hook_create
+   ...
+}

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -660,7 +660,6 @@
    Memcheck:Leak
    fun:calloc
    fun:get_avl_tls
-   fun:avl_*
    ...
 }
 {


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Fix couple of memory leaks as described below:
1. 268 bytes in 2 blocks are definitely lost in loss record 521 of 700
   at 0x4C29F73: malloc (vg_replace_malloc.c:309)
   by 0x556A80: decode_DIS_svrattrl (dec_svrattrl.c:136)
   by 0x556236: decode_DIS_Manage (dec_Manage.c:110)
   by 0x44A3A0: dis_request_read (dis_read.c:576)
   by 0x47C84F: process_request (process_request.c:326)
   by 0x507E08: process_socket (net_server.c:521)
   by 0x508117: wait_request (net_server.c:637)
   by 0x47B069: main (pbsd_main.c:1778)

2. 335 (109 direct, 226 indirect) bytes in 1 blocks are definitely lost in loss record 556 of 722
   at 0x4C2E43F: malloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
   by 0x54C594: make_attr (db_postgres_attr.c:122)
   by 0x54C8D5: dbarray_to_attrlist (db_postgres_attr.c:223)
   by 0x55124E: load_que (db_postgres_que.c:165)
   by 0x551635: pg_db_next_que (db_postgres_que.c:309)
   by 0x54A60B: pbs_db_cursor_next (db_postgres_impl.c:234)
   by 0x47D70F: pbsd_init (pbsd_init.c:721)
   by 0x4826E0: main (pbsd_main.c:1384)

Both of these leaks were introduced by my PR #1847 

Aside from this, supressing a couple very frequently and sure shot false warnings in valgrind.supp.
1. Syscall param write(buf) points to uninitialised byte(s)
   at 0x50826FD: ??? (in /usr/lib64/libpthread-2.17.so)
   by 0x436FDD: save_struct (attr_recov.c:142)
   by 0x4372A5: save_attr_fs (attr_recov.c:262)
   by 0x454CC5: job_save_fs (job_recov_fs.c:252)
   by 0x43E04A: req_commit_now (req_quejob.c:1759)
   by 0x43E0B4: req_commit (req_quejob.c:1896)
   by 0x43AEED: dispatch_request (process_request.c:741)
   by 0x47D535: process_IS_CMD (mom_server.c:456)
   by 0x47E503: is_request (mom_server.c:1022)
   by 0x475AB3: do_tpp (mom_main.c:6180)
   by 0x475B10: tpp_request (mom_main.c:6217)
   by 0x4A6033: process_socket (net_server.c:521)

2. 2,560 bytes in 4 blocks are possibly lost in loss record 574 of 629
   at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
   by 0x23E57E: hook_alloc (in /opt/pbs/sbin/pbs_mom.vlgd)
   by 0x241083: hook_recov (in /opt/pbs/sbin/pbs_mom.vlgd)
   by 0x1DFD37: req_copy_hookfile (requests.c:4833)
   by 0x189FB7: dispatch_request (process_request.c:1008)
   by 0x1D36AE: process_IS_CMD (mom_server.c:456)
   by 0x1D4786: is_request (mom_server.c:1022)
   by 0x1CB02E: do_tpp (mom_main.c:6180)
   by 0x1CB0A4: tpp_request (mom_main.c:6217)
   by 0x20026E: process_socket (net_server.c:521)
   by 0x20060B: wait_request (net_server.c:637)
   by 0x1CB54F: finish_loop (mom_main.c:6496)

3. 48 bytes in 1 blocks are definitely lost in loss record 55 of 615
   at 0x4C2A9B5: calloc (vg_replace_malloc.c:711)
   by 0x4DFB2A: get_avl_tls (avltree.c:160)
   by 0x4E0ADB: avl_find_key (avltree.c:650)
   by 0x4C7AE8: pbs_idx_find (pbs_idx.c:246)
   by 0x4CCC3F: free_stream (tpp_client.c:3781)
   by 0x4CBD50: act_strm (tpp_client.c:3183)
   by 0x4CC2C6: leaf_timer_handler (tpp_client.c:3380)
   by 0x4D217D: work (tpp_transport.c:1631)
   by 0x4E3CDF2: start_thread (in /usr/lib64/libpthread-2.17.so)
   by 0x62EE3DC: clone (in /usr/lib64/libc-2.17.so)

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

Before fix valgrind.log: 
[valgrind_before.log](https://github.com/openpbs/openpbs/files/4925789/valgrind_before.log)

Valgrind log after
[valgrind_after.log](https://github.com/openpbs/openpbs/files/4931332/valgrind_after.log)


Description: Tests from given sources on platforms CENTOS7, UBUNTU1804, SUSE15
Platforms: CENTOS7,UBUNTU1804,SUSE15
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|2581|1794|0|0|0|0|1794|

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
