### PR TITLE
scheduler might leak node spec in corner cases

### DIFF
--- a/src/lib/Libtpp/tpp_util.c
+++ b/src/lib/Libtpp/tpp_util.c
@@ -311,8 +311,6 @@ set_tpp_config(void (*log_fn)(int, const char *, char *), struct pbs_config *pbs
 
 		hlen = strlen(nm);
 		if ((tmp = realloc(formatted_names, len + hlen + 2)) == NULL) { /* 2 for command and null char */
-			free(formatted_names);
-			free(nm);
 			snprintf(log_buffer, TPP_LOGBUF_SZ, "Failed to make formatted node name");
 			fprintf(stderr, "%s\n", log_buffer);
 			tpp_log_func(LOG_CRIT, NULL, log_buffer);
@@ -435,8 +433,6 @@ set_tpp_config(void (*log_fn)(int, const char *, char *), struct pbs_config *pbs
 		tpp_conf->routers = malloc(sizeof(char *) * (num_routers + 1));
 		if (!tpp_conf->routers) {
 			tpp_log_func(LOG_CRIT, __func__, "Out of memory allocating routers array");
-			if (routers)
-				free(routers);
 			return -1;
 		}
 
@@ -482,9 +478,6 @@ set_tpp_config(void (*log_fn)(int, const char *, char *), struct pbs_config *pbs
 				(tpp_conf->routers[i]) ?(tpp_conf->routers[i]) : "");
 			fprintf(stderr, "%s\n", log_buffer);
 			tpp_log_func(LOG_CRIT, NULL, log_buffer);
-
-			if (tpp_conf->routers)
-				free(tpp_conf->routers);
 			return -1;
 		}
 	}

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -1541,6 +1541,7 @@ run_update_resresv(status *policy, int pbs_sd, server_info *sinfo,
 			rr = queue_subjob(resresv, sinfo, qinfo);
 			if(rr == NULL) {
 				set_schd_error_codes(err, NOT_RUN, SCHD_ERROR);
+				free_nspecs(ns_arr);
 				return -1;
 			}
 		} else
@@ -1658,6 +1659,8 @@ run_update_resresv(status *policy, int pbs_sd, server_info *sinfo,
 		 */
 		rr->can_not_run = 1;
 
+		if (rr->nspec_arr != NULL && rr->nspec_arr != ns && rr->nspec_arr != ns_arr)
+			free_nspecs(rr->nspec_arr);
 		/* The nspec array coming out of the node selection code could
 		 * have a node appear multiple times.  This is how we need to
 		 * send the execvnode to the server.  We now need to combine
@@ -1809,11 +1812,15 @@ sim_run_update_resresv(status *policy, resource_resv *resresv, nspec **ns_arr, u
 	if(err == NULL)
 		err = new_schd_error();
 
-	if (resresv == NULL)
+	if (resresv == NULL) {
+		free_nspecs(ns_arr);
 		return -1;
+	}
 
-	if (!is_resource_resv_valid(resresv, NULL))
+	if (!is_resource_resv_valid(resresv, NULL)) {
+		free_nspecs(ns_arr);
 		return -1;
+	}
 
 	sinfo = resresv->server;
 	if (resresv->is_job)

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -656,6 +656,29 @@
    fun:main
 }
 {
+   From PBS - Suppress intentional unfreed memory of auth struct inside global tpp_conf struct
+   Memcheck:Leak
+   fun:malloc
+   fun:mk_hostname
+   fun:set_tpp_config
+   fun:main
+}
+{
+   From PBS - Suppress intentional unfreed memory of auth struct inside global tpp_conf struct
+   Memcheck:Leak
+   fun:malloc
+   fun:strdup
+   fun:set_tpp_config
+   fun:main
+}
+{
+   From PBS - Suppress intentional unfreed memory of auth struct inside global tpp_conf struct
+   Memcheck:Leak
+   fun:realloc
+   fun:set_tpp_config
+   fun:main
+}
+{
    From PBS - Suppress intentional unfreed avl tree tls data
    Memcheck:Leak
    fun:calloc


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Scheduler might leak node spec while trying to run a job


#### Describe Your Change
This leak can only happen in error cases.
I've also addressed set_tpp_config freeing partial data in case of error. It is anyways expected that upon failure of set_tpp_config function the daemon needs to exit. So it does not help to free partial data. Added these possible leaks to the suppression file as well.

#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
Since all of these leaks are only possible in corner cases, I couldn't test them out.
#### Regression results
Description: Tests from given sources on platforms CENTOS7, UBUNTU1804, SUSE15
Platforms: CENTOS7,UBUNTU1804,SUSE15
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|2606|1794|0|0|0|0|1794|