### PR TITLE
In revert_to_defaults set the pbs_cgroups memory based on if the memo…

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -14072,12 +14072,12 @@ class MoM(PBSService):
         pat = 'cgroup /sys/fs/cgroup'
         enablemem = False
         for line in mounts:
-             entries = line.split()
-             if entries[2] != 'cgroup':
-                 continue
-             flags = entries[3].split(',')
-             if 'memory' in flags:
-                 enablemem = True
+            entries = line.split()
+            if entries[2] != 'cgroup':
+                continue
+            flags = entries[3].split(',')
+            if 'memory' in flags:
+                enablemem = True
         if str(mounts).count(pat) >= 6 and str(mounts).count('cpuset') >= 2:
             pbs_conf_val = self.du.parse_pbs_config(self.hostname)
             f1 = os.path.join(pbs_conf_val['PBS_EXEC'], 'lib',

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -14070,6 +14070,14 @@ class MoM(PBSService):
         file = os.path.join(os.sep, 'proc', 'mounts')
         mounts = self.du.cat(self.hostname, file)['out']
         pat = 'cgroup /sys/fs/cgroup'
+        enablemem = False
+        for line in mounts:
+             entries = line.split()
+             if entries[2] != 'cgroup':
+                 continue
+             flags = entries[3].split(',')
+             if 'memory' in flags:
+                 enablemem = True
         if str(mounts).count(pat) >= 6 and str(mounts).count('cpuset') >= 2:
             pbs_conf_val = self.du.parse_pbs_config(self.hostname)
             f1 = os.path.join(pbs_conf_val['PBS_EXEC'], 'lib',
@@ -14078,8 +14086,13 @@ class MoM(PBSService):
             # set vnode_per_numa_node = true, use_hyperthreads = true
             with open(f1, "r") as cfg:
                 cfg_dict = json.load(cfg)
-            cfg_dict['vnode_per_numa_node'] = 'true'
-            cfg_dict['use_hyperthreads'] = 'true'
+            cfg_dict['vnode_per_numa_node'] = True
+            cfg_dict['use_hyperthreads'] = True
+
+            # if the memory subsystem is not mounted, do not enable mem
+            # in the cgroups config otherwise PTL tests will fail.
+            # This matches what is documented for cgroups and mem.
+            cfg_dict['cgroup']['memory']['enabled'] = enablemem
             _, path = tempfile.mkstemp(prefix="cfg", suffix=".json")
             with open(path, "w") as cfg1:
                 json.dump(cfg_dict, cfg1, indent=4)


### PR DESCRIPTION
…ry subsystem is mounted

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
If the cgroups memory subsystem is not mounted on a cpuset system, then PTL revert to defaults should set memory enabled to False in the pbs_cgroups hook configuration.  By default, after installing PBS the memory is set as enabled too True.  However, our guides will suggest to set the hook's memory configuration based on the system settings.
Setting the cgroups hook memory configuration based on the system as part of revert to defaults will allow any PTL test to run with the cgroups hook enabled, even if that cpuset system does not have the memory subsystem mounted.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Check to see if the memory subsystem is mounted.  If mounted, set memory enabled to True, else set it to False.

I also made 2 minor fixes to existing settings for vnode_per_numa_node and use_hyperthreads to use a boolean.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

Test results from a system without memory subsystem enabled:
[nomemsys_cpuset_before.txt](https://github.com/openpbs/openpbs/files/4928660/nomemsys_cpuset_before.txt)
[nomemsys_cpuset_after.txt](https://github.com/openpbs/openpbs/files/4928669/nomemsys_cpuset_after.txt)

And to show it also works when the memory subsystem is enabled:
[cpuset_before.txt](https://github.com/openpbs/openpbs/files/4928670/cpuset_before.txt)
[cpuset_after.txt](https://github.com/openpbs/openpbs/files/4928671/cpuset_after.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
