### PR TITLE
TestQrun.test_qrun_hangs does not clean up child process

### DIFF
--- a/test/tests/functional/pbs_qrun.py
+++ b/test/tests/functional/pbs_qrun.py
@@ -129,6 +129,7 @@ class TestQrun(TestFunctional):
             try:
                 self.server.runjob(jobid=jid)
                 self.logger.info("Successfully runjob. Child process exit.")
+                os._exit(0)
             except PbsRunError as e:
                 self.logger.info("Runjob throws error: " + e.msg[0])
         else:


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->
**Cherry-Pick PR** for https://github.com/openpbs/openpbs/pull/1886
#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
In test_qrun_hangs:
We fork and and don't exit in child process. So both child and parent process invoke Teardown.
This results in 2 test results being generated. One of them errors out in test_qrun_subjob .

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Exit in child process

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[TestQrun_fail.txt](https://github.com/openpbs/openpbs/files/4929947/TestQrun_fail.txt)
[TestQrun_pass.txt](https://github.com/openpbs/openpbs/files/4929949/TestQrun_pass.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
