### PR TITLE
PTL supports running tests multiple times

### DIFF
--- a/test/fw/bin/pbs_benchpress
+++ b/test/fw/bin/pbs_benchpress
@@ -145,8 +145,8 @@ def usage():
             'fails\n']
     msg += ['--timeout=<seconds>: duration after which no test suites are '
             'run\n']
-    msg += ['--repeat-tests=<int>: number of times test is going to repeat\n']
-    msg += ['--repeat-tests-delay=<seconds>: delay between two repetition\n']
+    msg += ['--repeat-count=<count>: repeat given all tests <count> times\n']
+    msg += ['--repeat-delay=<seconds>: delay between two repetition\n']
     msg += ['--follow-child: if set, walk the test hierarchy and run ' +
             'each test\n']
     msg += ['--tags=<tag>: Select only tests that have <tag> tag.']
@@ -216,8 +216,8 @@ if __name__ == '__main__':
     lcov_baseurl = None
     genhtml_bin = None
     timeout = None
-    repeat_tests = 1
-    repeat_tests_delay = 0
+    repeat_count = 1
+    repeat_delay = 0
     nosedebug = False
     only_info = False
     tags = []
@@ -232,14 +232,14 @@ if __name__ == '__main__':
     user_plugins = None
     PtlConfig()
 
-    largs = ['exclude=', 'log-conf=', 'timeout=', 'repeat-tests=']
+    largs = ['exclude=', 'log-conf=', 'timeout=', 'repeat-count=']
     largs += ['param-file=', 'min-pyver=', 'max-pyver=']
     largs += ['db-name=', 'db-access=', 'db-type=', 'genhtml-bin=']
     largs += ['lcov-bin=', 'lcov-data=', 'lcov-out=', 'lcov-nosrc']
     largs += ['lcov-baseurl=', 'tags=', 'eval-tags=', 'tags-info', 'list-tags']
     largs += ['version', 'verbose', 'follow-child']
     largs += ['stop-on-failure', 'enable-nose-debug']
-    largs += ['post-analysis-data=', 'gen-ts-tree', 'repeat-tests-delay=']
+    largs += ['post-analysis-data=', 'gen-ts-tree', 'repeat-delay=']
     largs += ['tc-failure-threshold=', 'cumulative-tc-failure-threshold=']
     largs += ['max-postdata-threshold=', 'user-plugins=', 'use-current-setup']
 
@@ -300,10 +300,10 @@ if __name__ == '__main__':
             testgroup = val
         elif o == '--timeout':
             timeout = int(val)
-        elif o == '--repeat-tests':
-            repeat_tests = int(val)
-        elif o == '--repeat-tests-delay':
-            repeat_tests_delay = int(val)
+        elif o == '--repeat-count':
+            repeat_count = int(val)
+        elif o == '--repeat-delay':
+            repeat_delay = int(val)
         elif o == '--db-type':
             dbtype = val
         elif o == '--db-name':
@@ -469,8 +469,8 @@ if __name__ == '__main__':
         data = PTLTestData()
         loader.set_data(testgroup, testsuites, excludes, follow, testfiles)
         testtags.set_data(tags, eval_tags)
-        runner.set_data(paramfile, testparam, repeat_tests,
-                        repeat_tests_delay, lcov_bin, lcov_data,
+        runner.set_data(paramfile, testparam, repeat_count,
+                        repeat_delay, lcov_bin, lcov_data,
                         lcov_out, genhtml_bin, lcov_nosrc,
                         lcov_baseurl, tc_failure_threshold,
                         cumulative_tc_failure_threshold, use_cur_setup)

--- a/test/fw/bin/pbs_benchpress
+++ b/test/fw/bin/pbs_benchpress
@@ -145,6 +145,8 @@ def usage():
             'fails\n']
     msg += ['--timeout=<seconds>: duration after which no test suites are '
             'run\n']
+    msg += ['--repeat-tests=<int>: number of times test is going to repeat\n']
+    msg += ['--repeat-tests-delay=<seconds>: delay between two repetition\n']
     msg += ['--follow-child: if set, walk the test hierarchy and run ' +
             'each test\n']
     msg += ['--tags=<tag>: Select only tests that have <tag> tag.']
@@ -214,6 +216,8 @@ if __name__ == '__main__':
     lcov_baseurl = None
     genhtml_bin = None
     timeout = None
+    repeat_tests = 1
+    repeat_tests_delay = 0
     nosedebug = False
     only_info = False
     tags = []
@@ -228,14 +232,14 @@ if __name__ == '__main__':
     user_plugins = None
     PtlConfig()
 
-    largs = ['exclude=', 'log-conf=', 'timeout=']
+    largs = ['exclude=', 'log-conf=', 'timeout=', 'repeat-tests=']
     largs += ['param-file=', 'min-pyver=', 'max-pyver=']
     largs += ['db-name=', 'db-access=', 'db-type=', 'genhtml-bin=']
     largs += ['lcov-bin=', 'lcov-data=', 'lcov-out=', 'lcov-nosrc']
     largs += ['lcov-baseurl=', 'tags=', 'eval-tags=', 'tags-info', 'list-tags']
     largs += ['version', 'verbose', 'follow-child']
     largs += ['stop-on-failure', 'enable-nose-debug']
-    largs += ['post-analysis-data=', 'gen-ts-tree']
+    largs += ['post-analysis-data=', 'gen-ts-tree', 'repeat-tests-delay=']
     largs += ['tc-failure-threshold=', 'cumulative-tc-failure-threshold=']
     largs += ['max-postdata-threshold=', 'user-plugins=', 'use-current-setup']
 
@@ -296,6 +300,10 @@ if __name__ == '__main__':
             testgroup = val
         elif o == '--timeout':
             timeout = int(val)
+        elif o == '--repeat-tests':
+            repeat_tests = int(val)
+        elif o == '--repeat-tests-delay':
+            repeat_tests_delay = int(val)
         elif o == '--db-type':
             dbtype = val
         elif o == '--db-name':
@@ -461,11 +469,11 @@ if __name__ == '__main__':
         data = PTLTestData()
         loader.set_data(testgroup, testsuites, excludes, follow, testfiles)
         testtags.set_data(tags, eval_tags)
-        runner.set_data(paramfile, testparam, lcov_bin,
-                        lcov_data, lcov_out,
-                        genhtml_bin, lcov_nosrc, lcov_baseurl,
-                        tc_failure_threshold, cumulative_tc_failure_threshold,
-                        use_cur_setup)
+        runner.set_data(paramfile, testparam, repeat_tests,
+                        repeat_tests_delay, lcov_bin, lcov_data,
+                        lcov_out, genhtml_bin, lcov_nosrc,
+                        lcov_baseurl, tc_failure_threshold,
+                        cumulative_tc_failure_threshold, use_cur_setup)
         db.set_data(dbtype, dbname, dbaccess)
         data.set_data(post_data_dir, max_postdata_threshold)
         plugins = (loader, testtags, runner, db, data)

--- a/test/fw/doc/howtotest.rst
+++ b/test/fw/doc/howtotest.rst
@@ -62,6 +62,8 @@ PBSTestSuite offers the following:
     - conn_timeout: set a timeout in seconds after which a pbs_connect IFL call is refreshed (i.e., disconnected)
     - skip-setup: Bypasses setUp of PBSTestSuite (not custom ones)
     - skip-teardown: Bypasses tearDown of PBSTestSuite (not custom ones)
+    - repeat-tests: Number of tests repetition
+    - repeat-tests-delay: delay between two repetition
     - procinfo: Enables process monitoring thread, logged into ptl_proc_info test metrics.
     - procmon: Colon-separated process name to monitor. For example to monitor server, sched, and mom use procmon=pbs_server:pbs_sched:pbs_mom
     - procmon-freq: Sets a polling frequency for the process monitoring tool. Defaults to 10 seconds.

--- a/test/fw/doc/howtotest.rst
+++ b/test/fw/doc/howtotest.rst
@@ -62,8 +62,8 @@ PBSTestSuite offers the following:
     - conn_timeout: set a timeout in seconds after which a pbs_connect IFL call is refreshed (i.e., disconnected)
     - skip-setup: Bypasses setUp of PBSTestSuite (not custom ones)
     - skip-teardown: Bypasses tearDown of PBSTestSuite (not custom ones)
-    - repeat-tests: Number of tests repetition
-    - repeat-tests-delay: delay between two repetition
+    - repeat-count: Number of tests repetition
+    - repeat-delay: delay between two repetition
     - procinfo: Enables process monitoring thread, logged into ptl_proc_info test metrics.
     - procmon: Colon-separated process name to monitor. For example to monitor server, sched, and mom use procmon=pbs_server:pbs_sched:pbs_mom
     - procmon-freq: Sets a polling frequency for the process monitoring tool. Defaults to 10 seconds.

--- a/test/fw/ptl/utils/plugins/ptl_test_runner.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_runner.py
@@ -467,11 +467,11 @@ class PtlTextTestRunner(TextTestRunner):
     """
 
     def __init__(self, stream=sys.stdout, descriptions=True, verbosity=3,
-                 config=None, repetition=1, repetition_delay=0):
+                 config=None, repeat_count=1, repeat_delay=0):
         self.logger = logging.getLogger(__name__)
         self.result = None
-        self.repetition = repetition
-        self.repetition_delay = repetition_delay
+        self.repeat_count = repeat_count
+        self.repeat_delay = repeat_delay
         TextTestRunner.__init__(self, stream, descriptions, verbosity, config)
 
     def _makeResult(self):
@@ -493,17 +493,15 @@ class PtlTextTestRunner(TextTestRunner):
         self.result = result = self._makeResult()
         self.result.start = datetime.datetime.now()
         try:
-            for i in range(self.repetition):
-                self.logger.info("====================================")
-                self.logger.info("tests are running (" + str(i + 1) + ") time")
-                self.logger.info("====================================")
-                if i is not 0:
-                    time.sleep(self.repetition_delay)
+            for i in range(self.repeat_count):
+                if i != 0:
+                    time.sleep(self.repeat_delay)
                 test(result)
-            self.logger.info("=============================================")
-            self.logger.info(" All tests are repeated " +
-                             str(self.repetition) + " times")
-            self.logger.info("=============================================")
+            if self.repeat_count > 1:
+                self.logger.info("==========================================")
+                self.logger.info("All Tests are repeated %d times"
+                                 % self.repeat_count)
+                self.logger.info("==========================================")
         except KeyboardInterrupt:
             do_exit = True
         self.result.stop = datetime.datetime.now()
@@ -526,8 +524,8 @@ class PTLTestRunner(Plugin):
     def __init__(self):
         Plugin.__init__(self)
         self.param = None
-        self.repeat_tests = 1
-        self.repeat_test_delay = 0
+        self.repeat_count = 1
+        self.repeat_delay = 0
         self.use_cur_setup = False
         self.lcov_bin = None
         self.lcov_data = None
@@ -552,8 +550,8 @@ class PTLTestRunner(Plugin):
         """
         pass
 
-    def set_data(self, paramfile, testparam, repeat_tests,
-                 repeat_test_delay, lcov_bin, lcov_data, lcov_out,
+    def set_data(self, paramfile, testparam, repeat_count,
+                 repeat_delay, lcov_bin, lcov_data, lcov_out,
                  genhtml_bin, lcov_nosrc, lcov_baseurl,
                  tc_failure_threshold, cumulative_tc_failure_threshold,
                  use_cur_setup):
@@ -573,8 +571,8 @@ class PTLTestRunner(Plugin):
             else:
                 testparam = _f
         self.param = testparam
-        self.repeat_tests = repeat_tests
-        self.repeat_test_delay = repeat_test_delay
+        self.repeat_count = repeat_count
+        self.repeat_delay = repeat_delay
         self.use_cur_setup = use_cur_setup
         self.lcov_bin = lcov_bin
         self.lcov_data = lcov_data
@@ -598,8 +596,8 @@ class PTLTestRunner(Plugin):
         Prepare test runner
         """
         return PtlTextTestRunner(verbosity=3, config=self.config,
-                                 repetition=self.repeat_tests,
-                                 repetition_delay=self.repeat_test_delay)
+                                 repeat_count=self.repeat_count,
+                                 repeat_delay=self.repeat_delay)
 
     def prepareTestResult(self, result):
         """

--- a/test/fw/ptl/utils/plugins/ptl_test_runner.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_runner.py
@@ -48,6 +48,7 @@ import re
 import signal
 import socket
 import sys
+import time
 import tempfile
 import unittest
 from threading import Timer
@@ -466,9 +467,11 @@ class PtlTextTestRunner(TextTestRunner):
     """
 
     def __init__(self, stream=sys.stdout, descriptions=True, verbosity=3,
-                 config=None):
+                 config=None, repetition=1, repetition_delay=0):
         self.logger = logging.getLogger(__name__)
         self.result = None
+        self.repetition = repetition
+        self.repetition_delay = repetition_delay
         TextTestRunner.__init__(self, stream, descriptions, verbosity, config)
 
     def _makeResult(self):
@@ -490,7 +493,17 @@ class PtlTextTestRunner(TextTestRunner):
         self.result = result = self._makeResult()
         self.result.start = datetime.datetime.now()
         try:
-            test(result)
+            for i in range(self.repetition):
+                self.logger.info("====================================")
+                self.logger.info("tests are running (" + str(i + 1) + ") time")
+                self.logger.info("====================================")
+                if i is not 0:
+                    time.sleep(self.repetition_delay)
+                test(result)
+            self.logger.info("=============================================")
+            self.logger.info(" All tests are repeated " +
+                             str(self.repetition) + " times")
+            self.logger.info("=============================================")
         except KeyboardInterrupt:
             do_exit = True
         self.result.stop = datetime.datetime.now()
@@ -513,6 +526,8 @@ class PTLTestRunner(Plugin):
     def __init__(self):
         Plugin.__init__(self)
         self.param = None
+        self.repeat_tests = 1
+        self.repeat_test_delay = 0
         self.use_cur_setup = False
         self.lcov_bin = None
         self.lcov_data = None
@@ -537,10 +552,11 @@ class PTLTestRunner(Plugin):
         """
         pass
 
-    def set_data(self, paramfile, testparam,
-                 lcov_bin, lcov_data, lcov_out, genhtml_bin, lcov_nosrc,
-                 lcov_baseurl, tc_failure_threshold,
-                 cumulative_tc_failure_threshold, use_cur_setup):
+    def set_data(self, paramfile, testparam, repeat_tests,
+                 repeat_test_delay, lcov_bin, lcov_data, lcov_out,
+                 genhtml_bin, lcov_nosrc, lcov_baseurl,
+                 tc_failure_threshold, cumulative_tc_failure_threshold,
+                 use_cur_setup):
         if paramfile is not None:
             _pf = open(paramfile, 'r')
             _params_from_file = _pf.readlines()
@@ -557,6 +573,8 @@ class PTLTestRunner(Plugin):
             else:
                 testparam = _f
         self.param = testparam
+        self.repeat_tests = repeat_tests
+        self.repeat_test_delay = repeat_test_delay
         self.use_cur_setup = use_cur_setup
         self.lcov_bin = lcov_bin
         self.lcov_data = lcov_data
@@ -579,7 +597,9 @@ class PTLTestRunner(Plugin):
         """
         Prepare test runner
         """
-        return PtlTextTestRunner(verbosity=3, config=self.config)
+        return PtlTextTestRunner(verbosity=3, config=self.config,
+                                 repetition=self.repeat_tests,
+                                 repetition_delay=self.repeat_test_delay)
 
     def prepareTestResult(self, result):
         """


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Test Framework should allow testers to run a test for multiple times. Tester can use delay between two repetition.

#### Describe Your Change
Introduces new pbs_benchpress options --repeat_tests=<int> for how many times test will run and
--repeat_tests_delay for delay=<seconds> delay between repeated test.

Each repetition includes all submitted tests. next repetition starts after finishing of all tests of first repetition.
If submits three tests then in first repetition all three tests run and after finishing all three tests, next repetition starts and again all three tests run.

At the end we get message " All tests are repeated times"


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
https://pbspro.atlassian.net/wiki/spaces/PD/pages/1386938446/Test+Framework+should+allow+testers+to+run+a+test+for+multiple+times

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[repetition_mixed_testsuite.txt](https://github.com/openpbs/openpbs/files/4947277/repetition_mixed_testsuite.txt)
[repetition_multiple_tests.txt](https://github.com/openpbs/openpbs/files/4947278/repetition_multiple_tests.txt)
[no_repetition.txt](https://github.com/openpbs/openpbs/files/4947306/no_repetition.txt)
[json_report.txt](https://github.com/openpbs/openpbs/files/4947305/json_report.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
