### PR TITLE
reconfirming running reservations can move available nodes

### DIFF
--- a/src/scheduler/resource.c
+++ b/src/scheduler/resource.c
@@ -872,12 +872,12 @@ collect_resources_from_requests(resource_resv **resresv_arr)
 		 * execselect: select created from the exec_vnode.  This is likely to
 		 * be a subset of resources from schedselect + 'vnode'.  It is possible
 		 * that a job was run with qrun -H (res=val) where res is not part of
-		 * the schedselect.  The exec_vnode is taken directly from the -H  argument
+		 * the schedselect.  The exec_vnode is taken directly from the -H argument
 		 * The qrun -H case is why we need to do this check.
 		 */
 		if (r->execselect != NULL && r->execselect->defs != NULL) {
-			if ((r->is_job && r->job != NULL && in_runnable_state(r)) ||
-				(r->is_resv && r->resv != NULL && r->resv->resv_state == RESV_BEING_ALTERED)) {
+			if ((r->job != NULL && in_runnable_state(r)) ||
+				(r->resv != NULL && (r->resv->resv_state == RESV_BEING_ALTERED || r->resv->resv_substate == RESV_DEGRADED))) {
 				for (j = 0; r->execselect->defs[j] != NULL;j++) {
 					if (!resdef_exists_in_array(defarr, r->execselect->defs[j]))
 						add_resdef_to_array(&defarr, r->execselect->defs[j]);

--- a/src/scheduler/resource_resv.c
+++ b/src/scheduler/resource_resv.c
@@ -1662,7 +1662,7 @@ update_resresv_on_run(resource_resv *resresv, nspec **nspec_arr)
 			}
 		}
 	}
-	else if (resresv->is_resv && resresv->resv !=NULL) {
+	else if (resresv->is_resv && resresv->resv != NULL) {
 		resresv->resv->resv_state = RESV_RUNNING;
 
 		resv_queue = find_queue_info(resresv->server->queues,

--- a/test/tests/functional/pbs_reservations.py
+++ b/test/tests/functional/pbs_reservations.py
@@ -1654,6 +1654,9 @@ class TestReservations(TestFunctional):
         time doesn't crashes PBS daemon.
         """
         self.common_steps()
+        # turn opt_backfill_fuzzy so both reservations are at the same time
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'opt_backfill_fuzzy': 'off'}, id='default')
 
         # Submit job j to consume all resources
         a = {'Resource_List.walltime': '5',
@@ -2157,6 +2160,9 @@ class TestReservations(TestFunctional):
         doesn't crashes PBS daemons on completion of reservation.
         """
         self.common_config()
+        # Turn opt_backfill_fuzzy off so both resvs are at the same time
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'opt_backfill_fuzzy': 'off'}, id='default')
         # Submit job array such that it consumes all the resources
         # on both vnodes
         attrs = {ATTR_J: '1-5',

--- a/test/tests/functional/pbs_reservations.py
+++ b/test/tests/functional/pbs_reservations.py
@@ -1654,9 +1654,6 @@ class TestReservations(TestFunctional):
         time doesn't crashes PBS daemon.
         """
         self.common_steps()
-        # turn opt_backfill_fuzzy so both reservations are at the same time
-        self.server.manager(MGR_CMD_SET, SCHED,
-                            {'opt_backfill_fuzzy': 'off'}, id='default')
 
         # Submit job j to consume all resources
         a = {'Resource_List.walltime': '5',
@@ -2160,9 +2157,6 @@ class TestReservations(TestFunctional):
         doesn't crashes PBS daemons on completion of reservation.
         """
         self.common_config()
-        # Turn opt_backfill_fuzzy off so both resvs are at the same time
-        self.server.manager(MGR_CMD_SET, SCHED,
-                            {'opt_backfill_fuzzy': 'off'}, id='default')
         # Submit job array such that it consumes all the resources
         # on both vnodes
         attrs = {ATTR_J: '1-5',

--- a/test/tests/functional/pbs_reservations.py
+++ b/test/tests/functional/pbs_reservations.py
@@ -376,6 +376,62 @@ class TestReservations(TestFunctional):
         self.assertNotEqual(nds1, nds2)
         self.assertEquals(sc, nds1.split('+')[0])
 
+    def test_degraded_running_only_replace(self):
+        """
+        Test that when a running degraded reservation is reconfirmed,
+        make sure that only the nodes that unavailable are repalced
+        """
+        self.server.manager(MGR_CMD_SET, SERVER, {'reserve_retry_time': 5})
+
+        a = {'resources_available.ncpus': 1}
+        self.server.create_vnodes('vn', a, 5, self.mom)
+
+        # Submit two jobs to take up nodes 0 and 1. This forces the reservation
+        # onto nodes 3 and 4. The idea is to delete the two jobs and see
+        # if the reservation shifts onto nodes 0 and 1 after the reconfirm
+        j1 = Job(attrs={'Resource_List.select': '1:ncpus=1'})
+        jid1 = self.server.submit(j1)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
+
+        j2 = Job(attrs={'Resource_List.select': '1:ncpus=1'})
+        jid2 = self.server.submit(j2)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
+
+        now = int(time.time())
+        start = now + 20
+        a = {'reserve_start': start, 'reserve_end': start + 60,
+             'Resource_List.select': '2:ncpus=1'}
+        R = Reservation(attrs=a)
+        rid = self.server.submit(R)
+        self.server.expect(RESV, {'reserve_state':
+                                  (MATCH_RE, 'RESV_CONFIRMED|2')}, id=rid)
+        resv_queue = rid.split('.')[0]
+        a = {'Resource_List.select': '1:ncpus=1', 'queue': resv_queue}
+        j3 = Job(attrs=a)
+        jid3 = self.server.submit(j3)
+
+        self.logger.info('Sleeping until reservation starts')
+        self.server.expect(RESV,
+                           {'reserve_state': (MATCH_RE, 'RESV_RUNNING|5')},
+                           id=rid, offset=start - int(time.time()))
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid3)
+
+        self.server.delete(jid1, wait=True)
+        self.server.delete(jid2, wait=True)
+        self.server.status(RESV)
+        rnodes = self.server.reservations[rid].get_vnodes()
+        self.server.status(JOB)
+        jnode = j3.get_vnodes()[0]
+        other_node = rnodes[rnodes[0] == jnode]
+        self.server.manager(MGR_CMD_SET, NODE, {
+                            'state': (INCR, 'offline')}, id=other_node)
+        self.server.expect(RESV, {'reserve_substate': 10}, id=rid)
+        self.logger.info('Waiting until reconfirmation')
+        self.server.expect(RESV, {'reserve_substate': 5}, id=rid, offset=7)
+        self.server.status(RESV)
+        rnodes2 = self.server.reservations[rid].get_vnodes()
+        self.assertIn(jnode, rnodes2, 'Reservation not on job node')
+
     @skipOnCpuSet
     def test_standing_reservation_occurrence_two_not_degraded(self):
         """

--- a/test/tests/functional/pbs_reservations.py
+++ b/test/tests/functional/pbs_reservations.py
@@ -379,7 +379,7 @@ class TestReservations(TestFunctional):
     def test_degraded_running_only_replace(self):
         """
         Test that when a running degraded reservation is reconfirmed,
-        make sure that only the nodes that unavailable are repalced
+        make sure that only the nodes that unavailable are replaced
         """
         self.server.manager(MGR_CMD_SET, SERVER, {'reserve_retry_time': 5})
 

--- a/test/tests/functional/pbs_reservations.py
+++ b/test/tests/functional/pbs_reservations.py
@@ -376,6 +376,7 @@ class TestReservations(TestFunctional):
         self.assertNotEqual(nds1, nds2)
         self.assertEquals(sc, nds1.split('+')[0])
 
+    @skipOnCpuSet
     def test_degraded_running_only_replace(self):
         """
         Test that when a running degraded reservation is reconfirmed,


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
When a running degraded reservation is reconfirmed, the scheduler  can replace all nodes, not just the unavailable ones.   This means the node a running job is on can be replaced.  This leaves the reservation with a job on a node that it doesn't own.

#### Describe Your Change
The main reason this happened is because when we were only reconfirming non-running reservations, we would mark the reservation as unconfirmed.  To the scheduler, a degraded reservation and an unconfirmed reservation were the same.  When we started reconfirming  running  reservations, this changed.  The problem is when we were choosing which select spec to use to confirm the reservation, we didn't detect the reservation was running.   We used the original select spec and treated the reservation like it was when it was not running.  This meant we could confirm it anywhere.  

I changed the code to leave  the reservation in the running state and have is_ok_to_run() detect it as confirmable in the degraded substate.  This meant check_nodes() sees it as running and we use the execselect.

#### Attach Test and Valgrind Logs/Output
[resv.log](https://github.com/openpbs/openpbs/files/4940516/resv.log)
