### PR TITLE
Server crash on make install

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -68,7 +68,6 @@ AC_PROG_CC
 AC_PROG_LEX
 AC_PROG_INSTALL
 AC_PROG_LN_S
-AM_PROG_LIBTOOL
 
 # Automake macros
 #AM_PROG_AR macro is defined with automake version >= 1.12
@@ -76,6 +75,7 @@ m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 AM_PROG_CC_C_O
 
 # Initialize libtool
+AM_PROG_LIBTOOL
 LT_INIT([shared static])
 
 # Checks for libraries.

--- a/src/lib/Libdb/Makefile.am
+++ b/src/lib/Libdb/Makefile.am
@@ -43,7 +43,7 @@ SUBDIRS = \
 	pgsql
 
 all-local:
-	install -D $(top_builddir)/src/lib/Libdb/pgsql/.libs/libdb.so.0.0.0 $(top_builddir)/src/lib/Libdb/libdb.so
+	cp -p $(top_builddir)/src/lib/Libdb/pgsql/.libs/libdb.so.0.0.0 $(top_builddir)/src/lib/Libdb/libdb.so
 
 clean-local:
 	rm -f $(top_builddir)/src/lib/Libdb/libdb.so

--- a/src/lib/Libdb/Makefile.am
+++ b/src/lib/Libdb/Makefile.am
@@ -43,7 +43,7 @@ SUBDIRS = \
 	pgsql
 
 all-local:
-	cp -p $(top_builddir)/src/lib/Libdb/pgsql/.libs/libdb.so.0.0.0 $(top_builddir)/src/lib/Libdb/libdb.so
+	install -D $(top_builddir)/src/lib/Libdb/pgsql/.libs/libdb.so.0.0.0 $(top_builddir)/src/lib/Libdb/libdb.so
 
 clean-local:
 	rm -f $(top_builddir)/src/lib/Libdb/libdb.so

--- a/src/lib/Libdb/pgsql/Makefile.am
+++ b/src/lib/Libdb/pgsql/Makefile.am
@@ -68,6 +68,6 @@ dist_sbin_SCRIPTS = \
 	pbs_ds_systemd
 
 install-exec-hook:
-	cp -p $(DESTDIR)$(libdir)/libdb.so.0.0.0 $(DESTDIR)$(libdir)/libdb_pg.so
+	install -D $(DESTDIR)$(libdir)/libdb.so.0.0.0 $(DESTDIR)$(libdir)/libdb_pg.so
 uninstall:
 	rm -f $(DESTDIR)$(libdir)/libdb_pg.so


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Libdb makefile was using cp to make a copy of the db shared library. When pbs server is running if 'make install' is done, it will corrupt the address space where libdb was loaded since with cp only directory entry (the name) is removed.

Also fixed a configure warning:
configure.ac:75: warning: LT_INIT was called before AM_PROG_AR
/usr/share/aclocal-1.16/ar-lib.m4:13: AM_PROG_AR is expanded from...
configure.ac:75: the top level

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
One way to solve this to do a rm of the file before doing cp. This will mark the libdb.so as deleted in /proc/server_pid/maps. So when we remove and copy, we basically create a "different" file.  Libtool uses install command to copy files. I replaced cp with install now and this makes sure the file is removed before copy.

For configure warning I had to move AM_PROG_LIBTOOL after AM_PROG_AR.


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
