### PR TITLE
Have PTL raise an error if it failed to set sched config and modified the error message in _log_match() on non-existence 

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -4061,7 +4061,7 @@ class PBSService(PBSObject):
                                          endtime=endtime)
             if not existence:
                 if rv:
-                    _msg = infomsg + ' - Match'
+                    _msg = infomsg + ' - but exists'
                     raise PtlLogMatchError(rc=1, rv=False, msg=_msg)
                 else:
                     self.logger.log(level, infomsg + attemptmsg + '... OK')

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -4059,9 +4059,13 @@ class PBSService(PBSObject):
             rv = self.logutils.match_msg(lines, msg, allmatch=allmatch,
                                          regexp=regexp, starttime=starttime,
                                          endtime=endtime)
-            if rv is None and not existence:
-                self.logger.log(level, infomsg + attemptmsg + '... OK')
-                break
+            if not existence:
+                if rv:
+                    _msg = infomsg + ' - Match'
+                    raise PtlLogMatchError(rc=1, rv=False, msg=_msg)
+                else:
+                    self.logger.log(level, infomsg + attemptmsg + '... OK')
+                    break
             if rv:
                 self.logger.log(level, infomsg + '... OK')
                 break
@@ -4084,7 +4088,7 @@ class PBSService(PBSObject):
             lines.close()
         except:
             pass
-        if (rv is None and existence) or (rv is not None and not existence):
+        if (rv is None and existence):
             _msg = infomsg + attemptmsg
             raise PtlLogMatchError(rc=1, rv=False, msg=_msg)
         return rv
@@ -11489,7 +11493,8 @@ class Scheduler(PBSService):
                                starttime=reconfig_time)
                 self.log_match("Error reading line", max_attempts=2,
                                starttime=reconfig_time, existence=False)
-            except PtlLogMatchError:
+            except PtlLogMatchError as log_error:
+                self.logger.error(log_error.msg)
                 _msg = 'Error in validating sched_config changes'
                 raise PbsSchedConfigError(rc=1, rv=False,
                                           msg=_msg)
@@ -11513,10 +11518,13 @@ class Scheduler(PBSService):
         if apply:
             try:
                 self.apply_config(validate=validate)
-            except PbsSchedConfigError:
+            except PbsSchedConfigError as sched_error:
+                _msg = sched_error.msg
+                self.logger.error(_msg)
                 for k in confs:
                     del self.sched_config[k]
                 self.apply_config(validate=validate)
+                raise PbsSchedConfigError(rc=1, rv=False, msg=_msg)
         return True
 
     def add_server_dyn_res(self, custom_resource, script_body=None,


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
PTL doesn't through any error if failed to set sched config. It deletes applied new sched configuration and revert back to  old configuration

In _log_match() If existence=False and log message is present then  _log_match() through  error message "log match: searching  for 'msg' with non-existence - No Match" . It is not a proper message.

If existence=True and log message is not present then it through error message "log match: searching  for 'msg' with existence - No Match" . It is meaningful.
So error message should be different.

#### Describe Your Change
PTL raise error if failed  to set sched configuration

For non-existence _log_match() through error message "log match: searching for msg - with non-existence - Match"

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[sched_config_not_matched.txt](https://github.com/openpbs/openpbs/files/4953145/sched_config_not_matched.txt)
[sched_config_matched.txt](https://github.com/openpbs/openpbs/files/4953146/sched_config_matched.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
