### PR TITLE
socket lib init and socket close made platform independent.

### DIFF
--- a/src/cmds/pbs_attach.c
+++ b/src/cmds/pbs_attach.c
@@ -261,9 +261,9 @@ main(int argc, char *argv[])
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-	if (initsocketlib()) {
+	if (initsocketlib())
 		return 1;
-	}
+
 #ifdef WIN32
 	/* Windows has an additional option -c, in order to run built-in DOS commands using a new command shell */
 	while ((c = getopt(argc, argv, "+j:p:h:m:csP")) != EOF) {

--- a/src/cmds/pbs_attach.c
+++ b/src/cmds/pbs_attach.c
@@ -261,10 +261,10 @@ main(int argc, char *argv[])
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-#ifdef WIN32
-	if (winsock_init()) {
+	if (initsocketlib()) {
 		return 1;
 	}
+#ifdef WIN32
 	/* Windows has an additional option -c, in order to run built-in DOS commands using a new command shell */
 	while ((c = getopt(argc, argv, "+j:p:h:m:csP")) != EOF) {
 #else

--- a/src/cmds/pbs_ralter.c
+++ b/src/cmds/pbs_ralter.c
@@ -249,9 +249,8 @@ main(int argc, char *argv[], char *envp[])		/* pbs_ralter */
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-	if (initsocketlib()) {
+	if (initsocketlib())
 		return 1;
-	}
 
 	destbuf[0] = '\0';
 	errflg = process_opts(argc, argv, &attrib, destbuf); /* get cmdline options */

--- a/src/cmds/pbs_ralter.c
+++ b/src/cmds/pbs_ralter.c
@@ -249,11 +249,9 @@ main(int argc, char *argv[], char *envp[])		/* pbs_ralter */
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-#ifdef WIN32
-	if (winsock_init()) {
+	if (initsocketlib()) {
 		return 1;
 	}
-#endif
 
 	destbuf[0] = '\0';
 	errflg = process_opts(argc, argv, &attrib, destbuf); /* get cmdline options */

--- a/src/cmds/pbs_rdel.c
+++ b/src/cmds/pbs_rdel.c
@@ -81,10 +81,8 @@ main(int argc, char **argv, char **envp)
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-	if (initsocketlib()) {
+	if (initsocketlib())
 		return 1;
-	}
-
 
 	while ((c = getopt(argc, argv, "q:")) != EOF)
 		switch (c) {

--- a/src/cmds/pbs_rdel.c
+++ b/src/cmds/pbs_rdel.c
@@ -81,11 +81,9 @@ main(int argc, char **argv, char **envp)
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-#ifdef WIN32
-	if (winsock_init()) {
+	if (initsocketlib()) {
 		return 1;
 	}
-#endif
 
 
 	while ((c = getopt(argc, argv, "q:")) != EOF)

--- a/src/cmds/pbs_release_nodes.c
+++ b/src/cmds/pbs_release_nodes.c
@@ -83,9 +83,8 @@ main(int argc, char **argv, char **envp) /* pbs_release_nodes */
 	/*test for real deal or just version and exit*/
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-	if (initsocketlib()) {
+	if (initsocketlib())
 		return 1;
-	}
 
 	job_id[0] = '\0';
 	while ((c = getopt(argc, argv, GETOPT_ARGS)) != EOF) {

--- a/src/cmds/pbs_release_nodes.c
+++ b/src/cmds/pbs_release_nodes.c
@@ -83,11 +83,9 @@ main(int argc, char **argv, char **envp) /* pbs_release_nodes */
 	/*test for real deal or just version and exit*/
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-#ifdef WIN32
-	if (winsock_init()) {
+	if (initsocketlib()) {
 		return 1;
 	}
-#endif
 
 	job_id[0] = '\0';
 	while ((c = getopt(argc, argv, GETOPT_ARGS)) != EOF) {

--- a/src/cmds/pbs_rstat.c
+++ b/src/cmds/pbs_rstat.c
@@ -242,9 +242,8 @@ main(int argc, char *argv[])
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-	if (initsocketlib()) {
+	if (initsocketlib())
 		return 1;
-	}
 
 	while ((c = getopt(argc, argv, "fFBS")) != EOF) {
 		switch (c) {

--- a/src/cmds/pbs_rstat.c
+++ b/src/cmds/pbs_rstat.c
@@ -242,11 +242,9 @@ main(int argc, char *argv[])
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-#ifdef WIN32
-	if (winsock_init()) {
+	if (initsocketlib()) {
 		return 1;
 	}
-#endif
 
 	while ((c = getopt(argc, argv, "fFBS")) != EOF) {
 		switch (c) {

--- a/src/cmds/pbs_rsub.c
+++ b/src/cmds/pbs_rsub.c
@@ -725,9 +725,8 @@ main(int argc, char *argv[], char *envp[])
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-	if (initsocketlib()) {
+	if (initsocketlib())
 		return 1;
-	}
 
 	destbuf[0] = '\0';
 	extend[0] = '\0';

--- a/src/cmds/pbs_rsub.c
+++ b/src/cmds/pbs_rsub.c
@@ -725,11 +725,9 @@ main(int argc, char *argv[], char *envp[])
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-#ifdef WIN32
-	if (winsock_init()) {
+	if (initsocketlib()) {
 		return 1;
 	}
-#endif
 
 	destbuf[0] = '\0';
 	extend[0] = '\0';

--- a/src/cmds/pbs_tmrsh.c
+++ b/src/cmds/pbs_tmrsh.c
@@ -205,9 +205,8 @@ main(int argc, char *argv[], char *envp[])
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-	if (initsocketlib()) {
+	if (initsocketlib())
 		return 1;
-	}
 
 	id = argv[0];
 	if (argc < 3)

--- a/src/cmds/pbs_tmrsh.c
+++ b/src/cmds/pbs_tmrsh.c
@@ -205,11 +205,9 @@ main(int argc, char *argv[], char *envp[])
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-#ifdef WIN32
-	if (winsock_init()) {
+	if (initsocketlib()) {
 		return 1;
 	}
-#endif
 
 	id = argv[0];
 	if (argc < 3)

--- a/src/cmds/pbsdsh.c
+++ b/src/cmds/pbsdsh.c
@@ -211,11 +211,10 @@ main(int argc, char *argv[], char *envp[])
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-#ifdef WIN32
-	if (winsock_init()) {
+	if (initsocketlib()) {
 		return 1;
 	}
-#endif
+
 	while ((c = getopt(argc, argv, "c:n:svo")) != EOF) {
 		switch (c) {
 			case 'c':

--- a/src/cmds/pbsdsh.c
+++ b/src/cmds/pbsdsh.c
@@ -211,9 +211,8 @@ main(int argc, char *argv[], char *envp[])
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-	if (initsocketlib()) {
+	if (initsocketlib())
 		return 1;
-	}
 
 	while ((c = getopt(argc, argv, "c:n:svo")) != EOF) {
 		switch (c) {

--- a/src/cmds/pbsnodes.c
+++ b/src/cmds/pbsnodes.c
@@ -922,11 +922,9 @@ main(int argc, char *argv[])
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-#ifdef WIN32
-	if (winsock_init()) {
+	if (initsocketlib()) {
 		return 1;
 	}
-#endif
 
 	/* get default server, may be changed by -s option */
 

--- a/src/cmds/pbsnodes.c
+++ b/src/cmds/pbsnodes.c
@@ -922,9 +922,8 @@ main(int argc, char *argv[])
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-	if (initsocketlib()) {
+	if (initsocketlib())
 		return 1;
-	}
 
 	/* get default server, may be changed by -s option */
 

--- a/src/cmds/qalter.c
+++ b/src/cmds/qalter.c
@@ -193,9 +193,8 @@ main(int argc, char **argv, char **envp) /* qalter */
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-	if (initsocketlib()) {
+	if (initsocketlib())
 		return 1;
-	}
 
 	while ((c = getopt(argc, argv, GETOPT_ARGS)) != EOF)
 		switch (c) {

--- a/src/cmds/qalter.c
+++ b/src/cmds/qalter.c
@@ -193,11 +193,9 @@ main(int argc, char **argv, char **envp) /* qalter */
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-#ifdef WIN32
-	if (winsock_init()) {
+	if (initsocketlib()) {
 		return 1;
 	}
-#endif
 
 	while ((c = getopt(argc, argv, GETOPT_ARGS)) != EOF)
 		switch (c) {

--- a/src/cmds/qdel.c
+++ b/src/cmds/qdel.c
@@ -102,11 +102,9 @@ char **envp;
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-#ifdef WIN32
-	if (winsock_init()) {
+	if (initsocketlib()) {
 		return 1;
 	}
-#endif
 
 	warg[0]='\0';
 	strcpy(warg1, NOMAIL);

--- a/src/cmds/qdel.c
+++ b/src/cmds/qdel.c
@@ -102,9 +102,8 @@ char **envp;
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-	if (initsocketlib()) {
+	if (initsocketlib())
 		return 1;
-	}
 
 	warg[0]='\0';
 	strcpy(warg1, NOMAIL);

--- a/src/cmds/qdisable.c
+++ b/src/cmds/qdisable.c
@@ -92,11 +92,9 @@ main(int argc, char **argv)
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-#ifdef WIN32
-	if (winsock_init()) {
+	if (initsocketlib()) {
 		return 1;
 	}
-#endif
 
 	if (argc == 1) {
 		fprintf(stderr, "Usage: qdisable [queue][@server] ...\n");

--- a/src/cmds/qdisable.c
+++ b/src/cmds/qdisable.c
@@ -92,9 +92,8 @@ main(int argc, char **argv)
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-	if (initsocketlib()) {
+	if (initsocketlib())
 		return 1;
-	}
 
 	if (argc == 1) {
 		fprintf(stderr, "Usage: qdisable [queue][@server] ...\n");

--- a/src/cmds/qenable.c
+++ b/src/cmds/qenable.c
@@ -91,9 +91,8 @@ main(int argc, char **argv)
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-	if (initsocketlib()) {
+	if (initsocketlib())
 		return 1;
-	}
 
 	if (argc == 1) {
 		fprintf(stderr, "Usage: qenable [queue][@server] ...\n");

--- a/src/cmds/qenable.c
+++ b/src/cmds/qenable.c
@@ -91,11 +91,9 @@ main(int argc, char **argv)
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-#ifdef WIN32
-	if (winsock_init()) {
+	if (initsocketlib()) {
 		return 1;
 	}
-#endif
 
 	if (argc == 1) {
 		fprintf(stderr, "Usage: qenable [queue][@server] ...\n");

--- a/src/cmds/qhold.c
+++ b/src/cmds/qhold.c
@@ -133,11 +133,9 @@ main(int argc, char **argv, char **envp) /* qhold */
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-#ifdef WIN32
-	if (winsock_init()) {
+	if (initsocketlib()) {
 		return 1;
 	}
-#endif
 
 	hold_type[0]='\0';
 

--- a/src/cmds/qhold.c
+++ b/src/cmds/qhold.c
@@ -133,9 +133,8 @@ main(int argc, char **argv, char **envp) /* qhold */
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-	if (initsocketlib()) {
+	if (initsocketlib())
 		return 1;
-	}
 
 	hold_type[0]='\0';
 

--- a/src/cmds/qmgr.c
+++ b/src/cmds/qmgr.c
@@ -1131,11 +1131,9 @@ main(int argc, char **argv)
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-#ifdef WIN32
-	if (winsock_init()) {
+	if (initsocketlib()) {
 		return 1;
 	}
-#endif
 
 	/* Command line options */
 	while ((c = getopt(argc, argv, opts)) != EOF) {

--- a/src/cmds/qmgr.c
+++ b/src/cmds/qmgr.c
@@ -1131,9 +1131,8 @@ main(int argc, char **argv)
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-	if (initsocketlib()) {
+	if (initsocketlib())
 		return 1;
-	}
 
 	/* Command line options */
 	while ((c = getopt(argc, argv, opts)) != EOF) {

--- a/src/cmds/qmove.c
+++ b/src/cmds/qmove.c
@@ -75,11 +75,9 @@ main(int argc, char **argv, char **envp) /* qmove */
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-#ifdef WIN32
-	if (winsock_init()) {
+	if (initsocketlib()) {
 		return 1;
 	}
-#endif
 
 	if (argc < 3) {
 		static char usage[]="usage: qmove destination job_identifier...\n";

--- a/src/cmds/qmove.c
+++ b/src/cmds/qmove.c
@@ -75,9 +75,8 @@ main(int argc, char **argv, char **envp) /* qmove */
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-	if (initsocketlib()) {
+	if (initsocketlib())
 		return 1;
-	}
 
 	if (argc < 3) {
 		static char usage[]="usage: qmove destination job_identifier...\n";

--- a/src/cmds/qmsg.c
+++ b/src/cmds/qmsg.c
@@ -81,11 +81,9 @@ main(int argc, char **argv, char **envp) /* qmsg */
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-#ifdef WIN32
-	if (winsock_init()) {
+	if (initsocketlib()) {
 		return 1;
 	}
-#endif
 
 	msg_string[0]='\0';
 	to_file = 0;

--- a/src/cmds/qmsg.c
+++ b/src/cmds/qmsg.c
@@ -81,9 +81,8 @@ main(int argc, char **argv, char **envp) /* qmsg */
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-	if (initsocketlib()) {
+	if (initsocketlib())
 		return 1;
-	}
 
 	msg_string[0]='\0';
 	to_file = 0;

--- a/src/cmds/qorder.c
+++ b/src/cmds/qorder.c
@@ -73,11 +73,9 @@ main(int argc, char **argv, char **envp)
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-#ifdef WIN32
-	if (winsock_init()) {
+	if (initsocketlib()) {
 		return 1;
 	}
-#endif
 
 	if (argc != 3) {
 		static char usage[]="usage: qorder job_identifier job_identifier\n";

--- a/src/cmds/qorder.c
+++ b/src/cmds/qorder.c
@@ -73,9 +73,8 @@ main(int argc, char **argv, char **envp)
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-	if (initsocketlib()) {
+	if (initsocketlib())
 		return 1;
-	}
 
 	if (argc != 3) {
 		static char usage[]="usage: qorder job_identifier job_identifier\n";

--- a/src/cmds/qrerun.c
+++ b/src/cmds/qrerun.c
@@ -78,9 +78,8 @@ main(int argc, char **argv, char **envp) /* qrerun */
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-	if (initsocketlib()) {
+	if (initsocketlib())
 		return 1;
-	}
 
 	while ((i = getopt(argc, argv, "W:")) != EOF) {
 		switch (i) {

--- a/src/cmds/qrerun.c
+++ b/src/cmds/qrerun.c
@@ -78,11 +78,9 @@ main(int argc, char **argv, char **envp) /* qrerun */
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-#ifdef WIN32
-	if (winsock_init()) {
+	if (initsocketlib()) {
 		return 1;
 	}
-#endif
 
 	while ((i = getopt(argc, argv, "W:")) != EOF) {
 		switch (i) {

--- a/src/cmds/qrls.c
+++ b/src/cmds/qrls.c
@@ -81,11 +81,9 @@ main(int argc, char **argv, char **envp) /* qrls */
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-#ifdef WIN32
-	if (winsock_init()) {
+	if (initsocketlib()) {
 		return 1;
 	}
-#endif
 
 	hold_type[0]='\0';
 

--- a/src/cmds/qrls.c
+++ b/src/cmds/qrls.c
@@ -81,9 +81,8 @@ main(int argc, char **argv, char **envp) /* qrls */
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-	if (initsocketlib()) {
+	if (initsocketlib())
 		return 1;
-	}
 
 	hold_type[0]='\0';
 

--- a/src/cmds/qrun.c
+++ b/src/cmds/qrun.c
@@ -95,9 +95,8 @@ main(int argc, char **argv)
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-	if (initsocketlib()) {
+	if (initsocketlib())
 		return 1;
-	}
 
 	/* Command line options */
 	while ((s = getopt(argc, argv, opts)) != EOF)

--- a/src/cmds/qrun.c
+++ b/src/cmds/qrun.c
@@ -95,11 +95,9 @@ main(int argc, char **argv)
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-#ifdef WIN32
-	if (winsock_init()) {
+	if (initsocketlib()) {
 		return 1;
 	}
-#endif
 
 	/* Command line options */
 	while ((s = getopt(argc, argv, opts)) != EOF)

--- a/src/cmds/qselect.c
+++ b/src/cmds/qselect.c
@@ -416,9 +416,8 @@ main(int argc, char **argv, char **envp) /* qselect */
 	/*test for real deal or just version and exit*/
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-	if (initsocketlib()) {
+	if (initsocketlib())
 		return 1;
-	}
 
 	while ((c = getopt(argc, argv, GETOPT_ARGS)) != EOF)
 		switch (c) {

--- a/src/cmds/qselect.c
+++ b/src/cmds/qselect.c
@@ -416,11 +416,9 @@ main(int argc, char **argv, char **envp) /* qselect */
 	/*test for real deal or just version and exit*/
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-#ifdef WIN32
-	if (winsock_init()) {
+	if (initsocketlib()) {
 		return 1;
 	}
-#endif
 
 	while ((c = getopt(argc, argv, GETOPT_ARGS)) != EOF)
 		switch (c) {

--- a/src/cmds/qsig.c
+++ b/src/cmds/qsig.c
@@ -80,11 +80,9 @@ main(int argc, char **argv, char **envp) /* qsig */
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-#ifdef WIN32
-	if (winsock_init()) {
+	if (initsocketlib()) {
 		return 1;
 	}
-#endif
 
 	while ((c = getopt(argc, argv, GETOPT_ARGS)) != EOF)
 		switch (c) {

--- a/src/cmds/qsig.c
+++ b/src/cmds/qsig.c
@@ -80,9 +80,8 @@ main(int argc, char **argv, char **envp) /* qsig */
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-	if (initsocketlib()) {
+	if (initsocketlib())
 		return 1;
-	}
 
 	while ((c = getopt(argc, argv, GETOPT_ARGS)) != EOF)
 		switch (c) {

--- a/src/cmds/qstart.c
+++ b/src/cmds/qstart.c
@@ -91,11 +91,9 @@ main(int argc, char **argv)
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-#ifdef WIN32
-	if (winsock_init()) {
+	if (initsocketlib()) {
 		return 1;
 	}
-#endif
 
 	if (argc == 1) {
 		fprintf(stderr, "Usage: qstart [queue][@server] ...\n");

--- a/src/cmds/qstart.c
+++ b/src/cmds/qstart.c
@@ -91,9 +91,8 @@ main(int argc, char **argv)
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-	if (initsocketlib()) {
+	if (initsocketlib())
 		return 1;
-	}
 
 	if (argc == 1) {
 		fprintf(stderr, "Usage: qstart [queue][@server] ...\n");

--- a/src/cmds/qstat.c
+++ b/src/cmds/qstat.c
@@ -2384,9 +2384,8 @@ main(int argc, char **argv, char **envp) /* qstat */
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 	delay_query();
-	if (initsocketlib()) {
+	if (initsocketlib())
 		return 1;
-	}
 
 	mode = JOBS; /* default */
 	alt_opt = 0;

--- a/src/cmds/qstat.c
+++ b/src/cmds/qstat.c
@@ -2384,11 +2384,9 @@ main(int argc, char **argv, char **envp) /* qstat */
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 	delay_query();
-#ifdef WIN32
-	if (winsock_init()) {
+	if (initsocketlib()) {
 		return 1;
 	}
-#endif
 
 	mode = JOBS; /* default */
 	alt_opt = 0;

--- a/src/cmds/qstop.c
+++ b/src/cmds/qstop.c
@@ -90,9 +90,8 @@ main(int argc, char **argv)
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-	if (initsocketlib()) {
+	if (initsocketlib())
 		return 1;
-	}
 
 	if (argc == 1) {
 		fprintf(stderr, "Usage: qstop [queue][@server] ...\n");

--- a/src/cmds/qstop.c
+++ b/src/cmds/qstop.c
@@ -90,11 +90,9 @@ main(int argc, char **argv)
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-#ifdef WIN32
-	if (winsock_init()) {
+	if (initsocketlib()) {
 		return 1;
 	}
-#endif
 
 	if (argc == 1) {
 		fprintf(stderr, "Usage: qstop [queue][@server] ...\n");

--- a/src/cmds/qsub.c
+++ b/src/cmds/qsub.c
@@ -2127,9 +2127,6 @@ set_sig_handlers(void)
 	signal(SIGBREAK, win_blockint);
 	signal(SIGTERM, win_blockint);
 
-	if (winsock_init()) {
-		return 1;
-	}
 	InitializeCriticalSection(&continuethread_cs);
 #else
 	/* Catch SIGPIPE on write() failures. */
@@ -5635,6 +5632,10 @@ main(int argc, char **argv, char **envp) /* qsub */
 	int daemon_up = 0;
 	char **argv_cpy; /* copy argv for getopt */
 	int i;
+
+	if (initsocketlib()) {
+		return 1;
+	}
 
 	/* Set signal handlers */
 	set_sig_handlers();

--- a/src/cmds/qsub.c
+++ b/src/cmds/qsub.c
@@ -1403,7 +1403,7 @@ no_suspend(int sig)
 
 /**
  * @brief
- *	Close a socket for both windows and unix.
+ *	Shut and Close a socket
  *
  * @return	void
  * @param	sock	file descriptor
@@ -1412,14 +1412,10 @@ no_suspend(int sig)
  *
  */
 static void
-close_sock(int sock)
+shut_close_sock(int sock)
 {
 	shutdown(sock, 2);
-#ifdef WIN32
 	closesocket(sock);
-#else
-	close(sock);
-#endif /* WIN32 */
 }
 
 /**
@@ -1436,7 +1432,7 @@ bailout(int ret)
 {
 	int c;
 
-	close_sock(comm_sock);
+	shut_close_sock(comm_sock);
 	printf("Job %s is being deleted\n", new_jobname);
 	c = cnt2server(server_out);
 	if (c <= 0) {
@@ -2235,7 +2231,7 @@ retry:
 
 	if ((ret != CS_SUCCESS) && (ret != CS_AUTH_USE_IFF)) {
 		fprintf(stderr, "qsub: failed authentication with execution host\n");
-		close_sock(news);
+		shut_close_sock(news);
 		goto retry;
 	}
 
@@ -2245,19 +2241,19 @@ retry:
 		/*
 		 * We couldn't read data so try again if it is a port scan.
 		 */
-		close_sock(news);
+		shut_close_sock(news);
 		goto retry;
 	}
 	if (version != 1) {
 		fprintf(stderr, "qsub: unknown protocol version %d\n", version);
-		close_sock(news);
+		shut_close_sock(news);
 		goto retry;
 	}
 
 	jobid = disrst(news, &ret);
 	if ((ret != DIS_SUCCESS) || (strcmp(jobid, new_jobname) != 0)) {
 		fprintf(stderr, "qsub: Unknown Job Identifier %s\n", jobid);
-		close_sock(news);
+		shut_close_sock(news);
 		goto retry;
 	}
 

--- a/src/cmds/qsub.c
+++ b/src/cmds/qsub.c
@@ -1405,7 +1405,6 @@ no_suspend(int sig)
  * @brief
  *	Shut and Close a socket
  *
- * @return	void
  * @param	sock	file descriptor
  *
  * @return Void
@@ -5633,9 +5632,8 @@ main(int argc, char **argv, char **envp) /* qsub */
 	char **argv_cpy; /* copy argv for getopt */
 	int i;
 
-	if (initsocketlib()) {
+	if (initsocketlib())
 		return 1;
-	}
 
 	/* Set signal handlers */
 	set_sig_handlers();

--- a/src/cmds/qterm.c
+++ b/src/cmds/qterm.c
@@ -113,11 +113,9 @@ main(int argc, char **argv)
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-#ifdef WIN32
-		if (winsock_init()) {
+	if (initsocketlib()) {
 		return 1;
 	}
-#endif
 
 	/* Command line options */
 	while ((s = getopt(argc, argv, opts)) != EOF)

--- a/src/cmds/qterm.c
+++ b/src/cmds/qterm.c
@@ -113,9 +113,8 @@ main(int argc, char **argv)
 
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-	if (initsocketlib()) {
+	if (initsocketlib())
 		return 1;
-	}
 
 	/* Command line options */
 	while ((s = getopt(argc, argv, opts)) != EOF)

--- a/src/iff/iff2.c
+++ b/src/iff/iff2.c
@@ -154,9 +154,8 @@ main(int argc, char *argv[], char *envp[])
 		return (1);
 	}
 
-	if (initsocketlib()) {
+	if (initsocketlib())
 		return 1;
-	}
 
 	/* first, make sure we have a valid server (host), and ports */
 

--- a/src/iff/iff2.c
+++ b/src/iff/iff2.c
@@ -154,11 +154,9 @@ main(int argc, char *argv[], char *envp[])
 		return (1);
 	}
 
-#ifdef WIN32
-	if (winsock_init()) {
+	if (initsocketlib()) {
 		return 1;
 	}
-#endif
 
 	/* first, make sure we have a valid server (host), and ports */
 

--- a/src/include/net_connect.h
+++ b/src/include/net_connect.h
@@ -176,7 +176,6 @@ conn_t *add_conn(int sock, enum conn_type, pbs_net_t, unsigned int port, int (*r
 conn_t *add_conn_priority(int sock, enum conn_type, pbs_net_t, unsigned int port, int (*ready_func)(conn_t *), void (*func)(int), int priority_flag);
 int add_conn_data(int sock, void *data); /* Adds the data to the connection */
 void *get_conn_data(int sock); /* Gets the pointer to the data present with the connection */
-void close_socket(int sock);
 int  client_to_svr(pbs_net_t, unsigned int port, int);
 int  client_to_svr_extend(pbs_net_t, unsigned int port, int, char*);
 void close_conn(int socket);

--- a/src/include/pbs_internal.h
+++ b/src/include/pbs_internal.h
@@ -392,9 +392,11 @@ enum accrue_types {
 #define LOCALHOST_SHORTNAME "localhost"
 #ifdef WIN32
 #define ERRORNO        WSAGetLastError()
+#define initsocketlib() winsock_init()
 #else
 #define closesocket(X) close(X)
 #define ERRORNO        errno
+#define initsocketlib() FALSE
 #endif
 
 #if HAVE__BOOL

--- a/src/include/pbs_internal.h
+++ b/src/include/pbs_internal.h
@@ -46,6 +46,7 @@ extern "C" {
 #endif
 
 #include "pbs_ifl.h"
+#include "portability.h"
 #include "libutil.h"
 #include "auth.h"
 
@@ -390,14 +391,6 @@ enum accrue_types {
 #define IN_LOOPBACKNET	127
 #endif
 #define LOCALHOST_SHORTNAME "localhost"
-#ifdef WIN32
-#define ERRORNO        WSAGetLastError()
-#define initsocketlib() winsock_init()
-#else
-#define closesocket(X) close(X)
-#define ERRORNO        errno
-#define initsocketlib() 0
-#endif
 
 #if HAVE__BOOL
 #include "stdbool.h"

--- a/src/include/pbs_internal.h
+++ b/src/include/pbs_internal.h
@@ -396,7 +396,7 @@ enum accrue_types {
 #else
 #define closesocket(X) close(X)
 #define ERRORNO        errno
-#define initsocketlib() FALSE
+#define initsocketlib() 0
 #endif
 
 #if HAVE__BOOL

--- a/src/include/pbs_internal.h
+++ b/src/include/pbs_internal.h
@@ -391,10 +391,9 @@ enum accrue_types {
 #endif
 #define LOCALHOST_SHORTNAME "localhost"
 #ifdef WIN32
-#define CLOSESOCKET(X) (void)closesocket(X)
 #define ERRORNO        WSAGetLastError()
 #else
-#define CLOSESOCKET(X) (void)close(X)
+#define closesocket(X) close(X)
 #define ERRORNO        errno
 #endif
 

--- a/src/include/portability.h
+++ b/src/include/portability.h
@@ -42,6 +42,6 @@
 
 #define closesocket(X) close(X)
 #define initsocketlib() 0
-#define ERRORNO        errno
+#define SOCK_ERRNO        errno
 
 #endif

--- a/src/include/portability.h
+++ b/src/include/portability.h
@@ -36,3 +36,12 @@
  * "OpenPBS®", "PBS Professional®", and "PBS Pro™" and Altair's logos is
  * subject to Altair's trademark licensing policies.
  */
+
+#ifndef	_PORTABILITY_H
+#define	_PORTABILITY_H
+
+#define closesocket(X) close(X)
+#define initsocketlib() 0
+#define ERRORNO        errno
+
+#endif

--- a/src/lib/Libifl/pbsD_connect.c
+++ b/src/lib/Libifl/pbsD_connect.c
@@ -740,7 +740,7 @@ pbs_connect_noblk(char *server, int tout)
 	if (connect_err == 1)
 	{
 		/* connect attempt failed */
-		pbs_errno = ERRORNO;
+		pbs_errno = SOCK_ERRNO;
 		switch (pbs_errno) {
 #ifdef WIN32
 			case WSAEWOULDBLOCK:
@@ -766,9 +766,9 @@ pbs_connect_noblk(char *server, int tout)
 							goto err;
 					} if ((n < 0) &&
 #ifdef WIN32
-						(ERRORNO == WSAEINTR)
+						(SOCK_ERRNO == WSAEINTR)
 #else
-						(ERRORNO == EINTR)
+						(SOCK_ERRNO == EINTR)
 #endif
 						) {
 						continue;

--- a/src/lib/Libifl/pbsD_connect.c
+++ b/src/lib/Libifl/pbsD_connect.c
@@ -386,7 +386,7 @@ __pbs_connect_extend(char *server, char *extend_data)
 			break;
 		} else {
 			/* connect attempt failed */
-			CLOSESOCKET(sock);
+			closesocket(sock);
 			pbs_errno = errno;
 		}
 	}
@@ -411,7 +411,7 @@ __pbs_connect_extend(char *server, char *extend_data)
 
 	/* setup connection level thread context */
 	if (pbs_client_thread_init_connect_context(sock) != 0) {
-		CLOSESOCKET(sock);
+		closesocket(sock);
 		pbs_errno = PBSE_SYSTEM;
 		return -1;
 	}
@@ -424,7 +424,7 @@ __pbs_connect_extend(char *server, char *extend_data)
 	 */
 
 	if (load_auths(AUTH_CLIENT)) {
-		CLOSESOCKET(sock);
+		closesocket(sock);
 		pbs_errno = PBSE_SYSTEM;
 		return -1;
 	}
@@ -444,12 +444,12 @@ __pbs_connect_extend(char *server, char *extend_data)
 	 */
 	if ((i = encode_DIS_ReqHdr(sock, PBS_BATCH_Connect, pbs_current_user)) ||
 		(i = encode_DIS_ReqExtend(sock, extend_data))) {
-		CLOSESOCKET(sock);
+		closesocket(sock);
 		pbs_errno = PBSE_SYSTEM;
 		return -1;
 	}
 	if (dis_flush(sock)) {
-		CLOSESOCKET(sock);
+		closesocket(sock);
 		pbs_errno = PBSE_SYSTEM;
 		return -1;
 	}
@@ -462,7 +462,7 @@ __pbs_connect_extend(char *server, char *extend_data)
 		fprintf(stderr, "auth: error returned: %d\n", pbs_errno);
 		if (errbuf[0] != '\0')
 			fprintf(stderr, "auth: %s\n", errbuf);
-		CLOSESOCKET(sock);
+		closesocket(sock);
 		return -1;
 	}
 
@@ -473,7 +473,7 @@ __pbs_connect_extend(char *server, char *extend_data)
 	 * Nagle's algorithm is hurting cmd-server communication.
 	 */
 	if (pbs_connection_set_nodelay(sock) == -1) {
-		CLOSESOCKET(sock);
+		closesocket(sock);
 		pbs_errno = PBSE_SYSTEM;
 		return -1;
 	}
@@ -579,7 +579,7 @@ __pbs_disconnect(int connect)
 	}
 
 	CS_close_socket(connect);
-	CLOSESOCKET(connect);
+	closesocket(connect);
 	dis_destroy_chan(connect);
 
 	/* unlock the connection level lock */
@@ -713,7 +713,7 @@ pbs_connect_noblk(char *server, int tout)
 	hints.ai_protocol = IPPROTO_TCP;
 
 	if (getaddrinfo(server, NULL, &hints, &pai) != 0) {
-		CLOSESOCKET(sock);
+		closesocket(sock);
 		pbs_errno = PBSE_BADHOST;
 		return -1;
 	}
@@ -726,7 +726,7 @@ pbs_connect_noblk(char *server, int tout)
 	}
 	if (aip == NULL) {
 		/* treat no IPv4 addresses as getaddrinfo() failure */
-		CLOSESOCKET(sock);
+		closesocket(sock);
 		pbs_errno = PBSE_BADHOST;
 		freeaddrinfo(pai);
 		return -1;
@@ -780,7 +780,7 @@ pbs_connect_noblk(char *server, int tout)
 
 			default:
 err:
-				CLOSESOCKET(sock);
+				closesocket(sock);
 				freeaddrinfo(pai);
 				return -1;	/* cannot connect */
 
@@ -803,7 +803,7 @@ err:
 	 */
 	/* setup connection level thread context */
 	if (pbs_client_thread_init_connect_context(sock) != 0) {
-		CLOSESOCKET(sock);
+		closesocket(sock);
 		/* pbs_errno set by the pbs_connect_init_context routine */
 		return -1;
 	}
@@ -815,7 +815,7 @@ err:
 	 */
 
 	if (load_auths(AUTH_CLIENT)) {
-		CLOSESOCKET(sock);
+		closesocket(sock);
 		return -1;
 	}
 
@@ -850,7 +850,7 @@ err:
 		fprintf(stderr, "auth: error returned: %d\n", pbs_errno);
 		if (errbuf[0] != '\0')
 			fprintf(stderr, "auth: %s\n", errbuf);
-		CLOSESOCKET(sock);
+		closesocket(sock);
 		pbs_errno = PBSE_PERM;
 		return -1;
 	}

--- a/src/lib/Libifl/tm.c
+++ b/src/lib/Libifl/tm.c
@@ -240,11 +240,7 @@ del_event(event_info *ep)
 
 	if (--event_count == 0) {
 		CS_close_socket(local_conn);
-#ifdef WIN32
 		closesocket(local_conn);
-#else
-		close(local_conn);
-#endif
 		local_conn = -1;
 	}
 	return;
@@ -502,11 +498,10 @@ localmom()
 				case ECONNREFUSED:
 #ifdef WIN32
 				case WSAEINTR:
-					(void)closesocket(sock);
 #else
 				case EINTR:
-					(void)close(sock);
 #endif
+					closesocket(sock);
 					sleep(1);
 					continue;
 				default:
@@ -536,11 +531,7 @@ localmom()
 
 failed:
 
-#ifdef WIN32
-	(void)closesocket(sock);
-#else
-	(void)close(sock);
-#endif
+	closesocket(sock);
 	local_conn = -1;
 	return -1;
 }
@@ -592,11 +583,7 @@ startcom(int com, tm_event_t event)
 done:
 	DBPRT(("startcom: send error %s\n", dis_emsg[ret]))
 	CS_close_socket(local_conn);
-#ifdef WIN32
 	closesocket(local_conn);
-#else
-	close(local_conn);
-#endif
 	local_conn = -1;
 	return ret;
 }
@@ -1435,11 +1422,7 @@ tm_poll(tm_event_t poll_event, tm_event_t *result_event, int wait, int *tm_errno
 	if ((ep = find_event(nevent)) == NULL) {
 		DBPRT(("%s: No event found for number %d\n", __func__, nevent));
 		CS_close_socket(local_conn);
-#ifdef WIN32
-		(void)closesocket(local_conn);
-#else
-		(void)close(local_conn);
-#endif
+		closesocket(local_conn);
 		local_conn = -1;
 		return TM_ENOEVENT;
 	}
@@ -1598,11 +1581,7 @@ err:
 	if (ep)
 		del_event(ep);
 	CS_close_socket(local_conn);
-#ifdef WIN32
-	(void)closesocket(local_conn);
-#else
-	(void)close(local_conn);
-#endif
+	closesocket(local_conn);
 	local_conn = -1;
 	return TM_ENOTCONNECTED;
 }

--- a/src/lib/Libnet/net_client.c
+++ b/src/lib/Libnet/net_client.c
@@ -291,22 +291,17 @@ client_to_svr_extend(pbs_net_t hostaddr, unsigned int port, int authport_flags, 
 #ifdef WIN32
 			errno = WSAGetLastError();
 			if (errno != EADDRINUSE && errno != EADDRNOTAVAIL && errno != WSAEACCES) {
-				closesocket(sock);
 #else
 			if (errno != EADDRINUSE && errno != EADDRNOTAVAIL) {
-				close(sock);
 #endif
+				closesocket(sock);
 				return PBS_NET_RC_FATAL;
 			}
 			else if (--tryport < (IPPORT_RESERVED/2)) {
 				tryport = IPPORT_RESERVED - 1;
 			}
 			if (tryport == start_port) {
-#ifdef WIN32
 				closesocket(sock);
-#else
-				close(sock);
-#endif
 				return PBS_NET_RC_RETRY;
 			}
 		}
@@ -335,16 +330,13 @@ client_to_svr_extend(pbs_net_t hostaddr, unsigned int port, int authport_flags, 
 
 	if (ioctlsocket(sock, FIONBIO, &non_block) == SOCKET_ERROR) {
 		errno = WSAGetLastError();
-		closesocket(sock);
-		return (PBS_NET_RC_FATAL);
-	}
 #else
 	oflag = fcntl(sock, F_GETFL);
 	if (fcntl(sock, F_SETFL, (oflag | O_NONBLOCK)) == -1) {
-		close(sock);
+#endif
+		closesocket(sock);
 		return (PBS_NET_RC_FATAL);
 	}
-#endif
 
 	if (connect(sock, (struct sockaddr *)&remote, sizeof(remote)) < 0) {
 
@@ -369,11 +361,7 @@ client_to_svr_extend(pbs_net_t hostaddr, unsigned int port, int authport_flags, 
 			case EADDRINUSE:
 			case ETIMEDOUT:
 			case ECONNREFUSED:
-#ifdef WIN32
 				closesocket(sock);
-#else
-				close(sock);
-#endif
 				return (PBS_NET_RC_RETRY);
 
 #ifdef WIN32
@@ -415,28 +403,24 @@ client_to_svr_extend(pbs_net_t hostaddr, unsigned int port, int authport_flags, 
 					/* socket may be connected and ready to write */
 					rc = 0;
 					if ((getsockopt(sock, SOL_SOCKET, SO_ERROR, &rc, &len) == -1) || (rc != 0)) {
-						close(sock);
+						closesocket(sock);
 						return PBS_NET_RC_FATAL;
 					}
 					break;
 
 				} else if (rc == 0) {
 					/* socket not ready - not connected in time */
-					close(sock);
+					closesocket(sock);
 					return PBS_NET_RC_RETRY;
 				} else {
 					/* socket not ready - error */
-					close(sock);
+					closesocket(sock);
 					return PBS_NET_RC_FATAL;
 				}
 #endif	/* end UNIX */
 
 			default:
-#ifdef WIN32
 				closesocket(sock);
-#else
-				close(sock);
-#endif
 				return (PBS_NET_RC_FATAL);
 		}
 	}
@@ -446,15 +430,12 @@ client_to_svr_extend(pbs_net_t hostaddr, unsigned int port, int authport_flags, 
 	non_block = 0;
 	if (ioctlsocket(sock, FIONBIO, &non_block) == SOCKET_ERROR) {
 		errno = WSAGetLastError();
+#else	/* UNIX */
+	if (fcntl(sock, F_SETFL, oflag) == -1) {
+#endif
 		closesocket(sock);
 		return PBS_NET_RC_FATAL;
 	}
-#else	/* UNIX */
-	if (fcntl(sock, F_SETFL, oflag) == -1) {
-		close(sock);
-		return (PBS_NET_RC_FATAL);
-	}
-#endif
 
 	if (engage_authentication(sock,
 		remote.sin_addr, port, authport_flags) != -1)
@@ -462,11 +443,7 @@ client_to_svr_extend(pbs_net_t hostaddr, unsigned int port, int authport_flags, 
 
 	/*authentication unsuccessful*/
 
-#ifdef WIN32
 	closesocket(sock);
-#else
-	close(sock);
-#endif
 	return (PBS_NET_RC_FATAL);
 }
 

--- a/src/lib/Libnet/net_server.c
+++ b/src/lib/Libnet/net_server.c
@@ -302,10 +302,8 @@ init_network(unsigned int port)
 	if (bind(sd, (struct sockaddr *)&socname, sizeof(socname)) < 0) {
 #ifdef WIN32
 		errno = WSAGetLastError();
-		(void)closesocket(sd);
-#else
-		(void)close(sd);
 #endif
+		closesocket(sd);
 		log_err(errno, __func__ , "bind failed");
 		return (-1);
 	}
@@ -361,10 +359,8 @@ init_network_add(int sd, int (*readyreadfunc)(conn_t *), void (*readfunc)(int))
 	if (add_conn(sd, type, (pbs_net_t)0, 0, NULL, accept_conn) == NULL) {
 #ifdef WIN32
 		errno = WSAGetLastError();
-		(void)closesocket(sd);
-#else
-		(void)close(sd);
 #endif
+		closesocket(sd);
 		log_err(errno, __func__, "add_conn failed");
 		return -1;
 	}
@@ -374,10 +370,8 @@ init_network_add(int sd, int (*readyreadfunc)(conn_t *), void (*readfunc)(int))
 		log_err(errno, __func__ , "listen failed");
 #ifdef WIN32
 		errno = WSAGetLastError();
-		(void)closesocket(sd);
-#else
-		(void)close(sd);
 #endif
+		closesocket(sd);
 		return (-1);
 	}
 
@@ -925,7 +919,7 @@ close_conn(int sd)
 		cleanup_conn(idx);
 		num_connections--;
 
-		CLOSESOCKET(sd);
+		closesocket(sd);
 	} else {
 		/* if there is a function to call on close, do it */
 		if (svr_conn[idx]->cn_oncl != 0)
@@ -933,7 +927,7 @@ close_conn(int sd)
 
 		cleanup_conn(idx);
 		num_connections--;
-		CLOSESOCKET(sd); /* pipe so use normal close */
+		closesocket(sd); /* pipe so use normal close */
 	}
 }
 
@@ -1174,7 +1168,7 @@ init_poll_context(void)
 		snprintf(logbuf, sizeof(logbuf),
 			"Could not add socket %d to the read set", sd_dummy);
 		log_err(err, __func__, logbuf);
-		CLOSESOCKET(sd_dummy);
+		closesocket(sd_dummy);
 		return -1;
 	}
 	if ((tpp_em_add_fd(priority_context, sd_dummy, EM_IN) == -1)) {
@@ -1182,26 +1176,10 @@ init_poll_context(void)
 		snprintf(logbuf, sizeof(logbuf),
 			"Could not add socket %d to the read set for priority socket", sd_dummy);
 		log_err(err, __func__, logbuf);
-		CLOSESOCKET(sd_dummy);
+		closesocket(sd_dummy);
 		return -1;
 	}
 #endif /* WIN32 */
 
 	return 0;
-}
-
-/**
- * @brief
- *	Close the socket descriptor.
- *
- * @param[in]   sd: socket descriptor.
- *
- */
-void
-close_socket(int sd) {
-#ifdef WIN32
-	(void)closesocket(sd);
-#else
-	(void) close(sd);
-#endif
 }

--- a/src/mom_rcp/rcp.c
+++ b/src/mom_rcp/rcp.c
@@ -313,11 +313,9 @@ main(int argc, char *argv[])
 	argc -= optind;
 	argv += optind;
 
-#ifdef WIN32
-	if (winsock_init()) {
+	if (initsocketlib()) {
 		return 1;
 	}
-#endif
 
 #ifdef KERBEROS
 	if (use_kerberos) {

--- a/src/mom_rcp/rcp.c
+++ b/src/mom_rcp/rcp.c
@@ -105,6 +105,7 @@
 #include "pbs_stat.h"
 #include "libutil.h"
 #include "pbs_ifl.h"
+#include "pbs_internal.h"
 
 #ifdef        USELOG
 #include <syslog.h>

--- a/src/mom_rcp/rcp.c
+++ b/src/mom_rcp/rcp.c
@@ -313,9 +313,8 @@ main(int argc, char *argv[])
 	argc -= optind;
 	argv += optind;
 
-	if (initsocketlib()) {
+	if (initsocketlib())
 		return 1;
-	}
 
 #ifdef KERBEROS
 	if (use_kerberos) {

--- a/src/mom_rcp/rcp.c
+++ b/src/mom_rcp/rcp.c
@@ -639,15 +639,14 @@ tolocal(int argc, char *argv[])
 
 #ifdef WIN32
 		sink(1, argv + argc - 1);
-		(void)closesocket(rem);
 #else
 		if (seteuid(userid) == -1)
 			exit(15);
 		sink(1, argv + argc - 1);
 		if (seteuid(0) == -1)
 			exit(15);
-		(void)close(rem);
 #endif
+		closesocket(rem);
 
 		rem = -1;
 	}

--- a/src/resmom/mom_comm.c
+++ b/src/resmom/mom_comm.c
@@ -5646,11 +5646,7 @@ tm_request(int fd, int version)
 	conn_t 	*conn = get_conn(fd);
 	if (!conn) {
 		sprintf(log_buffer, "not found fd=%d in connection table", fd);
-#ifdef WIN32
-		(void)closesocket(fd);
-#else
-		(void)close(fd);
-#endif
+		closesocket(fd);
 		if (cookie)
 			free(cookie);
 		return -1;

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -8731,9 +8731,8 @@ main(int argc, char *argv[])
 
 #endif  /* not DEBUG and not NO_SECURITY_CHECK */
 
-	if (initsocketlib()) {
+	if (initsocketlib())
 		return 1;
-	}
 
 #ifdef	WIN32
 	/* Under WIN32, create structure that will be used to track child processes. */
@@ -9188,7 +9187,7 @@ main(int argc, char *argv[])
 	tpp_fd = -1;
 	if (init_network_add(sock_bind_mom, NULL, process_request) != 0) {
 
-		c = ERRORNO;
+		c = SOCK_ERRNO;
 		(void)sprintf(log_buffer,
 			"server port = %u, errno = %d",
 			pbs_mom_port, c);
@@ -9208,7 +9207,7 @@ main(int argc, char *argv[])
 
 	if (init_network_add(sock_bind_rm, NULL, tcp_request) != 0) {
 
-		c = ERRORNO;
+		c = SOCK_ERRNO;
 		(void)sprintf(log_buffer,
 			"resource (tcp) port = %u, errno = %d",
 			pbs_rm_port, c);

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -8731,11 +8731,11 @@ main(int argc, char *argv[])
 
 #endif  /* not DEBUG and not NO_SECURITY_CHECK */
 
-#ifdef	WIN32
-	if (winsock_init()) {
+	if (initsocketlib()) {
 		return 1;
 	}
 
+#ifdef	WIN32
 	/* Under WIN32, create structure that will be used to track child processes. */
 	if (initpids() == 0) {
 		log_err(-1, "pbsd_init", "Creating pid handles table failed!");

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -5887,11 +5887,7 @@ rm_request(int iochan, int version, int prot)
 		if (!conn) {
 			log_err(errno, __func__,
 				"not find iochan in connection table");
-#ifdef	WIN32
-			(void)closesocket(iochan);
-#else
-			(void)close(iochan);
-#endif	/* WIN32 */
+			closesocket(iochan);
 			return -1;
 		}
 		ipadd = conn->cn_addr;
@@ -6306,11 +6302,7 @@ tcp_request(int fd)
 		sprintf(log_buffer, "could not find fd=%d in connection table",
 			fd);
 		log_err(-1, __func__, log_buffer);
-#ifdef	WIN32
-		(void)closesocket(fd);
-#else
-		(void)close(fd);
-#endif	/* WIN32 */
+		closesocket(fd);
 		return;
 	}
 

--- a/src/resmom/requests.c
+++ b/src/resmom/requests.c
@@ -2514,13 +2514,11 @@ req_rerunjob(struct batch_request *preq)
 #endif
 	}
 
-#ifdef WIN32
-	(void)closesocket(sock);
-	return;
-#else
-	(void)close(sock);
+	closesocket(sock);
+#ifndef WIN32
 	exit(rc);
 #endif
+	return;
 }
 
 #ifdef WIN32 /* WIN32 ------------------------------------------------------ */

--- a/src/server/process_request.c
+++ b/src/server/process_request.c
@@ -302,7 +302,7 @@ process_request(int sfds)
 
 	if (!conn) {
 		log_event(PBSEVENT_SYSTEM, PBS_EVENTCLASS_REQUEST, LOG_ERR, __func__, "did not find socket in connection table");
-		CLOSESOCKET(sfds);
+		closesocket(sfds);
 		return;
 	}
 

--- a/src/tools/hostn.c
+++ b/src/tools/hostn.c
@@ -107,11 +107,9 @@ main(int argc, char *argv[], char *env[])
 	/*the real deal or output pbs_version and exit?*/
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-#ifdef WIN32
-	if (winsock_init()) {
+	if (initsocketlib()) {
 		return 1;
 	}
-#endif
 
 	while ((i = getopt(argc, argv, "v-:")) != EOF) {
 		switch (i) {

--- a/src/tools/hostn.c
+++ b/src/tools/hostn.c
@@ -107,9 +107,8 @@ main(int argc, char *argv[], char *env[])
 	/*the real deal or output pbs_version and exit?*/
 	PRINT_VERSION_AND_EXIT(argc, argv);
 
-	if (initsocketlib()) {
+	if (initsocketlib())
 		return 1;
-	}
 
 	while ((i = getopt(argc, argv, "v-:")) != EOF) {
 		switch (i) {

--- a/src/tools/pbs_python.c
+++ b/src/tools/pbs_python.c
@@ -2296,9 +2296,8 @@ main(int argc, char *argv[], char *envp[])
 	_set_fmode(_O_BINARY);
 #endif
 
-	if (initsocketlib()) {
+	if (initsocketlib())
 		return 1;
-	}
 
 	/*the real deal or output pbs_version and exit?*/
 	PRINT_VERSION_AND_EXIT(argc, argv);

--- a/src/tools/pbs_python.c
+++ b/src/tools/pbs_python.c
@@ -2294,11 +2294,11 @@ main(int argc, char *argv[], char *envp[])
 	/* The following needed so that buffered writes (e.g. fprintf) */
 	/* won't end up getting ^M */
 	_set_fmode(_O_BINARY);
+#endif
 
-	if (winsock_init()) {
+	if (initsocketlib()) {
 		return 1;
 	}
-#endif
 
 	/*the real deal or output pbs_version and exit?*/
 	PRINT_VERSION_AND_EXIT(argc, argv);

--- a/src/unsupported/pbs_rmget.c
+++ b/src/unsupported/pbs_rmget.c
@@ -72,9 +72,8 @@ main(int argc, char *argv[])
 	fd_set selset;
 	struct timeval tv;
 
-	if (initsocketlib()) {
+	if (initsocketlib())
 		return 1;
-	}
 
 	if (gethostname(mom_name, (sizeof(mom_name) - 1)) < 0  )
 		mom_name[0] = '\0';

--- a/src/unsupported/pbs_rmget.c
+++ b/src/unsupported/pbs_rmget.c
@@ -72,11 +72,10 @@ main(int argc, char *argv[])
 	fd_set selset;
 	struct timeval tv;
 
-#ifdef WIN32
-	if (winsock_init()) {
+	if (initsocketlib()) {
 		return 1;
 	}
-#endif
+
 	if (gethostname(mom_name, (sizeof(mom_name) - 1)) < 0  )
 		mom_name[0] = '\0';
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
socket library initialization and socket close calls have been made platform independent.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Introduced initsocketlib() call to initialize any socket library. and use closesocket() to close socket fd or handle.

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Platforms: CENTOS7,UBUNTU1804,SUSE15,UBUNTU1604
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|3041|3507|3|4|0|2|3498|

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
