### PR TITLE
added mom restart in delete_vnode_def()

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -13867,13 +13867,15 @@ class MoM(PBSService):
         else:
             return False
 
-    def delete_vnode_defs(self, vdefname=None):
+    def delete_vnode_defs(self, vdefname=None, restart=True):
         """
         delete vnode definition(s) on this MoM
 
         :param vdefname: name of a vnode definition file to delete,
                          if None all vnode definitions are deleted
         :type vdefname: str
+        :param restart: If True, restart the MoM. Default is True
+        :type restart: bool
         :returns: True if delete succeed otherwise False
         """
         cmd = [os.path.join(self.pbs_conf['PBS_EXEC'], 'sbin', 'pbs_mom')]
@@ -13898,6 +13900,8 @@ class MoM(PBSService):
                         return False
                     else:
                         rv = True
+        if restart:
+            self.restart()
         return rv
 
     def has_pelog(self, filename=None):

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -13867,15 +13867,13 @@ class MoM(PBSService):
         else:
             return False
 
-    def delete_vnode_defs(self, vdefname=None, restart=True):
+    def delete_vnode_defs(self, vdefname=None):
         """
         delete vnode definition(s) on this MoM
 
         :param vdefname: name of a vnode definition file to delete,
                          if None all vnode definitions are deleted
         :type vdefname: str
-        :param restart: If True, restart the MoM. Default is True
-        :type restart: bool
         :returns: True if delete succeed otherwise False
         """
         cmd = [os.path.join(self.pbs_conf['PBS_EXEC'], 'sbin', 'pbs_mom')]
@@ -13900,8 +13898,6 @@ class MoM(PBSService):
                         return False
                     else:
                         rv = True
-        if restart:
-            self.restart()
         return rv
 
     def has_pelog(self, filename=None):

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -1462,7 +1462,6 @@ class PBSTestSuite(unittest.TestCase):
             self.assertTrue(mom.isUp(), msg)
         mom.pbs_version()
         restart = False
-        enabled_cpuset = False
         if ((self.revert_to_defaults and self.mom_revert_to_defaults and
              mom.revert_to_default) or force):
             # no need to delete vnodes as it is already deleted in
@@ -1476,25 +1475,6 @@ class PBSTestSuite(unittest.TestCase):
             if 'clienthost' in self.conf:
                 conf.update({'$clienthost': self.conf['clienthost']})
             mom.apply_config(conf=conf, hup=False, restart=False)
-            if mom.is_cpuset_mom():
-                self.server.manager(MGR_CMD_CREATE, NODE, None, mom.shortname)
-                # In order to avoid intermingling CF/HK/PY file copies from the
-                # create node and those caused by the following call, wait
-                # until the dialogue between MoM and the server is complete
-                time.sleep(4)
-                just_before_enable_cgroup_cset = time.time()
-                mom.enable_cgroup_cset()
-                # a high max_attempts is needed to tolerate delay receiving
-                # hook-related files, due to temporary network interruptions
-                mom.log_match('pbs_cgroups.CF;copy hook-related '
-                              'file request received', max_attempts=120,
-                              starttime=just_before_enable_cgroup_cset-1,
-                              interval=1)
-                # Make sure that the MoM will generate per-NUMA node vnodes
-                # when the natural node is created below
-                # HUP may not be enough if exechost_startup is delayed
-                restart = True
-                enabled_cpuset = True
         if restart:
             mom.restart()
         else:
@@ -1502,16 +1482,27 @@ class PBSTestSuite(unittest.TestCase):
         if not mom.isUp():
             self.logger.error('mom ' + mom.shortname + ' is down after revert')
         a = {'state': 'free'}
-        if enabled_cpuset:
-            # Checking whether the CF file was copied really belongs in code
-            # that changes the config file -- i.e. after enable_cgroup_cset
-            # called above. We're not sure it is always called here,
-            # since that call is in an if
+        self.server.manager(MGR_CMD_CREATE, NODE, None, mom.shortname)
+        if mom.is_cpuset_mom():
+            # In order to avoid intermingling CF/HK/PY file copies from the
+            # create node and those caused by the following call, wait
+            # until the dialogue between MoM and the server is complete
+            time.sleep(4)
+            just_before_enable_cgroup_cset = time.time()
+            mom.enable_cgroup_cset()
+            # a high max_attempts is needed to tolerate delay receiving
+            # hook-related files, due to temporary network interruptions
+            mom.log_match('pbs_cgroups.CF;copy hook-related '
+                          'file request received', max_attempts=120,
+                          starttime=just_before_enable_cgroup_cset-1,
+                          interval=1)
+            # Make sure that the MoM will generate per-NUMA node vnodes
+            # when the natural node was created above.
+            # HUP may not be enough if exechost_startup is delayed
             time.sleep(2)
             mom.signal('-HUP')
             self.server.expect(NODE, a, id=mom.shortname + '[0]', interval=1)
         else:
-            self.server.manager(MGR_CMD_CREATE, NODE, id=mom.shortname)
             self.server.expect(NODE, a, id=mom.shortname, interval=1)
         return mom
 

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -1462,6 +1462,7 @@ class PBSTestSuite(unittest.TestCase):
             self.assertTrue(mom.isUp(), msg)
         mom.pbs_version()
         restart = False
+        enabled_cpuset = False
         if ((self.revert_to_defaults and self.mom_revert_to_defaults and
              mom.revert_to_default) or force):
             # no need to delete vnodes as it is already deleted in
@@ -1475,6 +1476,8 @@ class PBSTestSuite(unittest.TestCase):
             if 'clienthost' in self.conf:
                 conf.update({'$clienthost': self.conf['clienthost']})
             mom.apply_config(conf=conf, hup=False, restart=False)
+            if mom.is_cpuset_mom():
+                enabled_cpuset = True
         if restart:
             mom.restart()
         else:
@@ -1483,7 +1486,7 @@ class PBSTestSuite(unittest.TestCase):
             self.logger.error('mom ' + mom.shortname + ' is down after revert')
         a = {'state': 'free'}
         self.server.manager(MGR_CMD_CREATE, NODE, None, mom.shortname)
-        if mom.is_cpuset_mom():
+        if enabled_cpuset:
             # In order to avoid intermingling CF/HK/PY file copies from the
             # create node and those caused by the following call, wait
             # until the dialogue between MoM and the server is complete


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Extra vnodes that remain from a previous test did not get cleaned up before running a test. This issue can be seen easily on a cpuset system.


#### Describe Your Change
In revert_mom(), moved the creation of node to after vnode def file is deleted and mom restarted.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
[before_cpuset.txt](https://github.com/openpbs/openpbs/files/4956641/before_cpuset.txt)
[after_cpuset.txt](https://github.com/openpbs/openpbs/files/4962800/after_cpuset.txt)

[before_linux.txt](https://github.com/openpbs/openpbs/files/4956642/before_linux.txt)
[after_linux.txt](https://github.com/openpbs/openpbs/files/4962803/after_linux.txt)








<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
