### PR TITLE
TestPbsAccumulateRescUsed fails due to too small a max_attempts value

### DIFF
--- a/test/tests/functional/pbs_accumulate_resc_used.py
+++ b/test/tests/functional/pbs_accumulate_resc_used.py
@@ -138,12 +138,9 @@ e.vnode_list[localnode].resources_available['foo_str'] = "seventyseven"
         self.assertEqual(rc, 0)
 
         # Ensure the new resource is seen by all moms.
-        self.momA.log_match(
-            "resourcedef;copy hook-related file", max_attempts=3)
-        self.momB.log_match(
-            "resourcedef;copy hook-related file", max_attempts=3)
-        self.momC.log_match(
-            "resourcedef;copy hook-related file", max_attempts=3)
+        self.momA.log_match("resourcedef;copy hook-related file")
+        self.momB.log_match("resourcedef;copy hook-related file")
+        self.momC.log_match("resourcedef;copy hook-related file")
 
         attr['type'] = 'string'
         attr['flag'] = 'h'
@@ -766,34 +763,25 @@ else:
         self.server.manager(
             MGR_CMD_CREATE, RSC, attr, id='foo_i2', runas=ROOT_USER)
         # Ensure the new resource is seen by all moms.
-        self.momA.log_match(
-            "resourcedef;copy hook-related file", max_attempts=3)
-        self.momB.log_match(
-            "resourcedef;copy hook-related file", max_attempts=3)
-        self.momC.log_match(
-            "resourcedef;copy hook-related file", max_attempts=3)
+        self.momA.log_match("resourcedef;copy hook-related file")
+        self.momB.log_match("resourcedef;copy hook-related file")
+        self.momC.log_match("resourcedef;copy hook-related file")
 
         attr['type'] = 'float'
         self.server.manager(
             MGR_CMD_CREATE, RSC, attr, id='foo_f2', runas=ROOT_USER)
         # Ensure the new resource is seen by all moms.
-        self.momA.log_match(
-            "resourcedef;copy hook-related file", max_attempts=3)
-        self.momB.log_match(
-            "resourcedef;copy hook-related file", max_attempts=3)
-        self.momC.log_match(
-            "resourcedef;copy hook-related file", max_attempts=3)
+        self.momA.log_match("resourcedef;copy hook-related file")
+        self.momB.log_match("resourcedef;copy hook-related file")
+        self.momC.log_match("resourcedef;copy hook-related file")
 
         attr['type'] = 'string_array'
         self.server.manager(
             MGR_CMD_CREATE, RSC, attr, id='stra2', runas=ROOT_USER)
         # Ensure the new resource is seen by all moms.
-        self.momA.log_match(
-            "resourcedef;copy hook-related file", max_attempts=3)
-        self.momB.log_match(
-            "resourcedef;copy hook-related file", max_attempts=3)
-        self.momC.log_match(
-            "resourcedef;copy hook-related file", max_attempts=3)
+        self.momA.log_match("resourcedef;copy hook-related file")
+        self.momB.log_match("resourcedef;copy hook-related file")
+        self.momC.log_match("resourcedef;copy hook-related file")
 
         # Create an epilogue hook
         hook_body = """
@@ -842,8 +830,7 @@ j.resources_used["stra2"] = '"glad"'
              'resources_used.stra2': "\"glad\"",
              'job_state': 'F'}
         self.server.expect(JOB, a, extend='x', attrop=PTL_AND,
-                           offset=30, interval=1,
-                           max_attempts=20, id=jid)
+                           offset=30, interval=1, id=jid)
 
         # Restart server and verifies that the values are still the same
         self.server.restart()
@@ -1168,12 +1155,9 @@ e.job.resources_used["foo_f"] = 0.10
 
         # Verify the copy message in the logs to avoid
         # race conditions
-        self.momA.log_match(
-            "pro.PY;copy hook-related file", max_attempts=10)
-        self.momB.log_match(
-            "pro.PY;copy hook-related file", max_attempts=10)
-        self.momC.log_match(
-            "pro.PY;copy hook-related file", max_attempts=10)
+        self.momA.log_match("pro.PY;copy hook-related file")
+        self.momB.log_match("pro.PY;copy hook-related file")
+        self.momC.log_match("pro.PY;copy hook-related file")
 
         hook_body = """
 import pbs
@@ -1190,12 +1174,9 @@ e.job.resources_used["cput"] = 10
 
         # Verify the copy message in the logs to avoid
         # race conditions
-        self.momA.log_match(
-            "epi.PY;copy hook-related file", max_attempts=10)
-        self.momB.log_match(
-            "epi.PY;copy hook-related file", max_attempts=10)
-        self.momC.log_match(
-            "epi.PY;copy hook-related file", max_attempts=10)
+        self.momA.log_match("epi.PY;copy hook-related file")
+        self.momB.log_match("epi.PY;copy hook-related file")
+        self.momC.log_match("epi.PY;copy hook-related file")
 
         a = {'Resource_List.select': '3:ncpus=1',
              'Resource_List.place': 'scatter'}
@@ -1231,7 +1212,7 @@ e.job.resources_used["cput"] = 10
             'job_state': 'R',
             'resources_used.foo_i': '30',
             'resources_used.foo_f': '0.3'}, attrop=PTL_AND,
-            id=jid1, max_attempts=30, interval=2)
+            id=jid1, interval=2)
 
         # Force delete the job
         self.server.deljob(id=jid1, wait=True, attr_W="force")

--- a/test/tests/functional/pbs_accumulate_resc_used.py
+++ b/test/tests/functional/pbs_accumulate_resc_used.py
@@ -138,8 +138,8 @@ e.vnode_list[localnode].resources_available['foo_str'] = "seventyseven"
         self.assertEqual(rc, 0)
 
         # Ensure the new resource is seen by all moms.
-        moms = [self.momA, self.momB, self.momC]
-        for m in moms:
+        momlist = [self.momA, self.momB, self.momC]
+        for m in momlist:
             m.log_match("resourcedef;copy hook-related file")
 
         attr['type'] = 'string'
@@ -150,7 +150,7 @@ e.vnode_list[localnode].resources_available['foo_str'] = "seventyseven"
         self.assertEqual(rc, 0)
 
         # Ensure the new resource is seen by all moms.
-        for m in moms:
+        for m in momlist:
             m.log_match("resourcedef;copy hook-related file")
 
         attr['type'] = 'string'
@@ -161,7 +161,7 @@ e.vnode_list[localnode].resources_available['foo_str'] = "seventyseven"
         self.assertEqual(rc, 0)
 
         # Ensure the new resource is seen by all moms.
-        for m in moms:
+        for m in momlist:
             m.log_match("resourcedef;copy hook-related file")
 
         attr['type'] = 'string_array'
@@ -173,7 +173,7 @@ e.vnode_list[localnode].resources_available['foo_str'] = "seventyseven"
 
         # Give the moms a chance to receive the updated resource.
         # Ensure the new resource is seen by all moms.
-        for m in moms:
+        for m in momlist:
             m.log_match("resourcedef;copy hook-related file")
 
     def test_epilogue(self):
@@ -760,25 +760,23 @@ else:
         self.server.manager(
             MGR_CMD_CREATE, RSC, attr, id='foo_i2', runas=ROOT_USER)
         # Ensure the new resource is seen by all moms.
-        self.momA.log_match("resourcedef;copy hook-related file")
-        self.momB.log_match("resourcedef;copy hook-related file")
-        self.momC.log_match("resourcedef;copy hook-related file")
+        momlist = [self.momA, self.momB, self.momC]
+        for m in momlist:
+            m.log_match("resourcedef;copy hook-related file")
 
         attr['type'] = 'float'
         self.server.manager(
             MGR_CMD_CREATE, RSC, attr, id='foo_f2', runas=ROOT_USER)
         # Ensure the new resource is seen by all moms.
-        self.momA.log_match("resourcedef;copy hook-related file")
-        self.momB.log_match("resourcedef;copy hook-related file")
-        self.momC.log_match("resourcedef;copy hook-related file")
+        for m in momlist:
+            m.log_match("resourcedef;copy hook-related file")
 
         attr['type'] = 'string_array'
         self.server.manager(
             MGR_CMD_CREATE, RSC, attr, id='stra2', runas=ROOT_USER)
         # Ensure the new resource is seen by all moms.
-        self.momA.log_match("resourcedef;copy hook-related file")
-        self.momB.log_match("resourcedef;copy hook-related file")
-        self.momC.log_match("resourcedef;copy hook-related file")
+        for m in momlist:
+            m.log_match("resourcedef;copy hook-related file")
 
         # Create an epilogue hook
         hook_body = """
@@ -1152,9 +1150,9 @@ e.job.resources_used["foo_f"] = 0.10
 
         # Verify the copy message in the logs to avoid
         # race conditions
-        self.momA.log_match("pro.PY;copy hook-related file")
-        self.momB.log_match("pro.PY;copy hook-related file")
-        self.momC.log_match("pro.PY;copy hook-related file")
+        momlist = [self.momA, self.momB, self.momC]
+        for m in momlist:
+            m.log_match("pro.PY;copy hook-related file")
 
         hook_body = """
 import pbs
@@ -1171,9 +1169,8 @@ e.job.resources_used["cput"] = 10
 
         # Verify the copy message in the logs to avoid
         # race conditions
-        self.momA.log_match("epi.PY;copy hook-related file")
-        self.momB.log_match("epi.PY;copy hook-related file")
-        self.momC.log_match("epi.PY;copy hook-related file")
+        for m in momlist:
+            m.log_match("epi.PY;copy hook-related file")
 
         a = {'Resource_List.select': '3:ncpus=1',
              'Resource_List.place': 'scatter'}

--- a/test/tests/functional/pbs_accumulate_resc_used.py
+++ b/test/tests/functional/pbs_accumulate_resc_used.py
@@ -138,9 +138,9 @@ e.vnode_list[localnode].resources_available['foo_str'] = "seventyseven"
         self.assertEqual(rc, 0)
 
         # Ensure the new resource is seen by all moms.
-        self.momA.log_match("resourcedef;copy hook-related file")
-        self.momB.log_match("resourcedef;copy hook-related file")
-        self.momC.log_match("resourcedef;copy hook-related file")
+        moms = [self.momA, self.momB, self.momC]
+        for m in moms:
+            m.log_match("resourcedef;copy hook-related file")
 
         attr['type'] = 'string'
         attr['flag'] = 'h'
@@ -150,9 +150,8 @@ e.vnode_list[localnode].resources_available['foo_str'] = "seventyseven"
         self.assertEqual(rc, 0)
 
         # Ensure the new resource is seen by all moms.
-        self.momA.log_match("resourcedef;copy hook-related file")
-        self.momB.log_match("resourcedef;copy hook-related file")
-        self.momC.log_match("resourcedef;copy hook-related file")
+        for m in moms:
+            m.log_match("resourcedef;copy hook-related file")
 
         attr['type'] = 'string'
         attr['flag'] = 'h'
@@ -162,9 +161,8 @@ e.vnode_list[localnode].resources_available['foo_str'] = "seventyseven"
         self.assertEqual(rc, 0)
 
         # Ensure the new resource is seen by all moms.
-        self.momA.log_match("resourcedef;copy hook-related file")
-        self.momB.log_match("resourcedef;copy hook-related file")
-        self.momC.log_match("resourcedef;copy hook-related file")
+        for m in moms:
+            m.log_match("resourcedef;copy hook-related file")
 
         attr['type'] = 'string_array'
         attr['flag'] = 'h'
@@ -175,9 +173,8 @@ e.vnode_list[localnode].resources_available['foo_str'] = "seventyseven"
 
         # Give the moms a chance to receive the updated resource.
         # Ensure the new resource is seen by all moms.
-        self.momA.log_match("resourcedef;copy hook-related file")
-        self.momB.log_match("resourcedef;copy hook-related file")
-        self.momC.log_match("resourcedef;copy hook-related file")
+        for m in moms:
+            m.log_match("resourcedef;copy hook-related file")
 
     def test_epilogue(self):
         """


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
If the test machines were heavily loaded and being slow, then setUp would fail because it had some checks that set max_attempts=3.

You can when the test fails the PTL output would have:
2020-07-18 04:43:05,892 INFO     mom x58-r7 log match: searching for "resourcedef;copy hook-related file" - with existence - No match
2020-07-18 04:43:06,437 INFO     mom x58-r7 log match: searching for "resourcedef;copy hook-related file" - with existence - attempt 2
2020-07-18 04:43:06,982 INFO     mom x58-r7 log match: searching for "resourcedef;copy hook-related file" - with existence - attempt 3

And then fail because it stopped looking.

But looking at the mom log I can see the log message it is expected to find, but 2 seconds after the third attempt.
07/18/2020 04:43:08.345610;0080;pbs_mom;Hook;resourcedef;copy hook-related file request received

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
I removed the setting of max_attempts from all places in the suite to prevent other parts of the tests besides setUp from failing on a slow machine.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
I couldn't get the test to fail since the machines were not heavily loaded when I ran.
[accum_after.txt](https://github.com/openpbs/openpbs/files/4956725/accum_after.txt)

[accum_after2.txt](https://github.com/openpbs/openpbs/files/4957127/accum_after2.txt)
[accum_after3.txt](https://github.com/openpbs/openpbs/files/4957205/accum_after3.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
