### PR TITLE
Fix for invalid write in reply_hook_bg

### DIFF
--- a/src/resmom/mom_hook_func.c
+++ b/src/resmom/mom_hook_func.c
@@ -3564,8 +3564,8 @@ reply_hook_bg(job *pjob)
 						req_reject(PBSE_SISCOMM, 0, preq); /* sis down */
 #endif
 					job_purge_mom(pjob);
-				}
-				pjob->ji_hook_running_bg_on = BG_NONE;
+				} else
+					pjob->ji_hook_running_bg_on = BG_NONE;
 				/*
 				* otherwise, job_purge() and dorestrict_user() are called in
 				* mom_comm when all the sisters have replied. The reply to


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
valgrind reports the following invalid write -
Invalid write of size 4
   **at 0x470E4B: reply_hook_bg (mom_hook_func.c:3568)**
   by 0x47126A: mom_process_background_hooks (mom_hook_func.c:3711)
   by 0x4EED37: dispatch_task (work_task.c:144)
   by 0x4EF045: default_next_task (work_task.c:293)
   by 0x48250D: main (mom_main.c:9616)
Address 0xb79a130 is 400 bytes inside a block of size 6,512 free'd Block was alloc'd at
   at 0x4C2B06D: free (vg_replace_malloc.c:540)
   by 0x43CCC5: job_free (job_func.c:600)
   by 0x43D6F3: job_purge (job_func.c:926)
   by 0x459557: job_purge_mom (catch_child.c:2593)
   **by 0x470E43: reply_hook_bg (mom_hook_func.c:3566)**
   by 0x47126A: mom_process_background_hooks (mom_hook_func.c:3711)
   by 0x4EED37: dispatch_task (work_task.c:144)
   by 0x4EF045: default_next_task (work_task.c:293)
   by 0x48250D: main (mom_main.c:9616)

We free pjob on line [3566](https://github.com/prakashcv13/openpbs/blob/0838e5f84775091ea6d22d192191009a376bd572/src/resmom/mom_hook_func.c#L3566) and immediately assign a value to pjob->ji_hook_running_bg_on on line [3568](https://github.com/prakashcv13/openpbs/blob/0838e5f84775091ea6d22d192191009a376bd572/src/resmom/mom_hook_func.c#L3568)

The assignment on line 3568 was introduced in PR #1867 

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
We need to do the assignment only if the condition in the if statement above is not true. Moved the assignment within the else.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[ptl_sisters.txt](https://github.com/openpbs/openpbs/files/4956760/ptl_sisters.txt)
[val_before.txt](https://github.com/openpbs/openpbs/files/4956762/val_before.txt)
[val_after.txt](https://github.com/openpbs/openpbs/files/4956764/val_after.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
