### PR TITLE
Fix assertion error and node state issue in TestSuspendResumeOnCray

### DIFF
--- a/test/tests/functional/pbs_cray_suspend_resume.py
+++ b/test/tests/functional/pbs_cray_suspend_resume.py
@@ -95,8 +95,8 @@ at least resid .* is exclusive"
 
         self.server.expect(JOB, 'exec_host', id=jid, op=SET)
         job_stat = self.server.status(JOB, id=jid)
-        s = self.mom.log_match(msg_expected, starttime=check_after, regexp=True,
-                              max_attempts=10)
+        s = self.mom.log_match(msg_expected, starttime=check_after,
+                               regexp=True, max_attempts=10)
         self.assertTrue(s)
 
     @tags('cray')

--- a/test/tests/functional/pbs_cray_suspend_resume.py
+++ b/test/tests/functional/pbs_cray_suspend_resume.py
@@ -95,9 +95,7 @@ at least resid .* is exclusive"
 
         self.server.expect(JOB, 'exec_host', id=jid, op=SET)
         job_stat = self.server.status(JOB, id=jid)
-        ehost = job_stat[0]['exec_host'].partition('/')[0]
-        run_mom = self.moms[ehost]
-        s = run_mom.log_match(msg_expected, starttime=check_after, regexp=True,
+        s = self.mom.log_match(msg_expected, starttime=check_after, regexp=True,
                               max_attempts=10)
         self.assertTrue(s)
 
@@ -106,7 +104,7 @@ at least resid .* is exclusive"
         """
         Test basic admin-suspend funcionality for jobs and array jobs with
         restart on Cray. The restart will test if the node recovers properly
-        in maintenance. After turning off scheduling and a server restart, a
+        in maintenance. After turning off scheduling and a mom restart, a
         subjob is always requeued and node shows up as free.
         """
         j1 = Job(TEST_USER)
@@ -173,9 +171,9 @@ at least resid .* is exclusive"
         self.server.expect(NODE, {'state': 'maintenance'}, id=vname2)
         self.server.expect(NODE, {'maintenance_jobs': jid2})
 
-        # Turn off scheduling and restart server
+        # Turn off scheduling and restart mom
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
-        self.server.restart()
+        self.mom.restart()
 
         # Check that nodes are now free
         self.server.expect(NODE, {'state': 'free'}, id=vname1)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
TestSuspendResumeOnCray.test_exclusive_job_not_suspended test case was failing due to AttributeError "'NoneType' object has no attribute 'log_match'".  In test case, instead of calling expect using mom object, it was called using hostname(string object)

TestSuspendResumeOnCray.test_exclusive_job_not_suspended test case was failing due to Node is not in Free state. This is due to test is checking for node state after server is restarted and not mom. This requires mom to be restarted.


#### Describe Your Change
In test case TestSuspendResumeOnCray.test_exclusive_job_not_suspended, replaced string with self.mom
In test case TestSuspendResumeOnCray.test_exclusive_job_not_suspended added, self.mom.restart instead of restarting the server.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
[TestSuspendResumeOnCray_before_fix.txt](https://github.com/openpbs/openpbs/files/4959813/TestSuspendResumeOnCray_before_fix.txt)
[TestSuspendResumeOnCray_test_basic_admin_suspend_restart_after_fix.txt](https://github.com/openpbs/openpbs/files/4959815/TestSuspendResumeOnCray_test_basic_admin_suspend_restart_after_fix.txt)
[TestSuspendResumeOnCray_test_exclusive_job_not_suspended_after_fix.txt](https://github.com/openpbs/openpbs/files/4959816/TestSuspendResumeOnCray_test_exclusive_job_not_suspended_after_fix.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
