### PR TITLE
Fix microseconds conversion in TestCrayAlpsReleaseTunables

### DIFF
--- a/test/tests/functional/pbs_alps_release_tunables.py
+++ b/test/tests/functional/pbs_alps_release_tunables.py
@@ -3,37 +3,39 @@
 # Copyright (C) 1994-2020 Altair Engineering, Inc.
 # For more information, contact Altair at www.altair.com.
 #
-# This file is part of the PBS Professional ("PBS Pro") software.
+# This file is part of both the OpenPBS software ("OpenPBS")
+# and the PBS Professional ("PBS Pro") software.
 #
 # Open Source License Information:
 #
-# PBS Pro is free software. You can redistribute it and/or modify it under the
-# terms of the GNU Affero General Public License as published by the Free
-# Software Foundation, either version 3 of the License, or (at your option) any
-# later version.
+# OpenPBS is free software. You can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
 #
-# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
-# FOR A PARTICULAR PURPOSE.
-# See the GNU Affero General Public License for more details.
+# OpenPBS is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+# License for more details.
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 # Commercial License Information:
 #
-# For a copy of the commercial license terms and conditions,
-# go to: (http://www.pbspro.com/UserArea/agreement.html)
-# or contact the Altair Legal Department.
+# PBS Pro is commercially licensed software that shares a common core with
+# the OpenPBS software.  For a copy of the commercial license terms and
+# conditions, go to: (http://www.pbspro.com/agreement.html) or contact the
+# Altair Legal Department.
 #
-# Altair’s dual-license business model allows companies, individuals, and
-# organizations to create proprietary derivative works of PBS Pro and
+# Altair's dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of OpenPBS and
 # distribute them - whether embedded or bundled with other software -
 # under a commercial license agreement.
 #
-# Use of Altair’s trademarks, including but not limited to "PBS™",
-# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
-# trademark licensing policies.
+# Use of Altair's trademarks, including but not limited to "PBS™",
+# "OpenPBS®", "PBS Professional®", and "PBS Pro™" and Altair's logos is
+# subject to Altair's trademark licensing policies.
 
 from tests.functional import *
 import math
@@ -98,7 +100,7 @@ class TestCrayAlpsReleaseTunables(TestFunctional):
             for data in out[1:]:
                 time_current = self.get_epoch(data[1])
                 fail_msg = "alps_release_wait_time not working"
-                self.assertGreaterEqual(int(time_current - time_prev),
+                self.assertGreaterEqual(time_current - time_prev,
                                         math.floor(arwt),
                                         msg=fail_msg)
                 time_prev = time_current
@@ -152,7 +154,7 @@ class TestCrayAlpsReleaseTunables(TestFunctional):
                 time_prev = self.get_epoch(out[0][1])
                 for data in out[1:]:
                     time_current = self.get_epoch(data[1])
-                    self.assertLessEqual(int(time_current - time_prev),
+                    self.assertLessEqual(time_current - time_prev,
                                          max_delay,
                                          msg="alps_release_jitter not working")
                     time_prev = time_current

--- a/test/tests/functional/pbs_alps_release_tunables.py
+++ b/test/tests/functional/pbs_alps_release_tunables.py
@@ -53,10 +53,10 @@ class TestCrayAlpsReleaseTunables(TestFunctional):
             self.skipTest("Test suite only meant to run on a Cray")
         TestFunctional.setUp(self)
 
-    def get_epoch(self, msg):
-        logutils = PBSLogUtils()
+    @staticmethod
+    def get_epoch(msg):
         # Since its a log message split on ';' to get timestamp
-        a = logutils.convert_date_time(msg.split(';')[0])
+        a = PBSLogUtils.convert_date_time(msg.split(';')[0])
         return a
 
     def test_alps_release_wait_time(self):
@@ -98,7 +98,7 @@ class TestCrayAlpsReleaseTunables(TestFunctional):
             for data in out[1:]:
                 time_current = self.get_epoch(data[1])
                 fail_msg = "alps_release_wait_time not working"
-                self.assertGreaterEqual(time_current - time_prev,
+                self.assertGreaterEqual(int(time_current - time_prev),
                                         math.floor(arwt),
                                         msg=fail_msg)
                 time_prev = time_current
@@ -116,7 +116,7 @@ class TestCrayAlpsReleaseTunables(TestFunctional):
         # measurable using mom log messages
         arj = 2.198
         arwt = 1
-        max_delay = (arwt + math.floor(arj))
+        max_delay = (arwt + math.ceil(arj))
         self.mom.add_config({'$alps_release_jitter': arj})
         self.mom.add_config({'$alps_release_wait_time': arwt})
         # There is no good way to test jitter and it is a random number
@@ -152,7 +152,7 @@ class TestCrayAlpsReleaseTunables(TestFunctional):
                 time_prev = self.get_epoch(out[0][1])
                 for data in out[1:]:
                     time_current = self.get_epoch(data[1])
-                    self.assertLessEqual(math.floor(time_current - time_prev),
+                    self.assertLessEqual(int(time_current - time_prev),
                                          max_delay,
                                          msg="alps_release_jitter not working")
                     time_prev = time_current

--- a/test/tests/functional/pbs_alps_release_tunables.py
+++ b/test/tests/functional/pbs_alps_release_tunables.py
@@ -44,7 +44,7 @@ import math
 
 def get_epoch(msg):
     # Since its a log message split on ';' to get timestamp
-    a = time.strptime(msg.split(';')[0], "%m/%d/%Y %H:%M:%S")
+    a = time.strptime(msg.split(';')[0], "%m/%d/%Y %H:%M:%S.%f")
     return int(time.mktime(a))
 
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Two tests from TestCrayAlpsReleaseTunables were failing with error "ValueError: unconverted data remains: .621222".
In PTL, we are adding high resolution logging in all daemons logs. In test case, we are getting only till seconds of string in strptime as "%m/%d/%Y %H:%M:%S" and hence the error.

After fixing above issue, test started failing with error : AssertionError: 3.2769370079040527 not less than or equal to 3 : alps_release_jitter not working

#### Describe Your Change
Added microseconds formatting while converting string to date time.
Add math.floor to get the time difference to an integer value.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
[TestCrayAlpsReleaseTunables_after_fix.txt](https://github.com/openpbs/openpbs/files/4959829/TestCrayAlpsReleaseTunables_after_fix.txt)
[TestCrayAlpsReleaseTunables_before_fix.txt](https://github.com/openpbs/openpbs/files/4959830/TestCrayAlpsReleaseTunables_before_fix.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
