### PR TITLE
Allow provisioned jobs to run even with pending hook copy action from nodes not part of job

### DIFF
--- a/src/include/job.h
+++ b/src/include/job.h
@@ -538,6 +538,7 @@ struct job {
 
 	struct preempt_ordering	*preempt_order;
 	int preempt_order_index;
+	struct work_task *ji_prov_startjob_task;
 
 #endif					/* END SERVER ONLY */
 

--- a/src/server/job_func.c
+++ b/src/server/job_func.c
@@ -369,6 +369,7 @@ job_alloc(void)
 	pj->ji_terminated = 0;
 	pj->ji_deletehistory = 0;
 	pj->ji_script = NULL;
+	pj->ji_prov_startjob_task = NULL;
 #endif
 	pj->ji_qs.ji_jsversion = JSVERSION;
 	pj->ji_momhandle = -1;		/* mark mom connection invalid */
@@ -538,6 +539,8 @@ job_free(job *pj)
 		free(pj->ji_clterrmsg);
 	if (pj->ji_script)
 		free(pj->ji_script);
+	if (pj->ji_prov_startjob_task)
+		delete_task(pj->ji_prov_startjob_task);
 
 #else	/* PBS_MOM  Mom Only */
 

--- a/src/server/svr_func.c
+++ b/src/server/svr_func.c
@@ -5524,12 +5524,12 @@ prov_startjob(struct work_task *ptask)
 
 	assert(ptask->wt_parm1 != NULL);
 	pjob = (job *) ptask->wt_parm1;
-        if (pjob == NULL) {
+	if (pjob == NULL) {
 		DBPRT(("%s: pjob is NULL\n", __func__))
 		return;
 	}
 	/* task being serviced here */
-        pjob->ji_prov_startjob_task = NULL;
+	pjob->ji_prov_startjob_task = NULL;
 	if ((do_sync_mom_hookfiles || sync_mom_hookfiles_proc_running) &&
 	    (prov_vnode_pending_hook_copy(pjob))) {
 
@@ -5543,14 +5543,13 @@ prov_startjob(struct work_task *ptask)
 			"hookfiles is not completed\n"
 			, __func__))
 
-                /* set a work task to run after 5 sec from now */
+		/* set a work task to run after 5 sec from now */
 		pjob->ji_prov_startjob_task = set_task(WORK_Timed, time_now + 5,
                         				prov_startjob, pjob);
-                if (pjob->ji_prov_startjob_task == NULL) {
-                        log_err(errno, __func__,
-				"Unable to set task for prov_startjob; requeuing the job");
+		if (pjob->ji_prov_startjob_task == NULL) {
+			log_err(errno, __func__, "Unable to set task for prov_startjob; requeuing the job");
 			(void)force_reque(pjob);
-                }
+		}
 		return;
         }
 

--- a/src/server/svr_func.c
+++ b/src/server/svr_func.c
@@ -5433,6 +5433,81 @@ is_vnode_prov_done(char * vnode)
 
 /**
  * @brief
+ *		Determines if any of the provisionable vnodes assigned to the job
+ *		has a pending mom hook-related file copy action.
+ *
+ * @param[in]   pjob	-	pointer to job struct
+ *
+ * @return	int
+ * @retval	1	: job has a pending hook-related copy action on at least
+ *			  of its provisioning vnodes.
+ * @retval	0	: either no pending hook-related action detected, or an
+ *			  an error has occurred. 
+ *
+ * @par Side Effects:
+ *      Unknown
+ *
+ * @par MT-safe: No
+ *
+ */
+
+static int
+prov_vnode_pending_hook_copy(job *pjob)
+{
+	struct			pbsnode	*np = NULL;
+	int			i;
+	exec_vnode_listtype 	prov_vnode_list = NULL;
+	int			num_of_prov_vnodes = 1;
+	int			rcode = 0;
+
+	if (pjob == NULL) {
+		DBPRT(("%s: job is NULL\n", __func__))
+		return 0;
+	}
+
+	DBPRT(("%s: Entered jobid=%s\n", __func__, pjob->ji_qs.ji_jobid))
+
+	num_of_prov_vnodes = parse_prov_vnode(
+		pjob->ji_wattr[(int)JOB_ATR_prov_vnode].at_val.at_str,
+		&prov_vnode_list);
+
+	if (num_of_prov_vnodes == -1) {
+		if (prov_vnode_list)
+			free(prov_vnode_list);
+		return 0;
+	}
+
+	for (i = 0; i < num_of_prov_vnodes; i++) {
+		int	j;
+
+		np = find_nodebyname(prov_vnode_list[i]);
+		if (np == NULL) {
+			DBPRT(("%s: node %s is null\n",
+				__func__, prov_vnode_list[i]))
+			goto prov_vnode_label;
+		}
+		/* hook has not been sent */
+		for (j = 0; j < np->nd_nummoms; j++) {
+
+			if ((np->nd_moms[j] != NULL) && (sync_mom_hookfiles_count(np->nd_moms[j]) > 0)) {
+				snprintf(log_buffer, sizeof(log_buffer),
+						"prov vnode %s's parent mom %s:%d has a pending copy hook or delete hook request", np->nd_name,  np->nd_moms[j]->mi_host, np->nd_moms[j]->mi_port);
+				log_event(PBSEVENT_DEBUG3, PBS_EVENTCLASS_NODE, LOG_WARNING, pjob->ji_qs.ji_jobid, log_buffer);
+				rcode = 1;
+				break;
+			}
+		}
+	}
+prov_vnode_label:
+
+	if (num_of_prov_vnodes > 0)
+		free(prov_vnode_list);
+
+	return rcode;
+}
+
+/**
+ * @brief
  * 	This function ensures that the hooks are synced with the
  * 	provisioned node before starting the job on it.
  *
@@ -5451,7 +5526,8 @@ prov_startjob(struct work_task *ptask)
 
 	assert(ptask->wt_parm1 != NULL);
 	pjob = (job *) ptask->wt_parm1;
-	if (do_sync_mom_hookfiles || sync_mom_hookfiles_proc_running) {
+	if ((do_sync_mom_hookfiles || sync_mom_hookfiles_proc_running) &&
+	    (prov_vnode_pending_hook_copy(pjob))) {
 
 		/**
 		 * If mom hook files sync is in process then create

--- a/test/tests/functional/pbs_provisioning.py
+++ b/test/tests/functional/pbs_provisioning.py
@@ -204,10 +204,7 @@ class TestProvisioningJob(TestFunctional):
         jid = self.server.submit(job)
         self.server.expect(NODE, {'state': 'provisioning'}, id=self.hostA)
         self.server.expect(JOB, {'job_state': 'R', 'substate': 71}, id=jid)
-        self.server.log_match(
-            "fake calling os provisioning script",
-            max_attempts=20,
-            interval=1)
+        self.server.log_match("fake calling os provisioning script")
 
         # Bring down the mom that is not part of the job
         self.momB.stop()

--- a/test/tests/functional/pbs_provisioning.py
+++ b/test/tests/functional/pbs_provisioning.py
@@ -177,3 +177,45 @@ class TestProvisioningJob(TestFunctional):
             "fake calling application provisioning script",
             max_attempts=20,
             interval=1)
+
+    @skipOnCpuSet
+    def test_os_provisioning_pending_hook_copy(self):
+        """
+        Test that job still runs after:
+        1. os provisioning succeeded
+        2. pending mom hook copy action has persisted on
+           downed node that is not part of job
+        """
+        if len(self.moms) < 2:
+            cmt = "need 2 non-server mom hosts: -p moms=<m1>:<m2>"
+            self.skip_test(reason=cmt)
+
+        a = {'resources_available.aoe': 'osimage1'}
+        self.server.manager(MGR_CMD_SET, NODE, a, id=self.hostA)
+
+        self.momB = self.moms.values()[1]
+        self.hostB = self.momB.shortname
+        self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostB)
+        self.server.expect(NODE, {'state': 'free'}, id=self.hostB)
+        self.server.expect(NODE, {'state': 'free'}, id=self.hostA)
+
+        job = Job(TEST_USER1, attrs={ATTR_l: 'aoe=osimage1'})
+        job.set_sleep_time(30)
+        jid = self.server.submit(job)
+        self.server.expect(NODE, {'state': 'provisioning'}, id=self.hostA)
+        self.server.expect(JOB, {'job_state': 'R', 'substate': 71}, id=jid)
+        self.server.log_match(
+            "fake calling os provisioning script",
+            max_attempts=20,
+            interval=1)
+
+        # Bring down the mom that is not part of the job
+        self.momB.stop()
+        # Force a server hook send of mom hooks
+        # With momB being down, pending hook copy to momB action persists
+        self.server.manager(MGR_CMD_SET, HOOK,
+                            {'enabled': 'True'}, self.hook_list[0])
+
+        # a restart is needed to complete os provisioning
+        self.momA.restart()
+        self.server.expect(JOB, {'job_state': 'R', 'substate': 42}, id=jid)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* Provisioning jobs stay in substate 71 after provisioning succeeds, when there's a pending copy hook operation.
* Server would continue to have pending copy hook operation when some of the mom nodes in the complex are down.
* Provisioning jobs would get blocked even if nodes that are not part of the job having a pending copy hook operation.
* Sample reproduction:
  

 ```
# cat prov.py
bayucan@corretja:~/bugs/pbs_23641> cat prov.py
import pbs
import time
pbs.logmsg(pbs.LOG_DEBUG, "prov hook: sleeping for 20 seconds")
time.sleep(20)
pbs.logmsg(pbs.LOG_DEBUG, "prov hook: done sleeping..")
pbs.event().accept(0)
# qmgr -c "create hook prov event=provision"
# qmgr -c "import hook prov application/x-python default prov.py"
Have 2 nodes that are not on the server host.
# qmgr -c "list node @default"
federer
     Mom = federer.pbspro.com
     state = free
     provision_enable = true
     resources_available.aoe = osimage1
    ...
lendl
     Mom = lendl.pbspro.com
     state = free

Bring down the node without provisioning enabled:
# ssh lendl systemctl stop pbs
Force a mom hook copy operation:
# qmgr -c "create hook begin event=execjob_begin"

At this point, the copy hook operation to the downed host 'lendl' would be pending.

Submit job:
% qsub -l select=aoe=osimage1 <job.scr>
1.corretja


% qstat
Job id            Name             User              Time Use S Queue
----------------  ---------------- ----------------  -------- - -----
1.corretja     STDIN            user1                    0 R workq

At this point, the provision hook has succeeded, and a reboot of the host needs to be done to complete provisioning:
# ssh federer systemctl stop pbs && sleep 5 && systemctl start pbs
 
Job would show up as stuck in substate=71 due to copy hook pending operation on the downed lendl, which is not even part of the job:
# qstat -f 1.corretja | egrep exec
exec_vnode = (federer:aoe=osimage1:ncpus=1)

# qstat -f 1.corretja | grep state
    job_state = R
    substate = 71
```
* One thing to note, if any of the non-provision nodes that are part of the job have a pending hook copy operation, it would not prevent the provision job from starting. This also happens with regular/non-provision jobs. This fix will only prevent starting the provisioned job, if any of the provision nodes have pending hook copy operation. 
#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* Updated code so that only if the nodes that have pending copy hook operation are the provisioned nodes assigned to the job.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
* [ptl.test_os_provisioning_hook_copy.FAIL.txt](https://github.com/openpbs/openpbs/files/4963085/ptl.test_os_provisioning_hook_copy.FAIL.txt)
* [ptl.test_os_provisioning_hook_copy.PASS.txt](https://github.com/openpbs/openpbs/files/4963088/ptl.test_os_provisioning_hook_copy.PASS.txt)
* valgrind log after running pbs_provisioning.py testsuite:
[valgrind.running_provision.txt](https://github.com/openpbs/openpbs/files/4974715/valgrind.running_provision.txt)

* [Results_after_running_provisioning_tests.pdf](https://github.com/openpbs/openpbs/files/4963263/Results_after_running_provisioning_tests.pdf)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
