### PR TITLE
Support rpm generation in centos:8

### DIFF
--- a/ci/ci
+++ b/ci/ci
@@ -647,7 +647,7 @@ def setup_config_dir():
         write_to_file(target_path, value)
     target_path = os.path.join(command_path, MACROS['BENCHPRESS_OPT_FILE'])
     if not os.path.exists(target_path):
-        value = "--tags=smoke"
+        value = "-t SmokeTest"
         write_to_file(target_path, value)
     target_path = os.path.join(ci_dirname, 'docker-compose.json')
     if not os.path.exists(target_path):

--- a/ci/etc/build-pbs-packages.sh
+++ b/ci/etc/build-pbs-packages.sh
@@ -79,7 +79,7 @@ if [ "x${ID}" == "xdebian" -o "x${ID}" == "xubuntu" ]; then
 	CFLAGS="${cflags} -Wno-unused-result" rpmbuild -ba --nodeps *.spec --with ptl
 else
 	if [ "x${ID}" == "xcentos" -a "x${VERSION_ID}" == "x8" ]; then
-		CFLAGS="${cflags}" rpmbuild -ba *.spec --with ptl --with swig
+		CFLAGS="${cflags}" rpmbuild -ba *.spec --with ptl -D '_with_swig ${swig_opt}'
 	else
 		CFLAGS="${cflags}" rpmbuild -ba *.spec --with ptl
 	fi

--- a/ci/etc/build-pbs-packages.sh
+++ b/ci/etc/build-pbs-packages.sh
@@ -79,7 +79,7 @@ if [ "x${ID}" == "xdebian" -o "x${ID}" == "xubuntu" ]; then
 	CFLAGS="${cflags} -Wno-unused-result" rpmbuild -ba --nodeps *.spec --with ptl
 else
 	if [ "x${ID}" == "xcentos" -a "x${VERSION_ID}" == "x8" ]; then
-		CFLAGS="${cflags}" rpmbuild -ba *.spec --with ptl -D '_with_swig ${swig_opt}'
+		CFLAGS="${cflags}" rpmbuild -ba *.spec --with ptl -D "_with_swig ${swig_opt}"
 	else
 		CFLAGS="${cflags}" rpmbuild -ba *.spec --with ptl
 	fi

--- a/ci/etc/ci-script-wrapper.service
+++ b/ci/etc/ci-script-wrapper.service
@@ -1,3 +1,40 @@
+# Copyright (C) 1994-2020 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of both the OpenPBS software ("OpenPBS")
+# and the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# OpenPBS is free software. You can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# OpenPBS is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# PBS Pro is commercially licensed software that shares a common core with
+# the OpenPBS software.  For a copy of the commercial license terms and
+# conditions, go to: (http://www.pbspro.com/agreement.html) or contact the
+# Altair Legal Department.
+#
+# Altair's dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of OpenPBS and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair's trademarks, including but not limited to "PBS™",
+# "OpenPBS®", "PBS Professional®", and "PBS Pro™" and Altair's logos is
+# subject to Altair's trademark licensing policies.
+
 [Unit]
 Description=Run ci docker entrypoint script at startup after all systemd services are loaded
 After=getty.target

--- a/ci/etc/configure_node.sh
+++ b/ci/etc/configure_node.sh
@@ -1,8 +1,45 @@
 #! /bin/bash -x
 
+# Copyright (C) 1994-2020 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of both the OpenPBS software ("OpenPBS")
+# and the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# OpenPBS is free software. You can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# OpenPBS is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# PBS Pro is commercially licensed software that shares a common core with
+# the OpenPBS software.  For a copy of the commercial license terms and
+# conditions, go to: (http://www.pbspro.com/agreement.html) or contact the
+# Altair Legal Department.
+#
+# Altair's dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of OpenPBS and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair's trademarks, including but not limited to "PBS™",
+# "OpenPBS®", "PBS Professional®", and "PBS Pro™" and Altair's logos is
+# subject to Altair's trademark licensing policies.
+
 . /src/etc/macros
-if [ -f /src/${CONFIG_DIR}/.${REQUIREMENT_DECORATOR_FILE} ]; then
-	. /src/${CONFIG_DIR}/.${REQUIREMENT_DECORATOR_FILE}
+if [ -f /src/${CONFIG_DIR}/${REQUIREMENT_DECORATOR_FILE} ]; then
+	. /src/${CONFIG_DIR}/${REQUIREMENT_DECORATOR_FILE}
 fi
 
 if [ "x${NODE_TYPE}" == "xmom" ]; then

--- a/ci/etc/container-env-setup.sh
+++ b/ci/etc/container-env-setup.sh
@@ -1,3 +1,40 @@
+# Copyright (C) 1994-2020 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of both the OpenPBS software ("OpenPBS")
+# and the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# OpenPBS is free software. You can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# OpenPBS is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# PBS Pro is commercially licensed software that shares a common core with
+# the OpenPBS software.  For a copy of the commercial license terms and
+# conditions, go to: (http://www.pbspro.com/agreement.html) or contact the
+# Altair Legal Department.
+#
+# Altair's dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of OpenPBS and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair's trademarks, including but not limited to "PBS™",
+# "OpenPBS®", "PBS Professional®", and "PBS Pro™" and Altair's logos is
+# subject to Altair's trademark licensing policies.
+
 export container=docker
 export TERM=xterm
 if [ -e /etc/debian_version ]; then

--- a/ci/etc/container-init
+++ b/ci/etc/container-init
@@ -1,5 +1,42 @@
 #!/bin/bash -x
 
+# Copyright (C) 1994-2020 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of both the OpenPBS software ("OpenPBS")
+# and the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# OpenPBS is free software. You can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# OpenPBS is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# PBS Pro is commercially licensed software that shares a common core with
+# the OpenPBS software.  For a copy of the commercial license terms and
+# conditions, go to: (http://www.pbspro.com/agreement.html) or contact the
+# Altair Legal Department.
+#
+# Altair's dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of OpenPBS and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair's trademarks, including but not limited to "PBS™",
+# "OpenPBS®", "PBS Professional®", and "PBS Pro™" and Altair's logos is
+# subject to Altair's trademark licensing policies.
+
 /workspace/etc/install-system-packages 2>&1 | tee -a /logs/build-$(hostname -s)
 
 # set environment var file

--- a/ci/etc/do.sh
+++ b/ci/etc/do.sh
@@ -79,6 +79,7 @@ if [ "x${IS_CI_BUILD}" != "x1" ] || [ "x${FIRST_TIME_BUILD}" == "x1" -a "x${IS_C
       yum -y install krb5-libs krb5-devel libcom_err libcom_err-devel
     fi
   elif [ "x${ID}" == "xcentos" -a "x${VERSION_ID}" == "x8" ]; then
+    export LANG="C.utf8"
     dnf -y clean all
     dnf -y install 'dnf-command(config-manager)'
     dnf -y config-manager --set-enabled PowerTools
@@ -133,6 +134,8 @@ if [ "x${FIRST_TIME_BUILD}" == "x1" -a "x${IS_CI_BUILD}" == "x1" ]; then
 fi
 
 if [ "x${ID}" == "xcentos" -a "x${VERSION_ID}" == "x8" ]; then
+  export LANG="C.utf8"
+  swig_opt="--with-swig=/usr/local"
   if [ ! -f /tmp/swig/swig/configure ]; then
     # source install swig
     dnf -y install gcc-c++ byacc pcre-devel
@@ -164,9 +167,6 @@ if [ "x${ONLY_REBUILD}" != "x1" -a "x${ONLY_INSTALL}" != "x1" -a "x${ONLY_TEST}"
   _cflags="-g -O2 -Wall -Werror"
   if [ "x${ID}" == "xubuntu" ]; then
     _cflags="${_cflags} -Wno-unused-result"
-  fi
-  if [ "x${VERSION_ID}" == "x8" -a "x${ID}" == "xcentos" ]; then
-    swig_opt="--with-swig=/usr/local"
   fi
   cd ${_targetdirname}
   if [ -f /src/ci ]; then

--- a/ci/etc/gen_ptl_json.sh
+++ b/ci/etc/gen_ptl_json.sh
@@ -1,5 +1,42 @@
 #!/bin/bash -x
 
+# Copyright (C) 1994-2020 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of both the OpenPBS software ("OpenPBS")
+# and the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# OpenPBS is free software. You can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# OpenPBS is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# PBS Pro is commercially licensed software that shares a common core with
+# the OpenPBS software.  For a copy of the commercial license terms and
+# conditions, go to: (http://www.pbspro.com/agreement.html) or contact the
+# Altair Legal Department.
+#
+# Altair's dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of OpenPBS and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair's trademarks, including but not limited to "PBS™",
+# "OpenPBS®", "PBS Professional®", and "PBS Pro™" and Altair's logos is
+# subject to Altair's trademark licensing policies.
+
 cleanup() {
 	cd ${etcdir}
 	rm -rf ./tmpptl

--- a/ci/etc/install-system-packages
+++ b/ci/etc/install-system-packages
@@ -1,5 +1,42 @@
 #!/bin/bash -x
 
+# Copyright (C) 1994-2020 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of both the OpenPBS software ("OpenPBS")
+# and the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# OpenPBS is free software. You can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# OpenPBS is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# PBS Pro is commercially licensed software that shares a common core with
+# the OpenPBS software.  For a copy of the commercial license terms and
+# conditions, go to: (http://www.pbspro.com/agreement.html) or contact the
+# Altair Legal Department.
+#
+# Altair's dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of OpenPBS and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair's trademarks, including but not limited to "PBS™",
+# "OpenPBS®", "PBS Professional®", and "PBS Pro™" and Altair's logos is
+# subject to Altair's trademark licensing policies.
+
 groupadd -g 1900 tstgrp00
 groupadd -g 1901 tstgrp01
 groupadd -g 1902 tstgrp02

--- a/openpbs.spec
+++ b/openpbs.spec
@@ -95,7 +95,6 @@ Prefix: %{?pbs_prefix}%{!?pbs_prefix:%{_prefix}}
 %bcond_with alps
 %bcond_with ptl
 %bcond_with pmix
-%bcond_with swig
 
 BuildRoot: %{buildroot}
 BuildRequires: gcc
@@ -329,9 +328,7 @@ cd build
 %if %{with ptl}
 	--enable-ptl \
 %endif
-%if %{with swig}
-	--with-swig=/usr/local \
-%endif
+	%{?_with_swig} \
 %if %{defined suse_version}
 	--libexecdir=%{pbs_prefix}/libexec \
 %endif

--- a/openpbs.spec
+++ b/openpbs.spec
@@ -95,6 +95,7 @@ Prefix: %{?pbs_prefix}%{!?pbs_prefix:%{_prefix}}
 %bcond_with alps
 %bcond_with ptl
 %bcond_with pmix
+%bcond_with swig
 
 BuildRoot: %{buildroot}
 BuildRequires: gcc
@@ -327,6 +328,9 @@ cd build
 	--prefix=%{pbs_prefix} \
 %if %{with ptl}
 	--enable-ptl \
+%endif
+%if %{with swig}
+	--with-swig=/usr/local \
 %endif
 %if %{defined suse_version}
 	--libexecdir=%{pbs_prefix}/libexec \

--- a/openpbs.spec.in
+++ b/openpbs.spec.in
@@ -95,7 +95,6 @@ Prefix: %{?pbs_prefix}%{!?pbs_prefix:%{_prefix}}
 %bcond_with alps
 %bcond_with ptl
 %bcond_with pmix
-%bcond_with swig
 
 BuildRoot: %{buildroot}
 BuildRequires: gcc
@@ -329,9 +328,7 @@ cd build
 %if %{with ptl}
 	--enable-ptl \
 %endif
-%if %{with swig}
-	--with-swig=/usr/local \
-%endif
+	%{?_with_swig} \
 %if %{defined suse_version}
 	--libexecdir=%{pbs_prefix}/libexec \
 %endif

--- a/openpbs.spec.in
+++ b/openpbs.spec.in
@@ -95,6 +95,7 @@ Prefix: %{?pbs_prefix}%{!?pbs_prefix:%{_prefix}}
 %bcond_with alps
 %bcond_with ptl
 %bcond_with pmix
+%bcond_with swig
 
 BuildRoot: %{buildroot}
 BuildRequires: gcc
@@ -327,6 +328,9 @@ cd build
 	--prefix=%{pbs_prefix} \
 %if %{with ptl}
 	--enable-ptl \
+%endif
+%if %{with swig}
+	--with-swig=/usr/local \
 %endif
 %if %{defined suse_version}
 	--libexecdir=%{pbs_prefix}/libexec \


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Rpm packages cannot be generated in centos:8 because of missing swig option in spec file.


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* Changed spec file to accommodate swig option
* Added compatibility in ci to build packages on centos:8
* Added missing license header files in ci
* Fixed path error for requirement decorator file. 
* Set the default test case as SmokeTest in ci as tag smoke spawns multiple nodes. 

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[pkglogs.txt](https://github.com/openpbs/openpbs/files/4965746/pkglogs.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
