### PR TITLE
PBS rpm install with --prefix fails due to missing lib

### DIFF
--- a/src/lib/Libdb/pgsql/pbs_db_env
+++ b/src/lib/Libdb/pgsql/pbs_db_env
@@ -41,7 +41,11 @@
 # If this is a legacy installation, setup the appropiate dynamic
 # library paths. Otherwise, set some variables the are used later.
 #
+
 PGSQL_LIBSTR=""
+if [ -z "$PBS_EXEC" ]; then
+	. ${PBS_CONF_FILE:-/etc/pbs.conf}
+fi
 if [ -d "$PBS_EXEC/pgsql" ]; then
 	# Using PostgreSQL packaged with PBS
 	if [ -n "$PGSQL_INST_DIR" ]; then
@@ -60,20 +64,10 @@ if [ -d "$PBS_EXEC/pgsql" ]; then
 		echo "\*\*\* $PGSQL_BIN/psql not executable"
 		exit 1
 	fi
-	case `uname` in
-		Linux)
-			[ -d "$PGSQL_DIR/lib" ] && LD_LIBRARY_PATH="$PGSQL_DIR/lib:$LD_LIBRARY_PATH"
-			[ -d "$PGSQL_DIR/lib64" ] && LD_LIBRARY_PATH="$PGSQL_DIR/lib64:$LD_LIBRARY_PATH"
-			export LD_LIBRARY_PATH
-			PGSQL_LIBSTR="LD_LIBRARY_PATH=$LD_LIBRARY_PATH; export LD_LIBRARY_PATH; "
-			export PGSQL_LIBSTR
-			;;
-		Darwin)
-			DYLD_LIBRARY_PATH="$PGSQL_DIR/lib:$DYLD_LIBRARY_PATH"
-			export DYLD_LIBRARY_PATH
-			PGSQL_LIBSTR="DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH; export DYLD_LIBRARY_PATH; "
-			;;
-	esac
+	[ -d "$PGSQL_DIR/lib" ] && LD_LIBRARY_PATH="$PGSQL_DIR/lib:$LD_LIBRARY_PATH"
+	[ -d "$PGSQL_DIR/lib64" ] && LD_LIBRARY_PATH="$PGSQL_DIR/lib64:$LD_LIBRARY_PATH"
+	PGSQL_LIBSTR="LD_LIBRARY_PATH=$LD_LIBRARY_PATH; export LD_LIBRARY_PATH; "
+	export PGSQL_LIBSTR
 else
 	# Using system installed PostgreSQL package
 	PGSQL_CMD=`type psql 2>/dev/null | cut -d' ' -f3`
@@ -91,3 +85,5 @@ else
 	[ "$PGSQL_DIR" = "/" ] && PGSQL_DIR=""
 fi
 export PGSQL_BIN=$PGSQL_BIN
+[ -d "$PBS_EXEC/lib" ] && LD_LIBRARY_PATH="$PBS_EXEC/lib:$LD_LIBRARY_PATH"
+export LD_LIBRARY_PATH


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
RPM install of PBS would fail when installed on a non-default path using --prefix option. This is happening because pbs_ds_monitor cannot resolve to PBS_EXEC/lib directory and pbs_habitat fails with error:
Error details:
Creating the PBS Data Service...
/opt/pbs_exec_new/sbin/pbs_ds_monitor: error while loading shared libraries: libdb.so.0: cannot open shared object file: No such file or directory - cannot start
Error starting PBS Data Service

Steps to reproduce:
Install pbs rpm on a non-default path:
        rpm -i --force --prefix=/opt/pbs_exec_new openpbs-server-20.0.0-0.x86_64.rpm
Run pbs_habitat script:
        source /etc/pbs.conf && $PBS_EXEC/libexec/pbs_habitat
#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Added export LD_LIBRARY_PATH=$PBS_EXEC/lib in pbs_db_env file.



#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[After fix.txt](https://github.com/openpbs/openpbs/files/4969387/After.fix.txt)
[Before fix.txt](https://github.com/openpbs/openpbs/files/4969389/Before.fix.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
