### PR TITLE
Logging messages for nodes marked  as already visited 

### DIFF
--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -3610,9 +3610,16 @@ eval_simple_selspec(status *policy, chunk *chk, node_info **pninfo_arr,
 					COMPARE_TOTAL | UNSET_RES_ZERO | CHECK_ALL_BOOLS,
 					policy->resdef_to_check_no_hostvnode,
 					INSUFFICIENT_RESOURCE, err) == 0) {
-					for (k = 0; ninfo_arr[k] != NULL; k++)
-						if (ninfo_arr[k]->nodesig_ind == ninfo_arr[i]->nodesig_ind)
+					log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_NODE, LOG_DEBUG,
+							"", "Marking nodes with signature %s ineligible", ninfo_arr[i]->nodesig);
+					for (k = 0; ninfo_arr[k] != NULL; k++) {
+						if (ninfo_arr[k]->nodesig_ind == ninfo_arr[i]->nodesig_ind) {
 							ninfo_arr[k]->nscr.visited = 1;
+							if (i != k)
+								schdlogerr(PBSEVENT_DEBUG3, PBS_EVENTCLASS_NODE, LOG_DEBUG,
+									ninfo_arr[k]->name, NULL, err);
+						}
+					}
 				}
 			}
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
For optimization in scheduler if one node cannot run a particular job, we mark similar nodes as already visited. But we were not emitting a message that the nodes were marked visited or the reason why job cannot run on those nodes. This PR adds a log message to sched logs the reason why a job cannot run on those nodes

#### Attach Test and Valgrind Logs/Output
Not writing a PTL test since this feature is only logging a existing functionality into logs. Manual test results are given below

**### System**

[root@0dc6520bf9f0 functional]# qmgr -c "p sched"
#
# Create and define scheduler default
#
create sched default
set sched sched_host = 0dc6520bf9f0
set sched sched_cycle_length = 00:20:00
set sched throughput_mode = True
set sched job_run_wait = runjob_hook
set sched opt_backfill_fuzzy = off
set sched sched_port = 15004
set sched partition = pbs-default
set sched sched_priv = /var/spool/pbs/sched_priv
set sched sched_log = /var/spool/pbs/sched_logs
set sched scheduling = True
set sched scheduler_iteration = 600
set sched state = idle
set sched preempt_queue_prio = 150
set sched preempt_prio = "express_queue, normal_jobs"
set sched preempt_order = SCR
set sched preempt_sort = min_time_since_start
set sched log_events = 1024
set sched server_dyn_res_alarm = 30
[root@0dc6520bf9f0 functional]# pbsnodes -av
0dc6520bf9f0
     Mom = 0dc6520bf9f0
     Port = 15002
     pbs_version = 20.0.0
     ntype = PBS
     state = free
     pcpus = 4
     resources_available.arch = linux
     resources_available.host = 0dc6520bf9f0
     resources_available.mem = 0b
     resources_available.ncpus = 0
     resources_available.vnode = 0dc6520bf9f0
     resources_assigned.accelerator_memory = 0kb
     resources_assigned.hbmem = 0kb
     resources_assigned.mem = 0kb
     resources_assigned.naccelerators = 0
     resources_assigned.ncpus = 0
     resources_assigned.vmem = 0kb
     resv_enable = True
     sharing = default_shared
     in_multivnode_host = 1
     last_state_change_time = Mon Jul 27 23:24:06 2020

vn[0]
     Mom = 0dc6520bf9f0
     Port = 15002
     pbs_version = 20.0.0
     ntype = PBS
     state = free
     resources_available.arch = linux
     resources_available.color = red
     resources_available.host = 0dc6520bf9f0
     resources_available.mem = 2gb
     resources_available.ncpus = 1
     resources_available.vnode = vn[0]
     resources_assigned.accelerator_memory = 0kb
     resources_assigned.hbmem = 0kb
     resources_assigned.mem = 0kb
     resources_assigned.naccelerators = 0
     resources_assigned.ncpus = 0
     resources_assigned.vmem = 0kb
     resv_enable = True
     sharing = default_shared
     in_multivnode_host = 1
     last_state_change_time = Mon Jul 27 23:24:06 2020

vn[1]
     Mom = 0dc6520bf9f0
     Port = 15002
     pbs_version = 20.0.0
     ntype = PBS
     state = free
     resources_available.arch = linux
     resources_available.color = green
     resources_available.host = 0dc6520bf9f0
     resources_available.mem = 2gb
     resources_available.ncpus = 1
     resources_available.vnode = vn[1]
     resources_assigned.accelerator_memory = 0kb
     resources_assigned.hbmem = 0kb
     resources_assigned.mem = 0kb
     resources_assigned.naccelerators = 0
     resources_assigned.ncpus = 0
     resources_assigned.vmem = 0kb
     resv_enable = True
     sharing = default_shared
     in_multivnode_host = 1
     last_state_change_time = Mon Jul 27 23:24:06 2020

vn[2]
     Mom = 0dc6520bf9f0
     Port = 15002
     pbs_version = 20.0.0
     ntype = PBS
     state = free
     resources_available.arch = linux
     resources_available.color = green
     resources_available.host = 0dc6520bf9f0
     resources_available.mem = 2gb
     resources_available.ncpus = 1
     resources_available.vnode = vn[2]
     resources_assigned.accelerator_memory = 0kb
     resources_assigned.hbmem = 0kb
     resources_assigned.mem = 0kb
     resources_assigned.naccelerators = 0
     resources_assigned.ncpus = 0
     resources_assigned.vmem = 0kb
     resv_enable = True
     sharing = default_shared
     in_multivnode_host = 1
     last_state_change_time = Mon Jul 27 23:24:06 2020

vn[3]
     Mom = 0dc6520bf9f0
     Port = 15002
     pbs_version = 20.0.0
     ntype = PBS
     state = free
     resources_available.arch = linux
     resources_available.color = blue
     resources_available.host = 0dc6520bf9f0
     resources_available.mem = 2gb
     resources_available.ncpus = 1
     resources_available.vnode = vn[3]
     resources_assigned.accelerator_memory = 0kb
     resources_assigned.hbmem = 0kb
     resources_assigned.mem = 0kb
     resources_assigned.naccelerators = 0
     resources_assigned.ncpus = 0
     resources_assigned.vmem = 0kb
     resv_enable = True
     sharing = default_shared
     in_multivnode_host = 1
     last_state_change_time = Mon Jul 27 23:24:06 2020

vn[4]
     Mom = 0dc6520bf9f0
     Port = 15002
     pbs_version = 20.0.0
     ntype = PBS
     state = free
     resources_available.arch = linux
     resources_available.color = green
     resources_available.host = 0dc6520bf9f0
     resources_available.mem = 2gb
     resources_available.ncpus = 1
     resources_available.vnode = vn[4]
     resources_assigned.accelerator_memory = 0kb
     resources_assigned.hbmem = 0kb
     resources_assigned.mem = 0kb
     resources_assigned.naccelerators = 0
     resources_assigned.ncpus = 0
     resources_assigned.vmem = 0kb
     resv_enable = True
     sharing = default_shared
     in_multivnode_host = 1
     last_state_change_time = Mon Jul 27 23:24:06 2020

vn[5]
     Mom = 0dc6520bf9f0
     Port = 15002
     pbs_version = 20.0.0
     ntype = PBS
     state = free
     resources_available.arch = linux
     resources_available.color = blue
     resources_available.host = 0dc6520bf9f0
     resources_available.mem = 2gb
     resources_available.ncpus = 1
     resources_available.vnode = vn[5]
     resources_assigned.accelerator_memory = 0kb
     resources_assigned.hbmem = 0kb
     resources_assigned.mem = 0kb
     resources_assigned.naccelerators = 0
     resources_assigned.ncpus = 0
     resources_assigned.vmem = 0kb
     resv_enable = True
     sharing = default_shared
     in_multivnode_host = 1
     last_state_change_time = Mon Jul 27 23:24:06 2020

vn[6]
     Mom = 0dc6520bf9f0
     Port = 15002
     pbs_version = 20.0.0
     ntype = PBS
     state = free
     resources_available.arch = linux
     resources_available.color = blue
     resources_available.host = 0dc6520bf9f0
     resources_available.mem = 2gb
     resources_available.ncpus = 1
     resources_available.vnode = vn[6]
     resources_assigned.accelerator_memory = 0kb
     resources_assigned.hbmem = 0kb
     resources_assigned.mem = 0kb
     resources_assigned.naccelerators = 0
     resources_assigned.ncpus = 0
     resources_assigned.vmem = 0kb
     resv_enable = True
     sharing = default_shared
     in_multivnode_host = 1
     last_state_change_time = Mon Jul 27 23:24:06 2020

vn[7]
     Mom = 0dc6520bf9f0
     Port = 15002
     pbs_version = 20.0.0
     ntype = PBS
     state = free
     resources_available.arch = linux
     resources_available.color = red
     resources_available.host = 0dc6520bf9f0
     resources_available.mem = 2gb
     resources_available.ncpus = 1
     resources_available.vnode = vn[7]
     resources_assigned.accelerator_memory = 0kb
     resources_assigned.hbmem = 0kb
     resources_assigned.mem = 0kb
     resources_assigned.naccelerators = 0
     resources_assigned.ncpus = 0
     resources_assigned.vmem = 0kb
     resv_enable = True
     sharing = default_shared
     in_multivnode_host = 1
     last_state_change_time = Mon Jul 27 23:24:06 2020

vn[8]
     Mom = 0dc6520bf9f0
     Port = 15002
     pbs_version = 20.0.0
     ntype = PBS
     state = free
     resources_available.arch = linux
     resources_available.color = green
     resources_available.host = 0dc6520bf9f0
     resources_available.mem = 2gb
     resources_available.ncpus = 1
     resources_available.vnode = vn[8]
     resources_assigned.accelerator_memory = 0kb
     resources_assigned.hbmem = 0kb
     resources_assigned.mem = 0kb
     resources_assigned.naccelerators = 0
     resources_assigned.ncpus = 0
     resources_assigned.vmem = 0kb
     resv_enable = True
     sharing = default_shared
     in_multivnode_host = 1
     last_state_change_time = Mon Jul 27 23:24:06 2020


**### Job Submission-**
[pbsroot@0dc6520bf9f0 ~]$ qsub -lselect=1:color=blue -- /bin/sleep 100
1.0dc6520bf9f0
[pbsroot@0dc6520bf9f0 ~]$ qsub -lselect=1:color=red -- /bin/sleep 100
2.0dc6520bf9f0
[pbsroot@0dc6520bf9f0 ~]$ qsub -lselect=1:color=green -- /bin/sleep 100
3.0dc6520bf9f0


Logs-


07/28/2020 01:35:50.799100;0400;pbs_sched;Node;1.0dc6520bf9f0;Evaluating subchunk: color=blue:ncpus=1
07/28/2020 01:35:50.799122;0400;pbs_sched;Node;0dc6520bf9f0;Insufficient amount of resource: color (blue != )
07/28/2020 01:35:50.799140;0400;pbs_sched;Node;;Marking nodes with signature ncpus=0 ineligible
07/28/2020 01:35:50.799159;0400;pbs_sched;Node;vn[0];Insufficient amount of resource: color (blue != red)
07/28/2020 01:35:50.799177;0400;pbs_sched;Node;;Marking nodes with signature color=red:ncpus=1 ineligible
07/28/2020 01:35:50.799194;0400;pbs_sched;Node;vn[7];Insufficient amount of resource: color (blue != red)
07/28/2020 01:35:50.799213;0400;pbs_sched;Node;vn[1];Insufficient amount of resource: color (blue != green)
07/28/2020 01:35:50.799231;0400;pbs_sched;Node;;Marking nodes with signature color=green:ncpus=1 ineligible
07/28/2020 01:35:50.799248;0400;pbs_sched;Node;vn[2];Insufficient amount of resource: color (blue != green)
07/28/2020 01:35:50.799265;0400;pbs_sched;Node;vn[4];Insufficient amount of resource: color (blue != green)
07/28/2020 01:35:50.799282;0400;pbs_sched;Node;vn[8];Insufficient amount of resource: color (blue != green)
07/28/2020 01:35:50.799300;0400;pbs_sched;Node;vn[3];Node allocated to job
07/28/2020 01:35:50.799317;0400;pbs_sched;Node;1.0dc6520bf9f0;Allocated one subchunk: color=blue:ncpus=1
07/28/2020 01:35:50.799355;0400;pbs_sched;Sched;worker;Thread 1 calling free_node_info_chunk()
07/28/2020 01:35:50.799461;0400;pbs_sched;Sched;worker;Thread 2 calling free_resource_resv_array_chunk()
07/28/2020 01:35:50.799492;0400;pbs_sched;Sched;worker;Thread 1 calling free_node_info_chunk()
07/28/2020 01:36:01.034916;0400;pbs_sched;Sched;worker;Thread 2 calling query_node_info_chunk()
07/28/2020 01:36:01.036995;0400;pbs_sched;Sched;worker;Thread 1 calling query_jobs_chunk()
07/28/2020 01:36:01.037126;0400;pbs_sched;Sched;create_resresv_sets;Number of job equivalence classes: 2
07/28/2020 01:36:01.037268;0400;pbs_sched;Node;create_node_buckets;Created node bucket ncpus=0:accelerator=False
07/28/2020 01:36:01.037328;0400;pbs_sched;Node;create_node_buckets;Created node bucket color=red:ncpus=1:accelerator=False
07/28/2020 01:36:01.037357;0400;pbs_sched;Node;create_node_buckets;Created node bucket color=green:ncpus=1:accelerator=False
07/28/2020 01:36:01.037368;0400;pbs_sched;Node;create_node_buckets;Created node bucket color=blue:ncpus=1:accelerator=False
07/28/2020 01:36:01.037455;0400;pbs_sched;Sched;worker;Thread 2 calling check_node_eligibility_chunk()
07/28/2020 01:36:01.037498;0400;pbs_sched;Node;vn[3];Node is in an ineligible state: job-busy
07/28/2020 01:36:01.037676;0400;pbs_sched;Node;2.0dc6520bf9f0;Evaluating host 0dc6520bf9f0
07/28/2020 01:36:01.037728;0400;pbs_sched;Sched;worker;Thread 1 calling dup_node_info_chunk()
07/28/2020 01:36:01.037808;0400;pbs_sched;Node;2.0dc6520bf9f0;Evaluating subchunk: color=red:ncpus=1
07/28/2020 01:36:01.037845;0400;pbs_sched;Node;0dc6520bf9f0;Insufficient amount of resource: color (red != )
07/28/2020 01:36:01.037864;0400;pbs_sched;Node;;Marking nodes with signature ncpus=0 ineligible
07/28/2020 01:36:01.037901;0400;pbs_sched;Node;vn[0];Node allocated to job
07/28/2020 01:36:01.037935;0400;pbs_sched;Node;2.0dc6520bf9f0;Allocated one subchunk: color=red:ncpus=1
07/28/2020 01:36:01.037989;0400;pbs_sched;Sched;worker;Thread 2 calling free_node_info_chunk()
07/28/2020 01:36:01.038115;0400;pbs_sched;Sched;worker;Thread 1 calling free_resource_resv_array_chunk()
07/28/2020 01:36:01.038150;0400;pbs_sched;Sched;worker;Thread 2 calling free_node_info_chunk()
07/28/2020 01:36:07.024043;0400;pbs_sched;Sched;worker;Thread 1 calling query_node_info_chunk()
07/28/2020 01:36:07.025902;0400;pbs_sched;Sched;worker;Thread 2 calling query_jobs_chunk()
07/28/2020 01:36:07.026054;0400;pbs_sched;Sched;create_resresv_sets;Number of job equivalence classes: 3
07/28/2020 01:36:07.026155;0400;pbs_sched;Node;create_node_buckets;Created node bucket ncpus=0:accelerator=False
07/28/2020 01:36:07.026187;0400;pbs_sched;Node;create_node_buckets;Created node bucket color=red:ncpus=1:accelerator=False
07/28/2020 01:36:07.026217;0400;pbs_sched;Node;create_node_buckets;Created node bucket color=green:ncpus=1:accelerator=False
07/28/2020 01:36:07.026247;0400;pbs_sched;Node;create_node_buckets;Created node bucket color=blue:ncpus=1:accelerator=False
07/28/2020 01:36:07.026304;0400;pbs_sched;Sched;worker;Thread 1 calling check_node_eligibility_chunk()
07/28/2020 01:36:07.026331;0400;pbs_sched;Node;vn[0];Node is in an ineligible state: job-busy
07/28/2020 01:36:07.026355;0400;pbs_sched;Node;vn[3];Node is in an ineligible state: job-busy
07/28/2020 01:36:07.026388;0400;pbs_sched;Node;3.0dc6520bf9f0;Evaluating host 0dc6520bf9f0
07/28/2020 01:36:07.026423;0400;pbs_sched;Sched;worker;Thread 2 calling dup_node_info_chunk()
07/28/2020 01:36:07.026490;0400;pbs_sched;Node;3.0dc6520bf9f0;Evaluating subchunk: color=green:ncpus=1
07/28/2020 01:36:07.026518;0400;pbs_sched;Node;0dc6520bf9f0;Insufficient amount of resource: color (green != )
07/28/2020 01:36:07.026541;0400;pbs_sched;Node;;Marking nodes with signature ncpus=0 ineligible
07/28/2020 01:36:07.026552;0400;pbs_sched;Node;vn[1];Node allocated to job
07/28/2020 01:36:07.026567;0400;pbs_sched;Node;3.0dc6520bf9f0;Allocated one subchunk: color=green:ncpus=1





<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
