### PR TITLE
Changed all strcpy to pbs_strncpy in scheduler

### DIFF
--- a/src/include/libutil.h
+++ b/src/include/libutil.h
@@ -48,8 +48,6 @@ extern "C" {
 #include <stdio.h>
 #include <netinet/in.h>
 
-#define PBS_FGETS_LINE_LEN 8192
-
 /* misc_utils specific */
 
 /* replace - Replace sub-string  with new pattern in string */

--- a/src/include/libutil.h
+++ b/src/include/libutil.h
@@ -48,6 +48,8 @@ extern "C" {
 #include <stdio.h>
 #include <netinet/in.h>
 
+#define PBS_FGETS_LINE_LEN 8192
+
 /* misc_utils specific */
 
 /* replace - Replace sub-string  with new pattern in string */
@@ -203,6 +205,12 @@ char *pbs_strcat(char **strbuf, int *ssize, char *str);
  * 
  */
 char *pbs_strcpy(char *dest, const char *src);
+
+/*
+ * general purpose strncpy function that will make sure to
+ * copy '\0' at the end of the buffer.
+ */
+char *pbs_strncpy(char *dest, const char *src, size_t n);
 
 char *pbs_fgets(char **pbuf, int *pbuf_size, FILE *fp);
 char *pbs_fgets_extend(char **pbuf, int *pbuf_size, FILE *fp);

--- a/src/lib/Libutil/misc_utils.c
+++ b/src/lib/Libutil/misc_utils.c
@@ -334,6 +334,26 @@ pbs_strcpy(char *dest, const char *src)
 
 	return dest;
 }
+/**
+ *
+ * @brief general purpose strncpy function that will make sure to
+ *        copy '\0' at the end of the buffer.
+ *
+ * @param[in] dest - pointer to the destination buffer
+ * @param[in] src  - pointer to the source string
+ * @param[in] n    - size of destination buffer
+ *
+ * @return char *
+ * @retval pointer to the destination string
+ *
+ * @note: Caller needs ensure non-NULL pointers
+ */
+char *pbs_strncpy(char *dest, const char *src, size_t n)
+{
+    strncpy(dest, src, n-1);
+    dest[n-1] = '\0';
+    return dest;
+}
 
 /**
  * @brief
@@ -348,7 +368,6 @@ pbs_strcpy(char *dest, const char *src)
  * @retval pointer to *pbuf(the string pbuf points at) on successful read
  * @retval NULL on EOF or error
  */
-#define PBS_FGETS_LINE_LEN 8192
 char *
 pbs_fgets(char **pbuf, int *pbuf_size, FILE *fp)
 {

--- a/src/lib/Libutil/misc_utils.c
+++ b/src/lib/Libutil/misc_utils.c
@@ -350,8 +350,8 @@ pbs_strcpy(char *dest, const char *src)
  */
 char *pbs_strncpy(char *dest, const char *src, size_t n)
 {
-    strncpy(dest, src, n-1);
-    dest[n-1] = '\0';
+    strncpy(dest, src, n - 1);
+    dest[n - 1] = '\0';
     return dest;
 }
 
@@ -368,6 +368,7 @@ char *pbs_strncpy(char *dest, const char *src, size_t n)
  * @retval pointer to *pbuf(the string pbuf points at) on successful read
  * @retval NULL on EOF or error
  */
+#define PBS_FGETS_LINE_LEN 8192
 char *
 pbs_fgets(char **pbuf, int *pbuf_size, FILE *fp)
 {

--- a/src/scheduler/fairshare.c
+++ b/src/scheduler/fairshare.c
@@ -627,7 +627,7 @@ write_usage(char *filename, fairshare_head *fhead)
 	 * ...
 	 */
 
-	strcpy(head.tag, USAGE_MAGIC);
+	pbs_strncpy(head.tag, USAGE_MAGIC, 9);
 	head.version = USAGE_VERSION;
 	fwrite(&head, sizeof(struct group_node_header), 1, fp);
 	fwrite(&fhead->last_decay, sizeof(time_t), 1, fp);

--- a/src/scheduler/fairshare.c
+++ b/src/scheduler/fairshare.c
@@ -627,7 +627,7 @@ write_usage(char *filename, fairshare_head *fhead)
 	 * ...
 	 */
 
-	pbs_strncpy(head.tag, USAGE_MAGIC, 9);
+	pbs_strncpy(head.tag, USAGE_MAGIC, sizeof(head.tag));
 	head.version = USAGE_VERSION;
 	fwrite(&head, sizeof(struct group_node_header), 1, fp);
 	fwrite(&fhead->last_decay, sizeof(time_t), 1, fp);

--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -4148,7 +4148,7 @@ modify_job_array_for_qrun(server_info *sinfo, char *jobid)
 	if (sinfo == NULL || jobid == NULL)
 		return -1;
 
-	pbs_strncpy(name, jobid, 128);
+	pbs_strncpy(name, jobid, sizeof(name));
 
 	if ((ptr = strchr(name, (int) '[')) == NULL)
 		return 0;
@@ -4159,7 +4159,7 @@ modify_job_array_for_qrun(server_info *sinfo, char *jobid)
 	if ((ptr = strchr(rangestr, ']')) == NULL)
 		return 0;
 
-	pbs_strncpy(rest, ptr, 128);
+	pbs_strncpy(rest, ptr, sizeof(rest));
 
 	*ptr = '\0';
 

--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -4148,7 +4148,7 @@ modify_job_array_for_qrun(server_info *sinfo, char *jobid)
 	if (sinfo == NULL || jobid == NULL)
 		return -1;
 
-	strcpy(name, jobid);
+	pbs_strncpy(name, jobid, 128);
 
 	if ((ptr = strchr(name, (int) '[')) == NULL)
 		return 0;
@@ -4159,7 +4159,7 @@ modify_job_array_for_qrun(server_info *sinfo, char *jobid)
 	if ((ptr = strchr(rangestr, ']')) == NULL)
 		return 0;
 
-	strcpy(rest, ptr);
+	pbs_strncpy(rest, ptr, 128);
 
 	*ptr = '\0';
 

--- a/src/scheduler/misc.c
+++ b/src/scheduler/misc.c
@@ -122,16 +122,17 @@ char *
 string_dup(char *str)
 {
 	char *newstr;
+	size_t len;
 
 	if (str == NULL)
 		return NULL;
-
-	if ((newstr = (char *) malloc(strlen(str) + 1)) == NULL) {
+	len = strlen(str) + 1;
+	if ((newstr = (char *) malloc(len)) == NULL) {
 		log_err(errno, __func__, MEM_ERR_MSG);
 		return NULL;
 	}
 
-	strcpy(newstr, str);
+	pbs_strncpy(newstr, str, len);
 
 	return newstr;
 }

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -1014,7 +1014,7 @@ set_node_info_state(node_info *ninfo, char *state)
 		ninfo->is_resv_exclusive = ninfo->is_job_exclusive = 0;
 		ninfo->is_sleeping = ninfo->is_maintenance = 0;
 
-		pbs_strncpy(statebuf, state, 256);
+		pbs_strncpy(statebuf, state, sizeof(statebuf));
 		tok = strtok_r(statebuf, ",", &saveptr);
 
 		while (tok != NULL) {
@@ -4037,7 +4037,7 @@ resources_avail_on_vnode(resource_req *specreq_cons, node_info *node,
 			}
 
 			if (pl->pack && num_chunks == 1 && cstat.smp_dist == SMP_ROUND_ROBIN)
-				pbs_strncpy(last_node_name, node->name, PBS_MAXSVRJOBID);
+				pbs_strncpy(last_node_name, node->name, sizeof(last_node_name));
 			return 1;
 		}
 	}
@@ -4095,7 +4095,7 @@ resources_avail_on_vnode(resource_req *specreq_cons, node_info *node,
 			}
 
 			if (pl->pack && cstat.smp_dist == SMP_ROUND_ROBIN)
-				pbs_strncpy(last_node_name, node->name, PBS_MAXSVRJOBID);
+				pbs_strncpy(last_node_name, node->name, sizeof(last_node_name));
 		}
 		return num_chunks;
 	}
@@ -4373,7 +4373,7 @@ parse_placespec(char *place_str)
 	if (pl == NULL)
 		return NULL;
 
-	pbs_strncpy(str, place_str, MAX_LOG_SIZE);
+	pbs_strncpy(str, place_str, sizeof(str));
 
 	tok = string_token(str, ":", &tokptr);
 
@@ -4716,7 +4716,7 @@ create_execvnode(nspec **ns)
 					return NULL;
 			}
 			else if (ns[i]->go_provision && strcmp(req->name, "aoe") ==0) {
-				pbs_strncpy(buf2, ":aoe=", 128);
+				pbs_strncpy(buf2, ":aoe=", sizeof(buf2));
 				if (pbs_strcat(&buf, &bufsize, buf2) == NULL)
 					return NULL;
 				if (pbs_strcat(&buf, &bufsize, req->res_str) == NULL)

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -1014,7 +1014,7 @@ set_node_info_state(node_info *ninfo, char *state)
 		ninfo->is_resv_exclusive = ninfo->is_job_exclusive = 0;
 		ninfo->is_sleeping = ninfo->is_maintenance = 0;
 
-		strcpy(statebuf, state);
+		pbs_strncpy(statebuf, state, 256);
 		tok = strtok_r(statebuf, ",", &saveptr);
 
 		while (tok != NULL) {
@@ -4037,7 +4037,7 @@ resources_avail_on_vnode(resource_req *specreq_cons, node_info *node,
 			}
 
 			if (pl->pack && num_chunks == 1 && cstat.smp_dist == SMP_ROUND_ROBIN)
-				strcpy(last_node_name, node->name);
+				pbs_strncpy(last_node_name, node->name, PBS_MAXSVRJOBID);
 			return 1;
 		}
 	}
@@ -4095,7 +4095,7 @@ resources_avail_on_vnode(resource_req *specreq_cons, node_info *node,
 			}
 
 			if (pl->pack && cstat.smp_dist == SMP_ROUND_ROBIN)
-				strcpy(last_node_name, node->name);
+				pbs_strncpy(last_node_name, node->name, PBS_MAXSVRJOBID);
 		}
 		return num_chunks;
 	}
@@ -4373,7 +4373,7 @@ parse_placespec(char *place_str)
 	if (pl == NULL)
 		return NULL;
 
-	strcpy(str, place_str);
+	pbs_strncpy(str, place_str, MAX_LOG_SIZE);
 
 	tok = string_token(str, ":", &tokptr);
 
@@ -4685,7 +4685,7 @@ create_execvnode(nspec **ns)
 
 	for (i = 0; ns[i] != NULL; i++) {
 		if (i > 0)
-			strcpy(buf, "+");
+			pbs_strncpy(buf, "+", bufsize);
 		else
 			buf[0] = '\0';
 
@@ -4716,7 +4716,7 @@ create_execvnode(nspec **ns)
 					return NULL;
 			}
 			else if (ns[i]->go_provision && strcmp(req->name, "aoe") ==0) {
-				strcpy(buf2, ":aoe=");
+				pbs_strncpy(buf2, ":aoe=", 128);
 				if (pbs_strcat(&buf, &bufsize, buf2) == NULL)
 					return NULL;
 				if (pbs_strcat(&buf, &bufsize, req->res_str) == NULL)

--- a/src/scheduler/parse.c
+++ b/src/scheduler/parse.c
@@ -103,7 +103,7 @@ parse_config(char *fname)
 	FILE *fp;			/* file pointer to config file */
 	char *buf = NULL;
 	int buf_size = 0;
-	char buf2[PBS_FGETS_LINE_LEN];	/* general purpose buffer */
+	char buf2[8192];		/* general purpose buffer */
 	char errbuf[1024];		/* buffer for reporting errors */
 	char *config_name;		/* parse first word of line */
 	char *config_value;		/* parsed second word - right after colen (:) */
@@ -389,7 +389,7 @@ parse_config(char *fname)
 					 * done by default prior to 7.1.
 					 */
 					if (strstr(config_value, "host") == NULL)
-						pbs_strncpy(buf2, "host,", PBS_FGETS_LINE_LEN);
+						pbs_strncpy(buf2, "host,", sizeof(buf2));
 
 					/* hack: add in "vnode" in 8.0 */
 					if (strstr(config_value, "vnode") == NULL)
@@ -414,19 +414,19 @@ parse_config(char *fname)
 					if (strlen(config_value) > PBS_MAXQUEUENAME)
 						error = 1;
 					else
-						pbs_strncpy(conf.ded_prefix, config_value, PBS_MAXQUEUENAME + 1);
+						pbs_strncpy(conf.ded_prefix, config_value, sizeof(conf.ded_prefix));
 				}
 				else if (!strcmp(config_name, PARSE_PRIMETIME_PREFIX)) {
 					if (strlen(config_value) > PBS_MAXQUEUENAME)
 						error = 1;
 					else
-						pbs_strncpy(conf.pt_prefix, config_value, PBS_MAXQUEUENAME + 1);
+						pbs_strncpy(conf.pt_prefix, config_value, sizeof(conf.pt_prefix));
 				}
 				else if (!strcmp(config_name, PARSE_NONPRIMETIME_PREFIX)) {
 					if (strlen(config_value) > PBS_MAXQUEUENAME)
 						error = 1;
 					else
-						pbs_strncpy(conf.npt_prefix, config_value, PBS_MAXQUEUENAME + 1);
+						pbs_strncpy(conf.npt_prefix, config_value, sizeof(conf.npt_prefix));
 				}
 				else if (!strcmp(config_name, PARSE_SMP_CLUSTER_DIST)) {
 					for (i = 0; i < HIGH_SMP_DIST; i++)

--- a/src/scheduler/parse.c
+++ b/src/scheduler/parse.c
@@ -103,7 +103,7 @@ parse_config(char *fname)
 	FILE *fp;			/* file pointer to config file */
 	char *buf = NULL;
 	int buf_size = 0;
-	char buf2[8192];		/* general purpose buffer */
+	char buf2[PBS_FGETS_LINE_LEN];	/* general purpose buffer */
 	char errbuf[1024];		/* buffer for reporting errors */
 	char *config_name;		/* parse first word of line */
 	char *config_value;		/* parsed second word - right after colen (:) */
@@ -389,7 +389,7 @@ parse_config(char *fname)
 					 * done by default prior to 7.1.
 					 */
 					if (strstr(config_value, "host") == NULL)
-						strcpy(buf2, "host,");
+						pbs_strncpy(buf2, "host,", PBS_FGETS_LINE_LEN);
 
 					/* hack: add in "vnode" in 8.0 */
 					if (strstr(config_value, "vnode") == NULL)
@@ -414,19 +414,19 @@ parse_config(char *fname)
 					if (strlen(config_value) > PBS_MAXQUEUENAME)
 						error = 1;
 					else
-						strcpy(conf.ded_prefix, config_value);
+						pbs_strncpy(conf.ded_prefix, config_value, PBS_MAXQUEUENAME + 1);
 				}
 				else if (!strcmp(config_name, PARSE_PRIMETIME_PREFIX)) {
 					if (strlen(config_value) > PBS_MAXQUEUENAME)
 						error = 1;
 					else
-						strcpy(conf.pt_prefix, config_value);
+						pbs_strncpy(conf.pt_prefix, config_value, PBS_MAXQUEUENAME + 1);
 				}
 				else if (!strcmp(config_name, PARSE_NONPRIMETIME_PREFIX)) {
 					if (strlen(config_value) > PBS_MAXQUEUENAME)
 						error = 1;
 					else
-						strcpy(conf.npt_prefix, config_value);
+						pbs_strncpy(conf.npt_prefix, config_value, PBS_MAXQUEUENAME + 1);
 				}
 				else if (!strcmp(config_name, PARSE_SMP_CLUSTER_DIST)) {
 					for (i = 0; i < HIGH_SMP_DIST; i++)

--- a/src/scheduler/pbs_sched.c
+++ b/src/scheduler/pbs_sched.c
@@ -732,9 +732,8 @@ lock_out(int fds, int op)
 	flock.l_start  = 0;
 	flock.l_len    = 0;	/* whole file */
 	if (fcntl(fds, F_SETLK, &flock) < 0) {
-		pbs_strncpy(log_buffer, "pbs_sched: another scheduler running\n", sizeof(log_buffer));
-		log_err(errno, msg_daemonname, log_buffer);
-		fprintf(stderr, "%s", log_buffer);
+		log_err(errno, msg_daemonname, "another scheduler running");
+		fprintf(stderr, "pbs_sched: another scheduler running\n");
 		exit(1);
 	}
 }

--- a/src/scheduler/pbs_sched.c
+++ b/src/scheduler/pbs_sched.c
@@ -732,7 +732,7 @@ lock_out(int fds, int op)
 	flock.l_start  = 0;
 	flock.l_len    = 0;	/* whole file */
 	if (fcntl(fds, F_SETLK, &flock) < 0) {
-		(void)strcpy(log_buffer, "pbs_sched: another scheduler running\n");
+		pbs_strncpy(log_buffer, "pbs_sched: another scheduler running\n", LOG_BUF_SIZE);
 		log_err(errno, msg_daemonname, log_buffer);
 		fprintf(stderr, "%s", log_buffer);
 		exit(1);

--- a/src/scheduler/pbs_sched.c
+++ b/src/scheduler/pbs_sched.c
@@ -732,7 +732,7 @@ lock_out(int fds, int op)
 	flock.l_start  = 0;
 	flock.l_len    = 0;	/* whole file */
 	if (fcntl(fds, F_SETLK, &flock) < 0) {
-		pbs_strncpy(log_buffer, "pbs_sched: another scheduler running\n", LOG_BUF_SIZE);
+		pbs_strncpy(log_buffer, "pbs_sched: another scheduler running\n", sizeof(log_buffer));
 		log_err(errno, msg_daemonname, log_buffer);
 		fprintf(stderr, "%s", log_buffer);
 		exit(1);

--- a/src/scheduler/simulate.c
+++ b/src/scheduler/simulate.c
@@ -576,19 +576,19 @@ perform_event(status *policy, timed_event *event)
 			}
 			break;
 		case TIMED_POLICY_EVENT:
-			strcpy(logbuf, "Policy change");
+			pbs_strncpy(logbuf, "Policy change", LOG_BUF_SIZE);
 			break;
 		case TIMED_DED_START_EVENT:
-			strcpy(logbuf, "Dedtime Start");
+			pbs_strncpy(logbuf, "Dedtime Start", LOG_BUF_SIZE);
 			break;
 		case TIMED_DED_END_EVENT:
-			strcpy(logbuf, "Dedtime End");
+			pbs_strncpy(logbuf, "Dedtime End", LOG_BUF_SIZE);
 			break;
 		case TIMED_NODE_UP_EVENT:
-			strcpy(logbuf, "Node Up");
+			pbs_strncpy(logbuf, "Node Up", LOG_BUF_SIZE);
 			break;
 		case TIMED_NODE_DOWN_EVENT:
-			strcpy(logbuf, "Node Down");
+			pbs_strncpy(logbuf, "Node Down", LOG_BUF_SIZE);
 			break;
 		default:
 			log_event(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_INFO,

--- a/src/scheduler/simulate.c
+++ b/src/scheduler/simulate.c
@@ -576,19 +576,19 @@ perform_event(status *policy, timed_event *event)
 			}
 			break;
 		case TIMED_POLICY_EVENT:
-			pbs_strncpy(logbuf, "Policy change", LOG_BUF_SIZE);
+			pbs_strncpy(logbuf, "Policy change", sizeof(logbuf));
 			break;
 		case TIMED_DED_START_EVENT:
-			pbs_strncpy(logbuf, "Dedtime Start", LOG_BUF_SIZE);
+			pbs_strncpy(logbuf, "Dedtime Start", sizeof(logbuf));
 			break;
 		case TIMED_DED_END_EVENT:
-			pbs_strncpy(logbuf, "Dedtime End", LOG_BUF_SIZE);
+			pbs_strncpy(logbuf, "Dedtime End", sizeof(logbuf));
 			break;
 		case TIMED_NODE_UP_EVENT:
-			pbs_strncpy(logbuf, "Node Up", LOG_BUF_SIZE);
+			pbs_strncpy(logbuf, "Node Up", sizeof(logbuf));
 			break;
 		case TIMED_NODE_DOWN_EVENT:
-			pbs_strncpy(logbuf, "Node Down", LOG_BUF_SIZE);
+			pbs_strncpy(logbuf, "Node Down", sizeof(logbuf));
 			break;
 		default:
 			log_event(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_INFO,


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
#### Describe Your Change
Using strcpy at times can be risky and cause problems like buffer overrun.

In this PR, I've added a generic pbs_strncpy function that always puts a '\0' at the end of the buffer.

Changed all strcpy in the scheduler module to pbs_strncpy.

In future, we need to also make changes to other modules.


#### Link to Design Doc
N/A

#### Attach Test and Valgrind Logs/Output

[smoketest.txt](https://github.com/openpbs/openpbs/files/4974728/smoketest.txt)

<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
