### PR TITLE
Make decorators skip tests before setup

### DIFF
--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -454,7 +454,7 @@ class PBSTestSuite(unittest.TestCase):
         cls.server.restart()
         cls.log_end_setup(True)
         # methods for skipping tests with ptl decorators
-        cls.populate_test_list()
+        cls.populate_test_dict()
         cls.skip_cray_tests()
         cls.skip_shasta_tests()
         cls.skip_cpuset_tests()
@@ -505,52 +505,47 @@ class PBSTestSuite(unittest.TestCase):
         self.measurements = []
 
     @classmethod
-    def populate_test_list(cls):
-        cls.test_list = [attr for attr in dir(cls)
-                         if attr.startswith('test')
-                         and callable(getattr(cls, attr))]
+    def populate_test_dict(cls):
+        cls.test_dict = {}
+        for attr in dir(cls):
+            if attr.startswith('test'):
+                obj = getattr(cls, attr)
+                if callable(obj):
+                    cls.test_dict[attr] = obj
 
     @classmethod
     def skip_cray_tests(cls):
         if not cls.mom.is_cray():
             return
         msg = 'capability not supported on Cray'
-        # check if we need to skip the whole test suite
-        if '__skip_on_cray__' in cls.__dict__ \
-           and cls.__skip_on_cray__ is True:
-            for test_name in cls.test_list:
-                test_item = getattr(cls, test_name)
+        if cls.__dict__.get('__skip_on_cray__', False):
+            # skip all test cases in this test suite
+            for test_item in cls.test_dict.values():
                 test_item.__unittest_skip__ = True
                 test_item.__unittest_skip_why__ = msg
-            return
-        # skip individual test cases
-        for test_name in cls.test_list:
-            test_item = getattr(cls, test_name)
-            if '__skip_on_cray__' in test_item.__dict__ \
-               and test_item.__skip_on_cray__ is True:
-                test_item.__unittest_skip__ = True
-                test_item.__unittest_skip_why__ = msg
+        else:
+            # skip individual test cases
+            for test_item in cls.test_dict.values():
+                if test_item.__dict__.get('__skip_on_cray__', False):
+                    test_item.__unittest_skip__ = True
+                    test_item.__unittest_skip_why__ = msg
 
     @classmethod
     def skip_shasta_tests(cls):
         if not cls.mom.is_shasta():
             return
         msg = 'capability not supported on Cray Shasta'
-        # check if we need to skip the whole test suite
-        if '__skip_on_shasta__' in cls.__dict__ \
-           and cls.__skip_on_shasta__ is True:
-            for test_name in cls.test_list:
-                test_item = getattr(cls, test_name)
+        if cls.__dict__.get('__skip_on_shasta__', False):
+            # skip all test cases in this test suite
+            for test_item in cls.test_dict.values():
                 test_item.__unittest_skip__ = True
                 test_item.__unittest_skip_why__ = msg
-            return
-        # skip individual test cases
-        for test_name in cls.test_list:
-            test_item = getattr(cls, test_name)
-            if '__skip_on_shasta__' in test_item.__dict__ \
-               and test_item.__skip_on_shasta__ is True:
-                test_item.__unittest_skip__ = True
-                test_item.__unittest_skip_why__ = msg
+        else:
+            # skip individual test cases
+            for test_item in cls.test_dict.values():
+                if test_item.__dict__.get('__skip_on_shasta__', False):
+                    test_item.__unittest_skip__ = True
+                    test_item.__unittest_skip_why__ = msg
 
     @classmethod
     def skip_cpuset_tests(cls):
@@ -558,26 +553,22 @@ class PBSTestSuite(unittest.TestCase):
         for mom in cls.moms.values():
             if mom.is_cpuset_mom():
                 skip_cpuset_tests = True
-                msg = 'capability not supported on cgroup cpuset system: ' +\
-                      mom.shortname
+                msg = 'capability not supported on cgroup cpuset system: '
+                msg += mom.shortname
                 break
         if not skip_cpuset_tests:
             return
-        # check if we need to skip the whole test suite
-        if '__skip_on_cpuset__' in cls.__dict__ \
-           and cls.__skip_on_cpuset__ is True:
-            for test_name in cls.test_list:
-                test_item = getattr(cls, test_name)
+        if cls.__dict__.get('__skip_on_cpuset__', False):
+            # skip all test cases in this test suite
+            for test_item in cls.test_dict.values():
                 test_item.__unittest_skip__ = True
                 test_item.__unittest_skip_why__ = msg
-            return
-        # skip individual test cases
-        for test_name in cls.test_list:
-            test_item = getattr(cls, test_name)
-            if '__skip_on_cpuset__' in test_item.__dict__ \
-               and test_item.__skip_on_cpuset__ is True:
-                test_item.__unittest_skip__ = True
-                test_item.__unittest_skip_why__ = msg
+        else:
+            # skip individual test cases
+            for test_item in cls.test_dict.values():
+                if test_item.__dict__.get('__skip_on_cpuset__', False):
+                    test_item.__unittest_skip__ = True
+                    test_item.__unittest_skip_why__ = msg
 
     @classmethod
     def log_enter_setup(cls, iscls=False):

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -102,8 +102,15 @@ skipOnCray = unittest.skipIf(os.path.isfile('/etc/xthostname'),
 skipOnShasta = unittest.skipIf(os.path.isfile('/etc/cray/xname'),
                                'capability not supported on Cray Shasta')
 
-skipOnCpuSet = unittest.skipIf(any(map(lambda m: m.is_cpuset_mom,
-                                       self.moms.values())),
+
+def anyMomIsCpuSet(self):
+    for mom in self.mom.values():
+        if mom.is_cpuset_mom():
+            return True
+    return False
+
+
+skipOnCpuSet = unittest.skipIf(anyMomIsCpuSet,
                                'capability not supported on cgroup '
                                'cpuset system')
 

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -102,17 +102,11 @@ skipOnCray = unittest.skipIf(os.path.isfile('/etc/xthostname'),
 skipOnShasta = unittest.skipIf(os.path.isfile('/etc/cray/xname'),
                                'capability not supported on Cray Shasta')
 
-
-def anyMomIsCpuSet(self):
-    for mom in self.mom.values():
-        if mom.is_cpuset_mom():
-            return True
-    return False
-
-
-skipOnCpuSet = unittest.skipIf(anyMomIsCpuSet,
-                               'capability not supported on cgroup '
-                               'cpuset system')
+skipOnCpuSet = unittest.skipIf(os.path.isfile('/etc/sgi-compute-node-release')
+                               or
+                               os.path.isfile('/etc/sgi-known-distributions'),
+                               'capability not supported on cgroups cpuset'
+                               ' system')
 
 
 def timeout(val):

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -94,13 +94,16 @@ default_requirements = {
     'no_comm_on_mom': True
 }
 
+
 def skip(reason="Skipped test execution"):
     """
     Unconditionally skip a test.
+
     :param reason: Reason for the skip
     :type reason: str or None
     """
     skip_flag = True
+
     def wrapper(test_item):
         test_item.__unittest_skip__ = skip_flag
         test_item.__unittest_skip_why__ = reason
@@ -133,6 +136,7 @@ def checkModule(modname):
         return function
     return decorated
 
+
 def skipOnCray(function):
     """
     Decorator to skip a test on a ``Cray`` system
@@ -154,22 +158,22 @@ def skipOnShasta(function):
 
 
 def skipOnCpuSet(function):
-     """
-     Decorator to skip a test on a cgroup cpuset system
-     """
+    """
+    Decorator to skip a test on a cgroup cpuset system
+    """
 
-     def wrapper(self, *args, **kwargs):
-         for mom in self.moms.values():
-             if mom.is_cpuset_mom():
-                 msg = 'capability not supported on cgroup cpuset system: ' +\
-                       mom.shortname
-                 self.skipTest(reason=msg)
-                 break
-         else:
-             function(self, *args, **kwargs)
-     wrapper.__doc__ = function.__doc__
-     wrapper.__name__ = function.__name__
-     return wrapper
+    def wrapper(self, *args, **kwargs):
+        for mom in self.moms.values():
+            if mom.is_cpuset_mom():
+                msg = 'capability not supported on cgroup cpuset system: ' +\
+                    mom.shortname
+                self.skipTest(reason=msg)
+                break
+        else:
+            function(self, *args, **kwargs)
+    wrapper.__doc__ = function.__doc__
+    wrapper.__name__ = function.__name__
+    return wrapper
 
 
 def requirements(*args, **kwargs):

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -94,21 +94,7 @@ default_requirements = {
     'no_comm_on_mom': True
 }
 
-
-def skip(reason="Skipped test execution"):
-    """
-    Unconditionally skip a test.
-
-    :param reason: Reason for the skip
-    :type reason: str or None
-    """
-    skip_flag = True
-
-    def wrapper(test_item):
-        test_item.__unittest_skip__ = skip_flag
-        test_item.__unittest_skip_why__ = reason
-        return test_item
-    return wrapper
+skip = unittest.skip
 
 
 def timeout(val):
@@ -122,72 +108,37 @@ def timeout(val):
 
 
 def checkModule(modname):
-    """
-    Decorator to check if named module is available on the system
-    and if not skip the test
-    """
-    def decorated(function):
-        def wrapper(self, *args, **kwargs):
-            import imp
-            try:
-                imp.find_module(modname)
-            except ImportError:
-                self.skipTest(reason='Module unavailable ' + modname)
-            else:
-                function(self, *args, **kwargs)
-        wrapper.__doc__ = function.__doc__
-        wrapper.__name__ = function.__name__
-        return wrapper
-    return decorated
-
-
-def skipOnCray(function):
-    """
-    Decorator to skip a test on a ``Cray`` system
-    """
-
-    def wrapper(self, *args, **kwargs):
-        if self.mom.is_cray():
-            self.skipTest(reason='capability not supported on Cray')
-        else:
-            function(self, *args, **kwargs)
-    wrapper.__doc__ = function.__doc__
-    wrapper.__name__ = function.__name__
+    def wrapper(func):
+        return func 
+    import imp
+    try:
+        imp.find_module(modname)
+    except ImportError:
+        return unittest.skip(func, reason='Module unavailable')
     return wrapper
 
 
-def skipOnShasta(function):
-    """
-    Decorator to skip a test on a ``Cray Shasta`` system
-    """
+def momIsCray(self):
+    return self.mom.is_cray()
 
-    def wrapper(self, *args, **kwargs):
-        if self.mom.is_shasta():
-            self.skipTest(reason='capability not supported on Cray Shasta')
-        else:
-            function(self, *args, **kwargs)
-    wrapper.__doc__ = function.__doc__
-    wrapper.__name__ = function.__name__
-    return wrapper
+skipOnCray = unittest.skipIf(momIsCray, 'capability not supported on Cray')
 
 
-def skipOnCpuSet(function):
-    """
-    Decorator to skip a test on a cgroup cpuset system
-    """
+def momIsShasta(self):
+    return self.mom.is_shasta()
 
-    def wrapper(self, *args, **kwargs):
-        for mom in self.moms.values():
-            if mom.is_cpuset_mom():
-                msg = 'capability not supported on cgroup cpuset system: ' +\
-                      mom.shortname
-                self.skipTest(reason=msg)
-                break
-        else:
-            function(self, *args, **kwargs)
-    wrapper.__doc__ = function.__doc__
-    wrapper.__name__ = function.__name__
-    return wrapper
+skipOnShasta = unittest.skipIf(momIsShasta,\
+    'capability not supported on Cray Shasta')
+
+
+def anyMomIsCpuSet(self):
+    for mom in self.moms.values():
+        if mom.is_cpuset_mom():
+            return True
+    return False
+
+skipOnCpuSet = unittest.skipIf(anyMomIsCpuSet,\
+    'capability not supported on cgroup cpuset system')
 
 
 def requirements(*args, **kwargs):

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -109,7 +109,7 @@ def timeout(val):
 
 def checkModule(modname):
     def wrapper(func):
-        return func 
+        return func
     import imp
     try:
         imp.find_module(modname)
@@ -121,14 +121,16 @@ def checkModule(modname):
 def momIsCray(self):
     return self.mom.is_cray()
 
+
 skipOnCray = unittest.skipIf(momIsCray, 'capability not supported on Cray')
 
 
 def momIsShasta(self):
     return self.mom.is_shasta()
 
-skipOnShasta = unittest.skipIf(momIsShasta,\
-    'capability not supported on Cray Shasta')
+
+skipOnShasta = unittest.skipIf(momIsShasta,
+                               'capability not supported on Cray Shasta')
 
 
 def anyMomIsCpuSet(self):
@@ -137,8 +139,10 @@ def anyMomIsCpuSet(self):
             return True
     return False
 
-skipOnCpuSet = unittest.skipIf(anyMomIsCpuSet,\
-    'capability not supported on cgroup cpuset system')
+
+skipOnCpuSet = unittest.skipIf(anyMomIsCpuSet,
+                               'capability not supported on cgroup '
+                               'cpuset system')
 
 
 def requirements(*args, **kwargs):

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -96,6 +96,16 @@ default_requirements = {
 
 skip = unittest.skip
 
+skipOnCray = unittest.skipIf(os.path.isfile('/etc/xthostname'),
+                             'capability not supported on Cray')
+
+skipOnShasta = unittest.skipIf(os.path.isfile('/etc/cray/xname'),
+                               'capability not supported on Cray Shasta')
+
+skipOnCpuSet = unittest.skipIf(any(map(lambda m: m.is_cpuset_mom, 
+                                       self.moms.values())),
+                               'capability not supported on cgroup '
+                               'cpuset system')
 
 def timeout(val):
     """
@@ -110,39 +120,13 @@ def timeout(val):
 def checkModule(modname):
     def wrapper(func):
         return func
+
     import imp
     try:
         imp.find_module(modname)
     except ImportError:
-        return unittest.skip(func, reason='Module unavailable')
+        unittest.skip(func, reason='Module unavailable')
     return wrapper
-
-
-def momIsCray(self):
-    return self.mom.is_cray()
-
-
-skipOnCray = unittest.skipIf(momIsCray, 'capability not supported on Cray')
-
-
-def momIsShasta(self):
-    return self.mom.is_shasta()
-
-
-skipOnShasta = unittest.skipIf(momIsShasta,
-                               'capability not supported on Cray Shasta')
-
-
-def anyMomIsCpuSet(self):
-    for mom in self.moms.values():
-        if mom.is_cpuset_mom():
-            return True
-    return False
-
-
-skipOnCpuSet = unittest.skipIf(anyMomIsCpuSet,
-                               'capability not supported on cgroup '
-                               'cpuset system')
 
 
 def requirements(*args, **kwargs):

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -120,15 +120,12 @@ def timeout(val):
 
 
 def checkModule(modname):
-    def wrapper(func):
-        return func
-
     import imp
     try:
         imp.find_module(modname)
     except ImportError:
-        unittest.skip(func, reason='Module unavailable')
-    return wrapper
+        return unittest.skip('%s Module unavailable' % modname)
+    return unittest._id
 
 
 def requirements(*args, **kwargs):

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -102,10 +102,11 @@ skipOnCray = unittest.skipIf(os.path.isfile('/etc/xthostname'),
 skipOnShasta = unittest.skipIf(os.path.isfile('/etc/cray/xname'),
                                'capability not supported on Cray Shasta')
 
-skipOnCpuSet = unittest.skipIf(any(map(lambda m: m.is_cpuset_mom, 
+skipOnCpuSet = unittest.skipIf(any(map(lambda m: m.is_cpuset_mom,
                                        self.moms.values())),
                                'capability not supported on cgroup '
                                'cpuset system')
+
 
 def timeout(val):
     """

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -515,6 +515,15 @@ class PBSTestSuite(unittest.TestCase):
         if not cls.mom.is_cray():
             return
         msg = 'capability not supported on Cray'
+        # check if we need to skip the whole test suite
+        if '__skip_on_cray__' in cls.__dict__ \
+           and cls.__skip_on_cray__ is True:
+            for test_name in cls.test_list:
+                test_item = getattr(cls, test_name)
+                test_item.__unittest_skip__ = True
+                test_item.__unittest_skip_why__ = msg
+            return
+        # skip individual test cases
         for test_name in cls.test_list:
             test_item = getattr(cls, test_name)
             if '__skip_on_cray__' in test_item.__dict__ \
@@ -527,6 +536,15 @@ class PBSTestSuite(unittest.TestCase):
         if not cls.mom.is_shasta():
             return
         msg = 'capability not supported on Cray Shasta'
+        # check if we need to skip the whole test suite
+        if '__skip_on_shasta__' in cls.__dict__ \
+           and cls.__skip_on_shasta__ is True:
+            for test_name in cls.test_list:
+                test_item = getattr(cls, test_name)
+                test_item.__unittest_skip__ = True
+                test_item.__unittest_skip_why__ = msg
+            return
+        # skip individual test cases
         for test_name in cls.test_list:
             test_item = getattr(cls, test_name)
             if '__skip_on_shasta__' in test_item.__dict__ \
@@ -545,6 +563,15 @@ class PBSTestSuite(unittest.TestCase):
                 break
         if not skip_cpuset_tests:
             return
+        # check if we need to skip the whole test suite
+        if '__skip_on_cpuset__' in cls.__dict__ \
+           and cls.__skip_on_cpuset__ is True:
+            for test_name in cls.test_list:
+                test_item = getattr(cls, test_name)
+                test_item.__unittest_skip__ = True
+                test_item.__unittest_skip_why__ = msg
+            return
+        # skip individual test cases
         for test_name in cls.test_list:
             test_item = getattr(cls, test_name)
             if '__skip_on_cpuset__' in test_item.__dict__ \


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

## Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
This PR aims to fix several issues with decorators:
1. make decorators skip test cases before setUp is run
2. make multiple decorators more reliable

## Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
1. Instead of checking for the machine platform inside the decorator and skipping tests, each decorator now only marks the test case object with an attribute (`__skip_on_cpuset__`, `__skip_on_cray__` etc.). 
2. Testing machine platform and skipping tests now happen at the end of `setUpClass`. I introduced three new functions inside `PbsTestSuite`: `skip_cray_tests`, `skip_shasta_tests` and `skip_cpuset_tests`.  Each function tests if it is running on the concerning platform, and if true, find all the tests marked with the corresponding attribute and skip them .
3. I also introduced a function `populate_test_list` to retrieve all the tests in a test suite, so this only has to happen once and the list can be reused. 

## Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
N/A

## Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

### Individual decorator

#### skipOnCpuSet
SmokeTests
* Test that test cases marked with skipOnCpuSet decorator skip on a cpuset machine
<img width="1656" alt="Screen Shot 2020-08-17 at 6 11 21 PM" src="https://user-images.githubusercontent.com/6920446/90385185-5223c600-e0b5-11ea-8927-ce39d3d46bff.png">


* Test that test cases marked with skipOnCpuSet decorator pass on a non cpuset machine
<img width="1655" alt="Screen Shot 2020-08-17 at 11 00 08 PM" src="https://user-images.githubusercontent.com/6920446/90411229-08030a80-e0de-11ea-8f3b-80b87bf80845.png">


TestPbsAccumulateRescUsed.test_periodic
TestPbsExecutePrologue.test_prologue_internal_error_offline_vnode
* Multi-mom tests: Test that skipOnCpuSet decorator works for multi-mom test cases
    Server: x50-centos7
    Mom: x69-s12-altix x48-centos7

[test_prologue_internal_error_offline_vnodes SKIP 3 nodes.txt](https://github.com/openpbs/openpbs/files/5087553/test_prologue_internal_error_offline_vnodes.SKIP.3.nodes.txt)
[test_periodic SKIP 3 nodes.txt](https://github.com/openpbs/openpbs/files/5087552/test_periodic.SKIP.3.nodes.txt)



#### skipOnCray
TestCgroupsHook.test_cgroup_assign_resources_mem_only_vnode
TestJobArray.test_subjob_wrong_state


* test that these tests skip on a cray machine (x81-s12-cray)
[test_cgroup_assign_resources_mem_only_vnode SKIP x81.txt](https://github.com/openpbs/openpbs/files/5083236/test_cgroup_assign_resources_mem_only_vnode.SKIP.x81.txt)
[test_subjob_wrong_state SKIP x81.txt](https://github.com/openpbs/openpbs/files/5083238/test_subjob_wrong_state.SKIP.x81.txt)


* test that these tests do not skip on a non-cray machine (x50-centos7)
[test_cgroup_assign_resources_mem_only_vnode PASS.txt](https://github.com/openpbs/openpbs/files/5082020/test_cgroup_assign_resources_mem_only_vnode.PASS.txt)
[TestJobArray.test_subjob_wrong_state PASS.txt](https://github.com/openpbs/openpbs/files/5082022/TestJobArray.test_subjob_wrong_state.PASS.txt)


#### skipOnShasta

* Test that skipOnShasta decorator works on a simulated Shasta machine (on x81 with a fake /etc/cray/xname file)
[SmokeTest.test_staging SKIP x81.txt](https://github.com/openpbs/openpbs/files/5083000/SmokeTest.test_staging.SKIP.x81.txt)
[SmokeTest.test_interactive_job SKIP x81.txt](https://github.com/openpbs/openpbs/files/5082999/SmokeTest.test_interactive_job.SKIP.x81.txt)


* Test that skipOnShasta decorator does not skip tests on a non-shasta machine
[SmokeTest.test_staging PASS x50-centos7.txt](https://github.com/openpbs/openpbs/files/5082081/SmokeTest.test_staging.PASS.x50-centos7.txt)
[SmokeTest.test_interactive_job PASS x50-centos7.txt](https://github.com/openpbs/openpbs/files/5082098/SmokeTest.test_interactive_job.PASS.x50-centos7.txt)


#### requirements
TestRequirementsDecorator
* one node, mom on server
<img width="682" alt="Screen Shot 2020-07-28 at 6 10 38 PM" src="https://user-images.githubusercontent.com/6920446/88653276-6b60d480-d0fe-11ea-80f9-badb5723af01.png">

* two nodes, mom not on server
<img width="663" alt="Screen Shot 2020-07-28 at 6 40 42 PM" src="https://user-images.githubusercontent.com/6920446/88655845-eaa3d780-d101-11ea-96a7-7e4cc315158c.png">

#### checkModule
SmokeTest.test_interactive_job

* Test case passes when "pexpect" module is available
[SmokeTest.test_interactive_job PASS x50-centos7.txt](https://github.com/openpbs/openpbs/files/5082056/SmokeTest.test_interactive_job.PASS.x50-centos7.txt)


* Test case is skipped when "pexpect" module is not available
[SmokeTest.test_interactive_job SKIP x50-centos7.txt](https://github.com/openpbs/openpbs/files/5082057/SmokeTest.test_interactive_job.SKIP.x50-centos7.txt)

-----------------------------------
### Mix decorators

#### requirements + skipOnCpuSet
TestPreemption.test_host_resource_contention, TestReservation.test_advance_resv_with_multi_node_job_array
* test that these two test cases skip when run on a single node
<img width="704" alt="Screen Shot 2020-07-27 at 7 41 34 PM" src="https://user-images.githubusercontent.com/6920446/88658357-e24d9b80-d105-11ea-967d-6f2a1a61785c.png">

* Test that these two test cases skip when run on two nodes, one of them is cpuset machine
<img width="1648" alt="Screen Shot 2020-08-18 at 10 20 00 AM" src="https://user-images.githubusercontent.com/6920446/90463138-c5bce600-e13c-11ea-952f-390b0b84cffc.png">

[test_advance_resv_with_multinode_job_array SKIP 2 nodes cpuset.txt](https://github.com/openpbs/openpbs/files/5087793/test_advance_resv_with_multinode_job_array.SKIP.2.nodes.cpuset.txt)
[test_host_resource_contention SKIP 2 nodes cpuset.txt](https://github.com/openpbs/openpbs/files/5087794/test_host_resource_contention.SKIP.2.nodes.cpuset.txt)


#### checkModule + skipOnShasta
SmokeTest.test_interactive_job
* System is Cray Shasta (x81-s12-cray with file /etc/cray/xname file)
  - pexpect module is available, skip reason should be "capability not supported on Cray Shasta"
     [SmokeTest.test_interactive_job with pexpect SKIP x81.txt](https://github.com/openpbs/openpbs/files/5083071/SmokeTest.test_interactive_job.with.pexpect.x81.txt)
  - pexpect module is not available, skip reason should also be "capability not supported on Cray Shasta" since skipOnShasta executes before checkModule
    [SmokeTest.test_interactive_job no expect SKIP x81.txt](https://github.com/openpbs/openpbs/files/5083088/SmokeTest.test_interactive_job.no.expect.x81.txt)

* System is not Shasta (x50-centos7)
Please see section "checkModule" above


#### skipOnCpuSet + skipOnCray
TestPbsnodes.test_pbsnodes_as_user
TestPbsnodes.test_pbsnodes_as_root

* Test that these tests skip on a cray machine (x81-s12-cray)
[test_pbsnodes_as_user SKIP x81.txt](https://github.com/openpbs/openpbs/files/5083301/test_pbsnodes_as_user.SKIP.x81.txt)
[test_pbsnodes_as_root SKIP x81.txt](https://github.com/openpbs/openpbs/files/5083302/test_pbsnodes_as_root.SKIP.x81.txt)

* Test that these tests skip on a cpuset machine (x69-s12-altix)
[test_pbsnodes_as_root SKIP x69.txt](https://github.com/openpbs/openpbs/files/5083387/test_pbsnodes_as_root.SKIP.x69.txt)
[test_pbsnodes_as_user SKIP x69.txt](https://github.com/openpbs/openpbs/files/5083389/test_pbsnodes_as_user.SKIP.x69.txt)

-----------------------------------
### Decorators on the test suite level
I could not find any PBS test suite that is being skipped on the test suite level using one of the skipOnXXX decorators, so I wrote a stub test suite with the following content:
```
from tests.functional import *


class TestSkipTestSuite(TestFunctional):

    def test_one(self):
        self.logger.info("## test one ran")

    def test_two(self):
        self.logger.info("## test two ran")
```
I decorated the class with each decorator to verify that it works on the test suite level. 

[x69-s12-altix skipOnCpuSet.txt](https://github.com/openpbs/openpbs/files/5095120/x69-s12-altix.skipOnCpuSet.txt)
[x81-s12-cray skipOnCray.txt](https://github.com/openpbs/openpbs/files/5095253/x81-s12-cray.skipOnCray.txt)
[x81-s12-cray skipOnShasta.txt](https://github.com/openpbs/openpbs/files/5095279/x81-s12-cray.skipOnShasta.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
