### PR TITLE
Fix habitat script missing pbs_db_utility

### DIFF
--- a/src/cmds/scripts/pbs_habitat.in
+++ b/src/cmds/scripts/pbs_habitat.in
@@ -244,13 +244,13 @@ if [ -f "$PBS_HOME/mom_priv/config" ]; then
 	done
 fi
 
-# Check for the db install script
-if [ ! -x "${PBS_EXEC}/libexec/pbs_db_utility" ]; then
-	echo "${PBS_EXEC}/libexec/pbs_db_utility not found"
-	exit 1
-fi
-
 if [ "${PBS_START_SERVER:-0}" != 0 ] ; then
+	# Check for the db install script
+	if [ ! -x "${PBS_EXEC}/libexec/pbs_db_utility" ]; then
+		echo "${PBS_EXEC}/libexec/pbs_db_utility not found"
+		exit 1
+	fi
+
 	# Source the file that sets DB env variables
 	. "$PBS_EXEC"/libexec/pbs_db_env
 	if [ $? -ne 0 ]; then


### PR DESCRIPTION
#### Describe Bug or Feature
Execution rpm installations failed after #1641.
The habitat script expects a file to be present that is only present in the server rpm.

#### Describe Your Change
Only check for pbs_db_utility if PBS_START_SERVER=1 is set.


#### Attach Test and Valgrind Logs/Output
```
[vstumpf@shecil x86_64]$ sudo /etc/init.d/pbs start
Starting PBS
PBS Home directory /var/spool/pbs needs updating.
Running /opt/pbs/libexec/pbs_habitat to update it.
***
*** End of /opt/pbs/libexec/pbs_habitat
Home directory /var/spool/pbs updated.
PBS mom
[vstumpf@shecil x86_64]$ sudo /etc/init.d/pbs stop
```
I dont really think I need to write a test, so here's a manual version.

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
