### PR TITLE
Execution only rpm install fails

### DIFF
--- a/src/cmds/scripts/pbs_habitat.in
+++ b/src/cmds/scripts/pbs_habitat.in
@@ -244,13 +244,13 @@ if [ -f "$PBS_HOME/mom_priv/config" ]; then
 	done
 fi
 
-# Check for the db install script
-if [ ! -x "${PBS_EXEC}/libexec/pbs_db_utility" ]; then
-	echo "${PBS_EXEC}/libexec/pbs_db_utility not found"
-	exit 1
-fi
-
 if [ "${PBS_START_SERVER:-0}" != 0 ] ; then
+	# Check for the db install script
+	if [ ! -x "${PBS_EXEC}/libexec/pbs_db_utility" ]; then
+		echo "${PBS_EXEC}/libexec/pbs_db_utility not found"
+		exit 1
+	fi
+
 	# Source the file that sets DB env variables
 	. "$PBS_EXEC"/libexec/pbs_db_env
 	if [ $? -ne 0 ]; then


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Check for pbs_db_utility check fails in an execution-only rpm install. Since we dont add this file to the package in execution-only mode, habitat errors out and exits.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Move the check inside pbs_server install check.



#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

Before fix:
[root@server-centos-8-1 x86_64]# /opt/pbs/libexec/pbs_habitat
***
/opt/pbs/libexec/pbs_db_utility not found
[root@server-centos-8-1 x86_64]# echo $?
1

After fix:
[root@server-centos-8-1 x86_64]# /opt/pbs/libexec/pbs_habitat
***
*** End of /opt/pbs/libexec/pbs_habitat
[root@server-centos-8-1 x86_64]# echo $?
0

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
