### PR TITLE
pbs_ralter -lselect for running reservations

### DIFF
--- a/src/scheduler/constant.h
+++ b/src/scheduler/constant.h
@@ -629,6 +629,13 @@ enum preempt_sort_vals {
 	PS_HIGH
 };
 
+enum nscr_vals {
+	NSCR_NONE = 0,
+	NSCR_VISITED = 1,
+	NSCR_SCATTERED = 2,
+	NSCR_INELIGIBLE = 4
+};
+
 #ifdef	__cplusplus
 }
 #endif

--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -735,7 +735,7 @@ struct node_info
 	int nodesig_ind;		/* resource signature index in server array */
 	node_info *svr_node;		/* ptr to svr's node if we're a resv node */
 	node_partition *hostset;	/* other vnodes on on the same host */
-	node_scratch nscr;		/* scratch space local to node search code */
+	unsigned int nscr;		/* scratch space local to node search code */
 	char *partition;		/* partition to which node belongs to */
 	time_t last_state_change_time;	/* Node state change at time stamp */
 	time_t last_used_time;		/* Node was last active at this time */

--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -1397,8 +1397,7 @@ query_job(struct batch_status *job, server_info *sinfo, schd_error *err)
 
 	if (execvnode != NULL) {
 		resresv->orig_nspec_arr = parse_execvnode(execvnode, sinfo, resresv->select);
-		resresv->nspec_arr = dup_nspecs(resresv->orig_nspec_arr, sinfo->nodes, resresv->select);
-		combine_nspec_array(resresv->nspec_arr);
+		resresv->nspec_arr = combine_nspec_array(resresv->orig_nspec_arr);
 
 		if (resresv->nspec_arr != NULL)
 			resresv->ninfo_arr = create_node_array_from_nspec(resresv->nspec_arr);

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -5023,7 +5023,7 @@ combine_nspec_array(nspec **nspec_arr)
 							req_i->res_str = string_dup(req_j->res_str);
 					} else { /* nspec_arr[j] has a resource nspec_arr[i] does not */
 						resource_req *tmpreq;
-						tmpreq = dup_resource_req(req_i);
+						tmpreq = dup_resource_req(req_j);
 						tmpreq->next = ns->resreq;
 						ns->resreq = tmpreq;
 					}

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -4986,8 +4986,8 @@ combine_nspec_array(nspec **nspec_arr)
 	}
 
 	for (i = 0; nspec_arr[i] != NULL; i++) {
-		ns = NULL;
 		int found = 0;
+		ns = NULL;
 		for (k = 0; new_nspec_arr[k] != NULL; k++)
 			if (new_nspec_arr[k]->ninfo == nspec_arr[i]->ninfo) {
 				found = 1;
@@ -4995,13 +4995,11 @@ combine_nspec_array(nspec **nspec_arr)
 			}
 		if (found)
 			continue;
-			
+
+		new_nspec_arr[k] = ns = new_nspec();
 		if (ns == NULL) {
-			new_nspec_arr[k] = ns = new_nspec();
-			if (ns == NULL) {
-				free_nspecs(new_nspec_arr);
-				return NULL;
-			}
+			free_nspecs(new_nspec_arr);
+			return NULL;
 		}
 
 		ns->end_of_chunk = 1;

--- a/src/scheduler/node_info.h
+++ b/src/scheduler/node_info.h
@@ -335,7 +335,7 @@ int compare_selspec(selspec *sel1, selspec *sel2);
  *	combine_nspec_array - find and combine any nspec's for the same node
  *				in an nspec array
  */
-void combine_nspec_array(nspec **nspec_arr);
+nspec **combine_nspec_array(nspec **nspec_arr);
 
 /*
  *	eval_selspec - eval a select spec to see if it is satisifable
@@ -619,17 +619,6 @@ node_info *find_node_by_rank(node_info **ninfo_arr, int rank);
 
 /* find node by index into sinfo->unordered_nodes or by unique rank */
 node_info *find_node_by_indrank(node_info **ninfo_arr, int ind, int rank);
-
-/*
- * node scratch constructor
- */
-node_scratch *new_node_scratch(void);
-
-
-/*
- * node_scratch destructor
- */
-void free_node_scratch(node_scratch *nscr);
 
 /* determine if resresv conflicts with future events on ninfo based on the exclhost state */
 int sim_exclhost(event_list *calendar, resource_resv *resresv, node_info *ninfo);

--- a/src/scheduler/resource_resv.c
+++ b/src/scheduler/resource_resv.c
@@ -682,11 +682,16 @@ dup_resource_resv(resource_resv *oresresv, server_info *nsinfo, queue_info *nqin
 		}
 	}
 	else if (oresresv->is_resv) {
+		selspec *sel;
 		nresresv->is_resv = 1;
 		nresresv->resv = dup_resv_info(oresresv->resv, nsinfo);
 
 		nresresv->ninfo_arr = copy_node_ptr_array(oresresv->ninfo_arr, nsinfo->nodes);
-		nresresv->orig_nspec_arr = dup_nspecs(oresresv->orig_nspec_arr, nsinfo->nodes, nresresv->select);
+		if (nresresv->resv->select_orig != NULL)
+			sel = nresresv->resv->select_orig;
+		else
+			sel = nresresv->select;
+		nresresv->orig_nspec_arr = dup_nspecs(oresresv->orig_nspec_arr, nsinfo->nodes, sel);
 		nresresv->nspec_arr = dup_nspecs(oresresv->nspec_arr, nsinfo->nodes, NULL);
 	}
 	else  { /* error */

--- a/src/scheduler/resv_info.h
+++ b/src/scheduler/resv_info.h
@@ -115,6 +115,9 @@ node_info **create_resv_nodes(nspec **nspec_arr, server_info *sinfo);
  */
 void release_running_resv_nodes(resource_resv *resv, server_info *sinfo);
 
+/* Reduce resv_nodes of a reservation on pbs_ralter -lselect for running jobs */
+int ralter_reduce_chunks(resource_resv *resv);
+
 /* Will we try and confirm this reservation in this cycle */
 int will_confirm(resource_resv *resv, time_t server_time);
 

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -2127,7 +2127,7 @@ check_running_job_not_in_reservation(resource_resv *job, void *arg)
 int
 check_resv_running_on_node(resource_resv *resv, void *arg)
 {
-	if (resv->is_resv && resv->resv !=NULL) {
+	if (resv->is_resv && resv->resv != NULL) {
 		if (resv->resv->is_running || resv->resv->resv_state == RESV_BEING_DELETED)
 			if (find_node_info(resv->ninfo_arr, (char *) arg))
 				return 1;

--- a/src/server/req_delete.c
+++ b/src/server/req_delete.c
@@ -999,15 +999,14 @@ req_deleteReservation(struct batch_request *preq)
 	if (presv->ri_qs.ri_state != RESV_UNCONFIRMED) {
 		char hook_msg[HOOK_MSG_SIZE] = {0};
 		switch (process_hooks(preq, hook_msg, sizeof(hook_msg), pbs_python_set_interrupt)) {
-	                case 0: /* explicit reject */
-	                case 1: /* no recreate request as there are only read permissions */
-	                case 2: /* no hook script executed - go ahead and accept event*/
-	                        break;
-	                default:
-	                        log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_HOOK, LOG_INFO, __func__, "resv_end event: accept req by default");
-        	}
+		case 0: /* explicit reject */
+		case 1: /* no recreate request as there are only read permissions */
+		case 2: /* no hook script executed - go ahead and accept event*/
+			break;
+		default:
+			log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_HOOK, LOG_INFO, __func__, "resv_end event: accept req by default");
+		}
 	}
-
 
 	/*If there are any jobs associated with the reservation, construct and
 	 *issue a PBS_BATCH_DeleteJob request for each job.

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -3266,9 +3266,9 @@ struct batch_request *preq;
 
 	save_nodes_db(1, NULL);
 
-	if (numnodes > 1) {          /*modification was for all nodes  */
+	if (numnodes > 1) {		/*modification was for all nodes  */
 
-		if (problem_cnt) {  /*one or more problems encountered*/
+		if (problem_cnt) {	/*one or more problems encountered*/
 
 			for (len=0, i=0; i<problem_cnt; i++)
 				len += strlen(problem_nodes[i]->nd_name) + 3;

--- a/src/server/req_modify.c
+++ b/src/server/req_modify.c
@@ -801,7 +801,7 @@ req_modifyReservation(struct batch_request *preq)
 		return;
 	}
 
-		num_jobs = presv->ri_qp->qu_numjobs;
+	num_jobs = presv->ri_qp->qu_numjobs;
 	if (svr_chk_history_conf()) {
 		num_jobs -= (presv->ri_qp->qu_njstate[JOB_STATE_MOVED] + presv->ri_qp->qu_njstate[JOB_STATE_FINISHED] +
 			presv->ri_qp->qu_njstate[JOB_STATE_EXPIRED]);
@@ -921,7 +921,7 @@ req_modifyReservation(struct batch_request *preq)
 					return;
 				}
 
-					send_to_scheduler = 1;
+				send_to_scheduler = 1;
 				presv->ri_alter.ra_flags |= RESV_SELECT_MODIFIED;
 				if (pseldef == NULL) /* do one time to keep handy */
 					pseldef = &svr_resc_def[RESC_SELECT];

--- a/test/tests/functional/pbs_ralter.py
+++ b/test/tests/functional/pbs_ralter.py
@@ -2120,9 +2120,9 @@ class TestPbsResvAlter(TestFunctional):
 
     def test_alter_select_complex(self):
         """
-        Test more complex use of pbs_ralter -l select 
+        Test more complex use of pbs_ralter -l select
         to shrink a reservation
-        We start with a 2 +'d spec, and shrink each chunk by one, and 
+        We start with a 2 +'d spec, and shrink each chunk by one, and
         then we shrink further and drop out the middle chunk
         """
         select = "2:ncpus=1:mem=1gb+4:ncpus=1:mem=2gb+2:ncpus=1:mem=3gb"
@@ -2143,7 +2143,7 @@ class TestPbsResvAlter(TestFunctional):
         """
         Test more complex use of pbs_ralter -l select to
         shrink a running reservation
-        We start with a 2 +'d spec, and shrink each chunk by one, and 
+        We start with a 2 +'d spec, and shrink each chunk by one, and
         then we shrink further and drop out the middle chunk
         """
         select = "2:ncpus=1:mem=1gb+4:ncpus=1:mem=2gb+2:ncpus=1:mem=3gb"

--- a/test/tests/functional/pbs_ralter.py
+++ b/test/tests/functional/pbs_ralter.py
@@ -241,10 +241,10 @@ class TestPbsResvAlter(TestFunctional):
         self.server.expect(RESV, attrs, id=rid, max_attempts=10,
                            interval=5)
         if wait is True:
-                attr = {'reserve_state': (MATCH_RE, 'RESV_RUNNING|5')}
-                t = start + freq - time.time()
-                self.server.expect(RESV, attr, id=rid,
-                                   offset=t, max_attempts=10)
+            attr = {'reserve_state': (MATCH_RE, 'RESV_RUNNING|5')}
+            t = start + freq - time.time()
+            self.server.expect(RESV, attr, id=rid,
+                               offset=t, max_attempts=10)
 
     def submit_job_to_resv(self, rid, sleep=10, user=None):
         """
@@ -2078,34 +2078,202 @@ class TestPbsResvAlter(TestFunctional):
     def test_alter_select_basic(self):
         """
         Test basic use of pbs_ralter -l select to shrink a reservation
+        We start with a 2 +'d reservation, and then we drop out the 1st and 3rd
+        chunk, and then reduce further
         """
-        offset = 3600
-        duration = 3600
-        select = "2:ncpus=1+4:ncpus=1+2:ncpus=1"
-        new_select1 = "4:ncpus=1"
-        new_select2 = "2:ncpus=1"
+        select = "2:ncpus=1:mem=1gb+4:ncpus=1:mem=2gb+2:ncpus=1:mem=3gb"
+        aselect1 = "4:ncpus=1:mem=2gb"
+        aselect2 = "2:ncpus=1:mem=2gb"
 
-        rid, start, end = self.submit_and_confirm_reservation(offset, duration,
+        rid, start, end, rnodes = self.alter_select_initial(True, select)
+
+        nodes = [4, rnodes, 0, [], 0, []]
+
+        self.alter_select(
+            rid, start, end, True, aselect1, 4, nodes, 1)
+
+        nodes = [2, rnodes, 0, [], 0, []]
+
+        self.alter_select(rid, start, end, True, aselect2, 2, nodes, 2)
+
+    def test_alter_select_basic_running(self):
+        """
+        Test basic use of pbs_ralter -l select
+        to shrink a running reservation
+        We start with a 2 +'d reservation, and then we drop out the 1st and 3rd
+        chunk, and then reduce further
+        """
+        select = "2:ncpus=1:mem=1gb+4:ncpus=1:mem=2gb+2:ncpus=1:mem=3gb"
+        aselect1 = "4:ncpus=1:mem=2gb"
+        aselect2 = "2:ncpus=1:mem=2gb"
+
+        rid, start, end, rnodes = self.alter_select_initial(False, select)
+
+        nodes = [0, [], 4, rnodes[2:6], 0, []]
+
+        rnodes2 = self.alter_select(
+            rid, start, end, False, aselect1, 4, nodes, 1)
+
+        nodes = [0, [], 2, rnodes2, 0, []]
+
+        self.alter_select(rid, start, end, False, aselect2, 2, nodes, 2)
+
+    def test_alter_select_complex(self):
+        """
+        Test more complex use of pbs_ralter -l select 
+        to shrink a reservation
+        We start with a 2 +'d spec, and shrink each chunk by one, and 
+        then we shrink further and drop out the middle chunk
+        """
+        select = "2:ncpus=1:mem=1gb+4:ncpus=1:mem=2gb+2:ncpus=1:mem=3gb"
+        aselect1 = "1:ncpus=1:mem=1gb+2:ncpus=1:mem=2gb+1:ncpus=1:mem=3gb"
+        aselect2 = "1:ncpus=1:mem=2gb"
+
+        rid, start, end, rnodes = self.alter_select_initial(True, select)
+
+        nodes = [4, rnodes, 0, [], 0, []]
+
+        self.alter_select(rid, start, end, True, aselect1, 4, nodes, 1)
+
+        nodes = [1, rnodes, 0, [], 0, []]
+
+        self.alter_select(rid, start, end, True, aselect2, 1, nodes, 2)
+
+    def test_alter_select_complex_running(self):
+        """
+        Test more complex use of pbs_ralter -l select to
+        shrink a running reservation
+        We start with a 2 +'d spec, and shrink each chunk by one, and 
+        then we shrink further and drop out the middle chunk
+        """
+        select = "2:ncpus=1:mem=1gb+4:ncpus=1:mem=2gb+2:ncpus=1:mem=3gb"
+        aselect1 = "1:ncpus=1:mem=1gb+2:ncpus=1:mem=2gb+1:ncpus=1:mem=3gb"
+        aselect2 = "1:ncpus=1:mem=2gb"
+
+        rid, start, end, rnodes = self.alter_select_initial(False, select)
+
+        nodes = [1, rnodes[0:2], 2, rnodes[2:6], 1, rnodes[6:]]
+
+        rnodes2 = self.alter_select(rid, start, end, False,
+                                    aselect1, 4, nodes, 1)
+
+        nodes = [0, [], 1, rnodes2, 0, []]
+
+        self.alter_select(rid, start, end, False, aselect2, 1, nodes, 2)
+
+    def test_alter_select_complex2(self):
+        """
+        Test more complex use of pbs_ralter -l select
+        to shrink a reservation
+        We start with a 2 +'d chunk and then shrink each chunk by 1
+        We then shrink further and drop out the middle chunk
+        Lastly we drop out the first chunk
+        """
+        select = "3:ncpus=1:mem=1gb+2:ncpus=1:mem=2gb+3:ncpus=1:mem=3gb"
+        aselect1 = "2:ncpus=1:mem=1gb+1:ncpus=1:mem=2gb+2:ncpus=1:mem=3gb"
+        aselect2 = "1:ncpus=1:mem=1gb+1:ncpus=1:mem=3gb"
+        aselect3 = "1:ncpus=1:mem=3gb"
+
+        rid, start, end, rnodes = self.alter_select_initial(True, select)
+
+        nodes = [5, rnodes, 0, [], 0, []]
+
+        rnodes2 = self.alter_select(rid, start, end,
+                                    True, aselect1, 5, nodes, 1)
+
+        nodes = [2, rnodes, 0, [], 0, []]
+
+        self.alter_select(rid, start, end, True, aselect2, 2, nodes, 2)
+
+        nodes = [1, rnodes, 0, [], 0, []]
+
+        self.alter_select(rid, start, end, True, aselect3, 1, nodes, 3)
+
+    def test_alter_select_complex_running2(self):
+        """
+        Test more complex use of pbs_ralter -l select to
+        shrink a running reservation
+        We start with a 2 +'d chunk and then shrink each chunk by 1
+        We then shrink further and drop out the middle chunk
+        Lastly we drop out the first chunk
+        """
+        select = "3:ncpus=1:mem=1gb+2:ncpus=1:mem=2gb+3:ncpus=1:mem=3gb"
+        aselect1 = "2:ncpus=1:mem=1gb+1:ncpus=1:mem=2gb+2:ncpus=1:mem=3gb"
+        aselect2 = "1:ncpus=1:mem=1gb+1:ncpus=1:mem=3gb"
+        aselect3 = "1:ncpus=1:mem=3gb"
+
+        rid, start, end, rnodes = self.alter_select_initial(False, select)
+
+        nodes = [2, rnodes[0:3], 1, rnodes[3:5], 2, rnodes[5:]]
+
+        rnodes2 = self.alter_select(rid, start, end,
+                                    False, aselect1, 5, nodes, 1)
+
+        nodes = [1, rnodes2[0:2], 0, [], 1, rnodes2[3:]]
+
+        rnodes3 = self.alter_select(rid, start, end,
+                                    False, aselect2, 2, nodes, 2)
+
+        nodes = [0, [], 0, [], 1, rnodes3[1:]]
+
+        self.alter_select(rid, start, end, False, aselect3, 1, nodes, 3)
+
+    def alter_select_initial(self, confirm, select):
+        """
+        Submit initial reservation and possibly wait until it starts
+        """
+        numnodes = 8
+        offset = 30
+        dur = 3600
+
+        a = {'resources_available.ncpus': 1,
+             'resources_available.mem': '8gb'}
+        self.server.create_vnodes('vnode', a, num=8, mom=self.mom)
+
+        rid, start, end = self.submit_and_confirm_reservation(offset, dur,
                                                               select=select)
         st = self.server.status(RESV)
-        self.assertEquals(len(st[0]['resv_nodes'].split('+')), 8)
-        a = {'Resource_List.ncpus': 8, 'Resource_List.nodect': 8}
+        resv_nodes = self.server.reservations[rid].get_vnodes()
+
+        self.assertEquals(len(st[0]['resv_nodes'].split('+')), numnodes)
+        a = {'Resource_List.ncpus': numnodes,
+             'Resource_List.nodect': numnodes}
         self.server.expect(RESV, a, id=rid)
 
-        self.alter_a_reservation(rid, start, end, select=new_select1)
+        if not confirm:
+            a = {'reserve_state': (MATCH_RE, 'RESV_RUNNING|5')}
+            off = start - int(time.time())
+            self.logger.info('Waiting until reservation runs')
+            self.server.expect(RESV, a, id=rid, offset=off)
 
-        st2 = self.server.status(RESV)
-        self.assertEquals(len(st2[0]['resv_nodes'].split('+')), 4)
-        a = {'Resource_List.ncpus': 4, 'Resource_List.nodect': 4}
+        return rid, start, end, resv_nodes
+
+    def alter_select(self, rid, start, end,
+                     confirm, selectN, numnodes, nodes, seq):
+        """
+        Alter a reservation and make sure it is on the correct nodes
+        """
+
+        self.alter_a_reservation(rid, start, end, select=selectN,
+                                 confirm=confirm, sequence=seq)
+
+        st = self.server.status(RESV)
+        self.assertEquals(len(st[0]['resv_nodes'].split('+')), numnodes)
+        a = {'Resource_List.ncpus': numnodes,
+             'Resource_List.nodect': numnodes}
         self.server.expect(RESV, a, id=rid)
-
-        self.alter_a_reservation(rid, start, end, sequence=2,
-                                 select=new_select2)
-
-        st2 = self.server.status(RESV)
-        self.assertEquals(len(st2[0]['resv_nodes'].split('+')), 2)
-        a = {'Resource_List.ncpus': 2, 'Resource_List.nodect': 2}
-        self.server.expect(RESV, a, id=rid)
+        resv_nodes = self.server.reservations[rid].get_vnodes()
+        # format is [N, [], N, [], N, []], we look at it in pairs
+        for i in range(0, len(nodes), 2):
+            if nodes[i]:
+                num = nodes[i]
+                for n in nodes[i + 1]:
+                    if n in resv_nodes:
+                        num -= 1
+                        if not num:
+                            break
+                self.assertFalse(num, 'Correct nodes not found after alter')
+        return resv_nodes
 
     def test_alter_select_with_times(self):
         """
@@ -2113,8 +2281,8 @@ class TestPbsResvAlter(TestFunctional):
         """
         offset = 3600
         duration = 3600
-        select = "6:ncpus=1"
-        new_select = "4:ncpus=1"
+        select = '6:ncpus=1'
+        new_select = '4:ncpus=1'
         shift = 300
 
         rid, start, end = self.submit_and_confirm_reservation(offset, duration,
@@ -2133,14 +2301,116 @@ class TestPbsResvAlter(TestFunctional):
         t = int(time.mktime(time.strptime(st[0]['reserve_end'], '%c')))
         self.assertEquals(t, end+shift)
 
+    def test_alter_select_with_running_jobs(self):
+        """
+        Test that when a reservation is running and has running jobs,
+        that an ralter -lselect will release nodes without running jobs
+        """
+        offset = 20
+        duration = 600
+        select = '3:ncpus=4'
+        select2 = '2:ncpus=4'
+        select3 = '1:ncpus=4'
+
+        a = {'resources_available.ncpus': 4, 'resources_available.mem': '1gb'}
+        self.server.create_vnodes('vnode', a, num=3, mom=self.mom,
+                                  usenatvnode=True)
+
+        rid, start, end = self.submit_and_confirm_reservation(offset, duration,
+                                                              select=select)
+        resv_queue = rid.split('.')[0]
+        a = {'queue': resv_queue}
+        j1 = Job(attrs=a)
+        jid = self.server.submit(j1)
+
+        self.logger.info('Waiting for reservation to start')
+        a = {'reserve_state': (MATCH_RE, 'RESV_RUNNING|5')}
+        off = int(start - time.time())
+        self.server.expect(RESV, a, id=rid, offset=off)
+
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        self.server.status(JOB)
+        job_node = j1.get_vnodes()[0]
+
+        self.alter_a_reservation(rid, start, end,
+                                 select=select2, confirm=False)
+        self.server.status(RESV)
+        resv_nodes = self.server.reservations[rid].get_vnodes()
+        errmsg1 = 'Reservation does not have the right number of nodes'
+        self.assertEquals(len(resv_nodes), 2, errmsg1)
+
+        errmsg2 = 'Reservation does not contain job node'
+        self.assertIn(job_node, resv_nodes, errmsg2)
+
+        self.alter_a_reservation(rid, start, end,
+                                 select=select3, confirm=False, sequence=2)
+        self.server.status(RESV)
+        resv_nodes = self.server.reservations[rid].get_vnodes()
+
+        self.assertEquals(len(resv_nodes), 1, errmsg1)
+        self.assertIn(job_node, resv_nodes, errmsg2)
+
+    def test_alter_select_running_degraded(self):
+        """
+        Test that when a degraded running reservation with a running job is
+        altered, the unavailable nodes are released and the node with the
+        running job is kept
+        """
+        offset = 20
+        duration = 3600
+        select = '3:ncpus=4'
+        select2 = '1:ncpus=4'
+
+        a = {'resources_available.ncpus': 4, 'resources_available.mem': '1gb'}
+        self.server.create_vnodes('vnode', a, num=3, mom=self.mom,
+                                  usenatvnode=True)
+
+        rid, start, end = self.submit_and_confirm_reservation(offset, duration,
+                                                              select=select)
+        resv_queue = rid.split('.')[0]
+        self.server.status(RESV)
+        resv_nodes = self.server.reservations[rid].get_vnodes()
+
+        self.assertEquals(len(resv_nodes), 3)
+
+        a = {'queue': resv_queue,
+             'Resource_List.select': '1:vnode=%s:ncpus=1' % resv_nodes[1]}
+        j1 = Job(attrs=a)
+        jid = self.server.submit(j1)
+
+        self.logger.info('Waiting for reservation to start')
+        a = {'reserve_state': (MATCH_RE, 'RESV_RUNNING|5')}
+        off = int(start - time.time())
+        self.server.expect(RESV, a, id=rid, offset=off)
+
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        self.server.status(JOB)
+        job_node = j1.get_vnodes()[0]
+
+        self.server.manager(MGR_CMD_SET, NODE, {'state': 'offline'},
+                            id=resv_nodes[2])
+
+        self.server.expect(RESV, {'reserve_substate': 10}, id=rid)
+
+        self.alter_a_reservation(rid, start, end,
+                                 select=select2, confirm=False)
+        self.server.status(RESV)
+        resv_nodes = self.server.reservations[rid].get_vnodes()
+
+        errmsg1 = 'Reservation does not have the right number of nodes'
+        self.assertEquals(len(resv_nodes), 1, errmsg1)
+
+        errmsg2 = 'Reservation does not contain job node'
+        self.assertIn(job_node, resv_nodes, errmsg2)
+
     def test_alter_select_with_times_standing(self):
         """
         Modify the select with start and end times on a standing reservation
         """
         offset = 20
         duration = 20
-        select = "6:ncpus=1"
-        new_select = "4:ncpus=1"
+        select = '6:ncpus=1'
+        new_select = '4:ncpus=1'
         shift = 15
 
         rid, start, end = self.submit_and_confirm_reservation(offset, duration,
@@ -2175,10 +2445,10 @@ class TestPbsResvAlter(TestFunctional):
 
         offset = 3600
         duration = 3600
-        select = "6:ncpus=1"
-        select_more = "7:ncpus=1"
-        select_extra = "6:ncpus=1+1:ncpus=1:mem=1gb"
-        select_different = "6:ncpus=4:mem=1gb"
+        select = '6:ncpus=1'
+        select_more = '7:ncpus=1'
+        select_extra = '6:ncpus=1+1:ncpus=1:mem=1gb'
+        select_different = '6:ncpus=4:mem=1gb'
 
         rid, start, end = self.submit_and_confirm_reservation(offset, duration,
                                                               select=select)
@@ -2203,9 +2473,9 @@ class TestPbsResvAlter(TestFunctional):
         dur = 30
         dur2 = 20
         dur3 = 15
-        select = "6:ncpus=1"
-        select2 = "4:ncpus=1"
-        select3 = "2:ncpus=1"
+        select = '6:ncpus=1'
+        select2 = '4:ncpus=1'
+        select3 = '2:ncpus=1'
 
         rid, start, end = \
             self.submit_and_confirm_reservation(offset, dur, select=select,
@@ -2236,14 +2506,14 @@ class TestPbsResvAlter(TestFunctional):
         offset2 = 7200
         shift = 1800
         dur = 3600
-        select = "8:ncpus=1"
-        select2 = "4:ncpus=1"
+        select = '8:ncpus=1'
+        select2 = '4:ncpus=1'
 
-        rid, start, end = \
-            self.submit_and_confirm_reservation(offset, dur, select=select)
+        rid, start, end = self.submit_and_confirm_reservation(offset, dur,
+                                                              select=select)
 
-        rid2, start2, end2 = \
-            self.submit_and_confirm_reservation(offset2, dur, select=select)
+        rid2, start2, end2 = self.submit_and_confirm_reservation(offset2, dur,
+                                                                 select=select)
 
         self.alter_a_reservation(rid, start, end, alter_s=True, alter_e=True,
                                  shift=shift, select=select2, whichMessage=3)
@@ -2260,10 +2530,10 @@ class TestPbsResvAlter(TestFunctional):
 
         offset = 60
         dur = 60
-        select = "4:ncpus=1"
+        select = '4:ncpus=1'
 
-        rid, start, end = \
-            self.submit_and_confirm_reservation(offset, dur, select=select)
+        rid, start, end = self.submit_and_confirm_reservation(offset, dur,
+                                                              select=select)
 
         self.server.status(RESV, 'resv_nodes', id=rid)
         resv_node = self.server.reservations[rid].get_vnodes()[0]


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Enhance PBS to be able to shrink running reservations with pbs_alter -lselect

#### Describe Your Change
To be able to correctly keep the right nodes, the scheduler needs to map the unaltered resv_nodes to the unaltered schedselect.  It then maps the new select to this.  When releasing nodes, it will first release any unavailable nodes, and then go on to release other nodes.  No nodes that have running jobs on them can be released.  Once the nodes have been released, an internal select spec is generated based on the remaining nodes.  This is used to generate the new resv_nodes.

#### Link to Design Doc
 **[project documentation area](https://openpbs.atlassian.net/wiki/spaces/PD/pages/1664090170/Enhancing+pbs+ralter+for+-lselect)**


#### Attach Test and Valgrind Logs/Output
[ralter.log](https://github.com/openpbs/openpbs/files/4997141/ralter.log)
[resv.log](https://github.com/openpbs/openpbs/files/4997143/resv.log)
The 3 failures in the reservation test plan are known failures for tests that are slated to be removed.


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
