### PR TITLE
[WIP]DshUtil's function get_pbs_conf_file() incorrectly calls out to python

### DIFF
--- a/test/fw/ptl/utils/pbs_dshutils.py
+++ b/test/fw/ptl/utils/pbs_dshutils.py
@@ -404,7 +404,7 @@ class DshUtils(object):
                 dflt_conf = ret['out'][0]
             """
             print("******Executing else from get_conf_file****")
-            val = os.environ.get('PBS_CONF_FILE', False)
+            value = os.environ.get('PBS_CONF_FILE', False)
             if value is not False:
                 dflt_conf = value
 

--- a/test/fw/ptl/utils/pbs_dshutils.py
+++ b/test/fw/ptl/utils/pbs_dshutils.py
@@ -404,7 +404,7 @@ class DshUtils(object):
                 dflt_conf = ret['out'][0]
             """
             print("******Executing else from get_conf_file****")
-            val = os.environ.geti('PBS_CONF_FILE', False)
+            val = os.environ.get('PBS_CONF_FILE', False)
             if value is not False:
                 dflt_conf = value
 

--- a/test/fw/ptl/utils/pbs_dshutils.py
+++ b/test/fw/ptl/utils/pbs_dshutils.py
@@ -388,6 +388,7 @@ class DshUtils(object):
             if 'PBS_CONF_FILE' in os.environ:
                 dflt_conf = os.environ['PBS_CONF_FILE']
         else:
+            """
             pc = ('"import os;print([False, os.environ[\'PBS_CONF_FILE\']]'
                   '[\'PBS_CONF_FILE\' in os.environ])"')
             cmd = ['ls', '-1', dflt_python]
@@ -401,6 +402,11 @@ class DshUtils(object):
             if ((ret['rc'] != 0) and (len(ret['out']) > 0) and
                     (ret['out'][0] != 'False')):
                 dflt_conf = ret['out'][0]
+            """
+            print("******Executing else from get_conf_file****")
+            val = os.environ.geti('PBS_CONF_FILE', False)
+            if value is not False:
+                dflt_conf = value
 
         self._h2c[hostname] = dflt_conf
         return dflt_conf


### PR DESCRIPTION

#### Describe Bug or Feature
DshUtil's function get_pbs_conf_file() incorrectly calls out to python

#### Describe Your Change
The following code is in DshUtils.get_pbs_conf_file():
` pc = ('"import os;print [False, os.environ[\'PBS_CONF_FILE\']]'

                  '[\'PBS_CONF_FILE\' in os.environ]"')

            cmd = [_'python'_, _'-c'_, pc]

            ret = self.run_cmd(hostname, cmd, logerr=False)

            if ((ret[_'rc'_] != 0) and (len(ret[_'out'_]) > 0) and

                    (ret[_'out'_][0] != 'False')):

                dflt_conf = ret[_'out'_][0]`
          

The whole list indexing idea is not needed.  os.environ is a dictionary.  Do a os.environ.get('PBS_CONF_FILE', False).  The second argument to get() is returned if the key doesn't exist.  


