### PR TITLE
Fix for pgsql version parsing in pbs_habitat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ services:
   - docker
 env:
   - OS_TYPE=centos:7
-  - OS_TYPE=opensuse/leap:15
+  - OS_TYPE=opensuse/leap:15.1
   - OS_TYPE=ubuntu:18.04
   - OS_TYPE=debian:9
   - OS_TYPE=centos:7 BUILD_MODE=sanitize
@@ -57,7 +57,7 @@ before_install:
   - docker pull ${OS_TYPE}
   - '[ "${OS_TYPE}" == "ubuntu:18.04" -o "${OS_TYPE}" == "debian:9" ] && export DOCKER_EXTRA_ARG="-e DEBIAN_FRONTEND=noninteractive -e LANGUAGE=C.UTF-8 -e LANG=C.UTF-8 -e LC_ALL=C.UTF-8" || true'
   - '[ "${OS_TYPE}" == "centos:7" ] && export DOCKER_EXTRA_ARG="-e LC_ALL=en_US.utf-8 -e LANG=en_US.utf-8" || true'
-  - '[ "${OS_TYPE}" == "opensuse/leap:15" ] && export DOCKER_EXTRA_ARG="-e LC_ALL=C.utf8" || true'
+  - '[ "${OS_TYPE}" == "opensuse/leap:15.1" ] && export DOCKER_EXTRA_ARG="-e LC_ALL=C.utf8" || true'
   - docker run -it -d -h pbs.dev.local --name pbsdev -v $(pwd):$(pwd) --privileged -w $(pwd) ${DOCKER_EXTRA_ARG} ${OS_TYPE} /bin/bash
   - docker ps -a
   - export DOCKER_EXEC="docker exec -it ${DOCKER_EXTRA_ARG} -e BUILD_MODE="${BUILD_MODE}" --privileged pbsdev"

--- a/src/cmds/scripts/pbs_habitat.in
+++ b/src/cmds/scripts/pbs_habitat.in
@@ -241,7 +241,7 @@ upgrade_pbs_database() {
 		return 1
 	fi
 
-	sys_pgsql_ver=$(echo `${PGSQL_BIN}/postgres -V` | awk 'NR==1 {print $NF}' | cut -d '.' -f 1,2)
+	sys_pgsql_ver=$(echo `${PGSQL_BIN}/postgres -V` | awk -F'[ .]' '{ print $3"."$4 }')
 	old_pgsql_ver=`cat ${data_dir}/PG_VERSION`
 	# strip the minor version from sys_pgsql_ver if old_pgsql_ver does not have minor version (for comparison).
 	[[ ! $old_pgsql_ver =~ "." ]] && sys_pgsql_ver=$(echo $sys_pgsql_ver | cut -d '.' -f 1)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* pbs_habitat wrongly parses psql version on Ubuntu when it checks for whether to upgrade db or not
```
This is output is postgres -V:
in CentOS 8: postgres (PostgreSQL) 10.6
in OpenSuSE Leap 15: postgres (PostgreSQL) 10.12 
in Ubuntu 18.04: postgres (PostgreSQL) 10.12 (Ubuntu 10.12-0ubuntu0.18.04.1)

And pbs_habitat parses as below:
in CenOS 8: 10.6
in OpenSuSe Leap 15: 10.12
in Ubuntu 18.04: 10.12-0ubuntu0 --- This should be 10.12
```

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* Changed command in pbs_habitat to parse pgsql version correctly

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
* None

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
After fix:
```
in CenOS 8: 10.6
in OpenSuSe Leap 15: 10.12
in Ubuntu 18.04: 10.12
```

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
