### PR TITLE
Fix for PBS_SUPPORTED_AUTH_METHODS not honored

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -5,7 +5,7 @@ How to install PBS using the configure script.
 
 1. Install the prerequisite packages for building PBS.
 
-  For CentOS-8 systems you should configure and enable PowerTools 
+  For CentOS-8 systems you should configure and enable PowerTools
   repo for hwloc-devel and libedit-devel packages.
 
   You should run the following commands as root:
@@ -76,8 +76,8 @@ How to install PBS using the configure script.
 3. Open a terminal as a normal (non-root) user, unpack the PBS
   tarball, and cd to the package directory.
 
-    tar -xpvf openpbs-20.0.0.tar.gz
-    cd openpbs-20.0.0
+    tar -xpvf openpbs-20.0.1.tar.gz
+    cd openpbs-20.0.1
 
 4. Generate the configure script and Makefiles. (See note 1 below)
 

--- a/configure.ac
+++ b/configure.ac
@@ -41,9 +41,9 @@
 
 AC_PREREQ([2.63])
 # Use PBS_VERSION to override the version statically defined here. For example:
-# ./configure PBS_VERSION=20.0.0 --prefix=/opt/pbs
+# ./configure PBS_VERSION=20.0.1 --prefix=/opt/pbs
 AC_INIT([OpenPBS],
-  [20.0.0],
+  [20.0.1],
   [pbssupport@altair.com],
   [openpbs],
   [http://www.openpbs.org/])

--- a/openpbs.spec
+++ b/openpbs.spec
@@ -44,7 +44,7 @@
 %endif
 
 %if !%{defined pbs_version}
-%define pbs_version 20.0.0
+%define pbs_version 20.0.1
 %endif
 
 %if !%{defined pbs_release}

--- a/src/include/libutil.h
+++ b/src/include/libutil.h
@@ -265,6 +265,11 @@ int find_string_idx(char **strarr, char *str);
 int is_string_in_arr(char **strarr, char *str);
 
 /*
+ * Make copy of string array
+ */
+char **dup_string_arr(char **strarr);
+
+/*
  *      free_string_array - free an array of strings with NULL as sentinel
  */
 void free_string_array(char **arr);

--- a/src/include/tpp.h
+++ b/src/include/tpp.h
@@ -124,6 +124,7 @@ struct tpp_config {
 	int    buf_limit_per_conn; /* buffer limit per physical connection */
 	int    force_fault_tolerance; /* by default disabled */
 	pbs_auth_config_t *auth_config;
+	char **supported_auth_methods;
 };
 
 /* TPP specific functions */

--- a/src/lib/Libtpp/tpp_router.c
+++ b/src/lib/Libtpp/tpp_router.c
@@ -1237,9 +1237,13 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 		memcpy(&ahdr, data, sizeof(tpp_auth_pkt_hdr_t));
 
 		if (authdata == NULL) {
-			if (strcmp(ahdr.auth_method, AUTH_RESVPORT_NAME) != 0 &&
-				get_auth(ahdr.auth_method) == NULL) {
-
+			if (!is_string_in_arr(tpp_conf->supported_auth_methods, ahdr.auth_method)) {
+				snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tfd=%d, Authentication method %s not allowed in connection %s", tfd, ahdr.auth_method, tpp_netaddr(&connected_host));
+				tpp_log_func(LOG_CRIT, NULL, tpp_get_logbuf());
+				tpp_send_ctl_msg(tfd, TPP_MSG_AUTHERR, &connected_host, &this_router->router_addr, -1, 0, tpp_get_logbuf());
+				return 0; /* let connection be alive, so we can send error */
+			}
+			if (strcmp(ahdr.auth_method, AUTH_RESVPORT_NAME) != 0 && get_auth(ahdr.auth_method) == NULL) {
 				snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tfd=%d, Authentication method not supported in connection %s", tfd, tpp_netaddr(&connected_host));
 				tpp_log_func(LOG_CRIT, NULL, tpp_get_logbuf());
 				tpp_send_ctl_msg(tfd, TPP_MSG_AUTHERR, &connected_host, &this_router->router_addr, -1, 0, tpp_get_logbuf());
@@ -1340,6 +1344,14 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 						free(data_out);
 					return 0; /* let connection be alive, so we can send error */
 				} else {
+					if (!is_string_in_arr(tpp_conf->supported_auth_methods, AUTH_RESVPORT_NAME)) {
+						snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tfd=%d, Authentication method %s not allowed in connection %s", tfd, AUTH_RESVPORT_NAME, tpp_netaddr(&connected_host));
+						tpp_log_func(LOG_CRIT, NULL, tpp_get_logbuf());
+						tpp_send_ctl_msg(tfd, TPP_MSG_AUTHERR, &connected_host, &this_router->router_addr, -1, 0, tpp_get_logbuf());
+						if (data_out)
+							free(data_out);
+						return 0; /* let connection be alive, so we can send error */
+					}
 					/* reserved port based authentication, and is not yet authenticated, so check resv port */
 					if (tpp_transport_isresvport(tfd) != 0) {
 						snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Connection from non-reserved port, rejected");

--- a/src/lib/Libtpp/tpp_util.c
+++ b/src/lib/Libtpp/tpp_util.c
@@ -357,6 +357,11 @@ set_tpp_config(void (*log_fn)(int, const char *, char *), struct pbs_config *pbs
 		tpp_log_func(LOG_INFO, NULL, log_buffer);
 	}
 
+	if ((tpp_conf->supported_auth_methods = dup_string_arr(pbs_conf->supported_auth_methods)) == NULL) {
+		tpp_log_func(LOG_CRIT, __func__, "Out of memory while making copy of supported auth methods");
+		return -1;
+	}
+
 #ifdef PBS_COMPRESSION_ENABLED
 	tpp_conf->compress = pbs_conf->pbs_use_compression;
 #else

--- a/src/lib/Libutil/misc_utils.c
+++ b/src/lib/Libutil/misc_utils.c
@@ -1206,6 +1206,45 @@ is_string_in_arr(char **strarr, char *str)
 
 /**
  * @brief
+ *	make copy of string array
+ *
+ * @param[in] strarr - the string array to make copy
+ *
+ * @return char **
+ * @retval !NULL - copy of string array
+ * @retval NULL  - failed to make copy of string array
+ *
+ */
+char **
+dup_string_arr(char **strarr)
+{
+	int i = 0;
+	char **retarr = NULL;
+
+	if (strarr == NULL)
+		return NULL;
+
+	for (i = 0; strarr[i] != NULL; i++)
+		;
+
+	if ((retarr = (char **)malloc((i + 1) * sizeof(char *))) == NULL)
+		return NULL;
+
+	for (i = 0; strarr[i] != NULL; i++) {
+		retarr[i] = strdup(strarr[i]);
+		if (retarr[i] == NULL) {
+			for (i = 0; retarr[i] != NULL; i++)
+				free(retarr[i]);
+			free(retarr);
+			return NULL;
+		}
+	}
+	retarr[i] = NULL;
+	return retarr;
+}
+
+/**
+ * @brief
  * 		find index of str in strarr
  *
  * @param[in]	strarr	-	the string array to search


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* If resv port is not specified in PBS_SUPPORTED_AUTH_METHODS even then resv ports were being accepted as an authentication method

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* Added required check to honor given PBS_SUPPORTED_AUTH_METHODS

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
* None

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
* [test.txt](https://github.com/openpbs/openpbs/files/5000811/test.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
