### PR TITLE
Submit test job with a run_count=18 so test_execjob_abort_ms_prologue…

### DIFF
--- a/test/tests/functional/pbs_hook_execjob_abort.py
+++ b/test/tests/functional/pbs_hook_execjob_abort.py
@@ -133,15 +133,18 @@ time.sleep(2)
             hook_name, a, self.prolo_hook_body % (''))
         # Submit a job that eventually goes in H state
         start_time = time.time()
-        jid = self.server.submit(self.j)
+        j1attr = {ATTR_l + '.select': '3:ncpus=1', 
+                ATTR_l + '.place': 'scatter',
+                ATTR_W: 'run_count=18'}
+        j1 = Job(TEST_USER, attrs=j1attr)
+        jid = self.server.submit(j1)
         msg = "Job;%s;Job requeued, execution node  down" % jid
         self.server.log_match(msg, starttime=start_time)
         # Check for abort hook message in each of the moms
         msg = "called execjob_abort hook"
         for mom in self.moms.values():
             mom.log_match(msg, starttime=start_time)
-        self.server.expect(JOB, {ATTR_state: 'H'}, id=jid, max_attempts=100,
-                           offset=7)
+        self.server.expect(JOB, {ATTR_state: 'H'}, id=jid)
 
     def test_execjob_abort_exit_job_launch_reject(self):
         """

--- a/test/tests/functional/pbs_hook_execjob_abort.py
+++ b/test/tests/functional/pbs_hook_execjob_abort.py
@@ -133,9 +133,9 @@ time.sleep(2)
             hook_name, a, self.prolo_hook_body % (''))
         # Submit a job that eventually goes in H state
         start_time = time.time()
-        j1attr = {ATTR_l + '.select': '3:ncpus=1', 
-                ATTR_l + '.place': 'scatter',
-                ATTR_W: 'run_count=18'}
+        j1attr = {ATTR_l + '.select': '3:ncpus=1',
+                  ATTR_l + '.place': 'scatter',
+                  ATTR_W: 'run_count=18'}
         j1 = Job(TEST_USER, attrs=j1attr)
         jid = self.server.submit(j1)
         msg = "Job;%s;Job requeued, execution node  down" % jid


### PR DESCRIPTION
… can be in the H state quickly

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
TestPbsExecjobAbort.test_execjob_abort_ms_prologue sometimes fails when the machines are too overloaded and thus running more slowly.  The job is expected to be Held, but doesn't get to run enough times to be held before the expect checking hits the max attempts.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Increasing max_attempts to be higher than the current default of 180 was a possibility, but it seemed likely this timing issue would show up again.  It seemed like a better answer was to submit a run_count when submitting the job.  That way the test doesn't have to wait for many job runs for the run_count to equal 21 and be in the Held state.
Changing the job's starting run_count also allowed a 7 second offset to be removed.
Now the test will pass even faster on fast machines, and still pass on slow machines.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

[2021.after.txt](https://github.com/openpbs/openpbs/files/5004601/2021.after.txt)
<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
