### PR TITLE
Fix for PBS_SUPPORTED_AUTH_METHODS not honored

### DIFF
--- a/src/include/libutil.h
+++ b/src/include/libutil.h
@@ -279,6 +279,11 @@ int find_string_idx(char **strarr, char *str);
 int is_string_in_arr(char **strarr, char *str);
 
 /*
+ * Make copy of string array
+ */
+char **dup_string_arr(char **strarr);
+
+/*
  *      free_string_array - free an array of strings with NULL as sentinel
  */
 void free_string_array(char **arr);

--- a/src/include/tpp.h
+++ b/src/include/tpp.h
@@ -124,6 +124,7 @@ struct tpp_config {
 	int    buf_limit_per_conn; /* buffer limit per physical connection */
 	int    force_fault_tolerance; /* by default disabled */
 	pbs_auth_config_t *auth_config;
+	char **supported_auth_methods;
 };
 
 /* TPP specific functions */

--- a/src/lib/Libtpp/tpp_util.c
+++ b/src/lib/Libtpp/tpp_util.c
@@ -352,6 +352,11 @@ set_tpp_config(void (*log_fn)(int, const char *, char *), struct pbs_config *pbs
 		tpp_log_func(LOG_INFO, NULL, log_buffer);
 	}
 
+	if ((tpp_conf->supported_auth_methods = dup_string_arr(pbs_conf->supported_auth_methods)) == NULL) {
+		tpp_log_func(LOG_CRIT, __func__, "Out of memory while making copy of supported auth methods");
+		return -1;
+	}
+
 #ifdef PBS_COMPRESSION_ENABLED
 	tpp_conf->compress = pbs_conf->pbs_use_compression;
 #else

--- a/src/lib/Libutil/misc_utils.c
+++ b/src/lib/Libutil/misc_utils.c
@@ -1250,6 +1250,45 @@ is_string_in_arr(char **strarr, char *str)
 
 /**
  * @brief
+ *	make copy of string array
+ *
+ * @param[in] strarr - the string array to make copy
+ *
+ * @return char **
+ * @retval !NULL - copy of string array
+ * @retval NULL  - failed to make copy of string array
+ *
+ */
+char **
+dup_string_arr(char **strarr)
+{
+	int i = 0;
+	char **retarr = NULL;
+
+	if (strarr == NULL)
+		return NULL;
+
+	for (i = 0; strarr[i] != NULL; i++)
+		;
+
+	if ((retarr = (char **)malloc((i + 1) * sizeof(char *))) == NULL)
+		return NULL;
+
+	for (i = 0; strarr[i] != NULL; i++) {
+		retarr[i] = strdup(strarr[i]);
+		if (retarr[i] == NULL) {
+			for (i = 0; retarr[i] != NULL; i++)
+				free(retarr[i]);
+			free(retarr);
+			return NULL;
+		}
+	}
+	retarr[i] = NULL;
+	return retarr;
+}
+
+/**
+ * @brief
  * 		find index of str in strarr
  *
  * @param[in]	strarr	-	the string array to search

--- a/src/scheduler/misc.c
+++ b/src/scheduler/misc.c
@@ -39,50 +39,7 @@
 
 
 /**
- * @file    misc.c
- *
- * @brief
- * 		misc.c - This file contains Miscellaneous functions of scheduler.
- *
- * Functions included are:
- * 		string_dup()
- * 		add_str_to_unique_array()
- * 		add_str_to_array()
- * 		res_to_num()
- * 		skip_line()
- * 		schdlogerr()
- * 		filter_array()
- * 		dup_string_array()
- * 		find_string()
- * 		find_string_ind()
- * 		match_string_to_array()
- * 		match_string_array()
- * 		string_array_to_str()
- * 		string_array_verify()
- * 		calc_used_walltime()
- * 		calc_time_left_STF()
- * 		calc_time_left()
- * 		cstrcmp()
- * 		is_num()
- * 		count_array()
- * 		remove_ptr_from_array()
- * 		is_valid_pbs_name()
- * 		clear_schd_error()
- * 		new_schd_error()
- * 		dup_schd_error()
- * 		move_schd_error()
- * 		set_schd_error_arg()
- * 		set_schd_error_codes()
- * 		free_schd_error()
- * 		free_schd_error_list()
- * 		create_schd_error()
- * 		create_schd_error_complex()
- * 		add_err()
- * 		res_to_str()
- * 		res_to_str_c()
- * 		res_to_str_r()
- * 		res_to_str_re()
- *
+ * Miscellaneous functions of scheduler.
  */
 #include <pbs_config.h>
 
@@ -434,39 +391,6 @@ filter_array(void **ptrarr, int (*filter_func)(void*, void*),
 		new_arr = tmp;
 	}
 	return new_arr;
-}
-
-
-
-/**
- * @brief
- *      dup_string_array - duplicate an array of strings
- *
- * @param[in]	ostrs	-	the array to copy
- *
- * @return	the duplicated array.
- *
- */
-char **
-dup_string_array(char **ostrs)
-{
-	char **nstrs = NULL;
-	int i;
-
-	if (ostrs != NULL) {
-		i = count_array(ostrs);
-
-		if ((nstrs = (char **)malloc((i + 1) * sizeof(char *))) == NULL) {
-			log_err(errno, __func__, MEM_ERR_MSG);
-			return NULL;
-		}
-
-		for (i = 0; ostrs[i] != NULL; i++)
-			nstrs[i] = string_dup(ostrs[i]);
-
-		nstrs[i] = NULL;
-	}
-	return nstrs;
 }
 
 

--- a/src/scheduler/misc.h
+++ b/src/scheduler/misc.h
@@ -102,11 +102,6 @@ filter_array(void **ptrarr, int (*filter_func)(void*, void*),
 int calc_time_left_STF(resource_resv *resresv, sch_resource_t* min_time_left);
 
 /*
- *      dup_string_array - duplicate an array of strings
- */
-char **dup_string_array(char **ostrs);
-
-/*
  *      string_array_verify - verify two string arrays are equal
  */
 unsigned string_array_verify(char **sa1, char **sa2);

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -1705,8 +1705,8 @@ dup_node_info(node_info *onode, server_info *nsinfo,
 
 	nnode->priority = onode->priority;
 
-	nnode->jobs = dup_string_array(onode->jobs);
-	nnode->resvs = dup_string_array(onode->resvs);
+	nnode->jobs = dup_string_arr(onode->jobs);
+	nnode->resvs = dup_string_arr(onode->resvs);
 	if (flags & DUP_INDIRECT)
 		nnode->res = dup_ind_resource_list(onode->res);
 	else
@@ -4748,7 +4748,7 @@ create_execvnode(nspec **ns)
  *
  * @param[in]	execvnode	-	the execvnode to parse
  * @param[in]	sinfo		-	server to get the nodes from
- * @param[in]	sel		- select to map 
+ * @param[in]	sel		- select to map
  *
  * @return	a newly allocated nspec array for the execvnode
  *

--- a/src/scheduler/node_partition.c
+++ b/src/scheduler/node_partition.c
@@ -911,7 +911,7 @@ find_alloc_np_cache(status *policy, np_cache ***pnpc_arr,
 			npc = new_np_cache();
 			if (npc != NULL) {
 				npc->ninfo_arr = ninfo_arr;
-				npc->resnames = dup_string_array(resnames);
+				npc->resnames = dup_string_arr(resnames);
 				npc->num_parts = num_parts;
 				npc->nodepart = nodepart;
 				if (npc->resnames == NULL || add_np_cache(pnpc_arr, npc) ==0) {

--- a/src/scheduler/queue_info.c
+++ b/src/scheduler/queue_info.c
@@ -959,7 +959,7 @@ dup_queue_info(queue_info *oqinfo, server_info *nsinfo)
 	nqinfo->total_user_counts = dup_counts_list(oqinfo->total_user_counts);
 	nqinfo->nodepart = dup_node_partition_array(oqinfo->nodepart, nsinfo);
 	nqinfo->allpart = dup_node_partition(oqinfo->allpart, nsinfo);
-	nqinfo->node_group_key = dup_string_array(oqinfo->node_group_key);
+	nqinfo->node_group_key = dup_string_arr(oqinfo->node_group_key);
 
 	if (oqinfo->resv != NULL) {
 		nqinfo->resv = find_resource_resv_by_indrank(nsinfo->resvs, oqinfo->resv->resresv_ind, oqinfo->resv->rank);

--- a/src/scheduler/resource_resv.c
+++ b/src/scheduler/resource_resv.c
@@ -372,7 +372,7 @@ free_resource_resv(resource_resv *resresv)
 
 	if (resresv->nspec_arr != NULL)
 		free_nspecs(resresv->nspec_arr);
-	
+
 	if (resresv->orig_nspec_arr != NULL)
 		free_nspecs(resresv->orig_nspec_arr);
 
@@ -653,7 +653,7 @@ dup_resource_resv(resource_resv *oresresv, server_info *nsinfo, queue_info *nqin
 	nresresv->aoename = string_dup(oresresv->aoename);
 	nresresv->eoename = string_dup(oresresv->eoename);
 
-	nresresv->node_set_str = dup_string_array(oresresv->node_set_str);
+	nresresv->node_set_str = dup_string_arr(oresresv->node_set_str);
 
 	nresresv->resresv_ind = oresresv->resresv_ind;
 	nresresv->node_set = copy_node_ptr_array(oresresv->node_set, nsinfo->nodes);
@@ -2270,10 +2270,10 @@ free_chunk(chunk *ch)
 
 /**
  * @brief find_chunk_by_seq_num - find a chunk by its sequence number
- * 
+ *
  * @param[in] chunks - array of chunks to search
  * @param[in] seq_num - sequence number to search for
- * 
+ *
  * @return chunk *
  * @retval chunk found
  * @retval NULL if not found

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -2198,8 +2198,8 @@ dup_server_info(server_info *osinfo)
 	nsinfo->total_group_counts = dup_counts_list(osinfo->total_group_counts);
 	nsinfo->total_project_counts = dup_counts_list(osinfo->total_project_counts);
 	nsinfo->total_user_counts = dup_counts_list(osinfo->total_user_counts);
-	nsinfo->node_group_key = dup_string_array(osinfo->node_group_key);
-	nsinfo->nodesigs = dup_string_array(osinfo->nodesigs);
+	nsinfo->node_group_key = dup_string_arr(osinfo->node_group_key);
+	nsinfo->nodesigs = dup_string_arr(osinfo->nodesigs);
 
 	nsinfo->policy = dup_status(osinfo->policy);
 
@@ -2521,7 +2521,7 @@ dup_resource(schd_resource *res)
 		nres->orig_str_avail = string_dup(res->orig_str_avail);
 
 	if (res->str_avail != NULL)
-		nres->str_avail = dup_string_array(res->str_avail);
+		nres->str_avail = dup_string_arr(res->str_avail);
 
 	if (res->str_assigned != NULL)
 		nres->str_assigned = string_dup(res->str_assigned);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* If resv port is not specified in PBS_SUPPORTED_AUTH_METHODS even then resv ports were being accepted as an authentication method

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* Added required check to honor given PBS_SUPPORTED_AUTH_METHODS

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
* None

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
* [test.txt](https://github.com/openpbs/openpbs/files/5005859/test.txt)

Description: Tests from given sources on platforms CENTOS7, UBUNTU1804, SUSE15
Platforms: CENTOS7,UBUNTU1804,SUSE15
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|2891|1794|6|0|0|0|1788|

(NOTE: 6 failures are known issues)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
