### PR TITLE
Increase reservation end time to fix race condition in test

### DIFF
--- a/test/tests/functional/pbs_reservations.py
+++ b/test/tests/functional/pbs_reservations.py
@@ -2336,7 +2336,7 @@ class TestReservations(TestFunctional):
         self.server.create_vnodes('vn', a, num=2, mom=self.mom)
         now = int(time.time())
         rid = self.submit_reservation(user=TEST_USER, select='1:ncpus=1',
-                                      start=now + 5, end=now + 100)
+                                      start=now + 5, end=now + 300)
 
         a = {'reserve_state': (MATCH_RE, 'RESV_RUNNING|5')}
         self.server.expect(RESV, a, id=rid)


### PR DESCRIPTION

#### Describe Bug or Feature
Fixed race-condition in TestReservations.test_server_recover_resv_queue failing on machine where restart pbs took more than 100 sec

#### Describe Your Change
Test failed on few machine because of race condition 
In test we are submitting reservation with end time 100s and restarting pbs while reservation running and after that submitting job in running reservation , but in few machine pbs restart takes more than 100s so while pbs restart and comes up reservation got finished and test failed in expect with error:-

ptl.lib.pbs_testlib.PtlExpectError: rc=1, rv=False, msg=expected on server altair-mc990:  no data for reserve_state ~ RESV_RUNNING|5 reservation R0.altair-mc990 attempt: 180

Fix :- 
Increase end time of reservation to 300 sec ,as we are not waiting for reservation to be finished in test , so increasing reservation end time, it wont increase test execution time.

#### Attach Test and Valgrind Logs/Output

[after_fix.txt](https://github.com/openpbs/openpbs/files/5006866/after_fix.txt)
[before_fix.txt](https://github.com/openpbs/openpbs/files/5006867/before_fix.txt)


