### PR TITLE
SchedSelect_orig resv attribute leaks in server

### DIFF
--- a/src/server/job_func.c
+++ b/src/server/job_func.c
@@ -1627,6 +1627,9 @@ resv_free(resc_resv *presv)
 	if (dot)
 		*dot = '.';
 
+	free(presv->ri_alter.ra_select_revert);
+	free(presv->ri_alter.ra_select);
+
 	/* now free the main structure */
 	free(presv);
 }

--- a/src/server/req_rescq.c
+++ b/src/server/req_rescq.c
@@ -928,7 +928,7 @@ req_confirmresv(struct batch_request *preq)
 		if (presv->ri_alter.ra_flags & RESV_SELECT_MODIFIED) {
 			free(presv->ri_alter.ra_select);
 			presv->ri_alter.ra_select = NULL;
-			job_attr_def[RESV_ATR_SchedSelect_orig].at_free(&presv->ri_wattr[RESV_ATR_SchedSelect_orig]);
+			resv_attr_def[RESV_ATR_SchedSelect_orig].at_free(&presv->ri_wattr[RESV_ATR_SchedSelect_orig]);
 		}
 
 		presv->ri_alter.ra_flags = 0;
@@ -1035,7 +1035,7 @@ resv_revert_alter(resc_resv *presv)
 			     presv->ri_wattr[RESV_ATR_SchedSelect_orig].at_val.at_str);
 
 		presv->ri_alter.ra_select = NULL;
-		job_attr_def[RESV_ATR_SchedSelect_orig].at_free(&presv->ri_wattr[RESV_ATR_SchedSelect_orig]);
+		resv_attr_def[RESV_ATR_SchedSelect_orig].at_free(&presv->ri_wattr[RESV_ATR_SchedSelect_orig]);
 		presv->ri_wattr[RESV_ATR_resource].at_flags |= ATR_SET_MOD_MCACHE;
 		set_chunk_sum(&presc->rs_value, &presv->ri_wattr[RESV_ATR_resource]);
 	}


### PR DESCRIPTION
#### Describe Bug or Feature
Server leaks SchedSelect_orig reservation attribute.

#### Describe Your Change
We were referring to the wrong attribute definition array while trying to access free attribute methods.

#### Attach Test and Valgrind Logs/Output
No new tests required.

Valgrind logs - 
[server_leaks_before.txt](https://github.com/openpbs/openpbs/files/5007458/server_leaks_before.txt) 
[server_leaks_after.txt](https://github.com/openpbs/openpbs/files/5007456/server_leaks_after.txt)
