### PR TITLE
Fixed issues when the scheduler got confused when a resv was running or not

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,6 +157,7 @@ src/cmds/pbs_tmrsh
 src/cmds/pbsdsh
 src/cmds/pbsnodes
 src/cmds/pbs_release_nodes
+src/cmds/pbs_dataservice.bin
 src/cmds/pbsrun
 src/cmds/pbsrun_unwrap
 src/cmds/pbsrun_wrap

--- a/src/scheduler/check.c
+++ b/src/scheduler/check.c
@@ -1704,7 +1704,7 @@ should_check_resvs(server_info *sinfo, node_info *ninfo, resource_resv *job)
 
 	/* check if a job is in a reservation */
 	if (job->is_job && job->job != NULL && job->job->resv != NULL) {
-		if (job->job->resv->resv->resv_state == RESV_RUNNING) {
+		if (job->job->resv->resv->is_running) {
 			/* if we are not checking a specific node and the job is in a
 			 * running reservation, there can't be any conflicts
 			 */
@@ -1989,7 +1989,12 @@ void get_resresv_spec(resource_resv *resresv, selspec **spec, place **pl)
 			*spec = resresv->select;
 		}
 	} else if (resresv->is_resv && resresv->resv != NULL) {
-		if (resresv->resv->resv_state == RESV_BEING_ALTERED || resresv->resv->resv_state == RESV_RUNNING)
+		/* The execselect should be used when the resv is running.  We can't
+		 * trust the state/substate to be RESV_RUNNING when a reservation is both
+		 * RESV_DEGRADED and RESV_BEING_ALTERED and is running.
+		 */
+		if (resresv->resv->is_running)
+
 			*spec = resresv->execselect;
 		else
 			*spec = resresv->select;

--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -748,7 +748,7 @@ struct node_info
 struct resv_info
 {
 	unsigned is_standing:1;		/* set to 1 for a standing reservation */
-	unsigned is_running;		/* the reservation is running (not necessarily in the running state) */
+	unsigned is_running:1;		/* the reservation is running (not necessarily in the running state) */
 	char *queuename;		/* the name of the queue */
 	char *rrule;			/* recurrence rule for standing reservations */
 	char *execvnodes_seq;		/* sequence of execvnodes for standing resvs */

--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -748,6 +748,7 @@ struct node_info
 struct resv_info
 {
 	unsigned is_standing:1;		/* set to 1 for a standing reservation */
+	unsigned is_running;		/* the reservation is running (not necessarily in the running state) */
 	char *queuename;		/* the name of the queue */
 	char *rrule;			/* recurrence rule for standing reservations */
 	char *execvnodes_seq;		/* sequence of execvnodes for standing resvs */

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -2149,7 +2149,7 @@ find_ready_resv_job(resource_resv **resvs)
 
 	for (i = 0; resvs[i] != NULL && rjob == NULL; i++) {
 		if (resvs[i]->resv != NULL) {
-			if (resvs[i]->resv->resv_state == RESV_RUNNING) {
+			if (resvs[i]->resv->is_running) {
 				if (resvs[i]->resv->resv_queue != NULL) {
 					ind = find_runnable_resresv_ind(resvs[i]->resv->resv_queue->jobs, 0);
 					if (ind != -1)

--- a/src/scheduler/resource_resv.c
+++ b/src/scheduler/resource_resv.c
@@ -1664,6 +1664,7 @@ update_resresv_on_run(resource_resv *resresv, nspec **nspec_arr)
 	}
 	else if (resresv->is_resv && resresv->resv != NULL) {
 		resresv->resv->resv_state = RESV_RUNNING;
+		resresv->resv->is_running = 1;
 
 		resv_queue = find_queue_info(resresv->server->queues,
 			resresv->resv->queuename);
@@ -1753,6 +1754,7 @@ update_resresv_on_end(resource_resv *resresv, char *job_state)
 			set_timed_event_disabled(resresv->end_event, 1);
 	} else if (resresv->is_resv && resresv->resv != NULL) {
 		resresv->resv->resv_state = RESV_DELETED;
+		resresv->resv->is_running = 0;
 
 		resv_queue = find_queue_info(resresv->server->queues,
 			resresv->resv->queuename);
@@ -2002,7 +2004,7 @@ copy_resresv_array(resource_resv **resresv_arr,
  * @brief
  *		is_resresv_running - is a resource resv in the running state
  *			     for a job it's in the "R" state
- *			     for an advanced reservation it's in RESV_RUNNING
+ *			     for an advanced reservation its start time is in the past
  *
  *
  * @param[in]	resresv	-	the resresv to check if it's running
@@ -2030,7 +2032,7 @@ is_resresv_running(resource_resv *resresv)
 		if (resresv->resv == NULL)
 			return 0;
 
-		if (resresv->resv->resv_state ==RESV_RUNNING)
+		if (resresv->resv->is_running)
 			return 1;
 	}
 

--- a/src/scheduler/resource_resv.h
+++ b/src/scheduler/resource_resv.h
@@ -253,7 +253,7 @@ copy_resresv_array(resource_resv **resresv_arr,
 /*
  *	is_resresv_running - is a resource resv in the running state
  *			     for a job it's in the "R" state
- *			     for an advanced reservation it's in RESV_RUNNING
+ *			     for an advanced reservation it is running
  */
 int is_resresv_running(resource_resv *resresv);
 

--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -1519,7 +1519,7 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 				}
 				continue;
 			}
-			if (nresv->resv->is_running) {
+			if (!nresv->resv->is_running) {
 				if (disable_reservation_occurrence(nsinfo->calendar->events, nresv) != 1) {
 					log_event(PBSEVENT_RESV, PBS_EVENTCLASS_RESV, LOG_INFO, nresv->name,
 						  "Error determining if reservation can be confirmed: "

--- a/src/scheduler/resv_info.h
+++ b/src/scheduler/resv_info.h
@@ -113,7 +113,7 @@ node_info **create_resv_nodes(nspec **nspec_arr, server_info *sinfo);
  *	release_running_resv_nodes - adjust nodes resources for reservations that
  *				  that are being altered or are degraded.
  */
-void release_running_resv_nodes(resource_resv *resv, node_info **all_nodes);
+void release_running_resv_nodes(resource_resv *resv, server_info *sinfo);
 
 /* Will we try and confirm this reservation in this cycle */
 int will_confirm(resource_resv *resv, time_t server_time);

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -2026,7 +2026,7 @@ int
 check_run_resv(resource_resv *resv, void *arg)
 {
 	if (resv->is_resv && resv->resv != NULL)
-		return resv->resv->resv_state == RESV_RUNNING;
+		return resv->resv->is_running;
 
 	return 0;
 }
@@ -2128,7 +2128,7 @@ int
 check_resv_running_on_node(resource_resv *resv, void *arg)
 {
 	if (resv->is_resv && resv->resv !=NULL) {
-		if (resv->resv->resv_state == RESV_RUNNING || resv->resv->resv_state == RESV_BEING_DELETED)
+		if (resv->resv->is_running || resv->resv->resv_state == RESV_BEING_DELETED)
 			if (find_node_info(resv->ninfo_arr, (char *) arg))
 				return 1;
 	}


### PR DESCRIPTION

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
The scheduler was getting confused on whether a reservation was running or not.  If a reservation is running, it must place nodes on the nodes which are associated with the reservation.  If it isn't running, it can move anywhere.  The scheduler was getting confused that anytime a reservation was being altered, it was also "running"

#### Describe Your Change
Since we can't always detect if a reservation is running with its state/substate, we now detect it if the time is between the start/end of a reservation.  I use this instead of the state/substate to determine if a resv is running.

#### Attach Test and Valgrind Logs/Output
[ralter.log](https://github.com/openpbs/openpbs/files/5009447/ralter.log)
[resv.log](https://github.com/openpbs/openpbs/files/5009448/resv.log)

I reran the failed ralter test several times and it passed.  The 3 failed resv tests are expected and they are slated to be removed.