### PR TITLE
Fix dereferencing freed pointer in mom_deljob_wait2

### DIFF
--- a/src/resmom/catch_child.c
+++ b/src/resmom/catch_child.c
@@ -2445,15 +2445,6 @@ mom_deljob_wait2(job *pjob)
 #if MOM_ALPS
 	(void)mom_deljob_wait(pjob);
 
-	/*
-	* The delete job request from Server will have been
-	* or will be replied to and freed by the
-	* alps_cancel_reservation code in the sequence of
-	* functions started with the above call to
-	* mom_deljob_wait().  Set preq to NULL here so we
-	* don't try, mistakenly, to use it again.
-	*/
-	pjob->ji_preq = NULL;
 #else
 	int  		numnodes;
 	struct 	batch_request *preq;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Mom can core dump when MOM_ALPS is enabled because of dereference of pointer to freed structure.
The comment was from a long time ago when preq=NULL to make it clear others who added to the function that preq was no longer usable at that point.  Somehow the code got changed to pjob->ji_preq=NULL, which is not correct since right above that pjob got freed.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Remove the comment and the line setting pjob->ji_preq=NULL

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

Verified via code inspection.

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
