### PR TITLE
fix hook sync race when multiple set hooks command

### DIFF
--- a/src/server/hook_func.c
+++ b/src/server/hook_func.c
@@ -4861,6 +4861,8 @@ add_mom_hook_action(mom_hook_action_t ***hookact_array,
 				}
 				if (set_action) {
 					pact->action = action;
+				} else if ((pact->action & action) && sync_mom_hookfiles_proc_running) {
+					continue;  /* dont reuse the action object if replies are still expected for same action */
 				} else {
 					if (action & MOM_HOOK_ACTION_DELETE) {
 						if (pact->action & MOM_HOOK_SEND_ACTIONS) {


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
When multiple set hook commands are issued from qmgr, some updates were not being propagated to execution nodes due to race in pending hook action processing

Bug is visible in the below screenshot
![InkedScreenshot_hook_unsynced_LI](https://user-images.githubusercontent.com/30307577/89184620-ba9f7d00-d5b6-11ea-85f5-ad95ffbd6cb3.jpg)


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
fixed by using new hook action object when replies are pending for previous actions


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[instrumented_before_after_logs.zip](https://github.com/openpbs/openpbs/files/5016175/instrumented_before_after_logs.zip)


Description: Tests from given sources on platforms CENTOS7, UBUNTU1804, SUSE15
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|2950|1788|5|0|0|0|1783|

[valgrind.log](https://github.com/openpbs/openpbs/files/5016111/valgrind.log)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
