### PR TITLE
Remove '_' from special charcter list in convert_to_cli method

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -2391,7 +2391,7 @@ class BatchUtils(object):
                                       self.platform == 'craysim' or
                                       self.platform == 'shasta'):
                 v = v.translate({ord(c): "\\" +
-                                 c for c in r"~`!@#$%^&*()[]{};:,./<>?\|-=+"})
+                                 c for c in r"~`!@#$%^&*()[]{};:,/<>?\|="})
             if exclude_attrs is not None and a in exclude_attrs:
                 continue
 

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -2391,7 +2391,7 @@ class BatchUtils(object):
                                       self.platform == 'craysim' or
                                       self.platform == 'shasta'):
                 v = v.translate({ord(c): "\\" +
-                                 c for c in r"~`!@#$%^&*()[]{};:,./<>?\|-=_+"})
+                                 c for c in r"~`!@#$%^&*()[]{};:,./<>?\|-=+"})
             if exclude_attrs is not None and a in exclude_attrs:
                 continue
 


### PR DESCRIPTION
#### Describe Bug or Feature
Tests on Cray were failing due to qsub error while submitting a job requesting vntype as "cray_compute"/"cray_login" nodes.
This is due to we are adding escape character "\" to all special characters in PTL fw, which are given in qsub and this is how qsub is getting submitted in PTL:
qsub -l vntype=cray_login -N cray\_login job.script
This special character list has underscore as well "_" which is not special character. Hence, qsub is failing with PbsSubmitError.

#### Describe Your Change
Removed underscore "_" from special character list in conver_to_cli method.


#### Attach Test and Valgrind Logs/Output
[After_fix.txt](https://github.com/openpbs/openpbs/files/5014651/After_fix.txt)
[Before_fix.txt](https://github.com/openpbs/openpbs/files/5014652/Before_fix.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
