### PR TITLE
Fix snapshot failure on Ubunut platform

### DIFF
--- a/src/cmds/scripts/pbs_snapshot
+++ b/src/cmds/scripts/pbs_snapshot
@@ -44,7 +44,7 @@ ptl_prefix_lib=
 
 # Try package install paths
 if [ -f /etc/debian_version ]; then
-    __ptlpkgname=$(dpkg -W -f='${binary:Package}\n' 2>/dev/null | grep -E '*-ptl$')
+    __ptlpkgname=$(dpkg-query -W -f='${binary:Package}\n' 2>/dev/null | grep -E '*-ptl$')
     if [ "x${__ptlpkgname}" != "x" ]; then
         ptl_prefix_lib=$(dpkg -L ${__ptlpkgname} 2>/dev/null | grep -m 1 lib$ 2>/dev/null)
     fi
@@ -87,7 +87,7 @@ else
     if [ "X${__PBS_EXEC}" != "X" ]; then
         # Define PATH and PYTHONPATH for the users
         PTL_PREFIX=$(dirname ${__PBS_EXEC})/ptl
-        if [ ! -x "${PTL_PREFIX}/lib/site-packages" ]; then
+        if [ ! -d "${PTL_PREFIX}/lib/site-packages" ]; then
             ptlbinpath=${__PBS_EXEC}/unsupported/fw/bin
             ptllibpath=${__PBS_EXEC}/unsupported/fw
             __pbs_snapshot=${__pbs_snapshot}.py
@@ -103,7 +103,7 @@ fi
 
 export PYTHONPATH=${ptllibpath}:${PYTHONPATH}
 
-if [ -x $ptlbinpath ] && [ -x $ptllibpath ];then
+if [ -d $ptlbinpath ] && [ -d $ptllibpath ];then
     if [ -x "${__PBS_EXEC}/python/bin/python" ]; then
         ${__PBS_EXEC}/python/bin/python ${ptlbinpath}/${__pbs_snapshot} "${@}"
     else


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
pbs_snapshor fails with error on ubuntu platform

```
root@u18r:~/th3_packages# /opt/pbs/bin/qstat --version 
pbs_version = 20.0.0
root@u18r:~/th3_packages# /opt/pbs/sbin/pbs_snapshot 
***
*** Ptllib/Ptlbin Path Not found
***
root@u18r:~/th3_packages# 
```




#### Describe Your Change
Updated the ptl package finding command. 
Also while checking for dir updated to use -d flag instead of -x flag 

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
