### PR TITLE
Submit interactive jobs from remote host

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -14702,8 +14702,8 @@ class InteractiveJob(threading.Thread):
                 self.logger.info("Submit interactive job from a remote host")
                 if self.du.get_platform() == "shasta":
                     ssh_cmd = self.du.rsh_cmd + \
-                              ['-p', self._ru.port,
-                               self._ru.name + '@' + self.hostname]
+                        ['-p', self._ru.port,
+                         self._ru.name + '@' + self.hostname]
                     _p = pexpect.spawn(" ".join(ssh_cmd), timeout=_to)
                     _p.sendline(" ".join(self.cmd))
                 else:

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -5990,7 +5990,7 @@ class Server(PBSService):
                     appended to the tuple.
         :raises: PbsSubmitError
         """
-        ij = InteractiveJob(job, cmd, self.hostname)
+        ij = InteractiveJob(job, cmd, self.client)
         # start the interactive job submission thread and wait to pickup the
         # actual job identifier
         ij.start()
@@ -14647,6 +14647,11 @@ class InteractiveJob(threading.Thread):
         self.cmd = cmd
         self.jobid = None
         self.hostname = host
+        self.runas_user = ""
+        if self.du.get_platform() == "shasta":
+            self.runas_user = PbsUser.get_user(job.username)
+            self.hostname = self.runas_user.host \
+                if self.runas_user.host else self.hostname
 
     def __del__(self):
         del self.__dict__
@@ -14689,8 +14694,22 @@ class InteractiveJob(threading.Thread):
                            ['-u', job.username] + cmd)
 
             self.logger.debug(cmd)
-
-            _p = pexpect.spawn(" ".join(cmd), timeout=_to)
+            is_local = self.du.is_localhost(self.hostname)
+            _p = ""
+            if is_local:
+                _p = pexpect.spawn(" ".join(cmd), timeout=_to)
+            else:
+                self.logger.info("Submit interactive job from a remote host")
+                if self.du.get_platform() == "shasta":
+                    ssh_cmd = self.du.rsh_cmd + \
+                              ['-p', self.runas_user.port,
+                               self.runas_user.name + '@' + self.hostname]
+                    _p = pexpect.spawn(" ".join(ssh_cmd), timeout=_to)
+                    _p.sendline(" ".join(self.cmd))
+                else:
+                    ssh_cmd = self.du.rsh_cmd + [self.hostname]
+                    _p = pexpect.spawn(" ".join(ssh_cmd), timeout=_to)
+                    _p.sendline(" ".join(cmd))
             self.job.interactive_handle = _p
             time.sleep(_st)
             expstr = "qsub: waiting for job "
@@ -14711,11 +14730,22 @@ class InteractiveJob(threading.Thread):
                 _p.expect(out)
             self.logger.info('sending exit')
             _p.sendline("exit")
-            self.logger.info('waiting for the subprocess to finish')
-            _p.wait()
-            _p.close()
-            self.job.interactive_handle = None
-            self.logger.debug(_p.exitstatus)
+
+            if is_local:
+                self.logger.info('waiting for the subprocess to finish')
+                _p.wait()
+                _p.close()
+                self.job.interactive_handle = None
+                self.logger.debug(_p.exitstatus)
+            else:
+                while True:
+                    try:
+                        _p.read_nonblocking(timeout=5)
+                    except Exception:
+                        break
+                if _p.isalive():
+                    _p.close()
+                self.job.interactive_handle = None
         except Exception:
             self.logger.error(traceback.print_exc())
             return None

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -14701,9 +14701,10 @@ class InteractiveJob(threading.Thread):
             else:
                 self.logger.info("Submit interactive job from a remote host")
                 if self.du.get_platform() == "shasta":
-                    ssh_cmd = self.du.rsh_cmd + \
-                              ['-p', self.runas_user.port,
-                               self.runas_user.name + '@' + self.hostname]
+                    client = self.runas_user.name + '@' + self.hostname
+                    ssh_cmd = \
+                        self.du.rsh_cmd + \
+                        ['-p', self.runas_user.port, client]
                     _p = pexpect.spawn(" ".join(ssh_cmd), timeout=_to)
                     _p.sendline(" ".join(self.cmd))
                 else:


### PR DESCRIPTION
#### Describe Bug or Feature
PTL submits interactive jobs from server even though the client is a remote host.

#### Describe Your Change
Updated the interactive job class to ssh to client machines and submit as test user from the client. 

#### Attach Test Logs/Output
Few interactive job tests ran with -p client="hostname"
[smoketest.txt](https://github.com/openpbs/openpbs/files/5016167/smoketest.txt)
[suspend_resume_accounting.txt](https://github.com/openpbs/openpbs/files/5016172/suspend_resume_accounting.txt)

Regression results:
**Description**: Tests from given sources on platforms CENTOS7, UBUNTU1804, SUSE15
**Platforms**: CENTOS7,UBUNTU1804,SUSE15
**Profile**: regression

**Test Summary**: total: 5382, fail: 19, error: 0, timedout: 1, skip: 0, pass: 5362


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
