### PR TITLE
provide shell while submitting job that runs a bash script

### DIFF
--- a/test/tests/functional/pbs_passing_environment_variable.py
+++ b/test/tests/functional/pbs_passing_environment_variable.py
@@ -78,7 +78,8 @@ class Test_passing_environment_variable_via_qsub(TestFunctional):
              'Resource_List.walltime': 10}
         script = ['#PBS -v "var1=\'A,B,C,D\'"']
         script += ['env | grep var1']
-        jid = self.create_and_submit_job(user=TEST_USER, content=script)
+        jid = self.create_and_submit_job(user=TEST_USER, content=script,
+                                         attribs={ATTR_S: "/bin/bash"})
         qstat = self.server.status(JOB, ATTR_o, id=jid)
         job_outfile = qstat[0][ATTR_o].split(':')[1]
 
@@ -123,7 +124,8 @@ env | grep -A 3 foo\n
 foo\n
 """
         # Submit a job without hooks in the system
-        jid = self.create_and_submit_job(user=TEST_USER, content=script)
+        jid = self.create_and_submit_job(user=TEST_USER, content=script,
+                                         attribs={ATTR_S: "/bin/bash"})
         qstat = self.server.status(JOB, ATTR_o, id=jid)
         job_outfile = qstat[0][ATTR_o].split(':')[1]
         self.server.expect(JOB, 'queue', op=UNSET, id=jid, offset=2)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Test gets tty error on some machine while submitting job script(bash). On some machine default shell to run script is cshell so job script(bash) failed on run. 




#### Describe Your Change
Test run job script in bash shell


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
[failed_case.txt](https://github.com/openpbs/openpbs/files/5020405/failed_case.txt)
[qsub_job_script.txt](https://github.com/openpbs/openpbs/files/5020050/qsub_job_script.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
