### PR TITLE
Invalid write issue fix: pbsd_init_job should return after job_purge

### DIFF
--- a/src/server/pbsd_init.c
+++ b/src/server/pbsd_init.c
@@ -1298,6 +1298,7 @@ pbsd_init_job(job *pjob, int type)
 		svr_mailowner(pjob, MAIL_ABORT, MAIL_NORMAL, msg_init_abt);
 		check_block(pjob, msg_init_abt);
 		job_purge(pjob);
+		return 0;
 	}
 
 	pjob->ji_momhandle = -1;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
When PBS server recovers job during init, it checks if job belongs to a reservation that is no longer possible to requeue. This section of the code was initially inside a while loop and we used to do a job_purge and continue to next job by skipping pbsd_init_job(). 
During db refactoring, it was moved to a callback function and it missed a return. This caused a job being freed twice causing Valgrind to report invalid write.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Added a return when Rmv_if_resv_not_possible() returns 1 and job gets purged.


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Ran TestPbsAccumulateRescUsed with Valgrind and it showed 0 leaks.

Description: Tests from given sources on platforms CENTOS7, UBUNTU1804, SUSE15
Platforms: CENTOS7,UBUNTU1804,SUSE15
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|2995|13|0|0|0|0|13|


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
