### PR TITLE
Add possibility of resuming multinode jobs

### DIFF
--- a/src/include/job.h
+++ b/src/include/job.h
@@ -492,6 +492,8 @@ struct job {
 	int ji_stderr;				    /* socket for stderr */
 	int ji_ports[2];			    /* ports for stdout/err */
 	enum bg_hook_request ji_hook_running_bg_on; /* set when hook starts in the background*/
+	int		ji_msconnected; /* 0 - not connected, 1 - connected */
+	pbs_list_head	ji_multinodejobs;	/* links to recovered multinode jobs */
 #else						    /* END Mom ONLY -  start Server ONLY */
 	struct batch_request *ji_pmt_preq; /* outstanding preempt job request for deleting jobs */
 	int ji_discarding;		   /* discarding job */
@@ -592,6 +594,8 @@ struct job {
 #ifdef PBS_MOM
 			tm_host_id ji_nodeidx; /* my node id */
 			tm_task_id ji_taskidx; /* generate task id's for job */
+			int ji_stdout;
+			int ji_stderr;
 #if MOM_ALPS
 			long ji_reservation;
 			/* ALPS reservation identifier */
@@ -745,6 +749,8 @@ typedef struct	infoent {
 #define IM_EXEC_PROLOGUE	24
 #define IM_CRED 		25
 #define IM_PMIX			26
+#define IM_RECONNECT_TO_MS			27
+#define IM_JOIN_RECOV_JOB		28
 
 #define IM_ERROR		99
 #define IM_ERROR2		100

--- a/src/include/mom_func.h
+++ b/src/include/mom_func.h
@@ -368,7 +368,7 @@ extern pid_t fork_me(int sock);
 extern ssize_t readpipe(int pfd, void *vptr, size_t nbytes);
 extern ssize_t writepipe(int pfd, void *vptr, size_t nbytes);
 extern int   get_la(double *);
-extern void  init_abort_jobs(int);
+extern void  init_abort_jobs(int, pbs_list_head *);
 extern void  checkret(char **spot, int len);
 extern void  mom_nice(void);
 extern void  mom_unnice(void);

--- a/src/resmom/catch_child.c
+++ b/src/resmom/catch_child.c
@@ -443,6 +443,9 @@ scan_for_exiting(void)
 	for (pjob = (job *)GET_NEXT(svr_alljobs); pjob; pjob = nxjob) {
 		nxjob = (job *)GET_NEXT(pjob->ji_alljobs);
 
+		if (pjob->ji_numnodes > 1 && !pjob->ji_msconnected && pjob->ji_nodeid) /* assume that MS has a connection to itself at all times */
+			continue;
+
 		/*
 		 ** If a restart is active, skip this job since
 		 ** not all of the tasks may have started yet.
@@ -938,11 +941,12 @@ err:
  *	   terminated and requeued.
  *
  * @param [in]	recover - Specify recovering mode for MoM.
+ * @param [in]	multinode_jobs - Pointer to list of pointers to recovered multinode jobs
  *
  */
 
 void
-init_abort_jobs(int recover)
+init_abort_jobs(int recover, pbs_list_head *multinode_jobs)
 {
 	DIR		*dir;
 	int		i, sisters;
@@ -957,6 +961,8 @@ init_abort_jobs(int recover)
 	struct	stat	statbuf;
 	extern	char	*path_checkpoint;
 	extern	char	*path_spool;
+
+	CLEAR_HEAD((*multinode_jobs));
 
 	dir = opendir(path_jobs);
 	if (dir == NULL) {
@@ -1021,8 +1027,10 @@ init_abort_jobs(int recover)
 		 */
 		if ((pj->ji_qs.ji_svrflags & JOB_SVFLG_HERE) == 0) {
 			/* I am sister, junk the job files */
-			mom_deljob(pj);
-			continue;
+			if( recover != 2 ) {
+				mom_deljob(pj);
+				continue;
+			}
 		}
 
 		sisters = pj->ji_numnodes - 1;
@@ -1121,6 +1129,15 @@ init_abort_jobs(int recover)
 
 			if (mom_do_poll(pj))
 				append_link(&mom_polljobs, &pj->ji_jobque, pj);
+
+			if (sisters > 0)
+				append_link(multinode_jobs, &pj->ji_multinodejobs, pj);
+
+			if (pj->ji_qs.ji_svrflags & JOB_SVFLG_HERE) {
+				/* I am MS */
+				pj->ji_stdout = pj->ji_ports[0] = pj->ji_extended.ji_ext.ji_stdout;
+				pj->ji_stderr = pj->ji_ports[1] = pj->ji_extended.ji_ext.ji_stdout;
+			}
 		}
 	}
 	if (errno != 0 && errno != ENOENT) {

--- a/src/resmom/start_exec.c
+++ b/src/resmom/start_exec.c
@@ -5961,7 +5961,7 @@ void resume_multinode(job *pjob)
 
 		int stream = np->hn_stream;
 		im_compose(stream, pjob->ji_qs.ji_jobid,
-			pjob->ji_wattr[(int)JOB_ATR_Cookie].at_val.at_str,
+			get_jattr_str(pjob, JOB_ATR_Cookie),
 			com, ep->ee_event, TM_NULL_TASK,  IM_OLD_PROTOCOL_VER);
 		(void)diswsi(stream, pjob->ji_numnodes);
 		(void)diswsi(stream, pjob->ji_ports[0]);

--- a/src/resmom/start_exec.c
+++ b/src/resmom/start_exec.c
@@ -5929,6 +5929,52 @@ job_nodes(struct job *pjob)
 
 /**
  * @brief
+ * 	Resume multinode job after one or more sisters has been restarted
+ *
+ * @param[in] pjob - job pointer
+ *
+ * @return	Void
+ *
+ */
+
+void resume_multinode(job *pjob)
+{
+	if (pjob->ji_hosts == NULL)
+		return;
+
+	int com = IM_JOIN_RECOV_JOB;
+	hnodent *np = NULL;
+	eventent *ep = NULL;
+	int i;
+	for(i = 1; i < pjob->ji_numnodes; i++) {
+		np = &pjob->ji_hosts[i];
+
+		if( i == 1 )
+			ep = event_alloc(pjob, com, -1, np, TM_NULL_EVENT, TM_NULL_TASK);
+		else
+			ep = event_dup(ep, pjob, np);
+
+		if (ep == NULL) {
+			exec_bail(pjob, JOB_EXEC_FAIL1, NULL);
+			return;
+		}
+
+		int stream = np->hn_stream;
+		im_compose(stream, pjob->ji_qs.ji_jobid,
+			pjob->ji_wattr[(int)JOB_ATR_Cookie].at_val.at_str,
+			com, ep->ee_event, TM_NULL_TASK,  IM_OLD_PROTOCOL_VER);
+		(void)diswsi(stream, pjob->ji_numnodes);
+		(void)diswsi(stream, pjob->ji_ports[0]);
+		(void)diswsi(stream, pjob->ji_ports[1]);
+		dis_flush(stream);
+#if defined(PBS_SECURITY) && (PBS_SECURITY == KRB5)
+		send_cred_sisters(pjob);
+#endif
+	}
+}
+
+/**
+ * @brief
  * 	start_exec() - start execution of a job
  *
  * @param[in] pjob - job pointer
@@ -6189,6 +6235,8 @@ start_exec(job *pjob)
 			}
 			pjob->ji_stdout = socks[0];
 			pjob->ji_stderr = socks[1];
+			pjob->ji_extended.ji_ext.ji_stdout = pjob->ji_ports[0];
+			pjob->ji_extended.ji_ext.ji_stderr = pjob->ji_ports[1];
 		}
 
 		for (i = 1; i < nodenum; i++) {

--- a/src/server/job_func.c
+++ b/src/server/job_func.c
@@ -348,6 +348,10 @@ job_alloc(void)
 	pj->ji_stderr = 0;
 	pj->ji_setup = NULL;
 	pj->ji_momsubt = 0;
+	pj->ji_msconnected = 0;
+	CLEAR_HEAD(pj->ji_multinodejobs);
+	pj->ji_extended.ji_ext.ji_stdout = 0;
+	pj->ji_extended.ji_ext.ji_stderr = 0;
 #else	/* SERVER */
 	pj->ji_discarding = 0;
 	pj->ji_prunreq = NULL;
@@ -574,6 +578,8 @@ job_free(job *pj)
 	 */
 	if (job_free_extra != NULL)
 		job_free_extra(pj);
+
+	CLEAR_HEAD(pj->ji_multinodejobs);
 
 #ifdef WIN32
 	if (pj->ji_hJob) {

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -13340,14 +13340,14 @@ class MoM(PBSService):
                 raise PbsServiceError(rc=e.rc, rv=e.rv, msg=e.msg)
             return True
 
-    def restart(self):
+    def restart(self, args=None):
         """
         Restart the PBS mom
         """
         if self.isUp():
             if not self.stop():
                 return False
-        return self.start()
+        return self.start(args=args)
 
     def log_match(self, msg=None, id=None, n=50, tail=True, allmatch=False,
                   regexp=False, max_attempts=None, interval=None,

--- a/test/tests/functional/pbs_node_jobs_restart_multinode.py
+++ b/test/tests/functional/pbs_node_jobs_restart_multinode.py
@@ -1,0 +1,157 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2020 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of both the OpenPBS software ("OpenPBS")
+# and the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# OpenPBS is free software. You can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# OpenPBS is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# PBS Pro is commercially licensed software that shares a common core with
+# the OpenPBS software.  For a copy of the commercial license terms and
+# conditions, go to: (http://www.pbspro.com/agreement.html) or contact the
+# Altair Legal Department.
+#
+# Altair's dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of OpenPBS and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair's trademarks, including but not limited to "PBS™",
+# "OpenPBS®", "PBS Professional®", and "PBS Pro™" and Altair's logos is
+# subject to Altair's trademark licensing policies.
+
+
+from tests.functional import *
+from time import sleep
+
+
+@requirements(num_moms=2)
+class TestMultiNodeJobsRestart(TestFunctional):
+    """
+    Make sure that jobs remain active after node restart
+    """
+
+    def test_restart_hosts_resume(self):
+
+        if len(self.moms) != 2:
+            self.skipTest("test requires atleast two MoMs as input, " +
+                          "use -p moms=<mom1:mom2>")
+        momA = self.moms.values()[0]
+        momB = self.moms.values()[1]
+
+        # Make sure moms are running with -p flag
+        momA.restart(args=['-p'])
+        momB.restart(args=['-p'])
+
+        pbsdsh_path = os.path.join(self.server.pbs_conf['PBS_EXEC'],
+                                   "bin", "pbsdsh")
+        script = "sleep 30 && %s echo 'Hello, World'" % pbsdsh_path
+        j = Job(TEST_USER)
+        j.set_attributes({'Resource_List.select': '2',
+                          'Resource_List.place': 'scatter'})
+        j.create_script(script)
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+
+        momA.restart(args=['-p'])
+        momB.restart(args=['-p'])
+
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+
+        sleep(60)
+
+        self.server.log_match("%s;Exit_status=0" % jid)
+
+        # Restart moms without -p flag
+        momA.restart()
+        momB.restart()
+
+    def test_restart_hosts_resume_withoutp(self):
+
+        if len(self.moms) != 2:
+            self.skipTest("test requires atleast two MoMs as input, " +
+                          "use -p moms=<mom1:mom2>")
+        momA = self.moms.values()[0]
+        momB = self.moms.values()[1]
+
+        # Make sure moms are running with -p flag
+        momA.restart(args=[])
+        momB.restart(args=[])
+
+        pbsdsh_path = os.path.join(self.server.pbs_conf['PBS_EXEC'],
+                                   "bin", "pbsdsh")
+        script = "sleep 30 && %s echo 'Hello, World'" % pbsdsh_path
+        j = Job(TEST_USER)
+        j.set_attributes({'Resource_List.select': '2',
+                          'Resource_List.place': 'scatter'})
+        j.create_script(script)
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+
+        momA.restart(args=['-p'])
+        momB.restart(args=['-p'])
+
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+
+        sleep(60)
+
+        self.server.log_match("%s;Exit_status=0" % jid)
+
+        # Restart moms without -p flag
+        momA.restart()
+        momB.restart()
+
+    def test_premature_kill_restart(self):
+
+        if len(self.moms) != 2:
+            self.skipTest("test requires atleast two MoMs as input, " +
+                          "use -p moms=<mom1:mom2>")
+        momA = self.moms.values()[0]
+        momB = self.moms.values()[1]
+
+        # Make sure moms are running with -p flag
+        momA.restart(args=['-p'])
+        momB.restart(args=['-p'])
+
+        pbsdsh_path = os.path.join(self.server.pbs_conf['PBS_EXEC'],
+                                   "bin", "pbsdsh")
+        script = "sleep 30 && %s echo 'Hello, World'" % pbsdsh_path
+        j = Job(TEST_USER)
+        j.set_attributes({'Resource_List.select': '2',
+                          'Resource_List.place': 'scatter'})
+        j.create_script(script)
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+
+        momA.signal("-KILL")
+        momB.signal("-KILL")
+        sleep(5)
+        momA.start(args=['-p'])
+        momB.start(args=['-p'])
+
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+
+        sleep(55)
+
+        self.server.log_match("%s;Exit_status=0" % jid)
+
+        # Restart moms without -p flag
+        momA.restart()
+        momB.restart()


### PR DESCRIPTION
#### Describe Bug or Feature
I have added possibility of resuming jobs that are running on multiple nodes. It is already possible to resume a job running on single node after mom restarts, so allowing the same for multinode jobs seems like a good idea. This is done when `-p` flag is passed on command line.

Possible problems with the implementation:
  - If you run `pbsdsh` while one of the nodes is down it enters an infinite loop as it doesn't check for node availability
  - If you restart mother superior while `pbsdsh` is running, it will exit with error as it loses connection with mother superior
  - Starting `pbsdsh` right after a node restart may result in error on task spawn because the task can be sent to the node before the node rejoins the job (and receives ports through which it should communicate)


#### Describe Your Change
  - Mother superior now saves and recovers `ji_ports`, so it can communicate with demux program after recovering the job.
  - When a non-superior mom recovers multinode job, it sends `IM_RECONNECT_TO_MS` to mother superior, MS then sends `IM_JOIN_RECOV_JOB` to all sisters along with port numbers through which they should communicate
  - When MS recovers multinode job, it sends `IM_JOIN_RECOV_JOB` along with port numbers to all sisters
  - Obit information (if there is any) is saved/recover along with tasks, so moms know wheter to send an obit after task completion
  - Multinode jobs now check whether they have a connection to MS inside `scan_for_exiting`, so when they send an obit they can be sure that it is delivered

#### Attach Test and Valgrind Logs/Output
[test_multinode_restart.txt](https://github.com/openpbs/openpbs/files/5061012/test_multinode_restart.txt)
