### PR TITLE
Optimization in shutdown procedure by eliminating loop over Jobs/Resv/Nodes & Fixing bugs related to checkpoint_abort.

### DIFF
--- a/src/server/pbsd_init.c
+++ b/src/server/pbsd_init.c
@@ -520,6 +520,7 @@ pbsd_init(int type)
 
 	/* 3. Set default server attibutes values */
 	memset(&server, 0, sizeof(server));
+	server.sv_started = time(&time_now);	/* time server started */
 	if (server.sv_attr[(int)SVR_ATR_scheduling].at_flags & ATR_VFLAG_SET)
 		a_opt = server.sv_attr[(int)SVR_ATR_scheduling].at_val.at_long;
 

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -718,8 +718,6 @@ main(int argc, char **argv)
 	char hook_msg[HOOK_MSG_SIZE];
 	pbs_sched *psched;
 	char *keep_daemon_name = NULL;
-	job *pjob;
-	resc_resv *presv;
 	pid_t sid = -1;
 	long *state;
 	time_t waittime;
@@ -995,8 +993,6 @@ main(int argc, char **argv)
 		log_err(errno, msg_daemonname, log_buffer);
 		return (2);
 	}
-
-	server.sv_started = time(&time_now);	/* time server started */
 
 	CLEAR_HEAD(svr_requests);
 	CLEAR_HEAD(task_list_immed);
@@ -1458,7 +1454,6 @@ main(int argc, char **argv)
 	(void)contact_sched(SCH_CONFIGURE, NULL, pbs_scheduler_addr, pbs_scheduler_port);
 	(void)contact_sched(SCH_SCHEDULE_NULL, NULL, pbs_scheduler_addr, pbs_scheduler_port);
 
-
 	/*
 	 * main loop of server
 	 * stays in this loop until server's state is either
@@ -1612,16 +1607,6 @@ main(int argc, char **argv)
 	server.sv_qs.sv_lastid = server.sv_qs.sv_jobidnumber;
 	svr_save_db(&server);	/* final recording of server */
 	track_save(NULL);	/* save tracking data	     */
-
-	/* save any jobs that need saving */
-	for (pjob = (job *)GET_NEXT(svr_alljobs); pjob; pjob = (job *)GET_NEXT(pjob->ji_alljobs))
-		job_save_db(pjob);
-
-	/* save any reservations that need saving */
-	for (presv = (resc_resv *)GET_NEXT(svr_allresvs); presv; presv = (resc_resv *)GET_NEXT(presv->ri_allresvs))
-		resv_save_db(presv);
-
-	save_nodes_db(0, NULL);
 
 	/* if brought up the Secondary Scheduler, take it down */
 

--- a/src/server/req_message.c
+++ b/src/server/req_message.c
@@ -361,6 +361,8 @@ req_relnodesjob(struct batch_request *preq)
 
 	rc = free_sister_vnodes(pjob, nodeslist, keep_select, msg, LOG_BUF_SIZE, preq);
 
+	job_save_db(pjob); /* we must save the updates anyway, if any */
+
 	if (rc != 0) {
 		reply_text(preq, PBSE_SYSTEM, msg);
 	}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* During shutdown procedure, the server is looping over all the jobs, reservations, nodes and storing in the DB. This is an expensive operation and this could be easily avoided by storing the necessary objects as and when needed. 
* There were 2 test case failures reported due to the attr refactoring task, which demands code change in the product. 

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* As part of loop removal, I have identified the places where we were not saving objects and saving them appropriately. 
* For checkpoint_abort bugs, found out that the assigned value for server start time is cleared out using memset(). Updated the code to assign the correct value after the memset operation. 

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
NA

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

Test cases that were reported as a failure after attr refactoring are passing now. 

[test_checkpoint_abort_with_qterm_delay_restart_hot_ptl_logs.txt](https://github.com/openpbs/openpbs/files/5034966/test_checkpoint_abort_with_qterm_delay_restart_hot_ptl_logs.txt)
[test_checkpoint_abort_with_qterm_immediate_restart_hot_ptl_logs.txt](https://github.com/openpbs/openpbs/files/5034967/test_checkpoint_abort_with_qterm_immediate_restart_hot_ptl_logs.txt)
[test_release_nodes_excl_server_restart_quick_ptl_logs.txt](https://github.com/openpbs/openpbs/files/5034968/test_release_nodes_excl_server_restart_quick_ptl_logs.txt)
[test_release_nodes_shared_server_restart_quick_ptl_logs.txt](https://github.com/openpbs/openpbs/files/5034969/test_release_nodes_shared_server_restart_quick_ptl_logs.txt)

<img width="1540" alt="Screen Shot 2020-08-06 at 11 33 58 PM" src="https://user-images.githubusercontent.com/17980660/89606175-593d0f80-d83d-11ea-9234-8a19010d3ba6.png">


The above 2 test failures are already failing in the mainline. 

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
