### PR TITLE
PTL clean up multi scheds created by test

### DIFF
--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -1666,6 +1666,7 @@ class PBSTestSuite(unittest.TestCase):
 
         for sched in self.scheds:
             self.scheds[sched].cleanup_files()
+        self.server.delete_sched_config()
         if self.use_cur_setup:
             self.delete_current_state(self.server, self.moms)
             ret = self.server.load_configuration(self.saved_file)

--- a/test/fw/ptl/utils/plugins/ptl_test_runner.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_runner.py
@@ -71,6 +71,7 @@ from ptl.utils.pbs_testsuite import (MINIMUM_TESTCASE_TIMEOUT,
                                      REQUIREMENTS_KEY, TIMEOUT_KEY)
 from ptl.utils.plugins.ptl_test_info import get_effective_reqs
 from ptl.utils.pbs_testusers import PBS_ALL_USERS
+from ptl.lib.pbs_testlib import Server
 from io import StringIO
 
 log = logging.getLogger('nose.plugins.PTLTestRunner')
@@ -1020,6 +1021,7 @@ class PTLTestRunner(Plugin):
         if du.isdir(path=tmppath):
             du.rm(path=tmppath, recursive=True, sudo=True, force=True,
                   level=logging.DEBUG)
+        Server().delete_sched_config()
 
     def begin(self):
         command = sys.argv

--- a/test/fw/ptl/utils/plugins/ptl_test_runner.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_runner.py
@@ -71,7 +71,6 @@ from ptl.utils.pbs_testsuite import (MINIMUM_TESTCASE_TIMEOUT,
                                      REQUIREMENTS_KEY, TIMEOUT_KEY)
 from ptl.utils.plugins.ptl_test_info import get_effective_reqs
 from ptl.utils.pbs_testusers import PBS_ALL_USERS
-from ptl.lib.pbs_testlib import Server
 from io import StringIO
 
 log = logging.getLogger('nose.plugins.PTLTestRunner')
@@ -1021,7 +1020,6 @@ class PTLTestRunner(Plugin):
         if du.isdir(path=tmppath):
             du.rm(path=tmppath, recursive=True, sudo=True, force=True,
                   level=logging.DEBUG)
-        Server().delete_sched_config()
 
     def begin(self):
         command = sys.argv


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
PTL doesn't clean up multi scheds created by test


#### Describe Your Change
PTL clean up multi scheds created by test

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[multi_sched_fail.txt](https://github.com/openpbs/openpbs/files/5037035/multi_sched_fail.txt)
[multi_sched_pass.txt](https://github.com/openpbs/openpbs/files/5039289/multi_sched_pass.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
