### PR TITLE
Update CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,31 @@
-### OpenPBS Open Source Project Code of Conduct
+#### OpenPBS Open Source Project 
 
-Please see the Contributor's Portal for our **[Code of Conduct](https://pbspro.atlassian.net/wiki/spaces/PBSPro/pages/5537835/Code+of+Conduct)**.
+## **Code of Conduct**
+
+This code of conduct is a guide for members of the OpenPBS community. We are committed to providing an open and welcoming environment for the OpenPBS community.  We expect that all members of the community will behave according to this code of conduct.  This code of conduct is intended to explain the spirit in which we expect to communicate, not to be an exhaustive list.  This code of conduct applies to all elements of the OpenPBS community: mailing lists, bug tracking systems, etc.  Anyone who violates this code of conduct may be banned from the OpenPBS community.  It is unacceptable to follow the letter but not the spirit of this code of conduct.
+
+Guidelines for code of conduct:
+
+* **Be friendly and patient.**
+* **Be welcoming:** We strive to be a community that welcomes and supports people of all backgrounds and identities.
+* **Be considerate:** Your work will be used by other people, and you in turn will depend on the work of others. Decisions you make affect everyone in the community, so please be mindful of your actions and always choose a non-confrontational approach. Remember: this is a global community and English is not everyone's primary language.
+* **Be respectful:** Disagreements may occur, but we cannot abide personal attacks. The health of the community depends on all members feeling comfortable and supported. If you don't agree, use discretion and be polite.
+* **Be careful in the words that we choose:** we are a community of professionals, and we conduct ourselves professionally. Be kind to others. Do not insult or put down other participants. Harassment and other exclusionary behavior aren’t acceptable.
+* **Try to understand why we disagree:** Disagreements, both social and technical, happen all the time. It is important that we resolve disagreements and differing views constructively. Different people have different perspectives on issues. Being unable to understand why someone holds a viewpoint doesn’t mean that they’re wrong. Don’t forget that it is human to err and blaming each other doesn’t get us anywhere. Instead, focus on helping to resolve issues and learning from mistakes.
+In addition, our open source community members are expected to abide by the **[OpenPBS Acceptable Use Policy](https://openpbs.atlassian.net/wiki/spaces/PBSPro/pages/5537837/Acceptable+Use+Policy).
+
+### Reporting Issues
+If you experience or witness unacceptable behavior — or have any other concerns — please report it by sending e-mail to webmaster@pbspro.org. All reports will be handled with discretion. In your report please include:
+* Your contact information.
+* Names (real, nicknames, or pseudonyms) of any individuals involved. If there are additional witnesses, please include them as well. Your account of what occurred, and if you believe the incident is ongoing. If there is a publicly available record (e.g. a mailing list archive or a public IRC logger), please include a link.
+* Any additional information that may be helpful.
+
+After filing a report, a representative will contact you personally, review the incident, follow up with any additional questions, and make a decision as to how to respond. If the person who is harassing you is part of the response team, they will recuse themselves from handling your incident. If the complaint originates from a member of the response team, it will be handled by a different member of the response team. We will respect confidentiality requests for the purpose of protecting victims of abuse.
+
+### Attribution & Acknowledgements
+This code of conduct is based on the **[Open Code of Conduct v1.0](https://github.com/todogroup/opencodeofconduct)** from the **[TODOGroup](http://todogroup.org)**. We are thankful for their work and all the communities who have paved the way with codes of conduct.
+
+### PBS Pro Contributor's Portal
+Please see the PBS Pro Contributor's Portal for the PBS Pro **[Code of Conduct](https://openpbs.atlassian.net/wiki/spaces/PBSPro/pages/5537835/Code+of+Conduct)**.
 
 Note: In May 2020, OpenPBS became the new name for the PBS Professional Open Source Project. (PBS Professional will be used to refer to the commercial version; OpenPBS to the Open Source version -- same code, easier naming.) As there are many parts to the project, it will take several weeks to change the name in all places, so you will continue to see references to PBS Pro (as in the above) -- stay tuned.


### PR DESCRIPTION
Updated CODE_OF_CONDUCT.md file with a new markdown version of the PBS Pro Code of Conduct, but changed the words "PBS Pro" to "OpenPBS" in this new version.

<!--- Please review your changes in preview mode -->

<!--- Provide a general summary of your changes in the Title above -->
Copied the PBS Pro Code of Conduct, and created a new markdown version of the Code of Conduct for OpenPBS

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Old version said "PBS Pro" instead of "OpenPBS" and pointed to a third party website, and this new version specifically says "OpenPBS" and has the code of conduct in proper markdown format (with a reference link to the old "PBS Pro" link for "PBS Pro Code of Conduct".

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Created the new "OpenPBS Code of Conduct" in markdown language (based on the PBS Pro Code of Conduct).

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
https://openpbs.atlassian.net/wiki/spaces/PBSPro/pages/5537835/Code+of+Conduct

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
