### PR TITLE
Set JOB_EXEC_RERUN as the Exit_status when doing a qrerun

### DIFF
--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -900,12 +900,11 @@ post_discard_job(job *pjob, mominfo_t *pmom, int newstate)
 		sprintf(log_buffer, ndreque, downmom);
 		log_event(PBSEVENT_JOB, PBS_EVENTCLASS_JOB, LOG_INFO,
 			pjob->ji_qs.ji_jobid, log_buffer);
-		account_jobend(pjob, pjob->ji_acctrec, PBS_ACCT_RERUN);
+		force_reque(pjob);
 		if (pjob->ji_acctrec) {
 			free(pjob->ji_acctrec);	/* logged, so clear it */
 			pjob->ji_acctrec = NULL;
 		}
-		force_reque(pjob);
 
 		/* free resc_used */
 		if ((pjob->ji_wattr[(int)JOB_ATR_resc_used].at_flags & ATR_VFLAG_SET) &&

--- a/src/server/req_rerun.c
+++ b/src/server/req_rerun.c
@@ -464,6 +464,7 @@ req_rerunjob2(struct batch_request *preq, job *pjob)
 		if (pjob->ji_pmt_preq != NULL)
 			reply_preempt_jobs_request(rc, PREEMPT_METHOD_REQUEUE, pjob);
 
+		pjob->ji_qs.ji_un.ji_exect.ji_exitstat = JOB_EXEC_RERUN;
 		pjob->ji_qs.ji_substate = JOB_SUBSTATE_RERUN3;
 		discard_job(pjob, "Force rerun", 0);
 		pjob->ji_discarding = 1;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
JOB_EXEC_RERUN (-11) was not always set depending on whether the qrerun was done with -Wforce and the state of the job.  Thus the accounting log "R" record (for rerun jobs) did not always have an Exit_status =-11.

Also, I noticed 2 "R" records in the accounting log for the same job for the same rerun.  I removed one of the duplicate logs.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Set JOB_EXEC_RERUN in one path where it was not previously being set.
Reorder some code and remove a call to account_jobend() since account_jobend will be called in force_reque anyway.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
