### PR TITLE
New ralter -Wforce option

### DIFF
--- a/src/cmds/pbs_ralter.c
+++ b/src/cmds/pbs_ralter.c
@@ -157,11 +157,6 @@ process_opts(int argc, char **argv, struct attrl **attrp, char *dest)
 				}
 				break;
 			case 'W':
-				if (strlen(optarg) == 0) {
-					fprintf(stderr, "pbs_ralter: illegal -W value\n");
-					errflg++;
-					break;
-				}
 				if (strcmp(optarg, "force") == 0)
 					force_alter = TRUE;
 				else {

--- a/src/cmds/pbs_ralter.c
+++ b/src/cmds/pbs_ralter.c
@@ -51,6 +51,7 @@
 static struct attrl *attrib = NULL;
 static time_t dtstart;
 static time_t dtend;
+int force_alter = FALSE;
 
 /*
  * @brief process options input to the command.
@@ -75,8 +76,9 @@ process_opts(int argc, char **argv, struct attrl **attrp, char *dest)
 	char	*endptr = NULL;
 	long	temp = 0;
 	char dur_buf[800];
+	int	alter_duration = FALSE;
 
-	while ((c = getopt(argc, argv, "E:I:m:M:N:R:q:U:G:D:l:")) != EOF) {
+	while ((c = getopt(argc, argv, "E:I:m:M:N:R:q:U:G:D:l:W:")) != EOF) {
 		switch (c) {
 			case 'E':
 				t = cvtdate(optarg);
@@ -144,12 +146,26 @@ process_opts(int argc, char **argv, struct attrl **attrp, char *dest)
 			case 'D':
 				snprintf(dur_buf, sizeof(dur_buf), "%s", optarg);
 				set_attr_error_exit(&attrib, ATTR_resv_duration, dur_buf);
+				alter_duration = TRUE;
 				break;
 			case 'l':
 				if (strncmp(optarg, "select=", 7) == 0)
 					set_attr_resc_error_exit(&attrib, ATTR_l, "select", (optarg + 7));
 				else {
 					fprintf(stderr, "pbs_ralter -l only allows for select\n");
+					errflg++;
+				}
+				break;
+			case 'W':
+				if (strlen(optarg) == 0) {
+					fprintf(stderr, "pbs_ralter: illegal -W value\n");
+					errflg++;
+					break;
+				}
+				if (strcmp(optarg, "force") == 0)
+					force_alter = TRUE;
+				else {
+					fprintf(stderr, "pbs_ralter: illegal -W value\n");
 					errflg++;
 				}
 				break;
@@ -160,6 +176,11 @@ process_opts(int argc, char **argv, struct attrl **attrp, char *dest)
 		} /* End of lengthy 'switch on option' constuction */
 	}   /* End of lengthy while loop on 'options' */
 
+	/* Check that force option is used with 'R', 'E' or 'D' option */
+	if ((force_alter == TRUE) && (dtstart == 0) && (dtend == 0) && (alter_duration == 0)) {
+		fprintf(stderr, "pbs_ralter: No support for requested service\n");
+		errflg++;
+	}
 	*attrp = attrib;
 	return (errflg);
 }
@@ -178,6 +199,7 @@ print_usage()
 	"                [-U (+/-)username[,(+/-)username]...]\n"
 	"                [-G [(+/-)group[,(+/-)group]...]]\n"
 	"                [-D duration]\n"
+	"                [-W force]\n"
 	"                resv_id\n";
 	fprintf(stderr, "%s", usage);
 	fprintf(stderr, "%s", usag2);
@@ -244,6 +266,7 @@ main(int argc, char *argv[], char *envp[])		/* pbs_ralter */
 	char		resv_id_out[PBS_MAXCLTJOBID] = {0};
 	char		server_out[MAXSERVERNAME] = {0};
 	char		*stat = NULL;
+	char		*extend = NULL;
 
 	/*test for real deal or just version and exit*/
 
@@ -281,7 +304,10 @@ main(int argc, char *argv[], char *envp[])		/* pbs_ralter */
 		fprintf(stderr, "pbs_ralter: illegally formed reservation identifier: %s\n", resv_id);
 		exit(2);
 	}
-	stat = pbs_modify_resv(connect, resv_id_out, (struct attropl *)attrib, NULL);
+
+	if (force_alter == TRUE)
+		extend = "force";
+	stat = pbs_modify_resv(connect, resv_id_out, (struct attropl *)attrib, extend);
 
 	if (stat == NULL) {
 		if ((err_list = pbs_get_attributes_in_error(connect)))

--- a/src/cmds/qdel.c
+++ b/src/cmds/qdel.c
@@ -116,7 +116,7 @@ char **envp;
 					errflg++;
 					break;
 				}
-				if (strcmp(pc, FORCEDEL) == 0) {
+				if (strcmp(pc, FORCE) == 0) {
 					forcedel = TRUE;
 					break;
 				}
@@ -155,9 +155,9 @@ char **envp;
 	}
 
 	if (forcedel && deletehist)
-		snprintf(warg, sizeof(warg), "%s%s", FORCEDEL, DELETEHISTORY);
+		snprintf(warg, sizeof(warg), "%s%s", FORCE, DELETEHISTORY);
 	else if (forcedel)
-		strcpy(warg, FORCEDEL);
+		strcpy(warg, FORCE);
 	else if (deletehist)
 		strcpy(warg, DELETEHISTORY);
 

--- a/src/include/pbs_ifl.h
+++ b/src/include/pbs_ifl.h
@@ -499,10 +499,10 @@ enum batch_op {	SET, UNSET, INCR, DECR,
 
 /* messages that may be passsed  by pbs_deljob() api to the server  via its extend parameter*/
 
-#define FORCEDEL			"force"
+#define FORCE				"force"
 #define NOMAIL  			"nomail"
 #define SUPPRESS_EMAIL  		"suppress_email"
-#define DELETEHISTORY		"deletehist"
+#define DELETEHISTORY			"deletehist"
 /*
  ** This structure is identical to attropl so they can be used
  ** interchangably.  The op field is not used.

--- a/src/include/reservation.h
+++ b/src/include/reservation.h
@@ -66,6 +66,7 @@ extern "C" {
 #define RESV_END_TIME_MODIFIED		0x2
 #define RESV_DURATION_MODIFIED		0x4
 #define RESV_SELECT_MODIFIED		0x8
+#define RESV_ALTER_FORCED		0x10
 
 
 /*
@@ -119,7 +120,6 @@ struct resv_alter {
 	long ra_state;
 	unsigned long ra_flags;
 	char *ra_select_revert; /* used to revert select for future occurrences */
-	int ra_force;
 };
 
 /*

--- a/src/include/reservation.h
+++ b/src/include/reservation.h
@@ -119,6 +119,7 @@ struct resv_alter {
 	long ra_state;
 	unsigned long ra_flags;
 	char *ra_select_revert; /* used to revert select for future occurrences */
+	int ra_force;
 };
 
 /*
@@ -183,10 +184,10 @@ struct resc_resv {
 							 * Will only be useful if we later make
 							 */
 
-	struct batch_request	*ri_brp;		/*NZ if choose interactive (I) mode*/
+	struct batch_request	*ri_brp;		/* NZ if choose interactive (I) mode */
 
 	/*resource reservations routeable objs*/
-	int			ri_downcnt;		/*used when deleting the reservation*/
+	int			ri_downcnt;		/* used when deleting the reservation*/
 
 	long			ri_resv_retry;		/* time at which the reservation will be reconfirmed */
 
@@ -195,7 +196,7 @@ struct resc_resv {
 	pbsnode_list_t		*ri_pbsnode_list;	/* vnode list associated to the reservation */
 
 	/* objects used while altering a reservation. */
-	struct resv_alter 	ri_alter;		/* object used to alter a reservation */
+	struct resv_alter	ri_alter;		/* object used to alter a reservation */
 
 	/* Reservation start and end tasks */
 	struct work_task	*resv_start_task;

--- a/src/include/svrfunc.h
+++ b/src/include/svrfunc.h
@@ -345,7 +345,8 @@ extern int node_avail_complex(spec_and_context *, int *, int *, int *, int *);
 extern int node_reserve(spec_and_context *, pbs_resource_t);
 extern void node_unreserve(pbs_resource_t);
 extern int node_spec(struct spec_and_context *, int);
-extern void notify_scheds_about_resv(int, resc_resv *);
+extern int notify_scheds_about_resv(int, resc_resv *);
+extern char *create_resv_destination(resc_resv *presv);
 #endif /* _RESERVATION_H */
 
 #ifdef _LIST_LINK_H

--- a/src/lib/Libifl/pbs_ifl_wrap.c
+++ b/src/lib/Libifl/pbs_ifl_wrap.c
@@ -8624,7 +8624,7 @@ SWIG_init(void) {
   SWIG_Python_SetConstant(d, "SHUT_IMMEDIATE",SWIG_From_int((int)(0)));
   SWIG_Python_SetConstant(d, "SHUT_DELAY",SWIG_From_int((int)(1)));
   SWIG_Python_SetConstant(d, "SHUT_QUICK",SWIG_From_int((int)(2)));
-  SWIG_Python_SetConstant(d, "FORCEDEL",SWIG_FromCharPtr("force"));
+  SWIG_Python_SetConstant(d, "FORCE",SWIG_FromCharPtr("force"));
   SWIG_Python_SetConstant(d, "NOMAIL",SWIG_FromCharPtr("nomail"));
   SWIG_Python_SetConstant(d, "SUPPRESS_EMAIL",SWIG_FromCharPtr("suppress_email"));
   SWIG_Python_SetConstant(d, "DELETEHISTORY",SWIG_FromCharPtr("deletehist"));

--- a/src/scheduler/constant.h
+++ b/src/scheduler/constant.h
@@ -354,7 +354,7 @@ enum misc_constants
 {
 	NO_FLAGS = 0,
 	IGNORE_DISABLED_EVENTS = 1,
-	FORCE,
+	FORCE_SCHED,
 	SET_RESRESV_INDEX = 4,
 	DETECT_GHOST_JOBS = 8,
 	ALL_MASK = 0xffffffff

--- a/src/server/req_delete.c
+++ b/src/server/req_delete.c
@@ -367,7 +367,7 @@ req_deletejob(struct batch_request *preq)
 
 	if (preq->rq_extend && strstr(preq->rq_extend, DELETEHISTORY))
 		delhist = 1;
-	if (preq->rq_extend && strstr(preq->rq_extend, FORCEDEL))
+	if (preq->rq_extend && strstr(preq->rq_extend, FORCE))
 		forcedel = 1;
 	/* with nomail , nomail_force , nomail_deletehist or nomailforce_deletehist options are set
 	 *  no mail is sent
@@ -620,7 +620,7 @@ req_deletejob2(struct batch_request *preq, job *pjob)
 		sprintf(by_user, "%s@%s", preq->rq_user, preq->rq_host);
 	}
 
-	if ((preq->rq_extend && strstr(preq->rq_extend, FORCEDEL)))
+	if ((preq->rq_extend && strstr(preq->rq_extend, FORCE)))
 		forcedel = 1;
 
 	/* See if the request is coming from a manager */

--- a/src/server/req_modify.c
+++ b/src/server/req_modify.c
@@ -744,6 +744,66 @@ is_select_smaller(char *select_orig, char *select_smaller)
 }
 
 /**
+ * @brief This function creates a request run destination string for a reservation.
+ *	  This string is in the same format as preq->rq_ind.rq_run.rq_destin
+ * @param[in] presv - reservation for which string is being made.
+ * @return destination string
+ */
+char *create_resv_destination(resc_resv *presv)
+{
+	char * format = "%s";
+	int destin_len;
+	char * destin;
+	if (presv == NULL)
+		return NULL;
+	destin_len = strlen(presv->ri_wattr[RESV_ATR_resv_nodes].at_val.at_str) + 6;
+	/* allocate 6 extra bytes because for standing reservation format is different */
+	destin = malloc(destin_len);
+	if (destin == NULL) {
+	    return NULL;
+	}
+	if (presv->ri_wattr[RESV_ATR_resv_standing].at_val.at_long)
+	    format = "1#%s{0}";
+	snprintf(destin, destin_len, format, presv->ri_wattr[RESV_ATR_resv_nodes].at_val.at_str);
+	return destin;
+}
+
+/**
+ * @brief This function creates a batch_request to confirm a reservation
+ * @param[in] presv - reservation that is being confirmed.
+ *
+ * @return - Batch request
+ */
+static struct batch_request *create_resv_confirm_req(resc_resv *presv)
+{
+	struct batch_request *confirm_req;
+	char *part;
+	confirm_req = alloc_br(PBS_BATCH_ConfirmResv);
+	if (confirm_req == NULL) {
+		return NULL;
+	}
+	if (presv->ri_wattr[RESV_ATR_partition].at_flags & ATR_VFLAG_SET)
+		part = presv->ri_wattr[RESV_ATR_partition].at_val.at_str;
+	else
+		part = DEFAULT_PARTITION;
+
+	if (pbs_asprintf(&confirm_req->rq_extend, "%s:partition=%s", PBS_RESV_CONFIRM_SUCCESS, part) == -1) {
+		free_br(confirm_req);
+		return NULL;
+	}
+	pbs_strncpy(confirm_req->rq_ind.rq_run.rq_jid, presv->ri_qs.ri_resvID, sizeof(confirm_req->rq_ind.rq_run.rq_jid));
+	confirm_req->rq_ind.rq_run.rq_resch = presv->ri_wattr[RESV_ATR_start].at_val.at_long;
+	if (presv->ri_wattr[RESV_ATR_resv_nodes].at_flags & ATR_VFLAG_SET) {
+		confirm_req->rq_ind.rq_run.rq_destin = create_resv_destination(presv);
+		if (confirm_req->rq_ind.rq_run.rq_destin == NULL) {
+			free_br(confirm_req);
+			return NULL;
+		}
+	}
+	return confirm_req;
+}
+
+/**
  * @brief Service the Modify Reservation Request from client such as pbs_ralter.
  *
  *	This request atomically modifies one or more of a reservation's attributes.
@@ -775,6 +835,8 @@ req_modifyReservation(struct batch_request *preq)
 	int num_jobs;
 	long new_end_time = 0;
 	resource *presc = NULL;
+	int scheds_notified = 0;
+	int force_alter = FALSE;
 
 	if (preq == NULL)
 		return;
@@ -787,7 +849,10 @@ req_modifyReservation(struct batch_request *preq)
 	 */
 	if (presv == NULL)
 		return;
-	
+
+	if (preq->rq_extend != NULL && (strcmp(preq->rq_extend, FORCE) == 0))
+		force_alter = TRUE;
+
 	rid = preq->rq_ind.rq_modify.rq_objname;
 	presv = find_resv(rid);
 
@@ -909,6 +974,11 @@ req_modifyReservation(struct batch_request *preq)
 				presv->ri_alter.ra_flags |= RESV_DURATION_MODIFIED;
 				break;
 			case RESV_ATR_resource:
+				if (force_alter) {
+					resv_revert_alter(presv);
+					req_reject(PBSE_NOSUP, 0 , preq);
+					return;
+				}
 				if (strcmp(psatl->al_resc, "select") != 0) {
 					resv_revert_alter(presv);
 					req_reject(PBSE_BADATVAL, 0, preq);
@@ -944,7 +1014,12 @@ req_modifyReservation(struct batch_request *preq)
 
 		psatl = (svrattrl *)GET_NEXT(psatl->al_link);
 	}
-
+	/* Force option is only applied to attributes that require reconfirmation */
+	if ((send_to_scheduler == 0) && (force_alter == TRUE)) {
+		resv_revert_alter(presv);
+		req_reject(PBSE_NOSUP, 0 , preq);
+		return;
+	}
 
 	if (presv->ri_wattr[RESV_ATR_state].at_val.at_long == RESV_RUNNING && num_jobs) {
 		if ((presv->ri_alter.ra_flags & RESV_DURATION_MODIFIED) && (presv->ri_alter.ra_flags & RESV_END_TIME_MODIFIED)) {
@@ -1059,7 +1134,7 @@ req_modifyReservation(struct batch_request *preq)
 	}
 
 	if (send_to_scheduler)
-		notify_scheds_about_resv(SCH_SCHEDULE_RESV_RECONFIRM, presv);
+		scheds_notified = notify_scheds_about_resv(SCH_SCHEDULE_RESV_RECONFIRM, presv);
 
 	sprintf(log_buffer, "Attempting to modify reservation");
 	if (presv->ri_alter.ra_flags & RESV_START_TIME_MODIFIED) {
@@ -1077,6 +1152,40 @@ req_modifyReservation(struct batch_request *preq)
 		snprintf(log_buffer + log_len, sizeof(log_buffer) - log_len, " select=%s", presc->rs_value.at_val.at_str);
 	}
 	log_event(PBSEVENT_RESV, PBS_EVENTCLASS_RESV, LOG_INFO, preq->rq_ind.rq_modify.rq_objname, log_buffer);
+
+	if (force_alter == TRUE) {
+		if (scheds_notified == 0 ) { /* No schedulers notified, just enforce confirmation */
+			if (presv->ri_alter.ra_state == RESV_UNCONFIRMED) { /* No need to do anything, just make the change */
+				resv_setResvState(presv, RESV_UNCONFIRMED, RESV_UNCONFIRMED);
+				presv->ri_alter.ra_flags = 0;
+				presv->ri_alter.ra_stime = 0;
+				presv->ri_alter.ra_etime = 0;
+				presv->ri_alter.ra_duration = 0;
+				presv->ri_alter.ra_state = 0;
+			} else {
+				struct batch_request *confirm_req;
+				struct work_task *pwt;
+				confirm_req = create_resv_confirm_req(presv);
+				if (confirm_req == NULL) {
+					req_reject(PBSE_SYSTEM, 0, preq);
+					resv_revert_alter(presv);
+					return;
+				}
+				confirm_req->rq_perm = preq->rq_perm;
+				if (issue_Drequest(PBS_LOCAL_CONNECTION, confirm_req, release_req, &pwt, 0) == -1) {
+					free_br(confirm_req);
+					req_reject(PBSE_SYSTEM, 0, preq);
+					resv_revert_alter(presv);
+					return;
+				}
+				append_link(&presv->ri_svrtask, &pwt->wt_linkobj, pwt);
+			}
+			snprintf(buf, sizeof(buf), "%s CONFIRMED", presv->ri_qs.ri_resvID);
+			reply_text(preq, PBSE_NONE, buf);
+			return;
+		} else
+			presv->ri_alter.ra_force = 1;
+	}
 
 	if ((presv->ri_wattr[RESV_ATR_interactive].at_flags &
 		ATR_VFLAG_SET) == 0) {

--- a/src/server/req_quejob.c
+++ b/src/server/req_quejob.c
@@ -1941,13 +1941,14 @@ locate_new_job(struct batch_request *preq, char *jobid)
  * @param[in] cmd - The command that is to be notified to the scheduler
  * @param[in] resv - The reservation related to the command
  *
- * @return void
+ * @return Number of schedulers notified.
  *
  */
-void notify_scheds_about_resv(int cmd, resc_resv *resv)
+int notify_scheds_about_resv(int cmd, resc_resv *resv)
 {
 	pbs_sched *psched;
 	char *partition_name = NULL;
+	int num_scheds = 0;
 
 	if (resv != NULL) {
 		if (resv->ri_wattr[(int)RESV_ATR_partition].at_flags & ATR_VFLAG_SET)
@@ -1967,6 +1968,7 @@ void notify_scheds_about_resv(int cmd, resc_resv *resv)
 			if (strcmp(partition_name, DEFAULT_PARTITION) == 0) {
 				if (dflt_scheduler->sch_attr[(int)SCHED_ATR_scheduling].at_val.at_long == 1) {
 					set_scheduler_flag(cmd, dflt_scheduler);
+					num_scheds++;
 				}
 				break;
 			} else {
@@ -1974,6 +1976,7 @@ void notify_scheds_about_resv(int cmd, resc_resv *resv)
 				tmp = find_sched_from_partition(partition_name);
 				if (tmp != NULL && (tmp->sch_attr[(int)SCHED_ATR_scheduling].at_val.at_long == 1)) {
 					set_scheduler_flag(cmd, tmp);
+					num_scheds++;
 					break;
 				}
 			}
@@ -1982,10 +1985,11 @@ void notify_scheds_about_resv(int cmd, resc_resv *resv)
 				set_scheduler_flag(cmd, psched);
 				if (resv != NULL)
 					resv->req_sched_count++;
+				num_scheds++;
 			}
 		}
 	}
-	return;
+	return num_scheds;
 }
 
 /**

--- a/src/server/req_rescq.c
+++ b/src/server/req_rescq.c
@@ -569,6 +569,7 @@ req_confirmresv(struct batch_request *preq)
 	 * is invalid, set it to some time after the soonest occurrence is to start
 	 */
 	if (strcmp(preq->rq_extend, PBS_RESV_CONFIRM_FAIL) == 0) {
+		int force_requested = FALSE;
 		if (is_degraded && !is_being_altered) {
 			long retry_time;
 			retry_time = determine_resv_retry(presv);
@@ -589,12 +590,14 @@ req_confirmresv(struct batch_request *preq)
 				if ((presv->ri_brp != NULL) &&
 					(presv->ri_wattr[RESV_ATR_interactive].at_flags &
 					ATR_VFLAG_SET)) {
-					presv->ri_wattr[RESV_ATR_interactive].at_flags &= ~ATR_VFLAG_SET;
-					snprintf(buf, sizeof(buf), "%s DENIED",
-						presv->ri_qs.ri_resvID);
-					(void)reply_text(presv->ri_brp,
-						PBSE_NONE, buf);
-					presv->ri_brp = NULL;
+					if (presv->ri_alter.ra_force == FALSE) {
+						presv->ri_wattr[RESV_ATR_interactive].at_flags &= ~ATR_VFLAG_SET;
+						snprintf(buf, sizeof(buf), "%s DENIED",
+							presv->ri_qs.ri_resvID);
+						(void)reply_text(presv->ri_brp,
+							PBSE_NONE, buf);
+						presv->ri_brp = NULL;
+					}
 				}
 				if (!is_being_altered && !is_confirmed) {
 					log_event(PBS_EVENTCLASS_RESV, PBS_EVENTCLASS_RESV,
@@ -611,12 +614,38 @@ req_confirmresv(struct batch_request *preq)
 			}
 		}
 		if (presv->ri_qs.ri_state == RESV_BEING_ALTERED) {
-			resv_revert_alter(presv);
-			log_event(PBSEVENT_RESV, PBS_EVENTCLASS_RESV, LOG_INFO,
-				  presv->ri_qs.ri_resvID, "Reservation alter denied");
+			if (!presv->ri_alter.ra_force) {
+				resv_revert_alter(presv);
+				log_event(PBSEVENT_RESV, PBS_EVENTCLASS_RESV, LOG_INFO,
+					presv->ri_qs.ri_resvID, "Reservation alter denied");
+			} else if (presv->rep_sched_count >= presv->req_sched_count)
+				force_requested = TRUE;
 		}
-		reply_ack(preq);
-		return;
+		if (force_requested == FALSE) {
+			reply_ack(preq);
+			return;
+		} else {
+			/* This can only happen when ralter was requested with -Wforce option.
+			 * Even though all schedulers have rejected the change, enforce it.
+			 */
+			presv->ri_alter.ra_force = FALSE;
+			free(preq->rq_extend);
+			if (pbs_asprintf(&preq->rq_extend, "%s:partition=%s", PBS_RESV_CONFIRM_SUCCESS,
+					 presv->ri_wattr[RESV_ATR_partition].at_val.at_str) == -1) {
+				req_reject(PBSE_SYSTEM, 0, preq);
+				return;
+			}
+			/* set start time and destination in the preq structure */
+			if (presv->ri_wattr[RESV_ATR_start].at_flags & ATR_VFLAG_SET)
+				preq->rq_ind.rq_run.rq_resch = presv->ri_wattr[RESV_ATR_start].at_val.at_long;
+			if (presv->ri_wattr[RESV_ATR_resv_nodes].at_flags & ATR_VFLAG_SET) {
+				preq->rq_ind.rq_run.rq_destin = create_resv_destination(presv);
+				if (preq->rq_ind.rq_run.rq_destin == NULL) {
+					req_reject(PBSE_SYSTEM, 0, preq);
+					return;
+				}
+			}
+		}
 	}
 
 #ifdef NAS /* localmod 122 */
@@ -651,7 +680,6 @@ req_confirmresv(struct batch_request *preq)
 	 * describing the execvnodes associated to each occurrence.
 	 */
 	if (presv->ri_wattr[RESV_ATR_resv_standing].at_val.at_long) {
-
 		/* The number of occurrences in the standing reservation and index are parsed
 		 * from the execvnode string which is of the form:
 		 *     <num_occurrences>#<vnode1>[range1]<vnode2>[range2]...

--- a/src/server/req_rescq.c
+++ b/src/server/req_rescq.c
@@ -592,23 +592,16 @@ req_confirmresv(struct batch_request *preq)
 					ATR_VFLAG_SET)) {
 					if (!(presv->ri_alter.ra_flags & RESV_ALTER_FORCED)) {
 						presv->ri_wattr[RESV_ATR_interactive].at_flags &= ~ATR_VFLAG_SET;
-						snprintf(buf, sizeof(buf), "%s DENIED",
-							presv->ri_qs.ri_resvID);
-						(void)reply_text(presv->ri_brp,
-							PBSE_NONE, buf);
+						snprintf(buf, sizeof(buf), "%s DENIED", presv->ri_qs.ri_resvID);
+						(void)reply_text(presv->ri_brp, PBSE_NONE, buf);
 						presv->ri_brp = NULL;
 					}
 				}
 				if (!is_being_altered && !is_confirmed) {
-					log_event(PBS_EVENTCLASS_RESV, PBS_EVENTCLASS_RESV,
-						LOG_INFO, presv->ri_qs.ri_resvID,
-						"Reservation denied");
-					(void)snprintf(log_buffer, sizeof(log_buffer),
-						"requestor=%s@%s", msg_daemonname, server_host);
+					log_event(PBS_EVENTCLASS_RESV, PBS_EVENTCLASS_RESV, LOG_INFO, presv->ri_qs.ri_resvID, "Reservation denied");
+					(void)snprintf(log_buffer, sizeof(log_buffer), "requestor=%s@%s", msg_daemonname, server_host);
 					account_recordResv(PBS_ACCT_DRss, presv, log_buffer);
-					log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_RESV,
-						LOG_NOTICE, presv->ri_qs.ri_resvID,
-						"reservation deleted");
+					log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_RESV, LOG_NOTICE, presv->ri_qs.ri_resvID, "reservation deleted");
 					resv_purge(presv);
 				}
 			}

--- a/src/server/req_rescq.c
+++ b/src/server/req_rescq.c
@@ -590,7 +590,7 @@ req_confirmresv(struct batch_request *preq)
 				if ((presv->ri_brp != NULL) &&
 					(presv->ri_wattr[RESV_ATR_interactive].at_flags &
 					ATR_VFLAG_SET)) {
-					if (presv->ri_alter.ra_force == FALSE) {
+					if (!(presv->ri_alter.ra_flags & RESV_ALTER_FORCED)) {
 						presv->ri_wattr[RESV_ATR_interactive].at_flags &= ~ATR_VFLAG_SET;
 						snprintf(buf, sizeof(buf), "%s DENIED",
 							presv->ri_qs.ri_resvID);
@@ -614,7 +614,7 @@ req_confirmresv(struct batch_request *preq)
 			}
 		}
 		if (presv->ri_qs.ri_state == RESV_BEING_ALTERED) {
-			if (!presv->ri_alter.ra_force) {
+			if (!(presv->ri_alter.ra_flags & RESV_ALTER_FORCED)) {
 				resv_revert_alter(presv);
 				log_event(PBSEVENT_RESV, PBS_EVENTCLASS_RESV, LOG_INFO,
 					presv->ri_qs.ri_resvID, "Reservation alter denied");
@@ -628,7 +628,7 @@ req_confirmresv(struct batch_request *preq)
 			/* This can only happen when ralter was requested with -Wforce option.
 			 * Even though all schedulers have rejected the change, enforce it.
 			 */
-			presv->ri_alter.ra_force = FALSE;
+			presv->ri_alter.ra_flags &= ~RESV_ALTER_FORCED;
 			free(preq->rq_extend);
 			if (pbs_asprintf(&preq->rq_extend, "%s:partition=%s", PBS_RESV_CONFIRM_SUCCESS,
 					 presv->ri_wattr[RESV_ATR_partition].at_val.at_str) == -1) {

--- a/src/server/svr_chk_owner.c
+++ b/src/server/svr_chk_owner.c
@@ -575,6 +575,10 @@ svr_authorize_resvReq(struct batch_request *preq, resc_resv *presv)
 	if ((preq->rq_perm & (ATR_DFLAG_OPRD | ATR_DFLAG_OPWR |
 		ATR_DFLAG_MGRD | ATR_DFLAG_MGWR)) != 0)
 		return (0);
+	/* Only Manager has privilage to force modify reservation */
+	if (preq->rq_type == PBS_BATCH_ModifyResv && (preq->rq_extend != NULL) &&
+	    (strcmp(preq->rq_extend, FORCE) == 0) && ((preq->rq_perm & ATR_DFLAG_MGWR) == 0))
+		return (-1);
 
 	/* if not, see if requestor is the reservation owner */
 

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -1750,8 +1750,8 @@ class BatchUtils(object):
                       l[i - count].startswith('\t')):
                     _e = len(lines) - count
                     lines[_e] = lines[_e] + l[i]
-                    if ((i + 1) < len(l)
-                            and not l[i + 1].startswith(('\t', ' '))):
+                    if ((i + 1) < len(l) and not
+                            l[i + 1].startswith(('\t', ' '))):
                         count += 1
                     else:
                         count = 1
@@ -1779,8 +1779,8 @@ class BatchUtils(object):
                 m = self.pbsobjattrval_re.match(l)
                 if m:
                     attr = m.group('attribute')
-                    if (attribs is None or attr.lower() in attribs
-                            or attr in attribs):
+                    if (attribs is None or attr.lower() in attribs or
+                            attr in attribs):
                         if attr in d:
                             d[attr] = d[attr] + "," + m.group('value')
                         else:
@@ -2365,6 +2365,12 @@ class BatchUtils(object):
                 if ((attrs & SHUT_WHO_SECDONLY) == SHUT_WHO_SECDONLY):
                     _c.append('-i')
             return _c
+
+        elif op == IFL_RALTER:
+            if isinstance(attrs, dict):
+                if 'extend' in attrs and attrs['extend'] is 'force':
+                    ret.append('-Wforce')
+                    del attrs['extend']
 
         if attrs is None or len(attrs) == 0:
             return ret
@@ -4304,26 +4310,26 @@ class PBSService(PBSObject):
                     try:
                         rv = self.du.chmod(path=fn, mode=0o644)
                         if not rv:
-                            self.logger.error("Failed to restore "
-                                              + "configuration: %s" % k)
+                            self.logger.error("Failed to restore " +
+                                              "configuration: %s" % k)
                             return False
                         with open(fn, 'w') as fd:
                             fd.write("\n".join(v))
                         rv = self.du.run_copy(
                             self.hostname, src=fn, dest=k, sudo=True)
                         if rv['rc'] != 0:
-                            self.logger.error("Failed to restore "
-                                              + "configuration: %s" % k)
+                            self.logger.error("Failed to restore " +
+                                              "configuration: %s" % k)
                             return False
                         rv = self.du.chown(path=k, runas=ROOT_USER,
                                            uid=0, gid=0, sudo=True)
                         if not rv:
-                            self.logger.error("Failed to restore "
-                                              + "configuration: %s" % k)
+                            self.logger.error("Failed to restore " +
+                                              "configuration: %s" % k)
                             return False
                     except:
-                        self.logger.error("Failed to restore "
-                                          + "configuration: %s" % k)
+                        self.logger.error("Failed to restore " +
+                                          "configuration: %s" % k)
                         return False
                     finally:
                         if os.path.isfile(fn):
@@ -4336,8 +4342,8 @@ class PBSService(PBSObject):
                         fn = self.du.create_temp_file()
                         rv = self.du.chmod(path=fn, mode=0o644)
                         if not rv:
-                            self.logger.error("Failed to restore "
-                                              + "configuration: %s" % k)
+                            self.logger.error("Failed to restore " +
+                                              "configuration: %s" % k)
                             return False
                         with open(fn, 'w') as fd:
                             mom_config_data = "\n".join(v) + "\n"
@@ -4345,18 +4351,18 @@ class PBSService(PBSObject):
                         rv = self.du.run_copy(
                             self.hostname, src=fn, dest=k, sudo=True)
                         if rv['rc'] != 0:
-                            self.logger.error("Failed to restore "
-                                              + "configuration: %s" % k)
+                            self.logger.error("Failed to restore " +
+                                              "configuration: %s" % k)
                             return False
                         rv = self.du.chown(path=k, runas=ROOT_USER,
                                            uid=0, gid=0, sudo=True)
                         if not rv:
-                            self.logger.error("Failed to restore "
-                                              + "configuration: %s" % k)
+                            self.logger.error("Failed to restore " +
+                                              "configuration: %s" % k)
                             return False
                     except:
-                        self.logger.error("Failed to restore "
-                                          + "configuration: %s" % k)
+                        self.logger.error("Failed to restore " +
+                                          "configuration: %s" % k)
                         return False
                     finally:
                         if os.path.isfile(fn):
@@ -8245,6 +8251,8 @@ class Server(PBSService):
             pcmd = [os.path.join(self.client_conf['PBS_EXEC'], 'bin',
                                  'pbs_ralter')]
             if attrib is not None:
+                if extend is not None:
+                    attrib['extend'] = extend
                 _conf = self.default_client_pbs_conf
                 pcmd += self.utils.convert_to_cli(attrib, op=IFL_RALTER,
                                                   hostname=self.client,
@@ -8265,7 +8273,8 @@ class Server(PBSService):
                 self.last_out = ret['out']
             self.last_rc = rc
         elif runas is not None:
-            rc = self.pbs_api_as('alterresv', resvid, runas, data=attrib)
+            rc = self.pbs_api_as('alterresv', resvid, runas, data=attrib,
+                                 extend=extend)
         else:
             c = self._connect(self.hostname)
             if c < 0:

--- a/test/tests/functional/pbs_multi_sched.py
+++ b/test/tests/functional/pbs_multi_sched.py
@@ -130,10 +130,11 @@ class TestMultipleSchedulers(TestFunctional):
             tzone = 'America/Los_Angeles'
         return tzone
 
-    def set_scheduling(self, scheds=[], op=False):
-        for each in scheds:
-            self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': op},
-                                id=each)
+    def set_scheduling(self, scheds=None, op=False):
+        if scheds is not None:
+            for each in scheds:
+                self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': op},
+                                    id=each)
 
     @skipOnCpuSet
     def test_job_sort_formula_multisched(self):
@@ -2221,8 +2222,8 @@ e.accept()
 
     def test_resv_alter_force_for_confirmed_resv(self):
         """
-        Test that in a multi-sched setup when all schedulers are disabled
-        ralter -Wforce can still modify a reservation successfully even when
+        Test that in a multi-sched setup ralter -Wforce can
+        modify a confirmed reservation successfully even when
         the ralter results into over subscription of resources.
         """
 

--- a/test/tests/functional/pbs_ralter.py
+++ b/test/tests/functional/pbs_ralter.py
@@ -2775,13 +2775,15 @@ class TestPbsResvAlter(TestFunctional):
         off = int(start - time.time())
         self.server.expect(RESV, a, id=rid, offset=off)
 
+        # this alter command is rejected because the reservation has
+        # a running job in it.
         self.alter_a_reservation(rid, start, end, confirm=False, shift=-10,
                                  alter_s=True, extend='force', whichMessage=0)
 
         self.alter_a_reservation(rid, start, end, confirm=False, shift=-100,
                                  alter_e=True, extend='force')
         _, _, t_end = self.get_resv_time_info(rid)
-        end = end - 100
+        end -= 100
         self.assertEqual(int(t_end), end)
 
         self.alter_a_reservation(rid, start, end, confirm=False,

--- a/test/tests/functional/pbs_ralter.py
+++ b/test/tests/functional/pbs_ralter.py
@@ -2634,21 +2634,20 @@ class TestPbsResvAlter(TestFunctional):
         rid2, start2, end2 = self.submit_and_confirm_reservation(
             offset2, duration2, select="2:ncpus=4")
 
-        start1 = start2
-        end1 = end2
-
-        self.alter_a_reservation(rid1, start1, end1, confirm=True,
+        self.alter_a_reservation(rid1, start1, end1, confirm=True, shift=-3000,
                                  alter_s=True, alter_e=True, extend='force')
         t_duration, t_start, t_end = self.get_resv_time_info(rid1)
-        self.assertEqual(int(t_start), start2)
-        self.assertEqual(int(t_duration), duration2)
-        self.assertEqual(int(t_end), end2)
+        start1 = start1 - 3000
+        end1 = end1 - 3000
+        self.assertEqual(int(t_start), start1)
+        self.assertEqual(int(t_duration), duration1)
+        self.assertEqual(int(t_end), end1)
 
         # Try the same alter but in interactive mode
         duration = 300
         self.alter_a_reservation(rid1, start1, end1, confirm=True,
                                  a_duration=duration, extend='force',
-                                 interactive=2, sequence=2)
+                                 interactive=10, sequence=2)
         t_duration, _, _ = self.get_resv_time_info(rid1)
         self.assertEqual(int(t_duration), duration)
 
@@ -2668,6 +2667,7 @@ class TestPbsResvAlter(TestFunctional):
         new_start = start - 1800
         new_end = end - 3600
         new_duration = duration - 1800
+
         new_start_conv = self.bu.convert_seconds_to_datetime(new_start)
         attrs['reserve_start'] = new_start_conv
 
@@ -2687,7 +2687,7 @@ class TestPbsResvAlter(TestFunctional):
         new_end = new_end - 100
         new_end_conv = self.bu.convert_seconds_to_datetime(new_end)
         attrs['reserve_end'] = new_end_conv
-        attrs['interactive'] = 2
+        attrs['interactive'] = 10
         self.server.alterresv(rid, attrs, extend='force')
         msg = "pbs_ralter: " + rid + " CONFIRMED"
         self.assertEqual(msg, self.server.last_out[0])
@@ -2724,7 +2724,7 @@ class TestPbsResvAlter(TestFunctional):
         # Ideally, in 1 hr second occurrence of reservation will start running
         # and it will run for 3 mins. This means the new reservation will be
         # confirmed.
-        new_offset = (start + 3800) - time.time()
+        new_offset = (start + 3800) - int(time.time())
         rid2, start, end = self.submit_and_confirm_reservation(
             new_offset, 180, select="2:ncpus=4", ExpectSuccess=1)
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
This PR adds support for new '-Wforce' for pbs_ralter command. It will allow admins to force a change to start/end/duration of a reservation even if it is denied by the scheduler.

#### Describe Your Change
In this change, PBS server will enforce the change to the reservation which is being altered with '-Wforce' option. It will do so only when  - 
1 - It is not able to contact the scheduler because scheduling is turned off.
2 - When the scheduler replies with a 'failure' to honor 'ralter' request.


#### Link to Design Doc
[Design ](https://openpbs.atlassian.net/wiki/spaces/PD/pages/1996947457/New+-Wforce+option+for+pbs+ralter+to+enforce+changes+to+start+end+duration+of+a+reservation.)
[Forum discussion](https://community.openpbs.org/t/pbs-ralter-wforce-option/2228)


#### Attach Test and Valgrind Logs/Output
[test_multisched.txt](https://github.com/openpbs/openpbs/files/5059052/test_multisched.txt)
[test_resv.txt](https://github.com/openpbs/openpbs/files/5059053/test_resv.txt)
[test_ralter.txt](https://github.com/openpbs/openpbs/files/5059055/test_ralter.txt)
