### PR TITLE
Fix starttime in TestHighResLogging.test_disabled

### DIFF
--- a/test/tests/functional/pbs_highreslog.py
+++ b/test/tests/functional/pbs_highreslog.py
@@ -100,12 +100,13 @@ class TestHighResLogging(TestFunctional):
         there in the server logs lines
         """
         self.switch_microsecondlogging(highrestimestamp=0)
+        now = time.time()
 
         j = Job(TEST_USER)
         jid = self.server.submit(j)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid)
         lines = self.server.log_lines(logtype=self.server,
-                                      starttime=self.server.ctime)
+                                      starttime=now)
 
         _msg = 'Found high resolution time stamp in log,' \
                ' it shouldn\'t be there'


### PR DESCRIPTION
#### Describe Bug or Feature
TestHighResLogging.test_disabled was failing with high resultion timestamp found in server logs when it is disabled.
Error:
AssertionError: <_sre.SRE_Match object; span=(0, 26), match='06/05/2020 23:59:54.592358'> is not None : Found high resolution time stamp in log, it shouldn't be there


#### Describe Your Change
If a day changes while running a test, server logs will have two days logs and in test case, we are searching log not to be found in previous day logs. We need to send time after disabling HighResolutionLogging while searching for logs.


#### Attach Test and Valgrind Logs/Output
[TestHighResLogging_test_disabled_after_fix.txt](https://github.com/openpbs/openpbs/files/5055761/TestHighResLogging_test_disabled_after_fix.txt)
[TestHighResLogging_test_disabled_before_fix.txt](https://github.com/openpbs/openpbs/files/5055762/TestHighResLogging_test_disabled_before_fix.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
