### PR TITLE
 Tests "test_direct_write_job_array" and "test_direct_write_job_array_custom_dir" skip if don't get required ncpus

### DIFF
--- a/test/tests/functional/pbs_qsub_direct_write.py
+++ b/test/tests/functional/pbs_qsub_direct_write.py
@@ -54,6 +54,14 @@ class TestQsub_direct_write(TestFunctional):
         self.msg = "Job is sleeping for 10 secs as job should  be running"
         self.msg += " at the time we check for directly written files"
 
+    def checks_available_ncpus(self, ncpus=1):
+        nodes = self.server.counter(NODE, 'resources_available.ncpus',
+                                    grandtotal=True, level=logging.DEBUG)
+        if nodes and 'resources_available.ncpus' in nodes:
+            total_ncpus = nodes['resources_available.ncpus']
+            if total_ncpus < ncpus:
+                self.skip_test(reason="need %d available ncpus" % ncpus)
+
     def test_direct_write_when_job_succeeds(self):
         """
         submit a sleep job and make sure that the std_files
@@ -330,12 +338,7 @@ class TestQsub_direct_write(TestFunctional):
         accessible from mom and direct_files option is used
         but submission directory is not mapped in mom config file.
         """
-        nodes = self.server.counter(NODE, 'resources_available.ncpus',
-                                    grandtotal=True, level=logging.DEBUG)
-        if nodes and 'resources_available.ncpus' in nodes:
-            total_ncpus = nodes['resources_available.ncpus']
-            if total_ncpus < 4:
-                self.skip_test(reason="need %d available ncpus" % ncpus)
+        self.checks_available_ncpus(4)
         a = {'resources_available.ncpus': 4}
         self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
         j = Job(TEST_USER, attrs={ATTR_k: 'doe', ATTR_J: '1-4'})
@@ -363,12 +366,7 @@ class TestQsub_direct_write(TestFunctional):
         are getting directly written to the custom dir
         provided in -e and -o option even when -doe is set.
         """
-        nodes = self.server.counter(NODE, 'resources_available.ncpus',
-                                    grandtotal=True, level=logging.DEBUG)
-        if nodes and 'resources_available.ncpus' in nodes:
-            total_ncpus = nodes['resources_available.ncpus']
-            if total_ncpus < 4:
-                self.skip_test(reason="need %d available ncpus" % ncpus)
+        self.checks_available_ncpus(4)
         a = {'resources_available.ncpus': 4}
         self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
         tmp_dir = self.du.create_temp_dir(asuser=TEST_USER)

--- a/test/tests/functional/pbs_qsub_direct_write.py
+++ b/test/tests/functional/pbs_qsub_direct_write.py
@@ -323,6 +323,7 @@ class TestQsub_direct_write(TestFunctional):
             mapping_dir) if os.path.isfile(os.path.join(mapping_dir, name))])
         self.assertEqual(2, file_count)
 
+    @skipOnCpuSet
     def test_direct_write_job_array(self):
         """
         submit a job array and make sure that the std_files
@@ -351,6 +352,7 @@ class TestQsub_direct_write(TestFunctional):
                     raise self.failureException("std file " + f_name +
                                                 " not found")
 
+    @skipOnCpuSet
     def test_direct_write_job_array_custom_dir(self):
         """
         submit a job array and make sure that the files

--- a/test/tests/functional/pbs_qsub_direct_write.py
+++ b/test/tests/functional/pbs_qsub_direct_write.py
@@ -323,7 +323,6 @@ class TestQsub_direct_write(TestFunctional):
             mapping_dir) if os.path.isfile(os.path.join(mapping_dir, name))])
         self.assertEqual(2, file_count)
 
-    @skipOnCpuSet
     def test_direct_write_job_array(self):
         """
         submit a job array and make sure that the std_files
@@ -331,6 +330,12 @@ class TestQsub_direct_write(TestFunctional):
         accessible from mom and direct_files option is used
         but submission directory is not mapped in mom config file.
         """
+        nodes = self.server.counter(NODE, 'resources_available.ncpus',
+                                    grandtotal=True, level=logging.DEBUG)
+        if nodes and 'resources_available.ncpus' in nodes:
+            total_ncpus = nodes['resources_available.ncpus']
+            if total_ncpus < 4:
+                self.skip_test(reason="need %d available ncpus" % ncpus)
         a = {'resources_available.ncpus': 4}
         self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
         j = Job(TEST_USER, attrs={ATTR_k: 'doe', ATTR_J: '1-4'})
@@ -352,13 +357,18 @@ class TestQsub_direct_write(TestFunctional):
                     raise self.failureException("std file " + f_name +
                                                 " not found")
 
-    @skipOnCpuSet
     def test_direct_write_job_array_custom_dir(self):
         """
         submit a job array and make sure that the files
         are getting directly written to the custom dir
         provided in -e and -o option even when -doe is set.
         """
+        nodes = self.server.counter(NODE, 'resources_available.ncpus',
+                                    grandtotal=True, level=logging.DEBUG)
+        if nodes and 'resources_available.ncpus' in nodes:
+            total_ncpus = nodes['resources_available.ncpus']
+            if total_ncpus < 4:
+                self.skip_test(reason="need %d available ncpus" % ncpus)
         a = {'resources_available.ncpus': 4}
         self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
         tmp_dir = self.du.create_temp_dir(asuser=TEST_USER)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Tests "test_direct_write_job_array" and "test_direct_write_job_array_custom_dir" need 4 ncpus but on cpuset machines cpus set by cgroup are 1 so tests failed on cpuset machines.


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Added skipOnCpuSet decorator to the tests

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

[direct_write_skip.txt](https://github.com/openpbs/openpbs/files/5067651/direct_write_skip.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
