### PR TITLE
Fix pbs_hook_set_jobenv.py when mom is on remotehost

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -3863,7 +3863,7 @@ class PBSService(PBSObject):
         """
 
     def log_lines(self, logtype, id=None, n=50, tail=True, starttime=None,
-                  endtime=None):
+                  endtime=None, host=None):
         """
         Return the last ``<n>`` lines of a PBS log file, which
         can be one of ``server``, ``scheduler``, ``MoM``, or
@@ -3887,6 +3887,8 @@ class PBSService(PBSObject):
         :type day: int
         :param starttime: date timestamp to start matching
         :param endtime: date timestamp to end matching
+        :param host: Hostname
+        :type host: str
         :returns: Last ``<n>`` lines of logfile for ``Server``,
                   ``Scheduler``, ``MoM or tracejob``
         """
@@ -3897,6 +3899,8 @@ class PBSService(PBSObject):
             endtime = time.time()
         if starttime is None:
             starttime = self.ctime
+        if host is None:
+            host = self.hostname
         try:
             if logtype == 'tracejob':
                 if id is None:
@@ -3906,7 +3910,7 @@ class PBSService(PBSObject):
                        'bin',
                        'tracejob')]
                 cmd += [str(id)]
-                lines = self.du.run_cmd(self.hostname, cmd)['out']
+                lines = self.du.run_cmd(host, cmd)['out']
                 if n != 'ALL':
                     lines = lines[-n:]
             else:
@@ -3934,7 +3938,7 @@ class PBSService(PBSObject):
                     filename = os.path.join(logdir, day)
                     if n == 'ALL':
                         day_lines = self.du.cat(
-                            self.hostname, filename, sudo=sudo,
+                            host, filename, sudo=sudo,
                             level=logging.DEBUG2)['out']
                     else:
                         if tail:
@@ -3945,7 +3949,7 @@ class PBSService(PBSObject):
                         cmd += ['-n']
                         cmd += [str(n), filename]
                         day_lines = self.du.run_cmd(
-                            self.hostname, cmd, sudo=sudo,
+                            host, cmd, sudo=sudo,
                             level=logging.DEBUG2)['out']
                     lines.extend(day_lines)
                     firstday_obj = firstday_obj + datetime.timedelta(days=1)

--- a/test/tests/functional/pbs_hook_set_jobenv.py
+++ b/test/tests/functional/pbs_hook_set_jobenv.py
@@ -74,6 +74,7 @@ class TestPbsHookSetJobEnv(TestFunctional):
         Set environment variables
         """
         TestFunctional.setUp(self)
+        self.interactive = False
         # Set environment variables with special characters
         os.environ['TEST_COMMA'] = '1,2,3,4'
         os.environ['TEST_RETURN'] = """'3,
@@ -127,6 +128,8 @@ class TestPbsHookSetJobEnv(TestFunctional):
             os.remove(self.job_out1_tempfile)
             os.remove(self.job_out2_tempfile)
             os.remove(self.job_out3_tempfile)
+            self.du.rm(self.mom.hostname, self.job_out1_tempfile)
+            self.du.rm(self.mom.hostname, self.job_out2_tempfile)
 
         except OSError:
             pass
@@ -136,6 +139,10 @@ class TestPbsHookSetJobEnv(TestFunctional):
         Parse the output file and store the
         variable list in a dictionary
         """
+        if (not self.du.is_localhost(self.mom.hostname)) and self.interactive:
+            srchost = self.mom.hostname
+            destpath = self.du.get_tempdir(self.server.hostname)
+            self.du.run_copy(srchost=srchost, src=outputfile, dest=destpath)
 
         with open(outputfile) as fd:
             pkey = ""
@@ -196,9 +203,11 @@ class TestPbsHookSetJobEnv(TestFunctional):
         if (daemon == "mom"):
             self.logger.info("Matching in mom logs")
             logfile_type = self.mom
+            host = self.mom.hostname
         elif (daemon == "server"):
             self.logger.info("Matching in server logs")
             logfile_type = self.server
+            host = self.server.hostname
         else:
             self.logger.info("Provide a valid daemon name; server or mom")
             return
@@ -208,8 +217,9 @@ class TestPbsHookSetJobEnv(TestFunctional):
         nomatch_msg = ' No match for '
         for msg in logmsg:
             for attempt in range(1, 61):
-                lines = self.server.log_lines(
-                    logfile_type, starttime=self.server.ctime)
+                lines = self.server.log_lines(logfile_type,
+                                              starttime=self.server.ctime,
+                                              host=host, n='ALL')
                 match = logutils.match_msg(lines, msg=msg)
                 if match:
                     # Dont want the test to pass if there are
@@ -634,6 +644,7 @@ pbs.logmsg(pbs.LOG_DEBUG,"Variable_List is %s" % (j.Variable_List,))
         variable list with execjob_launch hook
         """
 
+        self.interactive = True
         self.exclude_env += ['happy']
 
         # submit an interactive job without hook
@@ -830,6 +841,7 @@ haa'"""
         job even when there is no hook present
         """
 
+        self.interactive = True
         os.environ['BROL'] = 'hii\\\haha'
         os.environ['BROL1'] = """'hii
 haa'"""

--- a/test/tests/functional/pbs_hook_set_jobenv.py
+++ b/test/tests/functional/pbs_hook_set_jobenv.py
@@ -128,9 +128,12 @@ class TestPbsHookSetJobEnv(TestFunctional):
             os.remove(self.job_out1_tempfile)
             os.remove(self.job_out2_tempfile)
             os.remove(self.job_out3_tempfile)
-            self.du.rm(self.mom.hostname, self.job_out1_tempfile)
-            self.du.rm(self.mom.hostname, self.job_out2_tempfile)
-
+            for _file in [self.job_out1_tempfile, self.job_out2_tempfile,
+                          self.job_out3_tempfile]:
+                rc = self.du.isfile(hostname=self.mom.shortname,
+                                    path=_file, sudo=True)
+                if rc:
+                    self.du.rm(self.mom.hostname, _file)
         except OSError:
             pass
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
The tests of "pbs_hook_set_jobenv.py" are currently written in such a way that it will work when pbs_mom is present in on the same host where pbs_server is present.
For example in one of the test(test_interactive_no_hook) where you are submitting an interactive job(this will be launched on compute node but on service node) and in that shell we need to capture output of env variable in a file. Later on we are creating a key value pair from the output of "env" variable. This is done using "read_env" function. These tests are failing with keyError because, read_env is trying to read a non existing file.

#### Describe Your Change
-> Added a parameter "host" in log_lines where user can send hostname on which logs has to be searched.
-> Changed common_log_match function to search log files on corresponding hosts.
-> Copying files from mom host to server in read_env function


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->

[TestPbsHookSetJobEnv_logs.txt](https://github.com/openpbs/openpbs/files/5073702/TestPbsHookSetJobEnv_logs.txt)
[TestPbsHookSetJobEnv_logs_before_fix.txt](https://github.com/openpbs/openpbs/files/5073704/TestPbsHookSetJobEnv_logs_before_fix.txt)
