### PR TITLE
Increase reservation duration to fix race condition in test

### DIFF
--- a/test/tests/functional/pbs_resv_end_hook.py
+++ b/test/tests/functional/pbs_resv_end_hook.py
@@ -163,7 +163,7 @@ if e.type == pbs.RESV_END:
                                 TestResvEndHook.advance_resv_hook_script)
 
         offset = 10
-        duration = 30
+        duration = 300
         rid = self.submit_resv(offset, duration)
 
         attrs = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}


### PR DESCRIPTION

#### Describe Bug or Feature
Fixed race-condition in TestResvEndHook.test_server_down_case_1 failing on machine where pbs_server stop and start took more than 30 sec

#### Describe Your Change
Test failed on few machine because of race condition
In test we are submitting reservation with end time 30s and stoping pbs_server and then starting pbs_server and then deleting reservation but in few machine pbs_server stop and start  takes more than 30s so by the time test is trying to delete reservation, reservation has already been deleted because in test case offset is used as 10 and duration of reservation is used as 30  so reservation got finished and test failed in  with error:-

ptl.lib.pbs_testlib.PbsDeleteError: rc=236, rv=False, msg=['pbs_rdel: Unknown Reservation Id R108.altair-mc990']

Fix :- Increase reservation duration to 300 in test ,anyways we are not waiting for reservation to be finished in test , so increasing reservation end  time wont increase test execution time .

#### Attach Test and Valgrind Logs/Output
[test_server_down_case_1_after_fix_master.txt](https://github.com/openpbs/openpbs/files/5074432/test_server_down_case_1_after_fix_master.txt)
[test_server_down_case_1_before_fix_master.txt](https://github.com/openpbs/openpbs/files/5074433/test_server_down_case_1_before_fix_master.txt)


