### PR TITLE
[WIP] Optimize updating of array_indices_remaining in job array during run/end/del job path

### DIFF
--- a/src/include/job.h
+++ b/src/include/job.h
@@ -372,6 +372,7 @@ struct jbdscrd {
 #define TKMFLG_NO_DELETE           0x01
 #define TKMFLG_REVAL_IND_REMAINING 0x02 /* Flag to re-evaluate "array_indices_remaining" */
 #define TKMFLG_CHK_ARRAY           0x04 /* chk_array_doneness() already in call stack*/
+#define TKMFLG_RUN_JOB_REQ         0x08 /* For denoting run_job request */
 
 /* Structure for block job reply processing */
 struct block_job_reply {

--- a/src/server/array_func.c
+++ b/src/server/array_func.c
@@ -380,6 +380,11 @@ update_array_indices_remaining_attr(job *parent)
 {
 	struct ajtrkhd	*ptbl = parent->ji_ajtrk;
 
+	if (ptbl->tkm_flags & TKMFLG_RUN_JOB_REQ) {
+		ptbl->tkm_flags &= ~TKMFLG_RUN_JOB_REQ;
+		return;
+	}
+
 	if (ptbl->tkm_flags & TKMFLG_REVAL_IND_REMAINING) {
 		attribute *premain = &parent->ji_wattr[(int)JOB_ATR_array_indices_remaining];
 		char *pnewstr = cvt_range(parent, JOB_STATE_QUEUED);

--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -307,6 +307,7 @@ req_runjob(struct batch_request *preq)
 	job *pjob = NULL;
 	job *pjobsub = NULL;
 	job *parent = NULL;
+	struct ajtrkhd  *ptbl = NULL;
 	char *range;
 	int start;
 	int end;
@@ -545,6 +546,10 @@ req_runjob(struct batch_request *preq)
 		if (pjob) {
 			/* free prov_vnode before use */
 			job_attr_def[(int) JOB_ATR_prov_vnode].at_free(&pjob->ji_wattr[(int) JOB_ATR_prov_vnode]);
+			ptbl = parent->ji_ajtrk;
+			if (ptbl == NULL)
+				return;
+			ptbl->tkm_flags |= TKMFLG_RUN_JOB_REQ;
 			req_runjob2(preq, pjob);
 		}
 		return;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Identified a possibility to optimize the job array run path while running a large number of sub-jobs.  Modified the code in a way that would save Server's execution time.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
For every sub job run request, there is a function [**update_array_indices_remaining_attr()**] getting called to update Job array's "array_indices_remaining" attributes in the run path. This function is a fully time-consuming operation that involves loops & massive string operations. It is not necessary to update in every job run path since the same attr would be updated eventually in the subsequent **stat_job** calls. Nonetheless, there wouldn’t be any difference to the external user since the user would see the same value as earlier.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
NA

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

Before optimization: 

<img width="1627" alt="Before optimization" src="https://user-images.githubusercontent.com/17980660/90466190-20bff000-e0df-11ea-9bd8-18ba9352370b.png">

After optimization:

<img width="1627" alt="After OPptimization" src="https://user-images.githubusercontent.com/17980660/90466197-27e6fe00-e0df-11ea-9318-6ff9cb4c7633.png">

**Point to Note:** Here in perf results, I have shown the optimization of time from update_array_indices_remaining_attr, It's not just shown percent, we should consider the entire function time is reduced. For more volume of jobs, we could see more reductions.  


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
