### PR TITLE
reverthooks will disable cgroups hook by default

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -5185,6 +5185,8 @@ class Server(PBSService):
 
         if delnodes:
             self.delete_nodes()
+        self.manager(MGR_CMD_SET, MGR_OBJ_HOOK,
+                     {'enabled': 'False'}, 'pbs_cgroups')
         if reverthooks:
             if self.platform == 'shasta':
                 dohup = False

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -5166,11 +5166,6 @@ class Server(PBSService):
         if self.platform == 'cray' or self.platform == 'craysim':
             setdict[ATTR_restrict_res_to_release_on_suspend] = 'ncpus'
         if delhooks:
-            if (self.platform == 'cray' or self.platform == 'craysim' or
-                    self.platform == 'shasta'):
-                reverthooks = True
-            else:
-                reverthooks = False
             self.delete_site_hooks()
         if delqueues:
             revertqueues = False
@@ -5185,9 +5180,6 @@ class Server(PBSService):
 
         if delnodes:
             self.delete_nodes()
-        # disable cgroups hook - mom revert will enable only if needed
-        self.manager(MGR_CMD_SET, MGR_OBJ_HOOK,
-                     {'enabled': 'False'}, 'pbs_cgroups')
         if reverthooks:
             if self.platform == 'shasta':
                 dohup = False

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -5185,6 +5185,7 @@ class Server(PBSService):
 
         if delnodes:
             self.delete_nodes()
+        # disable cgroups hook - mom revert will enable only if needed 
         self.manager(MGR_CMD_SET, MGR_OBJ_HOOK,
                      {'enabled': 'False'}, 'pbs_cgroups')
         if reverthooks:

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -5185,7 +5185,7 @@ class Server(PBSService):
 
         if delnodes:
             self.delete_nodes()
-        # disable cgroups hook - mom revert will enable only if needed 
+        # disable cgroups hook - mom revert will enable only if needed
         self.manager(MGR_CMD_SET, MGR_OBJ_HOOK,
                      {'enabled': 'False'}, 'pbs_cgroups')
         if reverthooks:

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -1564,6 +1564,8 @@ class PBSTestSuite(unittest.TestCase):
             mom.signal('-HUP')
             self.server.expect(NODE, a, id=mom.shortname + '[0]', interval=1)
         else:
+            self.server.manager(MGR_CMD_SET, HOOK,
+                                {'enabled': 'False'}, 'pbs_cgroups')
             self.server.expect(NODE, a, id=mom.shortname, interval=1)
         return mom
 

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -1564,8 +1564,6 @@ class PBSTestSuite(unittest.TestCase):
             mom.signal('-HUP')
             self.server.expect(NODE, a, id=mom.shortname + '[0]', interval=1)
         else:
-            self.server.manager(MGR_CMD_SET, HOOK,
-                                {'enabled': 'False'}, 'pbs_cgroups')
             self.server.expect(NODE, a, id=mom.shortname, interval=1)
         return mom
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
In the server revert to defaults reverthooks is True by default and is changed to False if platform is not 'cray', craysim' or 'shasta'.

One failure case is when there are more than one mom in a cluster and one of them is a cpuset machine we
would expect that the cgroups hook has been enabled.  If in the next test run, where setUp is called which calls
server revert to defaults, and the one and only cpuset mom is replaced in the cluster by a machine that is not a
cpuset machine and not cray-like (see above), the still enabled cgroups hook can get in the way and cause tests to fail.

#### Describe Your Change
With this change the cgroups hook is reverted to default during server revert to default on all platforms.
The PBS hooks are not reverted to default. As usual the cgroups hook is enabled as needed in mom revert to defaults which happens after server revert to defaults. 

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
The test is skipped when one of the moms is a cpuset mom:
[x56_x70_before.txt](https://github.com/openpbs/openpbs/files/5092947/x56_x70_before.txt)
The enabled cgroups hook gets in the way when using moms that are not cpuset machines:
[x56_x114_before.txt](https://github.com/openpbs/openpbs/files/5092948/x56_x114_before.txt)

The test is skipped when one of the moms is a cpuset mom:
[x56_x70_after.txt](https://github.com/openpbs/openpbs/files/5092949/x56_x70_after.txt)
The cgroups hook is now disabled when using moms that are not cpuset machines and test completes:
[x56_x114_after.txt](https://github.com/openpbs/openpbs/files/5092950/x56_x114_after.txt)

Test results after moving changes to server revert to defaults:
[x56_x70_after.1.txt](https://github.com/openpbs/openpbs/files/5098192/x56_x70_after.1.txt)
[x56_x70_x114_after.1.txt](https://github.com/openpbs/openpbs/files/5098193/x56_x70_x114_after.1.txt)
[x56_x114_after.1.txt](https://github.com/openpbs/openpbs/files/5098194/x56_x114_after.1.txt)

Test results with revert_hooks changes:
[x56_x114_after.2.txt](https://github.com/openpbs/openpbs/files/5110670/x56_x114_after.2.txt)

Before and after tests on x81:
[SmokeTest_x81_after.txt](https://github.com/openpbs/openpbs/files/5125664/SmokeTest_x81_after.txt)
[SmokeTest_x81_before.txt](https://github.com/openpbs/openpbs/files/5125663/SmokeTest_x81_before.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
