### PR TITLE
Increased reservation start time for test_advance_reservation to fix race condition

### DIFF
--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -103,7 +103,8 @@ class SmokeTest(PBSTestSuite):
         jid2 = self.server.submit(j2)
 
         a = {'reserve_state': (MATCH_RE, "RESV_RUNNING|5")}
-        self.server.expect(RESV, a, id=rid, offset=20, interval=1)
+        self.server.expect(RESV, a, id=rid, interval=1,
+                           offset=(now + 30 - int(time.time())))
         self.server.expect(JOB, {'job_state': 'R'}, jid1)
         self.server.expect(JOB, {'job_state': 'B'}, jid2)
 

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -83,7 +83,7 @@ class SmokeTest(PBSTestSuite):
         r = Reservation(TEST_USER)
         now = int(time.time())
         a = {'Resource_List.select': '1:ncpus=4',
-             'reserve_start': now + 20,
+             'reserve_start': now + 30,
              'reserve_end': now + 110}
         r.set_attributes(a)
         rid = self.server.submit(r)
@@ -103,7 +103,7 @@ class SmokeTest(PBSTestSuite):
         jid2 = self.server.submit(j2)
 
         a = {'reserve_state': (MATCH_RE, "RESV_RUNNING|5")}
-        self.server.expect(RESV, a, id=rid, interval=1)
+        self.server.expect(RESV, a, id=rid, offset=20, interval=1)
         self.server.expect(JOB, {'job_state': 'R'}, jid1)
         self.server.expect(JOB, {'job_state': 'B'}, jid2)
 

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -82,8 +82,9 @@ class SmokeTest(PBSTestSuite):
         self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom.shortname)
         r = Reservation(TEST_USER)
         now = int(time.time())
+        r_start_time = now + 30
         a = {'Resource_List.select': '1:ncpus=4',
-             'reserve_start': now + 30,
+             'reserve_start': r_start_time,
              'reserve_end': now + 110}
         r.set_attributes(a)
         rid = self.server.submit(r)
@@ -102,9 +103,10 @@ class SmokeTest(PBSTestSuite):
         j2 = Job(TEST_USER, attrs=a)
         jid2 = self.server.submit(j2)
 
+        offset = r_start_time - int(time.time())
         a = {'reserve_state': (MATCH_RE, "RESV_RUNNING|5")}
         self.server.expect(RESV, a, id=rid, interval=1,
-                           offset=(now + 30 - int(time.time())))
+                           offset=offset)
         self.server.expect(JOB, {'job_state': 'R'}, jid1)
         self.server.expect(JOB, {'job_state': 'B'}, jid2)
 

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -83,7 +83,7 @@ class SmokeTest(PBSTestSuite):
         r = Reservation(TEST_USER)
         now = int(time.time())
         a = {'Resource_List.select': '1:ncpus=4',
-             'reserve_start': now + 10,
+             'reserve_start': now + 20,
              'reserve_end': now + 110}
         r.set_attributes(a)
         rid = self.server.submit(r)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Test "test_advance_reservation" doesn't catch reservation confirmation message. Reservation submission and confirmation takes too long on slow machines, reservation comes in running state.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Increased reservation start time

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[advance_reservation_fail.txt](https://github.com/openpbs/openpbs/files/5102531/advance_reservation_fail.txt)

[advance_reservation.txt](https://github.com/openpbs/openpbs/files/5109220/advance_reservation.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
