### PR TITLE
Fix unprotected access of pjob->ji_hosts

### DIFF
--- a/src/resmom/requests.c
+++ b/src/resmom/requests.c
@@ -1192,6 +1192,12 @@ post_reply(job *pjob, int err)
 	if (pjob->ji_postevent == TM_NULL_EVENT)	/* no event */
 		return;
 
+	if (pjob->ji_hosts == NULL) {           /* No one to talk to */
+		pjob->ji_postevent = TM_NULL_EVENT;
+		pjob->ji_taskid = TM_NULL_TASK;
+		return;
+	}
+
 	stream = pjob->ji_hosts[0].hn_stream;	/* MS stream */
 	cookie = pjob->ji_wattr[(int)JOB_ATR_Cookie].at_val.at_str;
 	jobid = pjob->ji_qs.ji_jobid;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
*Unprotected access of pjob->ji_hosts would lead to mom crash*

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
*Added a null check before accessing pjob->ji_hosts*

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[SmokeTest.txt](https://github.com/openpbs/openpbs/files/5096182/SmokeTest.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
