### PR TITLE
Revert "fix hook sync race when multiple set hooks (#1947)"

### DIFF
--- a/src/server/hook_func.c
+++ b/src/server/hook_func.c
@@ -4858,8 +4858,6 @@ add_mom_hook_action(mom_hook_action_t ***hookact_array,
 				}
 				if (set_action) {
 					pact->action = action;
-				} else if ((pact->action & action) && sync_mom_hookfiles_proc_running) {
-					continue;  /* dont reuse the action object if replies are still expected for same action */
 				} else {
 					if (action & MOM_HOOK_ACTION_DELETE) {
 						if (pact->action & MOM_HOOK_SEND_ACTIONS) {


### PR DESCRIPTION
This reverts commit 277fe0e72c5cddc14481bf941aa400ed43704169. merged from #1947

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug
<!--- Describe the problem, ideally from the customer's viewpoint  -->
#1947 caused a regression for large hook files (> 64KB) which get sent in multiple sequences and two sets of sequences are getting triggered in the same mcast session causing the hook file received at mom having a bloated file containing repeated chunks and resulting in mom failing to compile the hook

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
This reverts commit 277fe0e72c5cddc14481bf941aa400ed43704169. merged from #1947  while a comprehensive solution will be worked upon


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

Platforms: UBUNTU1804,SUSE15,CENTOS8
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|3249|1731|5|0|0|0|1726|

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
