### PR TITLE
Fix node bucket marked as free when job is running

### DIFF
--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -2085,7 +2085,7 @@ update_node_on_end(node_info *ninfo, resource_resv *resresv, char *job_state)
 	}
 
 	ind = ninfo->node_ind;
-	if (ind != -1 && ninfo->bucket_ind != -1) {
+	if (ind != -1 && ninfo->bucket_ind != -1 && ninfo->num_jobs == 0) {
 		node_bucket *bkt = ninfo->server->buckets[ninfo->bucket_ind];
 
 		if (ninfo->node_events == NULL) {

--- a/test/tests/functional/pbs_calendaring.py
+++ b/test/tests/functional/pbs_calendaring.py
@@ -40,6 +40,7 @@
 
 import time
 from tests.functional import *
+from ptl.utils.pbs_logutils import PBSLogUtils
 
 
 class TestCalendaring(TestFunctional):
@@ -227,9 +228,7 @@ class TestCalendaring(TestFunctional):
         job2 = self.server.status(JOB, id=jid2)
         job3 = self.server.status(JOB, id=jid3)
 
-        stime = time.strptime(job2[0]['stime'], "%a %b %d %H:%M:%S %Y")
-        end_time = time.mktime(stime) + 45
+        end_time = time.mktime(time.strptime(job2[0]['stime'], '%c')) + 45
         est_time = job3[0]['estimated.start_time']
-        est_time = time.strptime(est_time, "%a %b %d %H:%M:%S %Y")
-
-        self.assertAlmostEqual(end_time, time.mktime(est_time), delta=1)
+        est_time = time.mktime(time.strptime(est_time, '%c'))
+        self.assertAlmostEqual(end_time, est_time, delta=1)

--- a/test/tests/functional/pbs_calendaring.py
+++ b/test/tests/functional/pbs_calendaring.py
@@ -191,3 +191,45 @@ class TestCalendaring(TestFunctional):
 
         msg = jid3 + ';Job is a top job and will run at'
         self.scheduler.log_match(msg)
+
+    @skipOnCpuSet
+    def test_topjob_bucket(self):
+        """
+        In this test we test that a bucket job will be calendared to start
+        at the end of the last job on a node
+        """
+
+        self.scheduler.set_sched_config({'strict_ordering': 'true all'})
+        a = {'resources_available.ncpus': 2}
+        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
+
+        res_req = {'Resource_List.select': '1:ncpus=1',
+                   'Resource_List.walltime': 30}
+        j1 = Job(TEST_USER, attrs=res_req)
+        j1.set_sleep_time(30)
+        jid1 = self.server.submit(j1)
+
+        res_req = {'Resource_List.select': '1:ncpus=1',
+                   'Resource_List.walltime': 45}
+        j2 = Job(TEST_USER, attrs=res_req)
+        j2.set_sleep_time(45)
+        jid2 = self.server.submit(j2)
+
+        res_req = {'Resource_List.select': '1:ncpus=1',
+                   'Resource_List.place': 'excl'}
+        j3 = Job(TEST_USER, attrs=res_req)
+        jid3 = self.server.submit(j3)
+
+        self.server.expect(JOB, {'job_state': 'R'}, jid1)
+        self.server.expect(JOB, {'job_state': 'R'}, jid2)
+        self.server.expect(JOB, {'job_state': 'Q'}, jid3)
+        job1 = self.server.status(JOB, id=jid1)
+        job2 = self.server.status(JOB, id=jid2)
+        job3 = self.server.status(JOB, id=jid3)
+
+        stime = time.strptime(job2[0]['stime'], "%a %b %d %H:%M:%S %Y")
+        end_time = time.mktime(stime) + 45
+        est_time = job3[0]['estimated.start_time']
+        est_time = time.strptime(est_time, "%a %b %d %H:%M:%S %Y")
+
+        self.assertAlmostEqual(end_time, time.mktime(est_time), delta=1)


### PR DESCRIPTION
### Describe Bug or Feature
In simualtion, when a job finished, the scheduler would mark the node's bucket as free, even if there was another job running on the node. 


#### Describe Your Change
Only change the state of the bucket if there are no more jobs on the node.


#### Attach Test and Valgrind Logs/Output
[afterfix.txt](https://github.com/openpbs/openpbs/files/5099360/afterfix.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
