### PR TITLE
fix acl hosts on queues (using gss)

### DIFF
--- a/src/server/req_quejob.c
+++ b/src/server/req_quejob.c
@@ -1003,7 +1003,7 @@ req_quejob(struct batch_request *preq)
 	 * job structure and attributes already set up.
 	 */
 
-	rc = svr_chkque(pj, pque, preq->rq_host, MOVE_TYPE_Move);
+	rc = svr_chkque(pj, pque, pj->ji_wattr[(int)JOB_ATR_submit_host].at_val.at_str, MOVE_TYPE_Move);
 	if (rc) {
 		if (pj->ji_clterrmsg)
 			reply_text(preq, rc, pj->ji_clterrmsg);

--- a/test/tests/functional/pbs_acl_host_queue.py
+++ b/test/tests/functional/pbs_acl_host_queue.py
@@ -1,0 +1,94 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2020 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of both the OpenPBS software ("OpenPBS")
+# and the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# OpenPBS is free software. You can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# OpenPBS is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# PBS Pro is commercially licensed software that shares a common core with
+# the OpenPBS software.  For a copy of the commercial license terms and
+# conditions, go to: (http://www.pbspro.com/agreement.html) or contact the
+# Altair Legal Department.
+#
+# Altair's dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of OpenPBS and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair's trademarks, including but not limited to "PBS™",
+# "OpenPBS®", "PBS Professional®", and "PBS Pro™" and Altair's logos is
+# subject to Altair's trademark licensing policies.
+
+
+from tests.functional import *
+
+
+class Test_acl_host_queue(TestFunctional):
+    """
+    This test suite is for testing the queue attributes acl_host_enable
+    and acl_hosts.
+    """
+
+    def setUp(self):
+        """
+        Set up test.
+        """
+
+        TestFunctional.setUp(self)
+
+    def test_acl_host_enable_refuse(self):
+        """
+        Set acl_host_enable = True on queue and check whether or not
+        the submit is refused.
+        """
+        a = {"acl_host_enable": True,
+             "acl_hosts": "foo"}
+        self.server.manager(MGR_CMD_SET, QUEUE, a,
+                            self.server.default_queue)
+
+        j = Job(TEST_USER)
+        try:
+            self.server.submit(j)
+        except PbsSubmitError as e:
+            error_msg = "qsub: Access from host not allowed, or unknown host"
+            if e.msg[0] != error_msg:
+                raise self.failureException("qsub unexpected err message: " +
+                                            e.msg[0])
+        else:
+            self.assertFalse(True, "Queue is violating acl_hosts")
+
+    def test_acl_host_enable_allow(self):
+        """
+        Set acl_host_enable = True along with acl_hosts and check
+        whether or not a job can be submitted.
+        """
+        a = {"acl_host_enable": True,
+             "acl_hosts": self.mom.hostname}
+        self.server.manager(MGR_CMD_SET, QUEUE, a,
+                            self.server.default_queue)
+
+        j = Job(TEST_USER)
+        try:
+            jid = self.server.submit(j)
+        except PbsSubmitError as e:
+            raise self.failureException("qsub err message: " + e.msg[0])
+        else:
+            self.logger.info('Job submitted successfully: ' + jid)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Using GSS, the acl_hosts on the queue do not work. The reason is the preq->rq_host contains the realm and not the hostname itself. It means the acl_hosts is checked against the realm, not the hostname.

#### Describe Your Change
With Kerberos and GSS support, the job attribute "[Submit_Host](https://openpbs.atlassian.net/wiki/spaces/PD/pages/29655043/PP-468+Kerberos+support)" was introduced. This attribute holds the hostname of job submission. This value is independent of the used auth method. Therefore the attribute can safely substitute the preq->rq_host with non-gss auth and it will fix the issue while using GSS.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
[ptl_acl_queue.log](https://github.com/openpbs/openpbs/files/5101331/ptl_acl_queue.log)

<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
