### PR TITLE
Fix test cases for checking the exit_status of a job after rerun

### DIFF
--- a/test/tests/functional/pbs_Rrecord_resources_used.py
+++ b/test/tests/functional/pbs_Rrecord_resources_used.py
@@ -543,14 +543,14 @@ class Test_Rrecord_with_resources_used(TestFunctional):
 
         self.server.accounting_match(
             msg='.*R;' + jid1 +
-            '.*Exit_status=0.*.*resources_used.*.*run_count=1.*',
+            '.*Exit_status=-11.*.*resources_used.*.*run_count=1.*',
             id=jid1, regexp=True)
         self.server.accounting_match(
             msg='.*R;' + jid2 +
-            '.*Exit_status=0.*.*resources_used.*.*run_count=1.*',
+            '.*Exit_status=-11.*.*resources_used.*.*run_count=1.*',
             id=jid2, regexp=True)
         self.server.accounting_match(msg='.*R;' + re.escape(
-            jid3s1) + '.*Exit_status=0.*.*resources_used.*.*run_count=1.*',
+            jid3s1) + '.*Exit_status=-11.*.*resources_used.*.*run_count=1.*',
             id=jid3s1, regexp=True)
         time.sleep(5)
 
@@ -561,15 +561,15 @@ class Test_Rrecord_with_resources_used(TestFunctional):
         # usage and run_count should be 3 for J1 and J2.
         self.server.accounting_match(
             msg='.*R;' + jid1 +
-            '.*Exit_status=0.*.*resources_used.*.*run_count=2.*',
+            '.*Exit_status=-11.*.*resources_used.*.*run_count=2.*',
             id=jid1, regexp=True)
         self.server.accounting_match(
             msg='.*R;' + jid2 +
-            '.*Exit_status=0.*.*resources_used.*.*run_count=2.*',
+            '.*Exit_status=-11.*.*resources_used.*.*run_count=2.*',
             id=jid2, regexp=True)
         self.server.accounting_match(msg='.*R;' + re.escape(
             jid3s1) +
-            '.*Exit_status=0.*.*resources_used.*.*run_count=1.*',
+            '.*Exit_status=-11.*.*resources_used.*.*run_count=2.*',
             id=jid3s1, regexp=True)
 
     def tearDown(self):

--- a/test/tests/functional/pbs_resource_usage_log.py
+++ b/test/tests/functional/pbs_resource_usage_log.py
@@ -312,7 +312,7 @@ class TestResourceUsageLog(TestFunctional):
 
         # Look for R record as job was force requeued
         self.server.accounting_match(
-            msg='.*R;' + jid1 + '.*Exit_status=0.*resources_used.*run_count=1',
+            msg='.*R;' + jid1 + '.*Exit_status=-11.*resources_used.*run_count=1',
             id=jid1, regexp=True)
 
     @skipOnCpuSet


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Two test cases were failing while checking for exit_status of the job after rerunning them. Tests were looking for the wrong exit_status. 

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Changed the exit_status to -11 while checking in the accounting log.
This fix was dependent one this PR: https://github.com/openpbs/openpbs/pull/1965


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Test logs before fix:
Description: Tests from given build on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|3257|2|2|0|0|0|0|

Test logs after fix:
Description: Tests from given sources on platforms UBUNTU1804, SUSE15, CENTOS8
Platforms: UBUNTU1804,SUSE15,CENTOS8
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|3262|2|0|0|0|0|2|


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
