### PR TITLE
Fixed rerun failures due to race condition deleting taskdir.

### DIFF
--- a/src/include/job.h
+++ b/src/include/job.h
@@ -837,6 +837,7 @@ task_find	(job		*pjob,
 #define JOB_CKPT_SUFFIX    ".CK"	/* job checkpoint file */
 #define JOB_TASKDIR_SUFFIX ".TK"	/* job task directory */
 #define JOB_BAD_SUFFIX     ".BD"	/* save bad job file */
+#define JOB_DEL_SUFFIX     ".RM"	/* file pending to be removed */
 
 /*
  * Job states are defined by POSIX as:
@@ -1092,7 +1093,7 @@ extern int   pbsd_init_job(job *pjob, int type);
 
 extern void del_job_related_file(job *pjob, char *fsuffix);
 #ifdef PBS_MOM
-extern void del_job_dirs(job *pjob);
+extern void del_job_dirs(job *pjob, char *taskdir);
 extern void del_chkpt_files(job *pjob);
 #endif
 

--- a/src/resmom/mock_run.c
+++ b/src/resmom/mock_run.c
@@ -269,7 +269,7 @@ mock_run_job_purge(job *pjob)
 	/* delete script file */
 	del_job_related_file(pjob, JOB_SCRIPT_SUFFIX);
 
-	del_job_dirs(pjob);
+	del_job_dirs(pjob, NULL);
 
 	/* delete job file */
 	del_job_related_file(pjob, JOB_FILE_SUFFIX);

--- a/src/server/job_func.c
+++ b/src/server/job_func.c
@@ -720,14 +720,12 @@ del_job_related_file(job *pjob, char *fsuffix)
 static char *
 rename_taskdir(job *pjob)
 {
-	char *namebuf;
-	char *renamebuf;
-	char *p;
-	int  path_len = 0;
+	char *namebuf = NULL;
+	char *renamebuf = NULL;
 	char *fprefix;	
 
 	if ((pjob == NULL) || (path_jobs == NULL))
-		return NULL;
+		return (NULL);
 
 	if (*pjob->ji_qs.ji_fileprefix != '\0')
 		fprefix = pjob->ji_qs.ji_fileprefix;
@@ -735,34 +733,18 @@ rename_taskdir(job *pjob)
 		fprefix = pjob->ji_qs.ji_jobid;
 
 	if (fprefix == NULL)
-		return NULL;
+		return (NULL);
 
-	path_len = strlen(path_jobs) + strlen(fprefix) + strlen(JOB_TASKDIR_SUFFIX) + 1;
-	namebuf = malloc(path_len);
-	if (namebuf == NULL) {
-		log_err(errno, __func__, "failed to allocate namebuf");
-		return NULL;
-	}
-	renamebuf = malloc(path_len + strlen(JOB_DEL_SUFFIX));
-	if (renamebuf == NULL) {
-		log_err(errno, __func__, "failed to allocate renamebuf");
-		free(namebuf);
-		return NULL;
-	}
-
-	p = pbs_strcpy(namebuf, path_jobs);
-	p = pbs_strcpy(p, fprefix);
-	pbs_strcpy(p, JOB_TASKDIR_SUFFIX);
-
-	p = pbs_strcpy(renamebuf, namebuf);
-	pbs_strcpy(p, JOB_DEL_SUFFIX);
-
+	if (pbs_asprintf(&namebuf, "%s%s%s", path_jobs, fprefix, JOB_TASKDIR_SUFFIX) == -1)
+		return (NULL);
+	if (pbs_asprintf(&renamebuf, "%s%s", namebuf, JOB_DEL_SUFFIX) == -1)
+		return (namebuf);
 	if (rename(namebuf, renamebuf) == 0) {
-    		free(namebuf);
-    		return renamebuf;
+		free(namebuf);
+		return (renamebuf);
 	}
 	free(renamebuf);
-	return namebuf;
+	return (namebuf);
 }
 
 /**


### PR DESCRIPTION



<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* Race condition  happens such that 1st attempt by server to send job back to same mom fails if it was rerun by a hook.
* This can be easily reproduced by running the TestMakeRunCountWriteable.test_t3_l1, with server_logs showing:
03/31/2019 12:45:19;0008;Server@x57-s12;Job;10.x57-s12;send of job to x57-s12 failed error = 15010 reject_msg=pbs_mom: System error: No such file or directory
and mom_Logs showing:
07/31/2020 22:38:28.343517;0100;pbs_mom;Req;;Type 1 request received from root@10.8.3.111:15001, sock=3   
07/31/2020 22:38:28.343678;0080;pbs_mom;Req;req_reject;Reject reply code=15010, aux=0, type=1, from root@10.8.3.111:15001
* Second attempt to rerun the job eventually succeeds:
07/31/2020 22:38:28.350151;0100;pbs_mom;Req;;Type 1 request received from root@10.8.3.111:15001, sock=3
07/31/2020 22:38:28.365323;0008;pbs_mom;Job;25.x57-s12;Started, pid = 1657
* Instrumenting mom code, found that the job is failing to start when trying to open/create the job taskdir (i.e. /var/spool/pbs/mom_priv/jobs/<jobid>.TK as the previous instance of the job was still doing cleanup of the same directory in a forked child process.
* This race condition was introduced by https://github.com/openpbs/openpbs/pull/902 (Create job purge as different process on mom end)
#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* For the instance of the job that is about to cleanup files in a forked process,  rename the <jobid>.TK to say <jobid>.TK.RM, and the child process can take its time deleting the *.TK.RM directory. This way, a new instance of the job would not conflict with the previous instance still deleting the task directory.



#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
* [ptl.runcount_t3_l1.FAIL.txt](https://github.com/openpbs/openpbs/files/5105910/ptl.runcount_t3_l1.FAIL.txt)

* [ptl.run_count.PASS.txt](https://github.com/openpbs/openpbs/files/5120146/ptl.run_count.PASS.txt)
* [valgrind.runcount_t3_l1.txt](https://github.com/openpbs/openpbs/files/5120148/valgrind.runcount_t3_l1.txt)
* [ptl2.runcount_t3_l1.PASS.txt](https://github.com/openpbs/openpbs/files/5128162/ptl2.runcount_t3_l1.PASS.txt)
* [valgrind2.mom.runcount_t3_l1.txt](https://github.com/openpbs/openpbs/files/5128163/valgrind2.mom.runcount_t3_l1.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
