### PR TITLE
Enforce pulling queue's limits when peering

### DIFF
--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -1157,7 +1157,7 @@ svr_chkque(job *pjob, pbs_queue *pque, char *hostname, int mtype)
 
 		if ((pque->qu_attr[QA_ATR_FromRouteOnly].at_flags&ATR_VFLAG_SET) &&
 			(pque->qu_attr[QA_ATR_FromRouteOnly].at_val.at_long == 1))
-			if (mtype == MOVE_TYPE_Move)  /* ok if not plain user */
+			if (mtype == MOVE_TYPE_Move)  /* ok if not plain user or scheduler */
 				return (PBSE_QACESS);
 	}
 

--- a/src/server/svr_movejob.c
+++ b/src/server/svr_movejob.c
@@ -227,7 +227,7 @@ local_move(job *jobp, struct batch_request *req)
 
 	if (req == NULL) {
 		mtype = MOVE_TYPE_Route;	/* route */
-	} else if (req->rq_perm & (ATR_DFLAG_MGRD | ATR_DFLAG_MGWR)) {
+	} else if (req->rq_perm & (ATR_DFLAG_MGRD | ATR_DFLAG_MGWR) && find_sched_from_sock(req->rq_conn) == NULL) {
 		mtype =	MOVE_TYPE_MgrMv;	/* privileged move */
 	} else {
 		mtype = MOVE_TYPE_Move;		/* non-privileged move */
@@ -274,7 +274,7 @@ local_move(job *jobp, struct batch_request *req)
 	jobp->ji_lastdest = 0;	/* reset in case of another route */
 
 	job_save_db(jobp);
-	
+
 
 	/* If a scheduling cycle is in progress, then this moved job may have
 	 * had changes resulting from the move that would impact scheduling or
@@ -550,7 +550,7 @@ send_job_exec(job *jobp, pbs_net_t hostaddr, int port, struct batch_request *req
 	/* add to pjob->svrtask list so its automatically cleared when job is purged */
 	append_link(&jobp->ji_svrtask, &ptask->wt_linkobj, ptask);
 
-	/* 
+	/*
 	 * svr-mom communication is asynchronous, so PBSD_quejob does not return in this flow
 	 * hence commit_done is meaningless here
 	 * We only need to check extend and skip sending the other messages

--- a/test/tests/functional/pbs_peer.py
+++ b/test/tests/functional/pbs_peer.py
@@ -142,6 +142,6 @@ class TestPeering(TestFunctional):
         s1.expect(JOB, {'job_state': 'Q'}, id=jid)
         msg = (jid + r';Failed to run: .* \(15039\)')
         self.scheduler.log_match(msg, regexp=True)
-        msg = jid + ';send of job to workq@shecil:15001 failed error = 15036'
-        s2.log_match(msg)
+        msg = jid + ';send of job to workq@.* failed error = 15036'
+        s2.log_match(msg, regexp=True)
         s1.expect(JOB, {'job_state': 'R'}, id=jid2)

--- a/test/tests/functional/pbs_peer.py
+++ b/test/tests/functional/pbs_peer.py
@@ -1,0 +1,147 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2020 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of both the OpenPBS software ("OpenPBS")
+# and the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# OpenPBS is free software. You can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# OpenPBS is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# PBS Pro is commercially licensed software that shares a common core with
+# the OpenPBS software.  For a copy of the commercial license terms and
+# conditions, go to: (http://www.pbspro.com/agreement.html) or contact the
+# Altair Legal Department.
+#
+# Altair's dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of OpenPBS and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair's trademarks, including but not limited to "PBS™",
+# "OpenPBS®", "PBS Professional®", and "PBS Pro™" and Altair's logos is
+# subject to Altair's trademark licensing policies.
+
+from tests.functional import *
+
+
+class TestPeering(TestFunctional):
+    """
+    Some tests for Peering queues
+    """
+
+    cres = "custom_res"
+    cqueue = "custom_queue"
+
+    def create_resource(self, name=None, server=None):
+        if not name:
+            name = self.cres
+
+        if not server:
+            server = self.server
+
+        server.manager(MGR_CMD_CREATE, RSC,
+                       {'type': 'long', 'flag': 'q'},
+                       id=name)
+
+        self.scheduler.add_resource(name)
+
+    def create_queue(self, name=None, server=None, a=None):
+        if not name:
+            name = self.cqueue
+
+        if not server:
+            server = self.server
+
+        if not a:
+            a = {'queue_type': 'execution', 'enabled': True, 'started': True}
+
+        server.manager(MGR_CMD_CREATE, QUEUE, a, id=name)
+
+    def test_local_resc_limits(self):
+        """
+        Test that a local peering queue enforces new limits
+        """
+        self.create_resource()
+        self.create_queue()
+        a = {'resources_max.' + self.cres: 4}
+        self.server.manager(MGR_CMD_SET, QUEUE, a, id=self.cqueue)
+        a = {'started': False}
+        self.server.manager(MGR_CMD_SET, QUEUE, a, id='workq')
+        self.server.manager(MGR_CMD_SET, QUEUE, a, id=self.cqueue)
+
+        a = {'peer_queue': '"' + self.cqueue + ' workq"'}
+        self.scheduler.set_sched_config(a)
+
+        j = Job(TEST_USER, attrs={'Resource_List.' + self.cres: 100})
+        jid = self.server.submit(j)
+        j = Job(TEST_USER, attrs={'Resource_List.' + self.cres: 1})
+        jid2 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid2)
+
+        a = {'started': True}
+        self.server.manager(MGR_CMD_SET, QUEUE, a, id=self.cqueue)
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': True})
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid)
+        msg = (jid + ';Failed to run: Job violates queue and/or server'
+               ' resource limits (15036)')
+        self.scheduler.log_match(msg)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
+
+    @requirements(num_servers=2)
+    def test_remote_resc_limits(self):
+        """
+        Test that a remote peering queue enforces new limits
+        """
+        s1 = self.servers.values()[0]
+        s2 = self.servers.values()[1]
+        self.create_resource(server=s1)
+        self.create_resource(server=s2)
+        a = {'resources_max.' + self.cres: 4}
+        s1.manager(MGR_CMD_SET, QUEUE, a, id='workq')
+        a = {'started': False}
+        s1.manager(MGR_CMD_SET, QUEUE, a, id='workq')
+        s2.manager(MGR_CMD_SET, QUEUE, a, id='workq')
+
+        a = {'flatuid': True}
+        s1.manager(MGR_CMD_SET, SERVER, a)
+        s2.manager(MGR_CMD_SET, SERVER, a)
+
+        a = {'peer_queue': '"workq workq@' + s2.hostname + '"'}
+        self.scheduler.set_sched_config(a)
+
+        a = {'Resource_List.' + self.cres: 100,
+             ATTR_queue: 'workq@' + s2.hostname}
+        j = Job(TEST_USER, attrs=a)
+        jid = s1.submit(j)
+        a['Resource_List.' + self.cres] = 1
+        j = Job(TEST_USER, attrs=a)
+        jid2 = s1.submit(j)
+        s2.expect(JOB, {'job_state': 'Q'}, id=jid)
+        s2.expect(JOB, {'job_state': 'Q'}, id=jid2)
+
+        a = {'started': True}
+        s1.manager(MGR_CMD_SET, QUEUE, a, id='workq')
+        s1.manager(MGR_CMD_SET, SERVER, {'scheduling': True})
+        s1.expect(JOB, {'job_state': 'Q'}, id=jid)
+        msg = (jid + r';Failed to run: .* \(15039\)')
+        self.scheduler.log_match(msg, regexp=True)
+        msg = jid + ';send of job to workq@shecil:15001 failed error = 15036'
+        s2.log_match(msg)
+        s1.expect(JOB, {'job_state': 'R'}, id=jid2)

--- a/test/tests/functional/pbs_peer.py
+++ b/test/tests/functional/pbs_peer.py
@@ -83,7 +83,7 @@ class TestPeering(TestFunctional):
         self.server.manager(MGR_CMD_SET, QUEUE, a, id=self.cqueue)
         a = {'started': False}
         self.server.manager(MGR_CMD_SET, QUEUE, a, id='workq')
-        self.server.manager(MGR_CMD_SET, QUEUE, a, id=self.cqueue)
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': False})
 
         a = {'peer_queue': '"' + self.cqueue + ' workq"'}
         self.scheduler.set_sched_config(a)
@@ -95,8 +95,6 @@ class TestPeering(TestFunctional):
         self.server.expect(JOB, {'job_state': 'Q'}, id=jid)
         self.server.expect(JOB, {'job_state': 'Q'}, id=jid2)
 
-        a = {'started': True}
-        self.server.manager(MGR_CMD_SET, QUEUE, a, id=self.cqueue)
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': True})
         self.server.expect(JOB, {'job_state': 'Q'}, id=jid)
         msg = (jid + ';Failed to run: Job violates queue and/or server'
@@ -115,9 +113,7 @@ class TestPeering(TestFunctional):
         self.create_resource(server=s2)
         a = {'resources_max.' + self.cres: 4}
         s1.manager(MGR_CMD_SET, QUEUE, a, id='workq')
-        a = {'started': False}
-        s1.manager(MGR_CMD_SET, QUEUE, a, id='workq')
-        s2.manager(MGR_CMD_SET, QUEUE, a, id='workq')
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': False})
 
         a = {'flatuid': True}
         s1.manager(MGR_CMD_SET, SERVER, a)
@@ -136,8 +132,7 @@ class TestPeering(TestFunctional):
         s2.expect(JOB, {'job_state': 'Q'}, id=jid)
         s2.expect(JOB, {'job_state': 'Q'}, id=jid2)
 
-        a = {'started': True}
-        s1.manager(MGR_CMD_SET, QUEUE, a, id='workq')
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': True})
         s1.manager(MGR_CMD_SET, SERVER, {'scheduling': True})
         s1.expect(JOB, {'job_state': 'Q'}, id=jid)
         msg = (jid + r';Failed to run: .* \(15039\)')


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
When a cluster has local peering set up, when the scheduler pulls a job from the furnishing queue to the pulling queue, the job can bypass the pulling queue's limits.

Scheduler is considered as a manager, and for local move jobs, the manager can bypass queue limit checks. 

#### Describe Your Change
Make local move requests from a scheduler unprivileged. 



#### Attach Test and Valgrind Logs/Output
[afterfix.txt](https://github.com/openpbs/openpbs/files/5111793/afterfix.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
