### PR TITLE
sched fails to reconfirm running degraded resv

### DIFF
--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -1524,7 +1524,7 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 					 */
 					sel = create_select_from_nspec(nresv->orig_nspec_arr);
 					nresv->execselect = parse_selspec(sel);
-					for (ind=0; nresv->orig_nspec_arr[ind] != NULL; ind++) {
+					for (ind = 0; nresv->orig_nspec_arr[ind] != NULL; ind++) {
 					    nresv->execselect->chunks[ind]->seq_num = nresv->orig_nspec_arr[ind]->seq_num;
 					}
 
@@ -1594,9 +1594,7 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 		if (!(simrc & TIMED_ERROR) && resv_start_time >= 0) {
 			clear_schd_error(err);
 			if ((ns = is_ok_to_run(nsinfo->policy, nsinfo, NULL, nresv, NO_ALLPART, err)) != NULL) {
-				if (vnodes_down == 1)
-					/* if we are confirming a running reservation, sort nspec array by seq number */
-					qsort(ns, count_array(ns), sizeof(nspec *), cmp_nspec);
+				qsort(ns, count_array(ns), sizeof(nspec *), cmp_nspec);
 				tmp = create_execvnode(ns);
 				free_nspecs(ns);
 				if (tmp == NULL) {
@@ -2043,8 +2041,12 @@ check_vnodes_unavailable(resource_resv *resv)
 			remove_ptr_from_array(resv->orig_nspec_arr, chunks_to_remove[i]);
 		}
 	}
-	/* move all nspec with down nodes at the back of orig_ncpec_arr */
-	qsort(resv->orig_nspec_arr, count_array(resv->orig_nspec_arr), sizeof(nspec *), cmp_nspec_by_sub_seq);
+	if (has_down_node == 1)
+		/* Move all the specific chunks ahead of the generic chunks.
+		 * This will ensure that we get all the nodes back we need to,
+		 * before we start looking for replacements
+		 */
+		qsort(resv->orig_nspec_arr, count_array(resv->orig_nspec_arr), sizeof(nspec *), cmp_nspec_by_sub_seq);
 
 	free(chunks_to_remove);
 

--- a/src/scheduler/sort.c
+++ b/src/scheduler/sort.c
@@ -212,7 +212,7 @@ cmp_placement_sets(const void *v1, const void *v2)
 int
 cmp_nspec(const void *v1, const void *v2)
 {
-	int s1, s2, ss1, ss2;
+	int s1, s2;
 	if (v1 == NULL && v2 == NULL)
 		return 0;
 
@@ -224,23 +224,50 @@ cmp_nspec(const void *v1, const void *v2)
 
 	s1 = (*(nspec**) v1)->seq_num;
 	s2 = (*(nspec**) v2)->seq_num;
-	ss1 = (*(nspec**) v1)->sub_seq_num;
-	ss2 = (*(nspec**) v2)->sub_seq_num;
 
 	if (s1 < s2)
 		return -1;
 	else if (s1 > s2)
 		return 1;
-	else {
-		if (ss1 < ss2)
-			return -1;
-		else if (ss1 > ss2)
-			return 1;
-		else
-			return 0;
-	}
+	else
+	    return cmp_nspec_by_sub_seq(v1, v2);
 }
 
+/**
+ * @brief
+ * 		cmp_nspec_by_sub_seq - sort nspec by sub sequence number
+ *
+ * @param[in]	v1	-	nspec 1
+ * @param[in]	v2	-	nspec 2
+ *
+ * @return	int
+ * @retval	-1	: if v1 < v2
+ * @retval	0 	: if v1 == v2
+ * @retval	1  	: if v1 > v2
+ */
+int
+cmp_nspec_by_sub_seq(const void *v1, const void *v2)
+{
+	int ss1, ss2;
+	if (v1 == NULL && v2 == NULL)
+		return 0;
+
+	if (v1 == NULL && v2 != NULL)
+		return -1;
+
+	if (v1 != NULL && v2 == NULL)
+		return 1;
+
+	ss1 = (*(nspec**) v1)->sub_seq_num;
+	ss2 = (*(nspec**) v2)->sub_seq_num;
+
+	if (ss1 < ss2)
+		return -1;
+	else if (ss1 > ss2)
+		return 1;
+	else
+		return 0;
+}
 
 
 /**

--- a/src/scheduler/sort.h
+++ b/src/scheduler/sort.h
@@ -61,8 +61,7 @@ int cmp_nspec(const void *v1, const void *v2);
 /*
  *cmp_nspec_by_sub_seq_dsc - sort nspec by sub sequence number
  */
-int
-cmp_nspec_by_sub_seq(const void *v1, const void *v2);
+int cmp_nspec_by_sub_seq(const void *v1, const void *v2);
 
 /*
  *	cmp_placement_sets - sort placement sets by

--- a/src/scheduler/sort.h
+++ b/src/scheduler/sort.h
@@ -58,6 +58,11 @@ int cmpres(sch_resource_t r1, sch_resource_t r2);
  */
 int cmp_nspec(const void *v1, const void *v2);
 
+/*
+ *cmp_nspec_by_sub_seq_dsc - sort nspec by sub sequence number
+ */
+int
+cmp_nspec_by_sub_seq(const void *v1, const void *v2);
 
 /*
  *	cmp_placement_sets - sort placement sets by

--- a/src/scheduler/sort.h
+++ b/src/scheduler/sort.h
@@ -59,7 +59,7 @@ int cmpres(sch_resource_t r1, sch_resource_t r2);
 int cmp_nspec(const void *v1, const void *v2);
 
 /*
- *cmp_nspec_by_sub_seq_dsc - sort nspec by sub sequence number
+ * cmp_nspec_by_sub_seq - sort nspec by sub sequence number
  */
 int cmp_nspec_by_sub_seq(const void *v1, const void *v2);
 

--- a/test/tests/functional/pbs_reservations.py
+++ b/test/tests/functional/pbs_reservations.py
@@ -2274,8 +2274,8 @@ class TestReservations(TestFunctional):
     def test_resv_reconfirm_holding_partial_nodes(self):
         """
         Test that scheduler is able to reconfirm a reservation when
-        only of the nodes reservation was running on goes down. Also
-        make sure it hangs on to the node that was not down.
+        only some of the nodes reservation was running on goes down.
+        Also make sure it hangs on to the node that was not down.
         """
         a = {'reserve_retry_time': 5}
         self.server.manager(MGR_CMD_SET, SERVER, a)
@@ -2295,8 +2295,6 @@ class TestReservations(TestFunctional):
         resv_node_list = self.server.reservations[rid].get_vnodes()
         resv_node = resv_node_list[0]
         resv_node2 = resv_node_list[1]
-        print(resv_node_list)
-        print(vn_list)
         vn = [i for i in vn_list if i not in resv_node_list]
 
         a = {'scheduling': 'False'}

--- a/test/tests/functional/pbs_reservations.py
+++ b/test/tests/functional/pbs_reservations.py
@@ -2270,3 +2270,45 @@ class TestReservations(TestFunctional):
         J = Job(TEST_USER, attrs=a)
         jid = self.server.submit(J)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+
+    def test_resv_reconfirm_holding_partial_nodes(self):
+        """
+        Test that scheduler is able to reconfirm a reservation when
+        only of the nodes reservation was running on goes down. Also
+        make sure it hangs on to the node that was not down.
+        """
+        a = {'reserve_retry_time': 5}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+        a = {'resources_available.ncpus': 2}
+        self.server.create_vnodes('vn', a, num=3, mom=self.mom)
+        vn_list = ['vn[0]', 'vn[1]', 'vn[2]']
+
+        now = int(time.time())
+        sel = '1:ncpus=2+1:ncpus=1'
+        rid = self.submit_reservation(user=TEST_USER, select=sel,
+                                      start=now + 5, end=now + 300)
+
+        a = {'reserve_state': (MATCH_RE, 'RESV_RUNNING|5')}
+        self.server.expect(RESV, a, id=rid)
+
+        self.server.status(RESV, 'resv_nodes', id=rid)
+        resv_node_list = self.server.reservations[rid].get_vnodes()
+        resv_node = resv_node_list[0]
+        resv_node2 = resv_node_list[1]
+        print(resv_node_list)
+        print(vn_list)
+        vn = [i for i in vn_list if i not in resv_node_list]
+
+        a = {'scheduling': 'False'}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+
+        self.server.manager(MGR_CMD_SET, NODE, {'state': 'offline'},
+                            id=resv_node)
+        self.server.expect(RESV, {'reserve_substate': 10}, id=rid)
+
+        a = {'scheduling': 'True'}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+
+        solution = '(' + vn[0] + ':ncpus=2)+(' + resv_node2 + ':ncpus=1)'
+        a = {'reserve_substate': '5', 'resv_nodes': solution}
+        self.server.expect(RESV, a, id=rid)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Sometimes when a multi-chunk running reservation goes into degraded state scheduler fails to reconfirm the reservation back.


#### Describe Your Change
What happens is that when one of the vnode that's associated to one of the chunk of a running reservation goes down, the scheduler tries to reconfirm this reservation buy creating a new execselect where it tries to retain the vnodes that are up and associated with the reservation and tries to replace the vnodes that are down.
In this process scheduler first start finding the solution for a chunk whose vnode is down. While doing so it finds out a vnode that is associated with one of the other chunks of the reservation. It allocates that node to the current chunk and moves on to the next chunk only to find out that the node next chunk had been running on, now has been allocated to the another chunk earlier. This results into a failure to reconfirm a running reservation.

In this change, we try to sort all the chunks associated with up and running nodes in front of the reservation's execselect. This makes scheduler assign nodes to chunks they were already associated with and helps to find new nodes for chunks associated with node that are in down state. Once we have the solution, we sort the nodes back to the way they were supposed to be (in sync with the schedselect).


#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
[test_ralter.txt](https://github.com/openpbs/openpbs/files/5111830/test_ralter.txt)
[test_reservation.txt](https://github.com/openpbs/openpbs/files/5111831/test_reservation.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
