### PR TITLE
(2nd) fix hook sync race when multiple set hooks command

### DIFF
--- a/src/include/hook_func.h
+++ b/src/include/hook_func.h
@@ -71,6 +71,7 @@ extern "C" {
 struct mom_hook_action {
 	char            hookname[PBS_HOOK_NAME_SIZE];
 	unsigned int	action;
+	unsigned int	reply_expected; /* reply expected from mom for sent out actions */
 	int		do_delete_action_first; /* force order between delete and send actions */
 	long long int	tid;	/* transaction id to group actions under */
 };
@@ -104,8 +105,8 @@ extern int has_pending_mom_action_delete(char *);
 
 extern void hook_track_save(void *, int);
 extern void hook_track_recov(void);
-extern int bg_sync_mom_hookfiles(void);
-extern int bg_delete_mom_hooks(void *);
+extern int mc_sync_mom_hookfiles(void);
+extern void uc_delete_mom_hooks(void *);
 extern int sync_mom_hookfiles_count(void *);
 extern void next_sync_mom_hookfiles(void);
 extern void send_rescdef(int);

--- a/src/server/hook_func.c
+++ b/src/server/hook_func.c
@@ -6099,11 +6099,11 @@ clear_timed_out_reply_expected(long long int tid)
 		if ((pmom = mominfo_array[i]) == NULL)
 			continue;
 
-		if (pmom->mi_num_action && pmom->mi_num_action) {
+		if (pmom->mi_num_action && pmom->mi_action) {
 
 			for (j = 0; j < pmom->mi_num_action; j++) {
 				pact = pmom->mi_action[j];
-				if (pact->reply_expected && (pact->tid == tid)) {
+				if (pact && pact->reply_expected && (pact->tid == tid)) {
 					snprintf(log_buffer, sizeof(log_buffer),
 						"timedout, clearing reply_expected for %d event[%lld] of %s hook for %s",
 						pact->reply_expected, tid, pact->hookname, pmom->mi_host);

--- a/src/server/hook_func.c
+++ b/src/server/hook_func.c
@@ -6063,98 +6063,14 @@ add_pending_mom_allhooks_action(void *minfo, unsigned int action)
 {
 	hook			*phook;
 
-
-	phook = (hook *)GET_NEXT(svr_execjob_begin_hooks);
+	phook = (hook *)GET_NEXT(svr_allhooks);
 	while (phook) {
-		add_pending_mom_hook_action((mominfo_t *)minfo,
-			phook->hook_name, action);
-		phook = (hook *)GET_NEXT(phook->hi_execjob_begin_hooks);
+		if (phook->hook_name &&	(phook->event & MOM_EVENTS)) {
+			add_pending_mom_hook_action((mominfo_t *)minfo,
+				phook->hook_name, action);
+		}
+		phook = (hook *)GET_NEXT(phook->hi_allhooks);
 	}
-
-	phook = (hook *)GET_NEXT(svr_execjob_prologue_hooks);
-	while (phook) {
-		add_pending_mom_hook_action((mominfo_t *)minfo,
-			phook->hook_name, action);
-		phook = (hook *)GET_NEXT(phook->hi_execjob_prologue_hooks);
-	}
-
-	phook = (hook *)GET_NEXT(svr_execjob_epilogue_hooks);
-	while (phook) {
-		add_pending_mom_hook_action((mominfo_t *)minfo,
-			phook->hook_name, action);
-		phook = (hook *)GET_NEXT(phook->hi_execjob_epilogue_hooks);
-	}
-
-	phook = (hook *)GET_NEXT(svr_execjob_end_hooks);
-	while (phook) {
-		add_pending_mom_hook_action((mominfo_t *)minfo,
-			phook->hook_name, action);
-		phook = (hook *)GET_NEXT(phook->hi_execjob_end_hooks);
-	}
-
-	phook = (hook *)GET_NEXT(svr_execjob_preterm_hooks);
-	while (phook) {
-		add_pending_mom_hook_action((mominfo_t *)minfo,
-			phook->hook_name, action);
-		phook = (hook *)GET_NEXT(phook->hi_execjob_preterm_hooks);
-	}
-
-	phook = (hook *)GET_NEXT(svr_exechost_periodic_hooks);
-	while (phook) {
-		add_pending_mom_hook_action((mominfo_t *)minfo,
-			phook->hook_name, action);
-		phook = (hook *)GET_NEXT(phook->hi_exechost_periodic_hooks);
-	}
-
-	phook = (hook *)GET_NEXT(svr_exechost_startup_hooks);
-	while (phook) {
-		add_pending_mom_hook_action((mominfo_t *)minfo,
-			phook->hook_name, action);
-		phook = (hook *)GET_NEXT(phook->hi_exechost_startup_hooks);
-	}
-
-	phook = (hook *)GET_NEXT(svr_execjob_launch_hooks);
-	while (phook) {
-		add_pending_mom_hook_action((mominfo_t *)minfo,
-			phook->hook_name, action);
-		phook = (hook *)GET_NEXT(phook->hi_execjob_launch_hooks);
-	}
-
-	phook = (hook *)GET_NEXT(svr_execjob_attach_hooks);
-	while (phook) {
-		add_pending_mom_hook_action((mominfo_t *)minfo,
-			phook->hook_name, action);
-		phook = (hook *)GET_NEXT(phook->hi_execjob_attach_hooks);
-	}
-
-	phook = (hook *)GET_NEXT(svr_execjob_resize_hooks);
-	while (phook) {
-		add_pending_mom_hook_action((mominfo_t *)minfo,
-			phook->hook_name, action);
-		phook = (hook *)GET_NEXT(phook->hi_execjob_resize_hooks);
-	}
-
-	phook = (hook *)GET_NEXT(svr_execjob_abort_hooks);
-	while (phook) {
-		add_pending_mom_hook_action((mominfo_t *)minfo,
-			phook->hook_name, action);
-		phook = (hook *)GET_NEXT(phook->hi_execjob_abort_hooks);
-	}
-
-	phook = (hook *)GET_NEXT(svr_execjob_postsuspend_hooks);
-	while (phook) {
-		add_pending_mom_hook_action((mominfo_t *)minfo,
-			phook->hook_name, action);
-		phook = (hook *)GET_NEXT(phook->hi_execjob_postsuspend_hooks);
-	}
-
-	phook = (hook *)GET_NEXT(svr_execjob_preresume_hooks);
-	while (phook) {
-		add_pending_mom_hook_action((mominfo_t *)minfo,
-			phook->hook_name, action);
-		phook = (hook *)GET_NEXT(phook->hi_execjob_preresume_hooks);
-	}
-
 }
 
 /**

--- a/src/server/mom_info.c
+++ b/src/server/mom_info.c
@@ -447,26 +447,22 @@ open_momstream(mominfo_t *pmom)
 void
 delete_svrmom_entry(mominfo_t *pmom)
 {
-	mom_svrinfo_t *psvrmom = NULL;
+	mom_svrinfo_t *psvrmom = (mom_svrinfo_t *)pmom->mi_data;
 	unsigned long *up;
 	extern struct tree  *ipaddrs;
 
-	if (pmom->mi_data) {
+	if (psvrmom) {
 
 #ifndef PBS_MOM
 		/* send request to this mom to delete all hooks known from this server. */
 		/* we'll just send this delete request only once */
 		/* if a hook fails to delete, then that mom host when it */
 		/* come back will still have the hook. */
-		if ((pmom->mi_action != NULL) && (mom_hooks_seen_count() > 0)) {
-			/* there should be at least one hook to */
-			/* add mom actions below, which are in behalf of */
-			/* existing hooks. */
-			(void)bg_delete_mom_hooks(pmom);
+		if (!(psvrmom->msr_state & INUSE_DOWN) && (mom_hooks_seen_count() > 0)) {
+			uc_delete_mom_hooks(pmom);
 		}
 #endif
 
-		psvrmom = (mom_svrinfo_t *)pmom->mi_data;
 		if (psvrmom->msr_arch)
 			free(psvrmom->msr_arch);
 

--- a/src/server/svr_func.c
+++ b/src/server/svr_func.c
@@ -153,7 +153,7 @@ long	node_fail_requeue = PBS_NODE_FAIL_REQUEUE_DEFAULT; /* default value for nod
 struct attribute attr_jobscript_max_size; /* to store default size value for jobscript_max_size */
 
 extern int do_sync_mom_hookfiles;
-extern int sync_mom_hookfiles_proc_running;
+extern int sync_mom_hookfiles_replies_pending;
 
 char primary_host[PBS_MAXHOSTNAME+1]; /* host_name of primary */
 
@@ -5530,7 +5530,7 @@ prov_startjob(struct work_task *ptask)
 	}
 	/* task being serviced here */
 	pjob->ji_prov_startjob_task = NULL;
-	if ((do_sync_mom_hookfiles || sync_mom_hookfiles_proc_running) &&
+	if ((do_sync_mom_hookfiles || sync_mom_hookfiles_replies_pending) &&
 	    (prov_vnode_pending_hook_copy(pjob))) {
 
 		/**


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
a. Alternate fix for the reverted https://github.com/openpbs/openpbs/pull/1947
b. two places where we are breaking instead of continuing while looping through all mom objects for hook related operations
1. https://github.com/openpbs/openpbs/blob/69d4e0258bd62541409305e3a0bd8b083dc52149/src/server/hook_func.c#L5072-L5075
2. https://github.com/openpbs/openpbs/blob/69d4e0258bd62541409305e3a0bd8b083dc52149/src/server/hook_func.c#L5161-L5164


When multiple set hook commands are issued from qmgr, some updates were not being propagated to execution nodes due to race in pending hook action processing

Bug is visible in the below screenshot
![InkedScreenshot_hook_unsynced_LI](https://user-images.githubusercontent.com/30307577/89184620-ba9f7d00-d5b6-11ea-85f5-ad95ffbd6cb3.jpg)
#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
fixed by 
1. using new hook action object when replies are pending for previous actions.
2. Introduced new flag member to `mom_hook_action_t` called `reply_expected` to track if we are waiting to hear back from mom.
3. Serialized mom hook sync operation triggers (`sync_mom_hookfilesTPP`)
4. Avoid marking hook sync pending during create node operation
5. simplified `add_pending_mom_allhooks_action()`
6. used direct unicast of batch request to delete mom hooks during node delete operation
7. renamed `bg_sync_mom_hookfiles()` to `mc_sync_mom_hookfiles()` to reflect the contemporary mechanism of hook syncs
8. renamed `bg_delete_mom_hooks()` to `uc_delete_mom_hooks()`

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[hook_sync_fix_2_logs.zip](https://github.com/openpbs/openpbs/files/5122788/hook_sync_fix_2_logs.zip)
![image](https://user-images.githubusercontent.com/30307577/91157845-7e59cb00-e6e3-11ea-8e26-51dc9ae05479.png)

Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|3354|3443|0|0|0|2|3441|

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
