### PR TITLE
Json report provides data of each repetition when test run multiple times

### DIFF
--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -192,6 +192,7 @@ def testparams(**kwargs):
             function.__doc__ += str(key) + ' : ' + str(value) + '\n\t'
 
         def wrapper(self, *args):
+            self.testconf = {}
             for key, value in kwargs.items():
                 keyname = type(self).__name__ + "." + key
                 if keyname not in self.conf.keys():

--- a/test/fw/ptl/utils/plugins/ptl_report_json.py
+++ b/test/fw/ptl/utils/plugins/ptl_report_json.py
@@ -259,7 +259,10 @@ class PTLJsonData(object):
                     for i in range(len(measurements_data)):
                         m_data = {}
                         if "test_measure" in measurements_data[i].keys():
-                            m_data = copy.deepcopy(measurements_data[i])
+                            measure = measurements_data[i]['test_measure']
+                            m_data['test_measure'] = measure
+                            m_data['unit'] = measurements_data[i]['unit']
+                            m_data['test_data'] = {}
                             div = count
                             m_data['test_data']['mean'] = t_sum[i][0] / div
                             m_data['test_data']['std_dev'] = t_sum[i][1] / div

--- a/test/fw/ptl/utils/plugins/ptl_test_runner.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_runner.py
@@ -466,6 +466,8 @@ class PtlTextTestRunner(TextTestRunner):
     output stream, results, and the test case itself.
     """
 
+    run_count = 1
+
     def __init__(self, stream=sys.stdout, descriptions=True, verbosity=3,
                  config=None, repeat_count=1, repeat_delay=0):
         self.logger = logging.getLogger(__name__)
@@ -494,6 +496,7 @@ class PtlTextTestRunner(TextTestRunner):
         self.result.start = datetime.datetime.now()
         try:
             for i in range(self.repeat_count):
+                PtlTextTestRunner.run_count = i + 1
                 if i != 0:
                     time.sleep(self.repeat_delay)
                 test(result)

--- a/test/fw/ptl/utils/plugins/ptl_test_runner.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_runner.py
@@ -466,7 +466,7 @@ class PtlTextTestRunner(TextTestRunner):
     output stream, results, and the test case itself.
     """
 
-    run_count = 1
+    cur_repeat_count = 1
 
     def __init__(self, stream=sys.stdout, descriptions=True, verbosity=3,
                  config=None, repeat_count=1, repeat_delay=0):
@@ -496,7 +496,7 @@ class PtlTextTestRunner(TextTestRunner):
         self.result.start = datetime.datetime.now()
         try:
             for i in range(self.repeat_count):
-                PtlTextTestRunner.run_count = i + 1
+                PtlTextTestRunner.cur_repeat_count = i + 1
                 if i != 0:
                     time.sleep(self.repeat_delay)
                 test(result)

--- a/test/tests/performance/pbs_qstat_performance.py
+++ b/test/tests/performance/pbs_qstat_performance.py
@@ -48,7 +48,6 @@ class TestQstatPerformance(TestPerformance):
     """
     Testing Qstat Performance
     """
-    qstat_query_list = []
     time_command = 'time'
 
     def setUp(self):
@@ -57,6 +56,7 @@ class TestQstatPerformance(TestPerformance):
             builds absolute path of commands to execute
         """
         TestPerformance.setUp(self)
+        self.qstat_query_list = []
         self.time_command = self.du.which(exe="time")
         if self.time_command == "time":
             self.skipTest("Time command not found")

--- a/test/tests/selftest/pbs_json_test_report.py
+++ b/test/tests/selftest/pbs_json_test_report.py
@@ -125,10 +125,10 @@ class TestJSONReport(TestSelf):
             if k not in jdata:
                 faulty_fields.append(k)
         for l in verify_data['test_summary_keys']:
-            if l not in jdata['test_summary']:
+            if l not in jdata['test_summary']['1']:
                 faulty_fields.append(l)
         for o in verify_data['test_results']:
-            if o not in jdata['test_summary']['result_summary']:
+            if o not in jdata['test_summary']['1']['result_summary']:
                 faulty_fields.append(o)
         for node in jdata['machine_info']:
             for m in verify_data['test_machine_info']:
@@ -148,14 +148,14 @@ class TestJSONReport(TestSelf):
             for t in jdata['testsuites'][s]['testcases']:
                 for v in verify_data['test_results_info']:
                     testcase = jdata['testsuites'][s]['testcases'][t]
-                    if v not in testcase['results']:
+                    if v not in testcase['results']['1']:
                         faulty_fields.append(v)
         for k, v in field_values.items():
             if k == 'machine_info_name':
                 if list(jdata['machine_info'].keys())[0] != v:
                     faulty_values.append(k)
             if k == 'testresult_status':
-                if vdata['results']['status'] != v:
+                if vdata['results']['1']['status'] != v:
                     faulty_values.append(k)
             if k == 'requirements':
                 if vdata['requirements'] != v:


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
When test run multiple times then json report of tests doesn't provide data of every repetition. Only last repetition data are present in it.
In setup of testsuite "TestQstatPerformance" qstat_query_list is appended by each next test . New data are same as previous qstate_query_list data. Because of that unnecessarily test takes more time to check duplicate queries of query_list. Also performance results are getting duplicate measurements. It should be fixed in setup().


#### Describe Your Change
Added each repetition data to the json report with repetition count, total run  time of all repetition.
fixed the queries in setup()

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Description: Tests from given sources on platforms SUSE15, CENTOS8, CENTOS7
Platforms: SUSE15,CENTOS8,CENTOS7
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|5032|1064|1|2|0|0|1061|


[json_report_proc.txt](https://github.com/openpbs/openpbs/files/5487775/json_report_proc.txt)
[json_report_config.txt](https://github.com/openpbs/openpbs/files/5487781/json_report_config.txt)

[after_changes_ptl_logs.txt](https://github.com/openpbs/openpbs/files/5267374/after_changes_ptl_logs.txt)
[after_changes_json_report.txt](https://github.com/openpbs/openpbs/files/5267375/after_changes_json_report.txt)
[before_change_json.txt](https://github.com/openpbs/openpbs/files/5182954/before_change_json.txt)


[updated_json_report.txt](https://github.com/openpbs/openpbs/files/5349115/updated_json_report.txt)
[perf_json_report.txt](https://github.com/openpbs/openpbs/files/5368934/perf_json_report.txt)
[non_perf_json.txt](https://github.com/openpbs/openpbs/files/5368936/non_perf_json.txt)


[new_json_report.txt](https://github.com/openpbs/openpbs/files/5375590/new_json_report.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
