### PR TITLE
race condition in server periodic hook test

### DIFF
--- a/test/tests/functional/pbs_server_periodic_hook.py
+++ b/test/tests/functional/pbs_server_periodic_hook.py
@@ -296,9 +296,9 @@ pbs.logmsg(pbs.LOG_DEBUG, "periodic hook ended at %%d" %% time.time())
         """
         hook_name = "medium_hook"
         scr = self.create_hook(accept=True, sleep_time=10)
-        attrs = {'event': 'periodic', 'alarm': 15, 'freq': 5}
+        attrs = {'event': 'periodic', 'alarm': 15, 'freq': 6}
         self.server.create_import_hook(hook_name, attrs, scr, overwrite=True)
-        self.check_next_occurances(2, freq=5, hook_run_time=10,
+        self.check_next_occurances(2, freq=6, hook_run_time=10,
                                    check_for_hook_end=True, alarm=15)
 
     def test_check_for_negative_freq(self):


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Server periodic hook test sometimes fails due to a race condition.
Test creates a periodic hook that sleeps for 10 seconds and has a freq of 5 seconds. It also sets a hook alarm of 15 seconds.
It tests for the first two occurrences of hook execution. 
It expects the first occurrence will start at time t and end at t + 10.
At time t + 15 it expects the second occurrence to start and end at t + 25.

Sometimes the server ends up running the second occurrence right after the first hook ends. This happens because server registers two work tasks for server periodic hooks. First work task is a timed task which runs at the freq of the hook itself (like at t, t+5, t+10, t+15 ...) and second task is a deferred task that runs when a hook ends.
What happens is that in this case, since the hook runs for 10 seconds (twice the freq), it creates a race between the timed task and the deferred task. If the timed task wins then it will notice a hook is already running and register a new timed task to run the hook at t+15 seconds, If the deferred task wins it mark the hook as not-running and that results into the t+10 timed task to run another occurrence of the hook.

#### Describe Your Change
I think hook implementation is correct and this particular case is an unusual scenario where hook's run time is a multiple of its freq. I just modified the test to ensure that hook's run time is not a multiple of the freq.

#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
[test_alarm.txt](https://github.com/openpbs/openpbs/files/5125388/test_alarm.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
