### PR TITLE
Introduce $jobdir_root 'shared' directive

### DIFF
--- a/src/include/mom_func.h
+++ b/src/include/mom_func.h
@@ -90,6 +90,7 @@ extern char	pbs_tmpdir[];
 
 /* used by mom_main.c and start_exec.c for PBS_JOBDIR */
 extern char	pbs_jobdir_root[];
+extern int	pbs_jobdir_root_shared;
 
 /* test bits */
 #define PBSQA_DELJOB_SLEEP	1
@@ -340,7 +341,7 @@ extern int local_or_remote(char **);
 extern void add_bad_list(char **, char *, int);
 extern int is_child_path(char *, char *);
 extern int pbs_glob(char *, char *);
-extern void  rmjobdir(char *, char *, uid_t, gid_t);
+extern void  rmjobdir(char *, char *, uid_t, gid_t, int);
 extern int stage_file(int, int, char *, struct rqfpair *, int, cpy_files *, char *, char *);
 #ifdef WIN32
 extern void  bld_wenv_variables(char *, char *);

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -234,6 +234,7 @@ char            pbs_jobdir_root[MAX_PATH]= "";
 char            pbs_tmpdir[_POSIX_PATH_MAX] = TMP_DIR;
 char            pbs_jobdir_root[_POSIX_PATH_MAX]= "";
 #endif
+int		pbs_jobdir_root_shared = FALSE;
 vnl_t		*vnlp = NULL;			/* vnode list */
 unsigned long	hooks_rescdef_checksum = 0;
 
@@ -3614,6 +3615,15 @@ static handler_ret_t
 set_jobdir_root(char *value)
 {
 	char	*cleaned_value;
+	char    *endptr;
+
+	endptr = value;
+	while ((!isspace((int)*endptr)) && *endptr)
+		endptr++;
+	if (*endptr != '\0') {
+		*endptr = '\0';
+		endptr++;
+	}
 
 	log_event(PBSEVENT_SYSTEM, PBS_EVENTCLASS_SERVER,
 		LOG_INFO, __func__, value);
@@ -3644,6 +3654,11 @@ set_jobdir_root(char *value)
 
 	strcpy(pbs_jobdir_root, cleaned_value);
 	free(cleaned_value);
+
+	if (*endptr != '\0') {
+		if (strstr(endptr, "shared"))
+			pbs_jobdir_root_shared = TRUE;
+	}
 	return HANDLER_SUCCESS;
 }
 

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -3656,7 +3656,7 @@ set_jobdir_root(char *value)
 	free(cleaned_value);
 
 	if (*endptr != '\0') {
-		if (strstr(endptr, "shared"))
+		if (strcmp(endptr, "shared") == 0)
 			pbs_jobdir_root_shared = TRUE;
 	}
 	return HANDLER_SUCCESS;

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -3615,16 +3615,13 @@ static handler_ret_t
 set_jobdir_root(char *value)
 {
 	char	*cleaned_value;
-	char    *endptr;
+	char    *savep = NULL;
+	char	*directive;
+	char	*p;
 
-	endptr = value;
-	while ((!isspace((int)*endptr)) && *endptr)
-		endptr++;
-	if (*endptr != '\0') {
-		*endptr = '\0';
-		endptr++;
-	}
-
+	p = value;
+	value = strtok_r(p, " ", &savep);
+	directive = strtok_r(NULL, " ", &savep);
 	log_event(PBSEVENT_SYSTEM, PBS_EVENTCLASS_SERVER,
 		LOG_INFO, __func__, value);
 	cleaned_value = remove_quotes(value); /* remove quotes if any present */
@@ -3655,8 +3652,8 @@ set_jobdir_root(char *value)
 	strcpy(pbs_jobdir_root, cleaned_value);
 	free(cleaned_value);
 
-	if (*endptr != '\0') {
-		if (strcmp(endptr, "shared") == 0)
+	if (directive != NULL) {
+		if (strcmp(directive, "shared") == 0)
 			pbs_jobdir_root_shared = TRUE;
 	}
 	return HANDLER_SUCCESS;

--- a/src/resmom/requests.c
+++ b/src/resmom/requests.c
@@ -3306,7 +3306,7 @@ req_cpyfile(struct batch_request *preq)
 		/* cd to user's home to be out of   */
 		/* the sandbox so it can be deleted */
 		chdir(pwdp->pw_dir);
-		rmjobdir(rqcpf->rq_jobid, pbs_jobdir, useruid, usergid);
+		rmjobdir(rqcpf->rq_jobid, pbs_jobdir, useruid, usergid, 0);
 	}
 
 	pbs_strncpy(dup_rqcpf_jobid, rqcpf->rq_jobid, sizeof(dup_rqcpf_jobid));

--- a/src/resmom/stage_func.c
+++ b/src/resmom/stage_func.c
@@ -1219,7 +1219,7 @@ rmjobdir(char *jobid, char *jobdir, uid_t uid, gid_t gid, int check_shared)
 	    (pbs_jobdir_root[0] != '\0') &&
 	    pbs_jobdir_root_shared &&
 	    (strncmp(pbs_jobdir_root, jobdir, strlen(pbs_jobdir_root)) == 0)) {
-		log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_JOB, LOG_DEBUG, jobid?jobid:__func__, "shared jobdir %s to be removed by primary mom", jobdir);
+		log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_JOB, LOG_DEBUG, jobid?jobid:"", "shared jobdir %s to be removed by primary mom", jobdir);
 
 		return;
 	}

--- a/src/server/job_func.c
+++ b/src/server/job_func.c
@@ -779,17 +779,23 @@ del_job_dirs(job *pjob, char *taskdir)
 	 */
 	if ((pjob->ji_wattr[(int)JOB_ATR_sandbox].at_flags & ATR_VFLAG_SET) &&
 		(strcasecmp(pjob->ji_wattr[JOB_ATR_sandbox].at_val.at_str, "PRIVATE") == 0)) {
+		int	check_shared = 0;
+		if ((pjob->ji_qs.ji_svrflags & JOB_SVFLG_HERE) == 0)
+			/* sister mom */
+			check_shared = 1;
 		if (!(pjob->ji_qs.ji_svrflags & JOB_SVFLG_StgoFal)) {
 			if (pjob->ji_grpcache != NULL)
 				rmjobdir(pjob->ji_qs.ji_jobid,
 					jobdirname(pjob->ji_qs.ji_jobid, pjob->ji_grpcache->gc_homedir),
 					pjob->ji_grpcache->gc_uid,
-					pjob->ji_grpcache->gc_gid);
+					pjob->ji_grpcache->gc_gid,
+					check_shared);
 			else
 				rmjobdir(pjob->ji_qs.ji_jobid,
 					jobdirname(pjob->ji_qs.ji_jobid, NULL),
 					0,
-					0);
+					0,
+					check_shared);
 		}
 	}
 }

--- a/test/tests/functional/pbs_qsub_opts_args.py
+++ b/test/tests/functional/pbs_qsub_opts_args.py
@@ -232,7 +232,7 @@ bhtiusabsdlg' % (os.environ['HOME'])
         errmsg = "sister mom deleted jobdir %s" % jobdir
         rc = self.du.isdir(hostname=momB.shortname, path=jobdir,
                            sudo=True)
-        self.assertEqual(rc, True, errmsg)
+        self.assertTrue(rc, errmsg)
         msg = "shared jobdir %s to be removed by primary mom" % jobdir
         momB.log_match(msg)
         self.server.expect(JOB, 'job_state', op=UNSET, id=jid)
@@ -240,4 +240,4 @@ bhtiusabsdlg' % (os.environ['HOME'])
         errmsg = "MS mom preserved jobdir %s" % jobdir
         rc = self.du.isdir(hostname=momA.shortname, path=jobdir,
                            sudo=True)
-        self.assertEqual(rc, False, errmsg)
+        self.assertFalse(rc, errmsg)

--- a/test/tests/functional/pbs_qsub_opts_args.py
+++ b/test/tests/functional/pbs_qsub_opts_args.py
@@ -56,6 +56,17 @@ class TestQsubOptionsArguments(TestFunctional):
         self.fn = self.du.create_temp_file(body=script)
         self.qsub_cmd = os.path.join(
             self.server.pbs_conf['PBS_EXEC'], 'bin', 'qsub')
+        self.jobdir_root = "/tmp"
+        self.jobdir = []
+
+    def tearDown(self):
+        for mom in self.moms.values():
+            for d in self.jobdir:
+                if d.startswith(self.jobdir_root):
+                    self.logger.info('%s:remove jobdir %s' % (mom.hostname, d))
+                    cmd = ['/bin/rm', '-rf', d]
+                    self.du.run_cmd(mom.hostname, cmd=cmd, sudo=True)
+        TestFunctional.tearDown(self)
 
     def validate_error(self, err):
         ret_msg = 'qsub: Failed to save job/resv, '\
@@ -177,3 +188,50 @@ bhtiusabsdlg' % (os.environ['HOME'])
         except PbsSubmitError as e:
             self.validate_error(e)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid_2)
+
+    @requirements(num_moms=2)
+    def test_qsub_sandbox_private_jobdir_shared(self):
+        """
+        Test submission of job with sandbox=PRIVATE,
+        and moms have $jobdir_root set to shared.
+        """
+        momA = self.moms.values()[0]
+        momB = self.moms.values()[1]
+
+        c = {'$jobdir_root': '%s shared' % self.jobdir_root}
+        l = {'$logevent': 4095}
+        for mom in [momA, momB]:
+            mom.add_config(c)
+            if mom == momB:
+                mom.add_config(l)
+            mom.restart()
+
+        a = {'Resource_List.select': '2:ncpus=1',
+             'Resource_List.place': 'scatter',
+             ATTR_sandbox: 'PRIVATE',
+             }
+        j = Job(TEST_USER, attrs=a)
+        j.set_sleep_time(10)
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        attribs = self.server.status(JOB, id=jid)
+        jobdir = attribs[0]['jobdir']
+        self.jobdir.append(jobdir)
+        relpath = os.path.join(
+            self.server.pbs_conf['PBS_EXEC'], 'bin', 'pbs_release_nodes')
+
+        rel_cmd = [relpath, '-j', jid, momB.shortname]
+        ret = self.server.du.run_cmd(self.server.hostname, cmd=rel_cmd,
+                                     runas=TEST_USER)
+        self.assertEqual(ret['rc'], 0)
+        test_cmd = ['test', '-e', jobdir]
+        ret = self.du.run_cmd(momB.hostname, cmd=test_cmd, sudo=True)
+        # sister mom has preserved the file
+        self.assertEqual(ret['rc'], 0, "sister mom deleted jobdir %s" % jobdir)
+        msg = "shared jobdir %s to be removed by primary mom" % jobdir
+        momB.log_match(msg)
+
+        self.server.expect(JOB, 'job_state', op=UNSET, id=jid)
+        ret = self.du.run_cmd(momA.hostname, cmd=test_cmd, sudo=True)
+        # primary mom has deleted the file
+        self.assertEqual(ret['rc'], 1, "MS mom preserved jobdir %s" % jobdir)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* If a job has been submitted with sandbox attribute set to PRIVATE, (i.e. qsub -W sandbox=PRIVATE), a special job’s staging and execution directory is created under the directory specified in MoM $jobdir_root configuration option.
* Putting jobdir_root to a shared location for multiple MoMs breaks when using the [Node Ramp down Feature](https://openpbs.atlassian.net/wiki/spaces/PD/pages/49897561/PP-339+and+PP-647+node+ramp+down+feature+release+vnodes+early+from+running+jobs). 
* When a node is released early from a job by calling 'pbs_release_nodes', any job-specific specific files including job temporary directories sitting on the $jobdir_root directory, are removed by the sister mom managing that node.
* Unfortunately, the job-specific files are sitting on the same shared location seen by primary mom and the other sister moms, causing user's files to disappear. Primary mom would lose the ability to  stage out files and return stdout/stderr files, and executing job could actually abort.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* Introduce a new, optional directive 'shared'  to the $jobdir_root mom configuration option, that tells mom that the specified path is a shared location among primary mom and sister moms.
$jobdir_root <stage directory root>[shared]
* Having this option set, the sister mom would not cleanup the job's directories, when a request to delete the job on the node managed by that sister mom is received. 
* At the end of the job, the primary mom would take care of cleaning up the files.
#### Link to Design Doc
 [Option for sister moms to not delete job's files sitting on shared location](https://openpbs.atlassian.net/wiki/spaces/PD/pages/1979482121/Option+for+sister+moms+to+not+delete+job+s+files+sitting+on+shared+location)


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

* [ptl.sandbox_private_jobdir_shared.FAIL.txt](https://github.com/openpbs/openpbs/files/5126354/ptl.sandbox_private_jobdir_shared.FAIL.txt)
* [ptl.sandbox_private_jobdir_shared.PASS.txt](https://github.com/openpbs/openpbs/files/5126357/ptl.sandbox_private_jobdir_shared.PASS.txt)
* [valgrind.qsub_sandbox_private_jobdir_shared.txt](https://github.com/openpbs/openpbs/files/5126358/valgrind.qsub_sandbox_private_jobdir_shared.txt)
* [valgrind.qsub_sandbox_private_jobdir_shared.sismom.txt](https://github.com/openpbs/openpbs/files/5126359/valgrind.qsub_sandbox_private_jobdir_shared.sismom.txt)

* [ptl.sandbox_private_jobdir_shared.PASS3.txt](https://github.com/openpbs/openpbs/files/5159372/ptl.sandbox_private_jobdir_shared.PASS3.txt)
* [valgrind.msmom.jobdir_root_shared.txt](https://github.com/openpbs/openpbs/files/5159376/valgrind.msmom.jobdir_root_shared.txt)
* [valgrind.sismom.jobdir_root_shared.txt](https://github.com/openpbs/openpbs/files/5159377/valgrind.sismom.jobdir_root_shared.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
