### PR TITLE
Job array optimization in run path

### DIFF
--- a/src/include/job.h
+++ b/src/include/job.h
@@ -325,6 +325,18 @@ typedef struct	noderes {
  * specific structures for Job Array attributes
  */
 
+typedef struct {
+	int start;
+	int end;
+} range_t;
+
+typedef struct {
+	int count;
+	int step;
+	range_t *ranges;
+} range_arr_t;
+
+
 /* individual entries in array job index table */
 struct ajtrk {
 	int trk_status;		 /* status */
@@ -346,6 +358,7 @@ struct ajtrkhd {
 	int tkm_flags;			  /* special flags for array job */
 	int tkm_subjsct[PBS_NUMJOBSTATE]; /* count of subjobs in various states */
 	int tkm_dsubjsct;		  /* count of deleted subjobs */
+	range_arr_t tkm_rarr;		 	/* array of ranges */
 	struct ajtrk tkm_tbl[1];	  /* ptr to array of individual entries */
 	/*
 	 * when table is malloced, room for the additional required number


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Identified a possibility to optimize the job array run path while running a large number of sub-jobs. Modified the code in a way that would save Server's execution time.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Optimized the computation part for identifying the remaining sub-job indices. For every job stat, the server would walk through all the submitted sub-jobs to find the queued jobs remaining in the array job. In this PR, the new range structures are introduced to maintain the remaining indices for quick reference. This change would increase overall performance in the job array. 

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

Submitted 1 million jobs in the server and measured the job run path utilization. 

Before change:
<img width="1665" alt="Before_job_array_run_path" src="https://user-images.githubusercontent.com/17980660/91241916-0657c900-e714-11ea-8aba-6dc4b88aae9d.png">

After change:
<img width="1665" alt="After_job_array_runpath" src="https://user-images.githubusercontent.com/17980660/91241926-0ce64080-e714-11ea-832f-3d4a612961de.png">

Valgrind logs: 
[valgrind.log](https://github.com/openpbs/openpbs/files/5127428/valgrind.log)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
