### PR TITLE
Fixed fairshare_entity: Account_Name

### DIFF
--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -1238,6 +1238,19 @@ update_last_running(server_info *sinfo)
 }
 
 /**
+ * @brief clear and free the last running array
+ * 
+ * @return void
+ */
+void 
+clear_last_running()
+{
+	free_pjobs(last_running, last_running_size);
+	last_running = NULL;
+	last_running_size = 0;
+}
+
+/**
  * @brief
  *		update_job_can_not_run - do post job 'can't run' processing
  *				 mark it 'can_not_run'

--- a/src/scheduler/fifo.h
+++ b/src/scheduler/fifo.h
@@ -234,8 +234,9 @@ int update_svr_schedobj(int connector, int cmd, int alarm_time);
 
 int set_validate_sched_attrs(int connector);
 
-int validate_running_user(char * exename);
+int validate_running_user(char *exename);
 
+void clear_last_running();
 
 #ifdef	__cplusplus
 }

--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -973,6 +973,7 @@ query_jobs(status *policy, int pbs_sd, queue_info *qinfo, resource_resv **pjobs,
 			ATTR_c,
 			ATTR_r,
 			ATTR_depend,
+			ATTR_A,
 			NULL
 	};
 

--- a/src/scheduler/resource.c
+++ b/src/scheduler/resource.c
@@ -93,6 +93,7 @@
 #include "sort.h"
 #include "parse.h"
 #include "limits_if.h"
+#include "fifo.h"
 
 
 
@@ -576,6 +577,8 @@ reset_global_resource_ptrs(void)
 		boolres = NULL;
 	}
 	update_sorting_defs(SD_FREE);
+
+	clear_last_running();
 
 	/* The above references into this array.  We now free the memory */
 	if (allres != NULL) {

--- a/test/tests/functional/pbs_fairshare.py
+++ b/test/tests/functional/pbs_fairshare.py
@@ -415,3 +415,49 @@ class TestFairshare(TestFunctional):
         jorder = [j.split('.')[0] for j in jorder]
         msg = 'Jobs ran out of order'
         self.assertEqual(jorder, c.political_order, msg)
+
+    def test_fairshare_acct_name(self):
+        """
+        Test fairshare with fairshare_entity as Account_Name
+        """
+        self.scheduler.set_sched_config({'fair_share': 'True'})
+        self.scheduler.set_sched_config({'fairshare_usage_res': 'ncpus'})
+        self.scheduler.set_sched_config({'fairshare_entity': ATTR_A})
+
+        self.scheduler.add_to_resource_group('acctA', 11, 'root', 10)
+        self.scheduler.set_fairshare_usage('acctA', 1)
+        self.scheduler.add_to_resource_group('acctB', 12, 'root', 25)
+        self.scheduler.set_fairshare_usage('acctB', 1)
+
+        self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': False})
+        self.server.manager(MGR_CMD_SET, NODE,
+                            {'resources_available.ncpus': 1},
+                            id=self.mom.shortname)
+        a = {ATTR_A: 'acctA'}
+        j1 = Job(attrs=a)
+        j1.set_sleep_time(15)
+        jid1 = self.server.submit(j1)
+
+        a = {ATTR_A: 'acctB'}
+        j2 = Job(attrs=a)
+        j2.set_sleep_time(15)
+        jid2 = self.server.submit(j2)
+
+        j3 = Job(attrs=a)
+        j3.set_sleep_time(15)
+        jid3 = self.server.submit(j3)
+
+        j4 = Job(attrs=a)
+        j4.set_sleep_time(15)
+        jid4 = self.server.submit(j4)
+
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': True})
+
+        # acctB has 2/3s of the shares, so 2 of its jobs will run before acctA
+        # a second cycle has to be kicked between jobs to make sure the
+        # scheduler acumulates the fairshare usage.
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': True})
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid3, offset=15)
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': True})
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid1, offset=15)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
One of the valid options for fairshare_entity is Account_Name.  Sometime recently the scheduler had an optimization put in to only query the job attributes it cared about (e.g. don't get huge environment).  The problem is Account_Name wasn't added to this list.  The scheduler wouldn't set the fairshare_entity correctly, so it would get the default of egroup:euser.

Also, another bug is when the scheduler is sent a SCH_CONFIGURE command (or on HUP), the scheduler frees its global resource definition array.  Fairshare usage works by keeping track of the resources_used values from the previous cycle and diffing them against the current values.  The resource_req structure that is used to store these pointed into that global resource def array which was freed.  While this didn't crash the scheduler, it did cause us to over allocate usage.

#### Describe Your Change
Added ATTR_A to the list of attributes queried from the server.

Also freed the last_running array when the scheduler gets a SCH_CONFIGURE.  This will cause the scheduler to lose fairshare usage, but better than having dangling pointers.

#### Attach Test and Valgrind Logs/Output

[fs.log](https://github.com/openpbs/openpbs/files/5133254/fs.log)
