### PR TITLE
Fix possible double free and better error message

### DIFF
--- a/src/cmds/pbs_ds_password.c
+++ b/src/cmds/pbs_ds_password.c
@@ -483,7 +483,10 @@ main(int argc, char *argv[])
 			/* start db only if it was not already running */
 			failcode = pbs_start_db(conn_db_host, pbs_conf.pbs_data_service_port);
 			if (failcode != 0) {
-				pbs_db_get_errmsg(failcode, &db_errmsg);
+				if (failcode == -1)
+					pbs_db_get_errmsg(PBS_DB_ERR, &db_errmsg);
+				else
+					pbs_db_get_errmsg(failcode, &db_errmsg);
 				if (db_errmsg)
 					fprintf(stderr, "%s: Failed to start PBS dataservice:[%s]\n", prog, db_errmsg);
 				else

--- a/src/lib/Libdb/pgsql/db_common.c
+++ b/src/lib/Libdb/pgsql/db_common.c
@@ -421,14 +421,16 @@ pbs_dataservice_control(char *cmd, char *pbs_ds_host, int pbs_ds_port)
 		if ((pg_bin = getenv("PGSQL_BIN")) == NULL) {
 			if (errmsg_cache)
 				free(errmsg_cache);
-			errmsg_cache = strdup("PGSQL_BIN not found in the environment");
+			errmsg_cache = strdup("PGSQL_BIN not found in the environment. Please run PBS_EXEC/libexec/pbs_db_env and try again.");
 			return -1;
 		}
 		sprintf(pg_ctl, "%s %s/pg_ctl -D %s/datastore", pg_libstr ? pg_libstr : "", pg_bin, pbs_conf.pbs_home_path);
 	}
 	if (pg_user == NULL) {
-		if (errmsg_cache)
+		if (errmsg_cache) {
 			free(errmsg_cache);
+			errmsg_cache = NULL;
+		}
 		errmsg = (char *)malloc(PBS_MAX_DB_CONN_INIT_ERR + 1);
 		if (errmsg == NULL) {
 			errmsg_cache = strdup("Out of memory\n");


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Inside pbs_dataservice_control() I missed to ser errmsg_cache to NULL after freeing it. There is a slim chance of this causing double free if the function returns and it never had to set errmsg_cache. 

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
- Added errmsg_cache=NULL after free.
- Also, I took this opportunity to improve the error message thrown when pbs_server or commands like pbs_ds_password are executed with their .bin counterparts than the wrapper script.


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

There is no direct way to test this, but here is the regression results:
Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|3413|3439|2|0|0|2|3435|

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
