### PR TITLE
strcpy to pbs_strncpy changes (mom, sched and cmds)

### DIFF
--- a/src/cmds/pbs_dataservice.c
+++ b/src/cmds/pbs_dataservice.c
@@ -82,7 +82,7 @@ main(int argc, char *argv[])
 	while ((i = getopt(argc, argv, "s:")) != EOF) {
 		switch (i) {
 			case 's':
-				strcpy(sopt, optarg);
+				pbs_strncpy(sopt, optarg, sizeof(sopt));
 				break;
 			case '?':
 			default:
@@ -106,9 +106,9 @@ main(int argc, char *argv[])
 	}
 
 	if (pbs_conf.pbs_data_service_host)
-		strncpy(conn_db_host, pbs_conf.pbs_data_service_host, PBS_MAXSERVERNAME);
+		pbs_strncpy(conn_db_host, pbs_conf.pbs_data_service_host, PBS_MAXSERVERNAME);
 	else
-		strncpy(conn_db_host, pbs_default(), PBS_MAXSERVERNAME);
+		pbs_strncpy(conn_db_host, pbs_default(), PBS_MAXSERVERNAME);
 
 	if (strcmp(sopt, PBS_DB_CONTROL_START) == 0) {
 		rc = pbs_start_db(conn_db_host, pbs_conf.pbs_data_service_port);

--- a/src/cmds/pbs_ds_password.c
+++ b/src/cmds/pbs_ds_password.c
@@ -416,7 +416,7 @@ main(int argc, char *argv[])
 				gen_pwd = 1;
 				break;
 			case 'C':
-				strcpy(userid, optarg);
+				pbs_strncpy(userid, optarg, sizeof(userid));
 				break;
 			case '?':
 			default:
@@ -435,8 +435,7 @@ main(int argc, char *argv[])
      */
 	if (argv[optind] != NULL) {
 		gen_pwd = 0;
-		strncpy(passwd, argv[optind], sizeof(passwd));
-		passwd[sizeof(passwd) - 1] = '\0';
+		pbs_strncpy(passwd, argv[optind], sizeof(passwd));
 	}
 
 	/* check admin privileges */
@@ -463,9 +462,9 @@ main(int argc, char *argv[])
 
 	atexit(cleanup);
 	if (pbs_conf.pbs_data_service_host)
-		strncpy(conn_db_host, pbs_conf.pbs_data_service_host, PBS_MAXSERVERNAME);
+		pbs_strncpy(conn_db_host, pbs_conf.pbs_data_service_host, sizeof(conn_db_host));
 	else
-		strncpy(conn_db_host, pbs_default(), PBS_MAXSERVERNAME); 
+		pbs_strncpy(conn_db_host, pbs_default(), sizeof(conn_db_host)); 
 
 	if (update_db == 1) {
 		/* then connect to database */

--- a/src/cmds/pbs_ralter.c
+++ b/src/cmds/pbs_ralter.c
@@ -48,6 +48,8 @@
 #include "cmds.h"
 #include "net_connect.h"
 
+#define OPT_BUF_LEN 256
+
 static struct attrl *attrib = NULL;
 static time_t dtstart;
 static time_t dtend;
@@ -133,7 +135,7 @@ process_opts(int argc, char **argv, struct attrl **attrp, char *dest)
 					errflg++;
 					break;
 				}
-				strcpy(dest, &optarg[1]);
+				pbs_strncpy(dest, &optarg[1], OPT_BUF_LEN);
 				break;
 
 			case 'U':
@@ -254,7 +256,7 @@ main(int argc, char *argv[], char *envp[])		/* pbs_ralter */
 	int		errflg = 0;			/* command line option error */
 	int		connect = -1;			/* return from pbs_connect */
 	char		*errmsg = NULL;			/* return from pbs_geterrmsg */
-	char		destbuf[256] = {0};		/* buffer for option server */
+	char		destbuf[OPT_BUF_LEN] = {0};		/* buffer for option server */
 	struct attrl 	*attrib = NULL;			/* the attrib list */
 	struct		ecl_attribute_errors *err_list = NULL;
 	char		resv_id[PBS_MAXCLTJOBID] = {0};
@@ -294,7 +296,7 @@ main(int argc, char *argv[], char *envp[])		/* pbs_ralter */
 		exit(pbs_errno);
 	}
 
-	strcpy(resv_id, argv[optind]);
+	pbs_strncpy(resv_id, argv[optind], sizeof(resv_id));
 	if (get_server(resv_id, resv_id_out, server_out)) {
 		fprintf(stderr, "pbs_ralter: illegally formed reservation identifier: %s\n", resv_id);
 		exit(2);

--- a/src/cmds/pbs_rdel.c
+++ b/src/cmds/pbs_rdel.c
@@ -114,7 +114,7 @@ main(int argc, char **argv, char **envp)
 		int connect;
 		int stat = 0;
 
-		strcpy(resv_id, argv[optind]);
+		pbs_strncpy(resv_id, argv[optind], sizeof(resv_id));
 		if (get_server(resv_id, resv_id_out, server_out)) {
 			fprintf(stderr, "pbs_rdel: illegally formed reservation identifier: %s\n", resv_id);
 			any_failed = 1;

--- a/src/cmds/pbs_release_nodes.c
+++ b/src/cmds/pbs_release_nodes.c
@@ -90,8 +90,7 @@ main(int argc, char **argv, char **envp) /* pbs_release_nodes */
 	while ((c = getopt(argc, argv, GETOPT_ARGS)) != EOF) {
 		switch (c) {
 			case 'j':
-				strncpy(job_id, optarg, PBS_MAXCLTJOBID);
-				job_id[PBS_MAXCLTJOBID-1] = '\0';
+				pbs_strncpy(job_id, optarg, sizeof(job_id));
 				break;
 			case 'k':
 				keep_opt = optarg;
@@ -106,8 +105,7 @@ main(int argc, char **argv, char **envp) /* pbs_release_nodes */
 	if (job_id[0] == '\0') {
 		char *jid;
 		jid = getenv("PBS_JOBID");
-		strncpy(job_id, jid?jid:"", PBS_MAXCLTJOBID);
-		job_id[PBS_MAXCLTJOBID-1] = '\0';
+		pbs_strncpy(job_id, jid?jid:"", sizeof(job_id));
 	}
 
 	if (all_opt && keep_opt) {

--- a/src/cmds/pbs_rsub.c
+++ b/src/cmds/pbs_rsub.c
@@ -54,6 +54,7 @@
 #include "attribute.h"
 
 #define DEFAULT_INTERACTIVE "-10"
+#define OPT_BUF_LEN 256
 
 static struct attrl *attrib = NULL;
 static int qmoveflg = FALSE;
@@ -175,7 +176,7 @@ process_opts(int argc, char **argv, struct attrl **attrp, char *dest)
 					errflg++;
 					break;
 				}
-				strcpy(dest, &optarg[1]);
+				pbs_strncpy(dest, &optarg[1], OPT_BUF_LEN);
 				break;
 
 			case 'R':
@@ -201,7 +202,7 @@ process_opts(int argc, char **argv, struct attrl **attrp, char *dest)
 					errflg++;
 					break;
 				}
-				strcpy(rrule, optarg);
+				pbs_strncpy(rrule, optarg, sizeof(rrule));
 				break;
 
 			case 'u':
@@ -701,7 +702,7 @@ main(int argc, char *argv[], char *envp[])
 	int errflg;			/* command line option error */
 	int connect;			/* return from pbs_connect */
 	char *errmsg;			/* return from pbs_geterrmsg */
-	char destbuf[256];		/* buffer for option server */
+	char destbuf[OPT_BUF_LEN];	/* buffer for option server */
 	struct attrl *attrib;		/* the attrib list */
 	char *new_resvname;		/* the name returned from pbs_submit_resv */
 	struct ecl_attribute_errors *err_list;

--- a/src/cmds/pbs_tmrsh.c
+++ b/src/cmds/pbs_tmrsh.c
@@ -174,7 +174,7 @@ host_match(char *line)
 			domain[i] = '\0';
 		}
 	}
-	strcpy(fullhost, line);
+	pbs_strncpy(fullhost, line, sizeof(fullhost));
 	strcat(fullhost, ".");
 	strcat(fullhost, domain);
 

--- a/src/cmds/qalter.c
+++ b/src/cmds/qalter.c
@@ -329,7 +329,7 @@ main(int argc, char **argv, char **envp) /* qalter */
 		int stat=0;
 		int located = FALSE;
 
-		strcpy(job_id, argv[optind]);
+		pbs_strncpy(job_id, argv[optind], sizeof(job_id));
 		if (get_server(job_id, job_id_out, server_out)) {
 			fprintf(stderr, "qalter: illegally formed job identifier: %s\n", job_id);
 			any_failed = 1;

--- a/src/cmds/qdel.c
+++ b/src/cmds/qdel.c
@@ -173,7 +173,7 @@ char **envp;
 		int stat=0;
 		int located = FALSE;
 
-		strcpy(job_id, argv[optind]);
+		pbs_strncpy(job_id, argv[optind], sizeof(job_id));
 		if (get_server(job_id, job_id_out, server_out)) {
 			fprintf(stderr, "qdel: illegally formed job identifier: %s\n", job_id);
 			any_failed = 1;
@@ -238,7 +238,7 @@ cnt:
 			mails_suppressed = TRUE;
 			/* current warg1 "nomail" should be at start */
 			strcat(warg1, warg);
-			strcpy(warg, warg1);
+			pbs_strncpy(warg, warg1, sizeof(warg));
 		}
 
 		stat = pbs_deljob(connect, job_id_out, warg);
@@ -255,7 +255,7 @@ cnt:
 			located = TRUE;
 			if (locate_job(job_id_out, server_out, rmt_server)) {
 				pbs_disconnect(connect);
-				strcpy(server_out, rmt_server);
+				pbs_strncpy(server_out, rmt_server, sizeof(server_out));
 				goto cnt;
 			}
 			prt_job_err("qdel", connect, job_id_out);

--- a/src/cmds/qhold.c
+++ b/src/cmds/qhold.c
@@ -147,7 +147,7 @@ main(int argc, char **argv, char **envp) /* qhold */
 					errflg++;
 				}
 				else
-					strcpy(hold_type, optarg);
+					pbs_strncpy(hold_type, optarg, sizeof(hold_type));
 				break;
 			default :
 				errflg++;
@@ -170,7 +170,7 @@ main(int argc, char **argv, char **envp) /* qhold */
 		int stat=0;
 		int located = FALSE;
 
-		strcpy(job_id, argv[optind]);
+		pbs_strncpy(job_id, argv[optind], sizeof(job_id));
 		if (get_server(job_id, job_id_out, server_out)) {
 			fprintf(stderr, "qhold: illegally formed job identifier: %s\n", job_id);
 			any_failed = 1;

--- a/src/cmds/qmgr.c
+++ b/src/cmds/qmgr.c
@@ -260,8 +260,7 @@ attrlist_add(struct attropl  **attrlist, char *attname,
 
 	ltxt = attname_len;
 	Mstring(paol->name, ltxt + 1);
-	strncpy(paol->name, attname, ltxt);
-	paol->name[ltxt] = '\0';
+	pbs_strncpy(paol->name, attname, ltxt + 1);
 
 	paol->op = SET;
 
@@ -270,8 +269,7 @@ attrlist_add(struct attropl  **attrlist, char *attname,
 	} else {
 		ltxt = attval_len;
 		Mstring(paol->value, ltxt+1);
-		strncpy(paol->value, attval, ltxt);
-		paol->value[ltxt] = '\0';
+		pbs_strncpy(paol->value, attval, ltxt + 1);
 	}
 }
 
@@ -778,7 +776,7 @@ main(int argc, char **argv)
 		exit(2);
 	}
 
-	strcpy((char *)cur_user, who());
+	pbs_strncpy(cur_user, who(), sizeof(cur_user));
 	cur_host[0] = '\0';
 
 	/* obtain global information for hooks */
@@ -798,14 +796,14 @@ main(int argc, char **argv)
 	 * 4. use my host name
 	 */
 	if (pbs_conf.pbs_primary != NULL) {
-		strncpy(conf_full_server_name, pbs_conf.pbs_primary,
-			(sizeof(conf_full_server_name) - 1));
+		pbs_strncpy(conf_full_server_name, pbs_conf.pbs_primary,
+			sizeof(conf_full_server_name));
 	} else if (pbs_conf.pbs_server_host_name != NULL) {
-		strncpy(conf_full_server_name, pbs_conf.pbs_server_host_name,
-			(sizeof(conf_full_server_name) - 1));
+		pbs_strncpy(conf_full_server_name, pbs_conf.pbs_server_host_name,
+			sizeof(conf_full_server_name));
 	} else if (pbs_conf.pbs_server_name != NULL) {
-		strncpy(conf_full_server_name, pbs_conf.pbs_server_name,
-			(sizeof(conf_full_server_name) - 1));
+		pbs_strncpy(conf_full_server_name, pbs_conf.pbs_server_name,
+			sizeof(conf_full_server_name));
 	}
 	if (conf_full_server_name[0] != '\0') {
 		get_fullhostname(conf_full_server_name, conf_full_server_name,
@@ -1059,8 +1057,7 @@ attributes(char *attrs, struct attropl **attrlist, int doper)
 			/* Copy attribute into structure */
 			ltxt = c - start;
 			Mstring(paol->name, ltxt+1);
-			strncpy(paol->name, start, ltxt);
-			paol->name[ltxt] = '\0';
+			pbs_strncpy(paol->name, start, ltxt + 1);
 
 			/* Resource, if any */
 			if (*c == '.') {
@@ -1080,8 +1077,7 @@ attributes(char *attrs, struct attropl **attrlist, int doper)
 					return (start - attrs);
 
 				Mstring(paol->resource, ltxt+1);
-				strncpy(paol->resource, start, ltxt);
-				paol->resource[ltxt] = '\0';
+				pbs_strncpy(paol->resource, start, ltxt + 1);
 			}
 		}
 		else
@@ -2340,12 +2336,12 @@ execute(int aopt, int oper, int type, char *names, struct attropl *attribs)
 					attribs_file = NULL;
 					while (attribs_tmp) {
 						if (strcmp(attribs_tmp->name, INPUT_FILE_PARAM) == 0) {
-							strcpy(infile, attribs_tmp->value);
+							pbs_strncpy(infile, attribs_tmp->value, sizeof(infile));
 							attribs_file = attribs_tmp;
 						} else if (strcmp(attribs_tmp->name, CONTENT_ENCODING_PARAM) == 0) {
-							strcpy(content_encoding, attribs_tmp->value);
+							pbs_strncpy(content_encoding, attribs_tmp->value, sizeof(content_encoding));
 						} else if (strcmp(attribs_tmp->name, CONTENT_TYPE_PARAM) == 0) {
-							strcpy(content_type, attribs_tmp->value);
+							pbs_strncpy(content_type, attribs_tmp->value, sizeof(content_type));
 						}
 						attribs_tmp = attribs_tmp->next;
 					}
@@ -2453,11 +2449,11 @@ execute(int aopt, int oper, int type, char *names, struct attropl *attribs)
 					attribs_file = NULL;
 					while (attribs_tmp) {
 						if (strcmp(attribs_tmp->name, OUTPUT_FILE_PARAM) == 0) {
-							strcpy(outfile, attribs_tmp->value);
+							pbs_strncpy(outfile, attribs_tmp->value, sizeof(outfile));
 							attribs_file = attribs_tmp;
 						} else if (strcmp(attribs_tmp->name,
 							CONTENT_ENCODING_PARAM) == 0) {
-							strcpy(content_encoding, attribs_tmp->value);
+							pbs_strncpy(content_encoding, attribs_tmp->value, sizeof(content_encoding));
 						}
 						attribs_tmp = attribs_tmp->next;
 					}
@@ -2638,8 +2634,7 @@ commalist2objname(char *names, int type)
 			if (*foreptr == '@') {
 				len = foreptr - backptr;
 				Mstring(cur_obj->obj_name, len + 1);
-				strncpy(cur_obj->obj_name, backptr, len);
-				cur_obj->obj_name[len] = '\0';
+				pbs_strncpy(cur_obj->obj_name, backptr, len + 1);
 				foreptr++;
 				backptr = foreptr;
 				while (*foreptr != ',' && !EOL(*foreptr)) foreptr++;
@@ -2653,8 +2648,7 @@ commalist2objname(char *names, int type)
 					cur_obj->svr_name = NULL;
 				else {
 					Mstring(cur_obj->svr_name, len + 1);
-					strncpy(cur_obj->svr_name, backptr, len);
-					cur_obj->svr_name[len] = '\0';
+					pbs_strncpy(cur_obj->svr_name, backptr, len + 1);
 				}
 
 				if (!EOL(*foreptr))
@@ -2669,8 +2663,7 @@ commalist2objname(char *names, int type)
 				}
 				else {
 					Mstring(cur_obj->obj_name, len + 1);
-					strncpy(cur_obj->obj_name, backptr, len);
-					cur_obj->obj_name[len] = '\0';
+					pbs_strncpy(cur_obj->obj_name, backptr, len + 1);
 				}
 
 				if (type == MGR_OBJ_SERVER)
@@ -3152,7 +3145,7 @@ parse(char *request, int *oper, int *type, char **names, struct attropl **attr)
 					exit(1);
 				}
 				(*names)[names_len] = '\0';
-				strncpy(*names, req[IND_NAME], names_len);
+				pbs_strncpy(*names, req[IND_NAME], names_len + 1);
 			}
 		}
 
@@ -3655,7 +3648,7 @@ parse_request(char *request, char ***req)
 		}
 		((*req)[i])[len] = '\0';
 		if (len > 0)
-			strncpy((*req)[i], backptr, len);
+			pbs_strncpy((*req)[i], backptr, len + 1);
 		i++;
 
 	}

--- a/src/cmds/qmgr.c
+++ b/src/cmds/qmgr.c
@@ -3144,7 +3144,6 @@ parse(char *request, int *oper, int *type, char **names, struct attropl **attr)
 					fprintf(stderr, "malloc failure (errno %d)\n", errno);
 					exit(1);
 				}
-				(*names)[names_len] = '\0';
 				pbs_strncpy(*names, req[IND_NAME], names_len + 1);
 			}
 		}

--- a/src/cmds/qmove.c
+++ b/src/cmds/qmove.c
@@ -86,7 +86,7 @@ main(int argc, char **argv, char **envp) /* qmove */
 		exit(2);
 	}
 
-	strcpy(destination, argv[1]);
+	pbs_strncpy(destination, argv[1], sizeof(destination));
 	if (parse_destination_id(destination, &q_n_out, &s_n_out)) {
 		fprintf(stderr, "qmove: illegally formed destination: %s\n", destination);
 		exit(2);
@@ -104,7 +104,7 @@ main(int argc, char **argv, char **envp) /* qmove */
 		int stat=0;
 		int located = FALSE;
 
-		strcpy(job_id, argv[optind]);
+		pbs_strncpy(job_id, argv[optind], sizeof(job_id));
 		if (get_server(job_id, job_id_out, server_out)) {
 			fprintf(stderr, "qmove: illegally formed job identifier: %s\n", job_id);
 			any_failed = 1;
@@ -131,7 +131,7 @@ cnt:
 			located = TRUE;
 			if (locate_job(job_id_out, server_out, rmt_server)) {
 				pbs_disconnect(connect);
-				strcpy(server_out, rmt_server);
+				pbs_strncpy(server_out, rmt_server, sizeof(server_out));
 				goto cnt;
 			}
 			prt_job_err("qmove", connect, job_id_out);

--- a/src/cmds/qmsg.c
+++ b/src/cmds/qmsg.c
@@ -110,7 +110,7 @@ main(int argc, char **argv, char **envp) /* qmsg */
 			exit(2);
 		}
 
-	strcpy(msg_string, argv[optind]);
+	pbs_strncpy(msg_string, argv[optind], sizeof(msg_string));
 
 	/*perform needed security library initializations (including none)*/
 
@@ -124,7 +124,7 @@ main(int argc, char **argv, char **envp) /* qmsg */
 		int stat=0;
 		int located = FALSE;
 
-		strcpy(job_id, argv[optind]);
+		pbs_strncpy(job_id, argv[optind], sizeof(job_id));
 		if (get_server(job_id, job_id_out, server_out)) {
 			fprintf(stderr, "qmsg: illegally formed job identifier: %s\n", job_id);
 			any_failed = 1;

--- a/src/cmds/qorder.c
+++ b/src/cmds/qorder.c
@@ -84,8 +84,8 @@ main(int argc, char **argv, char **envp)
 		exit(2);
 	}
 
-	strcpy(job_id1, argv[1]);
-	strcpy(job_id2, argv[2]);
+	pbs_strncpy(job_id1, argv[1], sizeof(job_id1));
+	pbs_strncpy(job_id2, argv[2], sizeof(job_id2));
 	svrtmp[0] = '\0';
 	if (get_server(job_id1, job_id1_out, svrtmp)) {
 		fprintf(stderr, "qorder: illegally formed job identifier: %s\n", job_id1);
@@ -93,7 +93,7 @@ main(int argc, char **argv, char **envp)
 	}
 	if (*svrtmp == '\0') {
 		if ((pn = pbs_default()) != NULL) {
-			(void)strcpy(svrtmp, pn);
+			pbs_strncpy(svrtmp, pn, sizeof(svrtmp));
 		} else {
 			fprintf(stderr, "qorder: could not get default server: %s\n", job_id1);
 			exit(1);
@@ -116,7 +116,7 @@ main(int argc, char **argv, char **envp)
 	}
 	if (*svrtmp == '\0') {
 		if ((pn = pbs_default()) != NULL) {
-			(void)strcpy(svrtmp, pn);
+			pbs_strncpy(svrtmp, pn, sizeof(svrtmp));
 		} else {
 			fprintf(stderr, "qorder: could not get default server: %s\n", job_id1);
 			exit(1);

--- a/src/cmds/qrerun.c
+++ b/src/cmds/qrerun.c
@@ -118,7 +118,7 @@ main(int argc, char **argv, char **envp) /* qrerun */
 		int stat=0;
 		int located = FALSE;
 
-		strcpy(job_id, argv[optind]);
+		pbs_strncpy(job_id, argv[optind], sizeof(job_id));
 		if (get_server(job_id, job_id_out, server_out)) {
 			fprintf(stderr, "qrerun: illegally formed job identifier: %s\n", job_id);
 			any_failed = 1;
@@ -141,7 +141,7 @@ cnt:
 			located = TRUE;
 			if (locate_job(job_id_out, server_out, rmt_server)) {
 				pbs_disconnect(connect);
-				strcpy(server_out, rmt_server);
+				pbs_strncpy(server_out, rmt_server, sizeof(server_out));
 				goto cnt;
 			}
 			prt_job_err("qrerun", connect, job_id_out);

--- a/src/cmds/qrls.c
+++ b/src/cmds/qrls.c
@@ -120,7 +120,7 @@ main(int argc, char **argv, char **envp) /* qrls */
 					errflg++;
 					break;
 				}
-				strcpy(hold_type, optarg);
+				pbs_strncpy(hold_type, optarg, sizeof(hold_type));
 				break;
 			default :
 				errflg++;
@@ -146,7 +146,7 @@ main(int argc, char **argv, char **envp) /* qrls */
 		int stat=0;
 		int located = FALSE;
 
-		strcpy(job_id, argv[optind]);
+		pbs_strncpy(job_id, argv[optind], sizeof(job_id));
 		if (get_server(job_id, job_id_out, server_out)) {
 			fprintf(stderr, "qrls: illegally formed job identifier: %s\n", job_id);
 			any_failed = 1;

--- a/src/cmds/qselect.c
+++ b/src/cmds/qselect.c
@@ -146,8 +146,7 @@ check_op(char *optarg, enum batch_op *op, char *optargout)
 	cp_pos = 0;
 
 	if (optarg[0] == '.') {
-		strncpy(opstring, &optarg[1], OP_LEN);
-		opstring[OP_LEN] = '\0';
+		pbs_strncpy(opstring, &optarg[1], OP_LEN + 1);
 		cp_pos = OPSTRING_LEN;
 		for (i=0; i<OP_ENUM_LEN; i++) {
 			if (strncmp(opstring, opstring_vals[i], OP_LEN) == 0) {
@@ -156,8 +155,7 @@ check_op(char *optarg, enum batch_op *op, char *optargout)
 			}
 		}
 	}
-	strncpy(optargout, &optarg[cp_pos], MAX_OPTARG_LEN+1);
-	optargout[MAX_OPTARG_LEN] = '\0';
+	pbs_strncpy(optargout, &optarg[cp_pos], MAX_OPTARG_LEN + 1);
 	return;
 }
 
@@ -245,13 +243,11 @@ check_res_op(char *optarg, char *resource_name, enum batch_op *op, char *resourc
 		return (1);
 	}
 	else {
-		strncpy(resource_name, optarg, p-optarg);
-		resource_name[p-optarg] = '\0';
+		pbs_strncpy(resource_name, optarg, p - optarg + 1);
 		*res_pos = p + OPSTRING_LEN;
 	}
 	if (p[0] == '.') {
-		strncpy(opstring, &p[1] , OP_LEN);
-		opstring[OP_LEN] = '\0';
+		pbs_strncpy(opstring, &p[1] , OP_LEN + 1);
 		hit = 0;
 		for (i=0; i<OP_ENUM_LEN; i++) {
 			if (strncmp(opstring, opstring_vals[i], OP_LEN) == 0) {
@@ -270,8 +266,7 @@ check_res_op(char *optarg, char *resource_name, enum batch_op *op, char *resourc
 	if (p == NULL) {
 		p = strchr(*res_pos, '\0');
 	}
-	strncpy(resource_value, *res_pos, p-(*res_pos));
-	resource_value[p-(*res_pos)] = '\0';
+	pbs_strncpy(resource_value, *res_pos, p - (*res_pos) + 1);
 	if (strlen(resource_value) == 0) {
 		fprintf(stderr, "qselect: illegal -l value\n");
 		fprintf(stderr, "resource_list: %s\n", optarg);
@@ -467,8 +462,7 @@ main(int argc, char **argv, char **envp) /* qselect */
 				set_attrop(&select_list, ATTR_p, NULL, optargout, op);
 				break;
 			case 'q':
-				strncpy(destination, optarg, sizeof(destination));
-				destination[sizeof(destination) - 1] = '\0';
+				pbs_strncpy(destination, optarg, sizeof(destination));
 				check_op(optarg, pop, optargout);
 				set_attrop(&select_list, ATTR_q, NULL, optargout, op);
 				break;
@@ -551,8 +545,7 @@ main(int argc, char **argv, char **envp) /* qselect */
 			exit(2);
 		} else {
 			if (notNULL(server_name_out)) {
-				strncpy(server_out, server_name_out, sizeof(server_out));
-				server_out[sizeof(server_out) - 1] = '\0';
+				pbs_strncpy(server_out, server_name_out, sizeof(server_out));
 			}
 		}
 	}

--- a/src/cmds/qsig.c
+++ b/src/cmds/qsig.c
@@ -86,7 +86,7 @@ main(int argc, char **argv, char **envp) /* qsig */
 	while ((c = getopt(argc, argv, GETOPT_ARGS)) != EOF)
 		switch (c) {
 			case 's':
-				strcpy(sig_string, optarg);
+				pbs_strncpy(sig_string, optarg, sizeof(sig_string));
 				break;
 			default :
 				errflg++;
@@ -112,7 +112,7 @@ main(int argc, char **argv, char **envp) /* qsig */
 		int stat=0;
 		int located = FALSE;
 
-		strcpy(job_id, argv[optind]);
+		pbs_strncpy(job_id, argv[optind], sizeof(job_id));
 		if (get_server(job_id, job_id_out, server_out)) {
 			fprintf(stderr, "qsig: illegally formed job identifier: %s\n", job_id);
 			any_failed = 1;
@@ -135,7 +135,7 @@ cnt:
 			located = TRUE;
 			if (locate_job(job_id_out, server_out, rmt_server)) {
 				pbs_disconnect(connect);
-				strcpy(server_out, rmt_server);
+				pbs_strncpy(server_out, rmt_server, sizeof(server_out));
 				goto cnt;
 			}
 			prt_job_err("qsig", connect, job_id_out);

--- a/src/cmds/qstat.c
+++ b/src/cmds/qstat.c
@@ -107,6 +107,8 @@ char *cnvt_est_start_time(char *start_time, int shortform);
 
 #define DISPLAY_TRUNC_CHAR '*'
 
+#define NUML    5
+
 static struct attrl basic_attribs[] = {
 	{	&basic_attribs[1],
 		ATTR_N,
@@ -311,7 +313,7 @@ states(char *string, char *q, char *r, char *h, char *w, char *t, char *e, int l
 					*(f - 1) = DISPLAY_TRUNC_CHAR;
 				*f = '\0';
 			}
-			strcpy(d, s);
+			pbs_strncpy(d, s, NUML + 1);
 			if (l != '\0') c++;
 		} else {
 			while (*c != ' ' && *c != '\0') c++;
@@ -893,13 +895,13 @@ altdsp_statjob(struct batch_status *pstat, struct batch_status *prtheader, int a
 		queuen = blank;
 		est_time  = NULL;
 		/*		*pfs      = *blank;  */
-		(void)strcpy(pfs, blank);
+		strcpy(pfs, blank);
 		/*		*rqmem    = *blank;  */
-		(void)strcpy(rqmem, blank);
+		strcpy(rqmem, blank);
 		/*		*srfsbig  = *blank;  */
-		(void)strcpy(srfsbig, blank);
+		strcpy(srfsbig, blank);
 		/*		*srfsfast = *blank;  */
-		(void)strcpy(srfsfast, blank);
+		strcpy(srfsfast, blank);
 		usecput = 0;
 
 		pat = pstat->attribs;
@@ -936,22 +938,22 @@ altdsp_statjob(struct batch_status *pstat, struct batch_status *prtheader, int a
 						trunc_value(tasks, SIZETSK, SIZETSK_W, wide);
 					}
 				} else if (strcmp(pat->resource, "mem") == 0) {
-					(void)strncpy(rqmem,
-						cnv_size(pat->value, alt_opt), sizeof(rqmem) - 1);
+					pbs_strncpy(rqmem,
+						cnv_size(pat->value, alt_opt), sizeof(rqmem));
 				} else if (strcmp(pat->resource, "walltime") == 0) {
 					rqtimewal = pat->value;
 				} else if (strcmp(pat->resource, "cput") == 0) {
 					rqtimecpu = pat->value;
 					usecput = 1;
 				} else if (strcmp(pat->resource, "srfs_big") == 0) {
-					(void)strncpy(srfsbig,
-						cnv_size(pat->value, alt_opt), sizeof(srfsbig) - 1);
+					pbs_strncpy(srfsbig,
+						cnv_size(pat->value, alt_opt), sizeof(srfsbig));
 				} else if (strcmp(pat->resource, "srfs_fast") == 0) {
-					(void)strncpy(srfsfast,
-						cnv_size(pat->value, alt_opt), sizeof(srfsfast) - 1);
+					pbs_strncpy(srfsfast,
+						cnv_size(pat->value, alt_opt), sizeof(srfsfast));
 				} else if (strcmp(pat->resource, "piofs") == 0) {
-					(void)strncpy(pfs,
-						cnv_size(pat->value, alt_opt), sizeof(pfs) - 1);
+					pbs_strncpy(pfs,
+						cnv_size(pat->value, alt_opt), sizeof(pfs));
 				}
 
 			} else if (strcmp(pat->name, ATTR_exechost) == 0) {
@@ -973,16 +975,14 @@ altdsp_statjob(struct batch_status *pstat, struct batch_status *prtheader, int a
 				if (strlen(pat->value) > COMMENTLENSCOPE_SHORT) {
 					if (wide) {
 						if (strlen(pat->value) > COMMENTLENSCOPE_WIDE) {
-							strncpy(buf, pat->value, COMMENTLEN_WIDE);
-							buf[COMMENTLEN_WIDE] = '\0';
+							pbs_strncpy(buf, pat->value, COMMENTLEN_WIDE);
 							strcat(buf, "...");
 							comment = buf;
 						} else {
 							comment = pat->value;
 						}
 					} else {
-						strncpy(buf, pat->value, COMMENTLEN_SHORT);
-						buf[COMMENTLEN_SHORT] = '\0';
+						pbs_strncpy(buf, pat->value, COMMENTLEN_SHORT);
 						strcat(buf, "...");
 						comment = buf;
 					}
@@ -1116,7 +1116,7 @@ altdsp_statque(char *serv, struct batch_status *pstat, int opt)
 
 	while (pstat) {
 		/* *rmem = '\0'; */
-		(void)strncpy(rmem, "--  ", sizeof(rmem) - 1);
+		strcpy(rmem, "--  ");
 		cput  = blank;
 		wallt = blank;
 		nodect= "-- ";
@@ -1144,8 +1144,8 @@ altdsp_statque(char *serv, struct batch_status *pstat, int opt)
 				tot_jrun += jrun;
 			} else if (strcmp(pat->name, ATTR_rescmax) == 0) {
 				if (strcmp(pat->resource, "mem") == 0) {
-					(void)strncpy(rmem,
-						cnv_size(pat->value, opt), sizeof(rmem) - 1);
+					pbs_strncpy(rmem,
+						cnv_size(pat->value, opt), sizeof(rmem));
 				} else if (strcmp(pat->resource, "cput") == 0) {
 					cput = pat->value;
 				} else if (strcmp(pat->resource, "walltime")==0) {
@@ -1399,11 +1399,10 @@ display_statjob(struct batch_status *status, struct batch_status *prtheader, int
 							 */
 							char noval[] = "UNKNOWN";
 							prt_attr(a->name, a->resource, noval, alt_opt & ALT_DISPLAY_w);
-						} else
-						{
+						} else {
 							char time_buffer[32];
-							strcpy(time_buffer,ctime(&epoch));
-							time_buffer[strlen(time_buffer)-1]='\0';
+							pbs_strncpy(time_buffer, ctime(&epoch), sizeof(time_buffer));
+							time_buffer[strlen(time_buffer)-1] = '\0';
 							prt_attr(a->name, a->resource, time_buffer, alt_opt & ALT_DISPLAY_w);
 						}
 					} else if (strcmp(a->name, ATTR_resv_state) == 0) {
@@ -1598,7 +1597,6 @@ display_statjob(struct batch_status *status, struct batch_status *prtheader, int
 
 
 
-#define NUML    5
 #define TYPEL   4
 
 /**
@@ -2031,7 +2029,7 @@ tcl_init()
 
 	snprintf(script, sizeof(script), "%s/.qstatrc", home);
 	if (stat(script, &sb) == -1) {
-		strcpy(script, QSTATRC_PATH);
+		pbs_strncpy(script, QSTATRC_PATH, sizeof(script));
 		if (stat(script, &sb) == -1)
 			return;
 	}
@@ -2076,9 +2074,9 @@ tcl_init()
 	if (pw == NULL)
 		return;
 
-	sprintf(script, "%s/.qstatrc", pw->pw_dir);
+	snprintf(script, sizeof(script), "%s/.qstatrc", pw->pw_dir);
 	if (stat(script, &sb) == -1) {
-		strcpy(script, QSTATRC_PATH);
+		pbs_strncpy(script, QSTATRC_PATH, sizeof(script));
 		if (stat(script, &sb) == -1)
 			return;
 	}
@@ -2759,7 +2757,7 @@ qstat -B [-f] [-F format] [-D delim] [ server_name... ]\n";
 
 			case JOBS:
 				server_out[0] = '@';
-				strcpy(&server_out[1], def_server);
+				pbs_strncpy(&server_out[1], def_server, sizeof(server_out) - 1);
 				tcl_addarg(ops, server_out);
 
 				job_id_out[0] = '\0';
@@ -2767,7 +2765,7 @@ qstat -B [-f] [-F format] [-D delim] [ server_name... ]\n";
 				goto job_no_args;
 			case QUEUES:
 				server_out[0] = '@';
-				strcpy(&server_out[1], def_server);
+				pbs_strncpy(&server_out[1], def_server, sizeof(server_out) - 1);
 				tcl_addarg(ops, server_out);
 
 				queue_name_out = NULL;
@@ -2794,14 +2792,14 @@ qstat -B [-f] [-F format] [-D delim] [ server_name... ]\n";
 
 		located = FALSE;
 
-		strcpy(operand, argv[optind]);
+		pbs_strncpy(operand, argv[optind], sizeof(operand));
 		tcl_addarg(ops, operand);
 		switch (mode) {
 
 			case JOBS:      /* get status of batch jobs */
 				if (pbs_isjobid(operand)) {  /* must be a job-id */
 					stat_single_job = 1;
-					strcpy(job_id, operand);
+					pbs_strncpy(job_id, operand, sizeof(job_id));
 					if (get_server(job_id, job_id_out, server_out)) {
 						fprintf(stderr, "qstat: illegally formed job identifier: %s\n", job_id);
 #ifdef NAS /* localmod 071 */
@@ -2817,7 +2815,7 @@ qstat -B [-f] [-F format] [-D delim] [ server_name... ]\n";
 						if (server_out[0] == '\0' || (strcmp(server_out, def_server) == 0)) {
 							/* This is probably the first job id requested from primary server */
 							if (prev_server[0] == '\0')
-								strcpy(prev_server, def_server);
+								pbs_strncpy(prev_server, def_server, sizeof(prev_server));
 							strncat(job_list, job_id_out, job_list_size - strlen(job_list));
 							strncat(job_list, ",", job_list_size - strlen(job_list));
 							if (optind != argc -1)
@@ -2833,7 +2831,7 @@ qstat -B [-f] [-F format] [-D delim] [ server_name... ]\n";
 							if ((prev_server[0] == '\0' ) || (strcmp(server_out, prev_server) == 0)) {
 								/* This is probably the first job id requested and not from primary server */
 								if (prev_server[0] == '\0')
-									strcpy(prev_server, server_out);
+									pbs_strncpy(prev_server, server_out, sizeof(prev_server));
 								strncat(job_list, job_id_out, job_list_size - strlen(job_list));
 								strncat(job_list, ",", job_list_size - strlen(job_list));
 								if (optind != argc-1)
@@ -2860,7 +2858,7 @@ qstat -B [-f] [-F format] [-D delim] [ server_name... ]\n";
 						return 1;
 					}
 					stat_single_job = 0;
-					strcpy(destination, operand);
+					pbs_strncpy(destination, operand, sizeof(destination));
 					if (parse_destination_id(destination,
 						&queue_name_out,
 						&server_name_out)) {
@@ -2874,11 +2872,11 @@ qstat -B [-f] [-F format] [-D delim] [ server_name... ]\n";
 						break;
 					} else {
 						if (notNULL(server_name_out)) {
-							strcpy(server_out, server_name_out);
+							pbs_strncpy(server_out, server_name_out, sizeof(server_out));
 						} else {
 							server_out[0] = '\0';
 						}
-						(void)strcpy(job_id_out, queue_name_out);
+						pbs_strncpy(job_id_out, queue_name_out, sizeof(job_id_out));
 						if (*queue_name_out != '\0') {
 							/* add "destination" to front of list */
 							add_atropl(&new_atropl, ATTR_q, NULL, queue_name_out, EQ);
@@ -2912,7 +2910,7 @@ job_no_args:
 #ifdef NAS /* localmod 071 */
 					p_rsvstat = pbs_statresv(connect, NULL, NULL, NULL);
 #endif /* localmod 071 */
-					(void)strcpy(server_old, pbs_server);
+					pbs_strncpy(server_old, pbs_server, sizeof(server_old));
 				} else {
 					p_server = NULL;
 				}
@@ -3058,7 +3056,7 @@ job_no_args:
 				break;
 
 			case QUEUES:        /* get status of batch queues */
-				strcpy(destination, operand);
+				pbs_strncpy(destination, operand, sizeof(destination));
 				if (parse_destination_id(destination,
 					&queue_name_out,
 					&server_name_out)) {
@@ -3123,7 +3121,7 @@ que_no_args:
 				break;
 
 			case SERVERS:           /* get status of batch servers */
-				strcpy(server_out, operand);
+				pbs_strncpy(server_out, operand, sizeof(server_out));
 svr_no_args:
 				connect = cnt2server(server_out);
 				if (connect <= 0) {
@@ -3248,7 +3246,7 @@ cvtResvstate(char *pcode)
 		case RESV_DELETED:
 		case RESV_DELETING_JOBS:
 		case RESV_BEING_ALTERED:
-			strcpy(acopy, resvStrings[i]);
+			pbs_strncpy(acopy, resvStrings[i], sizeof(acopy));
 			return  acopy;
 
 		default:

--- a/src/cmds/qsub.c
+++ b/src/cmds/qsub.c
@@ -3468,7 +3468,7 @@ job_env_basic(void)
 #ifdef WIN32
 			back2forward_slash(c_escaped);
 #endif
-			strncpy(p, c_escaped, len - (p - job_env));
+			pbs_strncpy(p, c_escaped, len - (p - job_env));
 			free(c_escaped);
 			c_escaped = NULL;
 		} else
@@ -3617,7 +3617,7 @@ set_job_env(char *basic_vlist, char *current_vlist)
 	if ((job_env = (char *) malloc(len)) == NULL) return FALSE;
 	*job_env = '\0';
 
-	strcpy(job_env, basic_vlist);
+	pbs_strncpy(job_env, basic_vlist, len);
 
 	/* Send these variables with the job. */
 	/* POSIX requirement: If a variable is given without a value, supply the
@@ -4059,10 +4059,11 @@ recv_attrl(void *s, struct attrl **attrib)
 			 * from the front end qsub
 			 */
 			if (strcmp(p, ATTR_v) == 0 && pbs_hostvar != NULL) {
-				attr_v_val = malloc(len_v + strlen(pbs_hostvar) + 1);
+				int attr_v_len = len_v + strlen(pbs_hostvar) + 1;
+				attr_v_val = malloc(attr_v_len);
 				if (!attr_v_val)
 					return -1;
-				strcpy(attr_v_val, p + len_n);
+				pbs_strncpy(attr_v_val, p + len_n, attr_v_len);
 				strcat(attr_v_val, pbs_hostvar);
 				set_attr_error_exit(&attr, p, attr_v_val);
 				free(attr_v_val);
@@ -5671,8 +5672,7 @@ main(int argc, char **argv, char **envp) /* qsub */
 		exit(0);
 	}
 
-	strncpy(qsub_exe, argv[0], sizeof(qsub_exe)); /* note the name of the qsub executable */
-	qsub_exe[sizeof(qsub_exe) - 1] = '\0';
+	pbs_strncpy(qsub_exe, argv[0], sizeof(qsub_exe)); /* note the name of the qsub executable */
 	if (strlen(qsub_exe) != strlen(argv[0])) { /* exit with error instead of silent truncation */
 		fprintf(stderr, "qsub: Name of executable is too long\n");
 		exit_qsub(2);

--- a/src/cmds/qsub.c
+++ b/src/cmds/qsub.c
@@ -4063,7 +4063,7 @@ recv_attrl(void *s, struct attrl **attrib)
 				attr_v_val = malloc(attr_v_len);
 				if (!attr_v_val)
 					return -1;
-				pbs_strncpy(attr_v_val, p + len_n, attr_v_len);
+				strcpy(attr_v_val, p + len_n);
 				strcat(attr_v_val, pbs_hostvar);
 				set_attr_error_exit(&attr, p, attr_v_val);
 				free(attr_v_val);

--- a/src/include/qmgr.h
+++ b/src/include/qmgr.h
@@ -79,6 +79,11 @@
                             pstderr("qmgr: Out of memory\n"); \
                             clean_up_and_exit(5); \
                         }
+/* This macro will duplicate string */
+#define Mstrdup(x,y)    if ( (x=strdup(y)) == NULL ) { \
+                            pstderr("qmgr: Out of memory\n"); \
+                            clean_up_and_exit(5); \
+                        }
 /* This macro will allocate memory for some fixed size object */
 #define Mstruct(x,y)    if ( (x=(y *)malloc(sizeof(y))) == NULL ) { \
                             pstderr("qmgr: Out of memory\n"); \

--- a/src/lib/Libutil/misc_utils.c
+++ b/src/lib/Libutil/misc_utils.c
@@ -347,7 +347,7 @@ pbs_strcpy(char *dest, const char *src)
  */
 char *pbs_strncpy(char *dest, const char *src, size_t n)
 {
-	if (strlen(src) < n-1)
+	if (strlen(src) < n - 1)
 		strcpy(dest, src);
 	else {
 		strncpy(dest, src, n - 1);

--- a/src/lib/Libutil/misc_utils.c
+++ b/src/lib/Libutil/misc_utils.c
@@ -350,7 +350,7 @@ char *pbs_strncpy(char *dest, const char *src, size_t n)
 	if (strlen(src) < n - 1)
 		strcpy(dest, src);
 	else {
-		strncpy(dest, src, n - 1);
+		memcpy(dest, src, n - 1);
 		dest[n - 1] = '\0';
 	}
 	return dest;

--- a/src/lib/Libutil/misc_utils.c
+++ b/src/lib/Libutil/misc_utils.c
@@ -347,9 +347,13 @@ pbs_strcpy(char *dest, const char *src)
  */
 char *pbs_strncpy(char *dest, const char *src, size_t n)
 {
-    strncpy(dest, src, n - 1);
-    dest[n - 1] = '\0';
-    return dest;
+	if (strlen(src) < n-1)
+		strcpy(dest, src);
+	else {
+		strncpy(dest, src, n - 1);
+		dest[n - 1] = '\0';
+	}
+	return dest;
 }
 
 /**

--- a/src/resmom/catch_child.c
+++ b/src/resmom/catch_child.c
@@ -192,7 +192,7 @@ chkpt_partial(job *pjob)
 
 	assert(pjob != NULL);
 
-	strcpy(namebuf, path_checkpoint);
+	pbs_strncpy(namebuf, path_checkpoint, sizeof(namebuf));
 	if (*pjob->ji_qs.ji_fileprefix != '\0')
 		strcat(namebuf, pjob->ji_qs.ji_fileprefix);
 	else
@@ -250,7 +250,7 @@ chkpt_partial(job *pjob)
 	}
 
 	if (texit == 0) {
-		char	oldname[MAXPATHLEN];
+		char	oldname[MAXPATHLEN + 1];
 		struct	stat	statbuf;
 
 		/*
@@ -709,8 +709,7 @@ encode_used(job *pjob, pbs_list_head *phead)
 					if ((at2->at_flags & ATR_VFLAG_SET) == 0)
 						continue;
 
-					strncpy(mom_hname, pjob->ji_resources[i].nodehost, PBS_MAXHOSTNAME);
-					mom_hname[PBS_MAXHOSTNAME] = '\0';
+					pbs_strncpy(mom_hname, pjob->ji_resources[i].nodehost, sizeof(mom_hname));
 					p = strchr(mom_hname, '.');
 					if (p != NULL)
 						*p = '\0';
@@ -1915,7 +1914,7 @@ init_abort_jobs(int recover)
 		 ** If so, remove the regular checkpoint dir
 		 ** and rename the old to the regular name.
 		 */
-		strcpy(path, path_checkpoint);
+		pbs_strncpy(path, path_checkpoint, sizeof(path));
 		if (*pj->ji_qs.ji_fileprefix != '\0')
 			strcat(path, pj->ji_qs.ji_fileprefix);
 		else

--- a/src/resmom/job_recov_fs.c
+++ b/src/resmom/job_recov_fs.c
@@ -326,7 +326,7 @@ job_recov_fs(char *filename)
 
 	/* change file name in case recovery fails so we don't try same file */
 
-	(void)strcpy(basen, pbs_recov_filename);
+	pbs_strncpy(basen, pbs_recov_filename, sizeof(basen));
 	psuffix = basen + strlen(basen) - strlen(JOB_BAD_SUFFIX);
 	(void)strcpy(psuffix, JOB_BAD_SUFFIX);
 #ifdef WIN32

--- a/src/resmom/linux/alps.c
+++ b/src/resmom/linux/alps.c
@@ -1100,7 +1100,7 @@ response_data_start(ud_t *d, const XML_Char *el, const XML_Char **atts)
 				return;
 			}
 		} else if (strcmp(BASIL_ATR_STATUS, *np) == 0) {
-			strcpy(d->status, *vp);
+			pbs_strncpy(d->status, *vp, sizeof(d->status));
 			if (strcmp(BASIL_VAL_SUCCESS, *vp) == 0) {
 				*brp->error = '\0';
 			} else if (strcmp(BASIL_VAL_FAILURE, *vp) == 0) {
@@ -1111,7 +1111,7 @@ response_data_start(ud_t *d, const XML_Char *el, const XML_Char **atts)
 				return;
 			}
 		} else if (strcmp(BASIL_ATR_ERROR_CLASS, *np) == 0) {
-			strcpy(d->error_class, *vp);
+			pbs_strncpy(d->error_class, *vp, sizeof(d->error_class));
 			/*
 			 * The existence of a PERMENENT error used to
 			 * reset the BASIL_ERR_TRANSIENT flag. This
@@ -1125,7 +1125,7 @@ response_data_start(ud_t *d, const XML_Char *el, const XML_Char **atts)
 				return;
 			}
 		} else if (strcmp(BASIL_ATR_ERROR_SOURCE, *np) == 0) {
-			strcpy(d->error_source, *vp);
+			pbs_strncpy(d->error_source, *vp, sizeof(d->error_source));
 			/*
 			 * Consider "BACKEND" errors TRANSIENT when trying
 			 * to create an ALPS reservation.
@@ -1140,8 +1140,7 @@ response_data_start(ud_t *d, const XML_Char *el, const XML_Char **atts)
 				}
 			}
 		} else if (strcmp(BASIL_ATR_TYPE, *np) == 0) {
-			strncpy(d->type, *vp, sizeof(d->type) - 1);
-			d->type[sizeof(d->type) - 1] = '\0';
+			pbs_strncpy(d->type, *vp, sizeof(d->type));
 			if ((strcmp(BASIL_VAL_SYSTEM, *vp) != 0) &&
 			    (strcmp(BASIL_VAL_ENGINE, *vp) != 0)) {
 				parse_err_illegal_attr_val(d, *np, *vp);
@@ -1546,8 +1545,7 @@ inventory_start(ud_t *d, const XML_Char *el, const XML_Char **atts)
 		basil11orig = 1;
 	}
 	if (inv->mpp_host[0] == '\0') {
-		strncpy(inv->mpp_host, FAKE_MPP_HOST, sizeof(inv->mpp_host));
-		inv->mpp_host[sizeof(inv->mpp_host)-1] = '\0';
+		pbs_strncpy(inv->mpp_host, FAKE_MPP_HOST, sizeof(inv->mpp_host));
 		basil11orig = 1;
 	}
 
@@ -3557,7 +3555,7 @@ parse_nidlist_char_data(ud_t *d, const char *s, int len)
 				log_err(errno, __func__, "malloc failure");
 				return;
 			}
-			strcpy(knl_node_list, d->current_sys.node_group->nidlist);
+			pbs_strncpy(knl_node_list, d->current_sys.node_group->nidlist, (len + 1));
 		} else {
 			/* Allocate an extra byte for the "," separation between rangelists. */
 			tmp_ptr = realloc(knl_node_list, sizeof(char) * (strlen(knl_node_list) + len + 2));
@@ -4141,7 +4139,7 @@ inventory_loop_on_segments(basil_node_t *node, vnl_t *nv, char *arch,
 
 	} while(socket);
 
-	strncpy(name_buf, vname, VNODE_NAME_LEN);
+	pbs_strncpy(name_buf, vname, VNODE_NAME_LEN);
 	*total_cpu = totcpus;
 	*total_mem = totmem;
 	*total_seg = totseg;
@@ -4220,9 +4218,8 @@ inventory_to_vnodes(basil_response_t *brp)
 		log_err(errno, __func__, "vnl_alloc failed!");
 		return -1;
 	}
-	strncpy(mpphost, brp->data.query.data.inventory.mpp_host,
-		sizeof(mpphost)-1);
-	mpphost[sizeof(mpphost) - 1] = '\0';
+	pbs_strncpy(mpphost, brp->data.query.data.inventory.mpp_host,
+		sizeof(mpphost));
 	nv->vnl_modtime = (long)brp->data.query.data.inventory.timestamp;
 
 	/*
@@ -4908,9 +4905,9 @@ alps_request_parent(int fdin, char *basil_ver)
 		inventory_size = strlen(alps_client_out) + 1;
 
 	if (basil_ver != NULL)
-		strncpy(ud.basil_ver, basil_ver, BASIL_STRING_SHORT);
+		pbs_strncpy(ud.basil_ver, basil_ver, BASIL_STRING_SHORT);
 	else
-		strncpy(ud.basil_ver, BASIL_VAL_UNKNOWN, BASIL_STRING_SHORT);
+		pbs_strncpy(ud.basil_ver, BASIL_VAL_UNKNOWN, BASIL_STRING_SHORT);
 	ud.basil_ver[BASIL_STRING_SHORT - 1] = '\0';
 
 	do {
@@ -5492,9 +5489,8 @@ alps_create_reserve_request(job *pjob, basil_request_reserve_t **req)
 		goto err;
 	sprintf(basil_req->user_name, "%s", pwent->pw_name);
 
-	strncpy(basil_req->batch_id, pjob->ji_qs.ji_jobid,
-		sizeof(basil_req->batch_id)-1);
-	basil_req->batch_id[sizeof(basil_req->batch_id)-1] = '\0';
+	pbs_strncpy(basil_req->batch_id, pjob->ji_qs.ji_jobid,
+		sizeof(basil_req->batch_id));
 
 	/* check for pstate or pgov */
 	for (pres = (resource *)
@@ -5755,7 +5751,7 @@ alps_create_reserve_request(job *pjob, basil_request_reserve_t **req)
 		}
 		if (pgov != NULL) {
 			if (strlen(pgov) < sizeof(p->pgovernor)) {
-				strcpy(p->pgovernor, pgov);
+				pbs_strncpy(p->pgovernor, pgov, sizeof(p->pgovernor));
 			} else {
 				sprintf(log_buffer, "pgov value %s is too long,"
 					" length must be less than %ld",
@@ -7286,7 +7282,7 @@ node_group_start(ud_t *d, const XML_Char *el, const XML_Char **atts)
 
 			if ((strcmp(BASIL_VAL_BATCH_SYS, *vp) == 0) ||
 			    (strcmp(BASIL_VAL_INTERACTIVE_SYS, *vp) == 0))
-				strncpy(node_group->role, *vp, sizeof(node_group->role) - 1);
+				pbs_strncpy(node_group->role, *vp, sizeof(node_group->role));
 			else
 				strcpy(node_group->role, BASIL_VAL_UNKNOWN);
 		} else if (strcmp(BASIL_ATR_STATE, *np) == 0) {
@@ -7301,7 +7297,7 @@ node_group_start(ud_t *d, const XML_Char *el, const XML_Char **atts)
 			    (strcmp(BASIL_VAL_ROUTING_SYS, *vp) == 0) ||
 			    (strcmp(BASIL_VAL_SUSPECT_SYS, *vp) == 0) ||
 			    (strcmp(BASIL_VAL_ADMIN_SYS, *vp) == 0))
-				strncpy(node_group->state, *vp, sizeof(node_group->state) - 1);
+				pbs_strncpy(node_group->state, *vp, sizeof(node_group->state));
 			else
 				strcpy(node_group->state, BASIL_VAL_UNKNOWN);
 		} else if (strcmp(BASIL_ATR_SPEED, *np) == 0) {
@@ -7327,7 +7323,7 @@ node_group_start(ud_t *d, const XML_Char *el, const XML_Char **atts)
 				parse_err_illegal_attr_val(d, *np, *vp);
 				return;
 			}
-			strncpy(node_group->numa_nodes, *vp, sizeof(node_group->numa_nodes) - 1);
+			pbs_strncpy(node_group->numa_nodes, *vp, sizeof(node_group->numa_nodes));
 		} else if (strcmp(BASIL_ATR_DIES, *np) == 0) {
 			if (*node_group->n_dies != '\0') {
 				parse_err_multiple_attrs(d, *np);
@@ -7339,7 +7335,7 @@ node_group_start(ud_t *d, const XML_Char *el, const XML_Char **atts)
 				parse_err_illegal_attr_val(d, *np, *vp);
 				return;
 			}
-			strncpy(node_group->n_dies, *vp, sizeof(node_group->n_dies) - 1);
+			pbs_strncpy(node_group->n_dies, *vp, sizeof(node_group->n_dies));
 		} else if (strcmp(BASIL_ATR_COMPUTE_UNITS, *np) == 0) {
 			if (*node_group->compute_units != '\0') {
 				parse_err_multiple_attrs(d, *np);
@@ -7351,7 +7347,7 @@ node_group_start(ud_t *d, const XML_Char *el, const XML_Char **atts)
 				parse_err_illegal_attr_val(d, *np, *vp);
 				return;
 			}
-			strncpy(node_group->compute_units, *vp, sizeof(node_group->compute_units) - 1);
+			pbs_strncpy(node_group->compute_units, *vp, sizeof(node_group->compute_units));
 		} else if (strcmp(BASIL_ATR_CPUS_PER_CU, *np) == 0) {
 			if (*node_group->cpus_per_cu != '\0') {
 				parse_err_multiple_attrs(d, *np);
@@ -7363,7 +7359,7 @@ node_group_start(ud_t *d, const XML_Char *el, const XML_Char **atts)
 				parse_err_illegal_attr_val(d, *np, *vp);
 				return;
 			}
-			strncpy(node_group->cpus_per_cu, *vp, sizeof(node_group->cpus_per_cu) - 1);
+			pbs_strncpy(node_group->cpus_per_cu, *vp, sizeof(node_group->cpus_per_cu));
 		} else if (strcmp(BASIL_ATR_PAGE_SIZE_KB, *np) == 0) {
 			if (*node_group->pgszl2 != '\0') {
 				parse_err_multiple_attrs(d, *np);
@@ -7417,7 +7413,7 @@ node_group_start(ud_t *d, const XML_Char *el, const XML_Char **atts)
 				parse_err_illegal_attr_val(d, *np, *vp);
 				return;
 			}
-			strncpy(node_group->accel_name, *vp, sizeof(node_group->accel_name) - 1);
+			pbs_strncpy(node_group->accel_name, *vp, sizeof(node_group->accel_name));
 		} else if (strcmp(BASIL_ATR_ACCEL_STATE, *np) == 0) {
 			if (*node_group->accel_state != '\0') {
 				parse_err_multiple_attrs(d, *np);
@@ -7426,7 +7422,7 @@ node_group_start(ud_t *d, const XML_Char *el, const XML_Char **atts)
 
 			if ((strcmp(BASIL_VAL_UP_SYS, *vp) == 0) ||
 			    (strcmp(BASIL_VAL_DOWN_SYS, *vp) == 0))
-				strncpy(node_group->accel_state, *vp, sizeof(node_group->accel_state) - 1);
+				pbs_strncpy(node_group->accel_state, *vp, sizeof(node_group->accel_state));
 			else
 				strcpy(node_group->accel_state, BASIL_VAL_UNKNOWN);
 		} else if (strcmp(BASIL_ATR_NUMA_CFG, *np) == 0) {
@@ -7441,7 +7437,7 @@ node_group_start(ud_t *d, const XML_Char *el, const XML_Char **atts)
 			    (strcmp(BASIL_VAL_SNC4_SYS, *vp) == 0) ||
 			    (strcmp(BASIL_VAL_HEMI_SYS, *vp) == 0) ||
 			    (strcmp(BASIL_VAL_QUAD_SYS, *vp) == 0))
-				strncpy(node_group->numa_cfg, *vp, sizeof(node_group->numa_cfg) - 1);
+				pbs_strncpy(node_group->numa_cfg, *vp, sizeof(node_group->numa_cfg));
 			else {
 				parse_err_illegal_attr_val(d, *np, *vp);
 				return;
@@ -7457,7 +7453,7 @@ node_group_start(ud_t *d, const XML_Char *el, const XML_Char **atts)
 				parse_err_illegal_attr_val(d, *np, *vp);
 				return;
 			}
-			strncpy(node_group->hbmsize, *vp, sizeof(node_group->hbmsize) - 1);
+			pbs_strncpy(node_group->hbmsize, *vp, sizeof(node_group->hbmsize));
 		} else if (strcmp(BASIL_ATR_HBM_CFG, *np) == 0) {
 			if (*node_group->hbm_cfg != '\0') {
 				parse_err_multiple_attrs(d, *np);
@@ -7468,7 +7464,7 @@ node_group_start(ud_t *d, const XML_Char *el, const XML_Char **atts)
 			    (strcmp(BASIL_VAL_25_SYS, *vp) == 0) ||
 			    (strcmp(BASIL_VAL_50_SYS, *vp) == 0) ||
 			    (strcmp(BASIL_VAL_100_SYS, *vp) == 0))
-				strncpy(node_group->hbm_cfg, *vp, sizeof(node_group->hbm_cfg) - 1);
+				pbs_strncpy(node_group->hbm_cfg, *vp, sizeof(node_group->hbm_cfg));
 			else {
 				parse_err_illegal_attr_val(d, *np, *vp);
 				return;

--- a/src/resmom/linux/mom_start.c
+++ b/src/resmom/linux/mom_start.c
@@ -813,7 +813,7 @@ open_master(char **rtn_name)
 		return (-1);
 	}
 
-	(void)strncpy(slavename, newslavename, sizeof(slavename) - 1);
+	pbs_strncpy(slavename, newslavename, sizeof(slavename));
 	assert(rtn_name != NULL);
 	*rtn_name = slavename;
 	return (masterfd);
@@ -845,7 +845,7 @@ open_master(char **rtn_name)
 	static char	ptcchar2[] = "0123456789abcdef";
 	static char	pty_name[PTY_SIZE+1];	/* "/dev/[pt]tyXY" */
 
-	(void)strncpy(pty_name, "/dev/ptyXY", PTY_SIZE);
+	pbs_strncpy(pty_name, "/dev/ptyXY", sizeof(pty_name));
 	for (pc1 = ptcchar1; *pc1 != '\0'; ++pc1) {
 		pty_name[8] = *pc1;
 		for (pc2 = ptcchar2; *pc2 != '\0'; ++pc2) {

--- a/src/resmom/mom_comm.c
+++ b/src/resmom/mom_comm.c
@@ -1915,8 +1915,7 @@ addr_to_hostname(struct sockaddr_in *ap)
 		hostname_sz = new_sz;
 		ret_hostname = tmp_str;
 	}
-	strncpy(ret_hostname, hp->h_name, hostname_sz);
-	ret_hostname[hostname_sz - 1] = '\0';
+	pbs_strncpy(ret_hostname, hp->h_name, hostname_sz);
 	return (ret_hostname);
 }
 /**
@@ -3093,12 +3092,12 @@ im_request(int stream, int version)
 			psatl = (svrattrl *)GET_NEXT(lhead);
 			while (psatl) {
 				if (!strcmp(psatl->al_name, ATTR_hashname)) {
-					strncpy(basename, psatl->al_value, MAXPATHLEN);
+					pbs_strncpy(basename, psatl->al_value, sizeof(basename));
 					break;
 				}
 				psatl = (svrattrl *)GET_NEXT(psatl->al_link);
 			}
-			strncpy(pjob->ji_qs.ji_jobid, jobid, PBS_MAXSVRJOBID);
+			pbs_strncpy(pjob->ji_qs.ji_jobid, jobid, sizeof(pjob->ji_qs.ji_jobid));
 			if (strlen(basename) <= PBS_JOBBASE)
 				strcpy(pjob->ji_qs.ji_fileprefix, basename);
 			else
@@ -3717,7 +3716,7 @@ join_err:
 				 * been deleted already.
 				 */
 				if ((pjob2 = job_alloc()) != NULL) {
-					(void)strncpy(pjob2->ji_qs.ji_jobid, jobid, PBS_MAXSVRJOBID);
+					pbs_strncpy(pjob2->ji_qs.ji_jobid, jobid, sizeof(pjob2->ji_qs.ji_jobid));
 					pjob2->ji_wattr[(int)JOB_ATR_run_version].at_val.at_long =
 								runver;
 					pjob2->ji_wattr[(int)JOB_ATR_run_version].at_flags |= ATR_VFLAG_SET;

--- a/src/resmom/mom_hook_func.c
+++ b/src/resmom/mom_hook_func.c
@@ -936,8 +936,8 @@ run_hook(hook *phook, unsigned int event_type, mom_hook_input_t *hook_input,
 
 	snprintf(path_hooks_rescdef, MAXPATHLEN, "%s%s", path_hooks, PBS_RESCDEF);
 
-	strncpy(hook_config_path, ((struct python_script *)phook->script)->path,
-		sizeof(hook_config_path)-1);
+	pbs_strncpy(hook_config_path, ((struct python_script *)phook->script)->path,
+		sizeof(hook_config_path));
 	p = strstr(hook_config_path, HOOK_SCRIPT_SUFFIX);
 	if (p != NULL) {
 		/* replace <HOOK_SCRIPT_SUFFIX> with <HOOK_CONFIG_SUFFIX>: */
@@ -1010,9 +1010,9 @@ run_hook(hook *phook, unsigned int event_type, mom_hook_input_t *hook_input,
 		pjob->ji_qs.ji_un.ji_momt.ji_exgid = \
 					pjob->ji_grpcache->gc_gid;
 
-		strncpy(script_path,
+		pbs_strncpy(script_path,
 			((struct python_script *)phook->script)->path,
-			MAXPATHLEN);
+			sizeof(script_path));
 
 		/* copy hook_config_path to user-accessible */
 		/* [PBS_HOME]/path_spool. */
@@ -1628,9 +1628,9 @@ run_hook_exit:
 			(file_data != NULL)) {
 			(void)rename(hook_datafile, file_data);
 		}
-		strncpy(script_path,
+		pbs_strncpy(script_path,
 			((struct python_script *)phook->script)->path,
-			MAXPATHLEN);
+			sizeof(script_path));
 		pc = strrchr(script_path, '/');
 		if (pc == NULL) {
 			pc = (char *)script_path;
@@ -2021,9 +2021,9 @@ get_hook_results(char *input_file, int *accept_flag, int *reject_flag,
 	/* pbs_event().hook_euser=<value> entries.  In that case, hook_euser */
 	/* is reset to the <value>.  A null string <value> means PBSADMIN.   */
 	if (phook && pjob &&  (phook->user == HOOK_PBSUSER)) {
-		strncpy(hook_euser,
+		pbs_strncpy(hook_euser,
 			pjob->ji_wattr[(int)JOB_ATR_euser].at_val.at_str,
-			PBS_MAXUSER);
+			sizeof(hook_euser));
 	}
 
 	if ((input_file != NULL) && (*input_file != '\0')) {
@@ -2267,7 +2267,7 @@ get_hook_results(char *input_file, int *accept_flag, int *reject_flag,
 
 		if (strcmp(obj_name, EVENT_OBJECT) == 0) {
 			if (strcmp(name_str, "hook_euser") == 0) {
-				strncpy(hook_euser, data_value, PBS_MAXUSER);
+				pbs_strncpy(hook_euser, data_value, sizeof(hook_euser));
 				start_new_vnl = 1;
 				/* Need to also clear 'hvnlp' as previous  */
 				/* one would have already been saved in */
@@ -2293,8 +2293,8 @@ get_hook_results(char *input_file, int *accept_flag, int *reject_flag,
 					*reject_flag = 0;
 			} else if ((reject_msg != NULL) &&
 				(strcmp(name_str, "reject_msg") == 0)) {
-				strncpy(reject_msg, data_value,
-					reject_msg_size-1);
+				pbs_strncpy(reject_msg, data_value,
+					reject_msg_size);
 			} else if (strcmp(name_str, PY_EVENT_PARAM_PROGNAME) == 0) {
 				char	**prog;
 				if (hook_output != NULL) {
@@ -2780,7 +2780,7 @@ get_hook_results(char *input_file, int *accept_flag, int *reject_flag,
 			} else if ((reboot_cmd != NULL) &&
 				(strcmp(name_str,
 				PBS_REBOOT_CMD_OBJECT) == 0)) {
-				strncpy(reboot_cmd, data_value, HOOK_BUF_SIZE-1);
+				pbs_strncpy(reboot_cmd, data_value, HOOK_BUF_SIZE);
 			}
 		}
 
@@ -2857,9 +2857,9 @@ do_reboot(char *reboot_cmd)
 	int	rcode;
 
 	if ((reboot_cmd == NULL) || (*reboot_cmd == '\0'))
-		strncpy(bootcmd, REBOOT_CMD, HOOK_BUF_SIZE-1);
+		pbs_strncpy(bootcmd, REBOOT_CMD, sizeof(bootcmd));
 	else
-		strncpy(bootcmd, reboot_cmd, HOOK_BUF_SIZE-1);
+		pbs_strncpy(bootcmd, reboot_cmd, sizeof(bootcmd));
 
 	snprintf(log_buffer, sizeof(log_buffer), "issuing cmd %s", bootcmd);
 	log_event(PBSEVENT_DEBUG3, 0,

--- a/src/resmom/mom_server.c
+++ b/src/resmom/mom_server.c
@@ -437,7 +437,7 @@ process_IS_CMD(int stream)
 	}
 
 	request->rq_conn = stream;
-	strcpy(request->rq_host, netaddr(addr));
+	pbs_strncpy(request->rq_host, netaddr(addr), sizeof(request->rq_host));
 	request->rq_fromsvr = 1;
 	request->prot = PROT_TPP;
 	request->tppcmd_msgid = msgid;

--- a/src/resmom/mom_vnode.c
+++ b/src/resmom/mom_vnode.c
@@ -412,7 +412,8 @@ static void
 resadj(vnl_t *vp, const char *vnid, const char *res, enum res_op op,
 	unsigned int adjval)
 {
-	int		i, j;
+	int	i, j;
+	char	*vna_newval;
 
 	sprintf(log_buffer, "vnode %s, resource %s, res_op %d, adjval %u",
 		vnid, res, (int) op, adjval);
@@ -475,25 +476,14 @@ resadj(vnl_t *vp, const char *vnid, const char *res, enum res_op op,
 				 *	the adjusted one.  This may involve
 				 *	surgery on the vna_t.
 				 */
-				if (op == RES_DECR) {
-					/*
-					 *	Since the resource value is now
-					 *	smaller than before, it ought to
-					 *	fit in the space that holds the
-					 *	current value.
-					 */
-					strcpy(vnap->vna_val, valbuf);
+				vna_newval = strdup(valbuf);
+				if (vna_newval != NULL) {
+					free(vnap->vna_val);
+					vnap->vna_val = vna_newval;
 				} else {
-					char	*vna_newval = strdup(valbuf);
-
-					if (vna_newval != NULL) {
-						free(vnap->vna_val);
-						vnap->vna_val = vna_newval;
-					} else {
-						log_event(PBSEVENT_ERROR, 0,
-							LOG_ERR, __func__,
-							"vna_newval strdup failed");
-					}
+					log_event(PBSEVENT_ERROR, 0,
+						LOG_ERR, __func__,
+						"vna_newval strdup failed");
 				}
 				return;
 			}

--- a/src/resmom/mom_vnode.c
+++ b/src/resmom/mom_vnode.c
@@ -480,11 +480,8 @@ resadj(vnl_t *vp, const char *vnid, const char *res, enum res_op op,
 				if (vna_newval != NULL) {
 					free(vnap->vna_val);
 					vnap->vna_val = vna_newval;
-				} else {
-					log_event(PBSEVENT_ERROR, 0,
-						LOG_ERR, __func__,
-						"vna_newval strdup failed");
-				}
+				} else
+					log_err(PBSE_SYSTEM, __func__, "vna_newval strdup failed");
 				return;
 			}
 		}

--- a/src/resmom/requests.c
+++ b/src/resmom/requests.c
@@ -256,10 +256,10 @@ fork_to_user(struct batch_request *preq, job *pjob)
 	} else
 		return (INVALID_HANDLE_VALUE);
 
-	strncpy(lpath, save_actual_homedir(pwdp, pjob), MAXPATHLEN + 1);
+	pbs_strncpy(lpath, save_actual_homedir(pwdp, pjob), sizeof(lpath));
 	CreateDirectory(lpath, 0); /* user homedir may not exist yet */
 	if (chdir(lpath) == -1) {
-		strcpy(lpath, set_homedir_to_local_default(pjob, preq->rq_ind.rq_cpyfile.rq_user));
+		pbs_strncpy(lpath, set_homedir_to_local_default(pjob, preq->rq_ind.rq_cpyfile.rq_user), sizeof(lpath));
 		CreateDirectory(lpath, 0); /* user homedir may not exist yet */
 		(void) chdir(lpath);
 	}
@@ -2246,13 +2246,13 @@ del_files(struct rq_cpyfile *rqcpf, job *pjob, char **pbadfile)
 		if (*rmt_file != '\0')
 			strcpy(prmt, rmt_file);
 		else
-			strcpy(prmt, pair->fp_rmt);
+			pbs_strncpy(prmt, pair->fp_rmt, sizeof(prmt));
 		path[0] = '\0';
 		if (pair->fp_flag == STDJOBFILE) { /* standard out or error */
 #ifndef NO_SPOOL_OUTPUT
 			if (!sandbox_private) {
 				DBPRT(("%s:, STDJOBFILE in %s\n", __func__, path_spool))
-				(void) strcpy(path, path_spool);
+				pbs_strncpy(path, path_spool, sizeof(path));
 			}
 #endif /* NO_SPOOL_OUTPUT */
 		}
@@ -2324,8 +2324,7 @@ del_files(struct rq_cpyfile *rqcpf, job *pjob, char **pbadfile)
 			/* has prefix path, save parent directory name */
 			int len = (int) (ps - path) + 1;
 
-			strncpy(dname, path, len);
-			dname[len] = '\0';
+			pbs_strncpy(dname, path, len);
 			ps++;
 		} else { /* no prefix path */
 			/*
@@ -2739,7 +2738,7 @@ req_cpyfile(struct batch_request *preq)
 		 * attribute, so we call map_unc_path to get it now
 		 */
 		if ((pw=getpwnam(preq->rq_ind.rq_cpyfile.rq_user)) != NULL) {
-			strncpy(actual_homedir,
+			pbs_strncpy(actual_homedir,
 				map_unc_path(pw->pw_dir, pw), sizeof(actual_homedir));
 			pbs_jobdir = jobdirname(rqcpf->rq_jobid, actual_homedir);
 		} else {
@@ -3310,7 +3309,7 @@ req_cpyfile(struct batch_request *preq)
 		rmjobdir(rqcpf->rq_jobid, pbs_jobdir, useruid, usergid);
 	}
 
-	strncpy(dup_rqcpf_jobid, rqcpf->rq_jobid, sizeof(dup_rqcpf_jobid) - 1);
+	pbs_strncpy(dup_rqcpf_jobid, rqcpf->rq_jobid, sizeof(dup_rqcpf_jobid));
 	if (preq->prot == PROT_TCP) {
 		if (stage_inout.bad_files) {
 			reply_text(preq, PBSE_NOCOPYFILE, stage_inout.bad_list);
@@ -3565,7 +3564,7 @@ mom_checkpoint_job(job *pjob, int abort)
 	DBPRT(("mom_checkpoint_job: %s %s abort\n", pjob->ji_qs.ji_jobid,
 		abort ? "with" : "no"))
 
-	strcpy(path, path_checkpoint);
+	pbs_strncpy(path, path_checkpoint, sizeof(path));
 	if (*pjob->ji_qs.ji_fileprefix != '\0')
 		strcat(path, pjob->ji_qs.ji_fileprefix);
 	else
@@ -3827,7 +3826,7 @@ post_chkpt(job *pjob, int  ev)
 	/*
 	 ** Set the TI_FLAGS_CHKPT flag for each task that was checkpointed.
 	 */
-	strcpy(path, path_checkpoint);
+	pbs_strncpy(path, path_checkpoint, sizeof(path));
 	if (*pjob->ji_qs.ji_fileprefix != '\0')
 		strcat(path, pjob->ji_qs.ji_fileprefix);
 	else
@@ -4172,7 +4171,7 @@ mom_restart_job(job *pjob)
 		goto done;
 	}
 
-	strcpy(path, path_checkpoint);
+	pbs_strncpy(path, path_checkpoint, sizeof(path));
 	if (*pjob->ji_qs.ji_fileprefix != '\0')
 		strcat(path, pjob->ji_qs.ji_fileprefix);
 	else

--- a/src/resmom/start_exec.c
+++ b/src/resmom/start_exec.c
@@ -113,7 +113,6 @@ extern	int		lockfds;
 extern	pbs_list_head	mom_polljobs;
 extern	int		next_sample_time;
 extern	int		min_check_poll;
-extern	char		*path_checkpoint;
 extern	char		*path_jobs;
 extern	char		*path_prolog;
 extern	char		*path_spool;
@@ -1929,10 +1928,8 @@ generate_pbs_nodefile(job *pjob, char *nodefile, int nodefile_sz,
 	}
 	fclose(nhow);
 
-	if ((nodefile != NULL) && (nodefile_sz > 0)) {
-		strncpy(nodefile, pbs_nodefile, nodefile_sz);
-		nodefile[nodefile_sz-1] = '\0';
-	}
+	if ((nodefile != NULL) && (nodefile_sz > 0))
+		pbs_strncpy(nodefile, pbs_nodefile, nodefile_sz);
 
 	return (0);
 }
@@ -5718,8 +5715,7 @@ job_nodes_inner(struct job *pjob, hnodent **mynp)
 					if (pbs_conf.pbs_leaf_name) {
 						if (strcmp(pbs_conf.pbs_leaf_name, node_name) != 0) {
 							/* PBS_LEAF_NAME has changed or node_name is uninitialized */
-							strncpy(node_name, pbs_conf.pbs_leaf_name, PBS_MAXHOSTNAME);
-							node_name[PBS_MAXHOSTNAME] = '\0';
+							pbs_strncpy(node_name, pbs_conf.pbs_leaf_name, sizeof(node_name));
 							/* Need to canonicalize PBS_LEAF_NAME */
 							if (get_fullhostname(node_name, canonical_name,
 									(sizeof(canonical_name) - 1)) != 0) {
@@ -5735,11 +5731,9 @@ job_nodes_inner(struct job *pjob, hnodent **mynp)
 					} else {
 						if (strcmp(mom_host, node_name) != 0) {
 							/* mom_host has changed or node_name is uninitialized */
-							strncpy(node_name, mom_host, PBS_MAXHOSTNAME);
-							node_name[PBS_MAXHOSTNAME] = '\0';
+							pbs_strncpy(node_name, mom_host, sizeof(node_name));
 							/* mom_host contains the canonical name */
-							strncpy(canonical_name, mom_host, PBS_MAXHOSTNAME);
-							canonical_name[PBS_MAXHOSTNAME] = '\0';
+							pbs_strncpy(canonical_name, mom_host, sizeof(canonical_name));
 						}
 					}
 
@@ -5876,8 +5870,8 @@ job_nodes_inner(struct job *pjob, hnodent **mynp)
 						return (PBSE_INTERNAL);
 					}
 					hp->hn_vlist = phv;
-					strncpy(phv[hp->hn_vlnum].hv_vname, nodep,
-						PBS_MAXNODENAME);
+					pbs_strncpy(phv[hp->hn_vlnum].hv_vname, nodep,
+						sizeof(phv[hp->hn_vlnum].hv_vname));
 					phv[hp->hn_vlnum].hv_ncpus = vnncpus;
 					phv[hp->hn_vlnum].hv_mem   = ndmem;
 					hp->hn_vlnum++;
@@ -6468,7 +6462,7 @@ create_file_securely(char *path, uid_t exuid, gid_t exgid)
 	/* create a uniquely named file using mkstemp() */
 	/* for that we need to setup the template       */
 
-	strncpy(buf, path, MAXPATHLEN);
+	pbs_strncpy(buf, path, sizeof(buf));
 	pc   = strrchr(buf, '/');  /* last slash in path */
 	if (pc == NULL)
 		return (-1);

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -2744,7 +2744,7 @@ parse_sched_obj(struct batch_status *status)
 					log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__, MEM_ERR_MSG);
 					goto cleanup;
 				}
-				strncpy(comment, "Unable to change the sched_log directory", MAX_LOG_SIZE - 1);
+				strcpy(comment, "Unable to change the sched_log directory");
 				patt = attribs;
 				patt->name = ATTR_comment;
 				patt->value = comment;
@@ -2783,13 +2783,13 @@ parse_sched_obj(struct batch_status *status)
 				if (c != 0) {
 					log_eventf(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__,
 						"PBS failed validation checks for directory %s", tmp_priv_dir);
-					strncpy(comment, "PBS failed validation checks for sched_priv directory", MAX_LOG_SIZE -1);
+					strcpy(comment, "PBS failed validation checks for sched_priv directory");
 					priv_dir_update_fail = 1;
 				}
 #endif  /* not DEBUG and not NO_SECURITY_CHECK */
 			if (c == 0) {
 				if (chdir(tmp_priv_dir) == -1) {
-					strncpy(comment, "PBS failed validation checks for sched_priv directory", MAX_LOG_SIZE -1);
+					strcpy(comment, "PBS failed validation checks for sched_priv directory");
 					log_eventf(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__,
 						"PBS failed validation checks for directory %s", tmp_priv_dir);
 					priv_dir_update_fail = 1;
@@ -2797,7 +2797,7 @@ parse_sched_obj(struct batch_status *status)
 					int lockfds;
 					lockfds = open("sched.lock", O_CREAT|O_WRONLY, 0644);
 					if (lockfds < 0) {
-						strncpy(comment, "PBS failed validation checks for sched_priv directory", MAX_LOG_SIZE -1);
+						strcpy(comment, "PBS failed validation checks for sched_priv directory");
 						log_eventf(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__,
 							"PBS failed validation checks for directory %s", tmp_priv_dir);
 						priv_dir_update_fail = 1;
@@ -2827,7 +2827,7 @@ parse_sched_obj(struct batch_status *status)
 			attribs = calloc(2, sizeof(struct attropl));
 			if (attribs == NULL) {
 				log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__, MEM_ERR_MSG);
-				strncpy(comment, "Unable to change the sched_priv directory", MAX_LOG_SIZE);
+				strcpy(comment, "Unable to change the sched_priv directory");
 				goto cleanup;
 			}
 			patt = attribs;

--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -3977,8 +3977,7 @@ create_subjob_name(char *array_id, int index)
 	if (*rest != ']')
 		return NULL;
 
-	strncpy(tmpid, array_id, spn+1);
-	tmpid[spn+1] = '\0';
+	pbs_strncpy(tmpid, array_id, spn+2);
 	sprintf(buf, "%s%d%s", tmpid, index, rest);
 
 	return string_dup(buf);

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -981,7 +981,7 @@ set_node_info_state(node_info *ninfo, char *state)
 		ninfo->is_resv_exclusive = ninfo->is_job_exclusive = 0;
 		ninfo->is_sleeping = ninfo->is_maintenance = 0;
 
-		pbs_strncpy(statebuf, state, sizeof(statebuf));
+		strcpy(statebuf, state);
 		tok = strtok_r(statebuf, ",", &saveptr);
 
 		while (tok != NULL) {
@@ -2726,10 +2726,8 @@ eval_placement(status *policy, selspec *spec, node_info **ninfo_arr, place *pl,
 						}
 					}
 					else {
-						if (hostsets[i]->free_nodes == 0) {
-							strncpy(reason, "No free nodes available", MAX_LOG_SIZE - 1);
-							reason[MAX_LOG_SIZE - 1] = '\0';
-						}
+						if (hostsets[i]->free_nodes == 0)
+							strcpy(reason, "No free nodes available");
 						else
 							translate_fail_code(err, NULL, reason);
 
@@ -2797,10 +2795,8 @@ eval_placement(status *policy, selspec *spec, node_info **ninfo_arr, place *pl,
 						}
 					}
 					else {
-						if (hostsets[i]->free_nodes == 0) {
-							strncpy(reason, "No free nodes available", MAX_LOG_SIZE - 1);
-							reason[MAX_LOG_SIZE - 1] = '\0';
-						}
+						if (hostsets[i]->free_nodes == 0)
+							strcpy(reason, "No free nodes available");
 						else
 							translate_fail_code(err, NULL, reason);
 
@@ -2900,10 +2896,8 @@ eval_placement(status *policy, selspec *spec, node_info **ninfo_arr, place *pl,
 						}
 					}
 					else {
-						if (hostsets[i]->free_nodes ==0) {
-							strncpy(reason, "No free nodes available", MAX_LOG_SIZE - 1);
-							reason[MAX_LOG_SIZE - 1] = '\0';
-						}
+						if (hostsets[i]->free_nodes ==0)
+							strcpy(reason, "No free nodes available");
 						else
 							translate_fail_code(err, NULL, reason);
 
@@ -4438,7 +4432,7 @@ create_execvnode(nspec **ns)
 
 	for (i = 0; ns[i] != NULL; i++) {
 		if (i > 0)
-			pbs_strncpy(buf, "+", bufsize);
+			strcpy(buf, "+");
 		else
 			buf[0] = '\0';
 
@@ -4469,7 +4463,7 @@ create_execvnode(nspec **ns)
 					return NULL;
 			}
 			else if (ns[i]->go_provision && strcmp(req->name, "aoe") ==0) {
-				pbs_strncpy(buf2, ":aoe=", sizeof(buf2));
+				strcpy(buf2, ":aoe=");
 				if (pbs_strcat(&buf, &bufsize, buf2) == NULL)
 					return NULL;
 				if (pbs_strcat(&buf, &bufsize, req->res_str) == NULL)

--- a/src/scheduler/parse.c
+++ b/src/scheduler/parse.c
@@ -365,7 +365,7 @@ parse_config(char *fname)
 					 * done by default prior to 7.1.
 					 */
 					if (strstr(config_value, "host") == NULL)
-						pbs_strncpy(buf2, "host,", sizeof(buf2));
+						strcpy(buf2, "host,");
 
 					/* hack: add in "vnode" in 8.0 */
 					if (strstr(config_value, "vnode") == NULL)

--- a/src/scheduler/pbs_sched.c
+++ b/src/scheduler/pbs_sched.c
@@ -486,10 +486,8 @@ badconn(char *msg)
 			strcat(buf, hold);
 		}
 	}
-	else {
-		strncpy(buf, phe->h_name, sizeof(buf));
-		buf[sizeof(buf)-1] = '\0';
-	}
+	else
+		pbs_strncpy(buf, phe->h_name, sizeof(buf));
 
 	sprintf(log_buffer, "%s on port %u %s",
 #ifdef NAS /* localmod 005 */

--- a/src/scheduler/pbsfs.c
+++ b/src/scheduler/pbsfs.c
@@ -181,8 +181,7 @@ main(int argc, char *argv[])
 				struct attrl *cur_attrl;
 				for (cur_attrl = cur_bs->attribs; cur_attrl != NULL; cur_attrl = cur_attrl->next) {
 					if (strcmp(cur_attrl->name, ATTR_sched_priv) == 0) {
-						strncpy(path_buf, cur_attrl->value, sizeof(path_buf));
-						path_buf[sizeof(path_buf) - 1] = '\0';
+						pbs_strncpy(path_buf, cur_attrl->value, sizeof(path_buf));
 						break;
 					}
 				}

--- a/src/scheduler/simulate.c
+++ b/src/scheduler/simulate.c
@@ -576,19 +576,19 @@ perform_event(status *policy, timed_event *event)
 			}
 			break;
 		case TIMED_POLICY_EVENT:
-			pbs_strncpy(logbuf, "Policy change", sizeof(logbuf));
+			strcpy(logbuf, "Policy change");
 			break;
 		case TIMED_DED_START_EVENT:
-			pbs_strncpy(logbuf, "Dedtime Start", sizeof(logbuf));
+			strcpy(logbuf, "Dedtime Start");
 			break;
 		case TIMED_DED_END_EVENT:
-			pbs_strncpy(logbuf, "Dedtime End", sizeof(logbuf));
+			strcpy(logbuf, "Dedtime End");
 			break;
 		case TIMED_NODE_UP_EVENT:
-			pbs_strncpy(logbuf, "Node Up", sizeof(logbuf));
+			strcpy(logbuf, "Node Up");
 			break;
 		case TIMED_NODE_DOWN_EVENT:
-			pbs_strncpy(logbuf, "Node Down", sizeof(logbuf));
+			strcpy(logbuf, "Node Down");
 			break;
 		default:
 			log_event(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_INFO,

--- a/src/server/job_func.c
+++ b/src/server/job_func.c
@@ -807,7 +807,7 @@ del_chkpt_files(job *pjob)
 	char namebuf[MAXPATHLEN + 1] = {'\0'};
 
 	if (path_checkpoint != NULL) {	/* delete checkpoint files */
-		(void)strcpy(namebuf, path_checkpoint);
+		pbs_strncpy(namebuf, path_checkpoint, sizeof(namebuf));
 		if (*pjob->ji_qs.ji_fileprefix != '\0')
 			(void)strcat(namebuf, pjob->ji_qs.ji_fileprefix);
 		else

--- a/test/tests/functional/pbs_qstat_formats.py
+++ b/test/tests/functional/pbs_qstat_formats.py
@@ -79,9 +79,7 @@ class TestQstatFormats(TestFunctional):
             attr = line.split("=")
             if not re.match(r'[\t]', attr[0]):
                 attrs_qstatf.append(attr[0].strip())
-        print (attrs_qstatf)
         attrs_qstatf.pop()
-        print (attrs_qstatf)
         ret = self.du.run_cmd(self.server.hostname, cmd=qstat_cmd_dsv)
         qstat_attrs = []
         for line in ret['out']:
@@ -92,9 +90,7 @@ class TestQstatFormats(TestFunctional):
         for item in attr_vals:
             qstat_attr = item.split("=")
             qstat_attrs.append(qstat_attr[0])
-        print (qstat_attrs)
         for attr in attrs_qstatf:
-            print (attr)
             if attr not in qstat_attrs:
                 self.assertFalse(attr + " is missing")
 

--- a/test/tests/functional/pbs_qstat_formats.py
+++ b/test/tests/functional/pbs_qstat_formats.py
@@ -79,7 +79,9 @@ class TestQstatFormats(TestFunctional):
             attr = line.split("=")
             if not re.match(r'[\t]', attr[0]):
                 attrs_qstatf.append(attr[0].strip())
+        print (attrs_qstatf)
         attrs_qstatf.pop()
+        print (attrs_qstatf)
         ret = self.du.run_cmd(self.server.hostname, cmd=qstat_cmd_dsv)
         qstat_attrs = []
         for line in ret['out']:
@@ -90,7 +92,9 @@ class TestQstatFormats(TestFunctional):
         for item in attr_vals:
             qstat_attr = item.split("=")
             qstat_attrs.append(qstat_attr[0])
+        print (qstat_attrs)
         for attr in attrs_qstatf:
+            print (attr)
             if attr not in qstat_attrs:
                 self.assertFalse(attr + " is missing")
 

--- a/test/tests/functional/pbs_svr_dyn_res.py
+++ b/test/tests/functional/pbs_svr_dyn_res.py
@@ -63,8 +63,7 @@ class TestServerDynRes(TestFunctional):
         self.scheduler.get_pid()
         self.scheduler.signal('-HUP')
         self.scheduler.log_match(fp + ' file has a non-secure file access',
-                                 starttime=match_from, existence=exist,
-                                 max_attempts=10)
+                                 starttime=match_from, existence=exist)
 
     def setup_dyn_res(self, resname, restype, script_body):
         """


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Moving some of the calls of strcpy to pbs_strncpy in mom, cmds and scheduler.

#### Describe Your Change
This is mostly for refactoring code. I've replaced calls of strcpy to pbs_strncpy for the cases where both destination and src buffers were of different lengths and where we were not sure of the length of source.
I've also modified pbs_strncpy to use strcpy as much as possible (because strcpy gives better performance).

#### Link to Design Doc
NA


#### Attach Test and Valgrind Logs/Output
Description: Rerun All Tests From #3424
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|3435|3439|4|0|0|2|3433|

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
