### PR TITLE
Job array optimization in run path

### DIFF
--- a/src/include/Makefile.am
+++ b/src/include/Makefile.am
@@ -101,6 +101,7 @@ noinst_HEADERS = \
 	provision.h \
 	qmgr.h \
 	queue.h \
+	range.h \
 	reservation.h \
 	resmon.h \
 	resource.h \

--- a/src/include/job.h
+++ b/src/include/job.h
@@ -45,6 +45,7 @@ extern "C" {
 
 #include "list_link.h"
 #include "attribute.h"
+#include "range.h"
 /*
  * job.h - structure definations for job objects
  *
@@ -346,6 +347,7 @@ struct ajtrkhd {
 	int tkm_flags;			  /* special flags for array job */
 	int tkm_subjsct[PBS_NUMJOBSTATE]; /* count of subjobs in various states */
 	int tkm_dsubjsct;		  /* count of deleted subjobs */
+	range * trk_rlist;			/* pointer to range list */
 	struct ajtrk tkm_tbl[1];	  /* ptr to array of individual entries */
 	/*
 	 * when table is malloced, room for the additional required number

--- a/src/include/job.h
+++ b/src/include/job.h
@@ -347,7 +347,7 @@ struct ajtrkhd {
 	int tkm_flags;			  /* special flags for array job */
 	int tkm_subjsct[PBS_NUMJOBSTATE]; /* count of subjobs in various states */
 	int tkm_dsubjsct;		  /* count of deleted subjobs */
-	range * trk_rlist;			/* pointer to range list */
+	range *trk_rlist;			/* pointer to range list */
 	struct ajtrk tkm_tbl[1];	  /* ptr to array of individual entries */
 	/*
 	 * when table is malloced, room for the additional required number

--- a/src/include/range.h
+++ b/src/include/range.h
@@ -41,8 +41,6 @@
 #ifndef _RANGE_H
 #define _RANGE_H
 
-#include "data_types.h"
-
 /**
  * Control whether to consider stepping or not
  */
@@ -50,6 +48,22 @@ enum range_step_type {
 	DISABLE_SUBRANGE_STEPPING,
 	ENABLE_SUBRANGE_STEPPING
 };
+
+typedef struct range range;
+
+struct range
+{
+	int start;
+	int end;
+	int step;
+	int count;
+	range *next;
+};
+
+/* Error message when we fail to allocate memory */
+#define MEM_ERR_MSG "Unable to allocate memory (malloc error)"
+
+#define INIT_ARR_SIZE 2048
 
 /*
  *	new_range - allocate and initialize a range structure
@@ -107,16 +121,15 @@ int range_contains_single(range *r, int val);
 
 /*
  *	range_remove_value - remove a value from a range list
- *	NOTE: only supports removing values from either the start or end
- *	      of a range, not in the middle
+ *
  */
 int range_remove_value(range **r, int val);
 
 /*
- *	range_add_value - add a value to a range list by adding it to the end
- *			  of the list
+ *	range_add_value - add a value to a range list 
+ *
  */
-int range_add_value(range *r, int val, enum range_step_type type);
+int range_add_value(range **r, int val, int range_step);
 
 /*
  *	range_intersection - create an intersection between two ranges

--- a/src/include/range.h
+++ b/src/include/range.h
@@ -49,29 +49,27 @@ enum range_step_type {
 	ENABLE_SUBRANGE_STEPPING
 };
 
-typedef struct range range;
-
-struct range
+typedef struct range
 {
 	int start;
 	int end;
 	int step;
 	int count;
-	range *next;
-};
+	struct range *next;
+} range;
 
 /* Error message when we fail to allocate memory */
-#define MEM_ERR_MSG "Unable to allocate memory (malloc error)"
+#define RANGE_MEM_ERR_MSG "Unable to allocate memory (malloc error)"
 
-#define INIT_ARR_SIZE 2048
+#define INIT_RANGE_ARR_SIZE 2048
 
 /*
  *	new_range - allocate and initialize a range structure
  */
 #ifdef NAS /* localmod 005 */
-range *new_range(void);
+range *new_range(int start, int end, int step, int count, range *next);
 #else
-range *new_range();
+range *new_range(int start, int end, int step, int count, range *next);
 #endif /* localmod 005 */
 
 /*

--- a/src/include/range.h
+++ b/src/include/range.h
@@ -66,11 +66,8 @@ typedef struct range
 /*
  *	new_range - allocate and initialize a range structure
  */
-#ifdef NAS /* localmod 005 */
+
 range *new_range(int start, int end, int step, int count, range *next);
-#else
-range *new_range(int start, int end, int step, int count, range *next);
-#endif /* localmod 005 */
 
 /*
  *	free_range_list - free a list of ranges

--- a/src/lib/Libutil/Makefile.am
+++ b/src/lib/Libutil/Makefile.am
@@ -60,7 +60,8 @@ libutil_a_SOURCES = \
 	pbs_array_list.c \
 	pbs_secrets.c \
 	pbs_aes_encrypt.c \
-	pbs_idx.c
+	pbs_idx.c \
+        range.c 
 
 if UNDOLR_ENABLED
 libutil_a_SOURCES += undolr.c

--- a/src/lib/Libutil/Makefile.am
+++ b/src/lib/Libutil/Makefile.am
@@ -61,7 +61,7 @@ libutil_a_SOURCES = \
 	pbs_secrets.c \
 	pbs_aes_encrypt.c \
 	pbs_idx.c \
-        range.c 
+	range.c 
 
 if UNDOLR_ENABLED
 libutil_a_SOURCES += undolr.c

--- a/src/lib/Libutil/range.c
+++ b/src/lib/Libutil/range.c
@@ -267,9 +267,9 @@ range_parse(char *str)
 
 			p = endp;
 		}
-	} while (!ret && *endp == ',');
+	} while (!ret);
 
-	if (ret) {
+	if (ret == -1) {
 		free_range_list(head);
 		return NULL;
 	}
@@ -428,10 +428,10 @@ range_remove_value(range **r, int val)
 			cur->count--;
 			done = 1;
 		} else if ((val > cur->start) && (val < cur->end)) {
-			range * next_range = NULL;
-			if ((next_range = new_range(0, 0, 1, 0, NULL)) == NULL) {
+			range *next_range = NULL;
+			if ((next_range = new_range(0, 0, 1, 0, NULL)) == NULL)
 				return 0;
-			}
+				
 			next_range->count = (cur->end - val)/cur->step;
 			next_range->step = cur->step;
 			next_range->start = val + cur->step;
@@ -566,7 +566,7 @@ range_add_value(range **r, int val, int range_step)
 			return 1;
 		} else {
 			/* Add new range at the end with same value */
-			range * end_range = NULL;
+			range *end_range = NULL;
 			if ((end_range = new_range(val, val, cur->step, 1, NULL)) == NULL) {
 				return 0;
 			}
@@ -635,6 +635,9 @@ parse_subjob_index(char *pc, char **ep, int *pstart, int *pend, int *pstep, int 
 	int end;
 	int step;
 	char *eptr;
+	
+	if (pc == NULL)
+		return (-1);
 
 	while (isspace((int) *pc) || (*pc == ','))
 		pc++;
@@ -739,7 +742,7 @@ range_to_str(range *r)
 		else
 			sprintf(numbuf, "%d", cur_r->start);
 
-		if (cur_r->step > 1) {
+		if (cur_r->step > 1 && cur_r->count > 1 ) {
 			if (pbs_strcat(&range_str, &size, numbuf) == NULL)
 				return "";
 			sprintf(numbuf, ":%d", cur_r->step);

--- a/src/scheduler/Makefile.am
+++ b/src/scheduler/Makefile.am
@@ -104,8 +104,6 @@ libpbs_sched_a_SOURCES = \
 	queue.h \
 	queue_info.c \
 	queue_info.h \
-	range.c \
-	range.h \
 	resource.h \
 	resource_resv.c \
 	resource_resv.h \

--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -63,6 +63,7 @@ extern "C" {
 #include "config.h"
 #include "pbs_bitmap.h"
 #include "pbs_share.h"
+#include "range.h"
 #ifdef NAS
 #include "site_queue.h"
 #endif
@@ -117,7 +118,6 @@ typedef struct resv_info resv_info;
 typedef struct counts counts;
 typedef struct nspec nspec;
 typedef struct node_partition node_partition;
-typedef struct range range;
 typedef struct resource_resv resource_resv;
 typedef struct place place;
 typedef struct schd_error schd_error;
@@ -1104,15 +1104,6 @@ struct nameval
 	unsigned int is_set:1;
 	char *str;
 	int value;
-};
-
-struct range
-{
-	int start;
-	int end;
-	int step;
-	int count;
-	range *next;
 };
 
 struct config

--- a/src/server/array_func.c
+++ b/src/server/array_func.c
@@ -366,8 +366,7 @@ set_subjob_tblstate(job *parent, int offset, int newstate)
 	
 	if (oldstate == JOB_STATE_QUEUED)
 		range_remove_value(&ptbl->trk_rlist , SJ_TBLIDX_2_IDX(parent, offset));
-
-	if (newstate == JOB_STATE_QUEUED) 
+	else if (newstate == JOB_STATE_QUEUED) 
 		range_add_value(&ptbl->trk_rlist, SJ_TBLIDX_2_IDX(parent, offset), ptbl->tkm_step);
 
 	/* set flags in attribute so stat_job will update the attr string */

--- a/src/server/job_func.c
+++ b/src/server/job_func.c
@@ -519,6 +519,7 @@ job_free(job *pj)
 			if (psubj)
 				psubj->ji_parentaj = NULL;
 		}
+		free_range_list(pj->ji_ajtrk->trk_rlist);
 		free(pj->ji_ajtrk);
 		pj->ji_ajtrk = NULL;
 	}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Identified a possibility to optimize the job array run path while running a large number of sub-jobs. Modified the code in a way that would save Server's execution time.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* Optimized the computation part for identifying the remaining sub-job indices. For every job stat, the server would walk through all the submitted sub-jobs to find the queued jobs remaining in the array job. 
* In this PR, the new range structures are introduced to maintain the remaining indices for quick reference. This change would increase overall performance in the job array. 
* Also, I have refactored the range.c functions related to adding/deleting elements in the sub-range. With these changes, range_add_value() has the ability to add elements in the sequence order & range_remove_value could remove elements in the middle of the sub-range. Moved those range functions to libutil library. 


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|3425|3439|2|1|0|2|3434|

Submitted 1 million jobs in the server and measured the job run path utilization.

Before optimization:
<img width="1665" alt="Before_job_array_run_path" src="https://user-images.githubusercontent.com/17980660/91520730-072f5d00-e8c4-11ea-8453-887161e123ca.png">

After Optimization:
<img width="1665" alt="ja_opti_after_range" src="https://user-images.githubusercontent.com/17980660/91520763-17dfd300-e8c4-11ea-991f-e1f4699c403f.png">


Valgrind logs: 
[valgrind_logs.log](https://github.com/openpbs/openpbs/files/5159691/valgrind_logs.log)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
