### PR TITLE
Fix multisched fairshare test

### DIFF
--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -1239,10 +1239,10 @@ update_last_running(server_info *sinfo)
 
 /**
  * @brief clear and free the last running array
- * 
+ *
  * @return void
  */
-void 
+void
 clear_last_running()
 {
 	free_pjobs(last_running, last_running_size);

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -51,8 +51,6 @@
 #include <sys/socket.h>
 
 #include <arpa/inet.h>
-
-#include "libpbs.h"
 #include <ctype.h>
 #include <memory.h>
 #include <string.h>
@@ -60,6 +58,8 @@
 #include <unistd.h>
 #include <netdb.h>
 #include <errno.h>
+
+#include "libpbs.h"
 #include "server_limits.h"
 #include "list_link.h"
 #include "work_task.h"
@@ -89,8 +89,6 @@
 #include "sched_cmds.h"
 #include "pbs_sched.h"
 #include "pbs_share.h"
-#include "pbs_license.h"
-#include <arpa/inet.h>
 
 
 #define PERM_MANAGER (ATR_DFLAG_MGWR | ATR_DFLAG_MGRD)
@@ -1619,6 +1617,7 @@ mgr_sched_set(struct batch_request *preq)
 	pbs_list_head unsetlist;
 	int	  rc;
 	pbs_sched *psched;
+	int only_scheduling = 0;
 
 	psched = find_sched(preq->rq_ind.rq_manager.rq_objname);
 	if (!psched) {
@@ -1629,6 +1628,11 @@ mgr_sched_set(struct batch_request *preq)
 	CLEAR_HEAD(unsetlist);
 	plist = (svrattrl *)GET_NEXT(preq->rq_ind.rq_manager.rq_attr);
 	while (plist) {
+		if (strcmp(plist->al_atopl.name, ATTR_scheduling) == 0) {
+			only_scheduling++;
+		} else {
+			only_scheduling--;
+		}
 		if (plist->al_atopl.value == NULL || plist->al_atopl.value[0] == '\0') {
 			tmp = (struct svrattrl *)GET_NEXT(plist->al_link);
 			delete_link(&plist->al_link);
@@ -1662,8 +1666,8 @@ mgr_sched_set(struct batch_request *preq)
 		reply_badattr(rc, bad_attr, plist, preq);
 		return;
 	}
-
-	set_scheduler_flag(SCH_CONFIGURE, psched);
+	if (only_scheduling != 1)
+		set_scheduler_flag(SCH_CONFIGURE, psched);
 
 	sched_save_db(psched);
 
@@ -1802,7 +1806,7 @@ mgr_queue_set(struct batch_request *preq)
 				free_attrlist(&unsetlist);
 				return;
 			}
-			free_attrlist(&unsetlist); /* since this is not part of plist anymore, we must free separately */	
+			free_attrlist(&unsetlist); /* since this is not part of plist anymore, we must free separately */
 		}
 
 		plist = (svrattrl *)GET_NEXT(preq->rq_ind.rq_manager.rq_attr);
@@ -2022,7 +2026,7 @@ mgr_node_set(struct batch_request *preq)
 	plist = (svrattrl *)GET_NEXT(preq->rq_ind.rq_manager.rq_attr);
 	while (plist) {
 		tmp = (struct svrattrl *)GET_NEXT(plist->al_link);
-		
+
 		delete_link(&plist->al_link);
 		if (plist->al_atopl.value == NULL || plist->al_atopl.value[0] == '\0')
 			append_link(&unsetlist, &plist->al_link, plist);

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -1617,7 +1617,7 @@ mgr_sched_set(struct batch_request *preq)
 	pbs_list_head unsetlist;
 	int	  rc;
 	pbs_sched *psched;
-	int only_scheduling = 0;
+	int only_scheduling = 1;
 
 	psched = find_sched(preq->rq_ind.rq_manager.rq_objname);
 	if (!psched) {
@@ -1628,10 +1628,8 @@ mgr_sched_set(struct batch_request *preq)
 	CLEAR_HEAD(unsetlist);
 	plist = (svrattrl *)GET_NEXT(preq->rq_ind.rq_manager.rq_attr);
 	while (plist) {
-		if (strcmp(plist->al_atopl.name, ATTR_scheduling) == 0) {
-			only_scheduling++;
-		} else {
-			only_scheduling--;
+		if (strcmp(plist->al_atopl.name, ATTR_scheduling)) {
+			only_scheduling = 0;
 		}
 		if (plist->al_atopl.value == NULL || plist->al_atopl.value[0] == '\0') {
 			tmp = (struct svrattrl *)GET_NEXT(plist->al_link);

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -11192,6 +11192,11 @@ class Scheduler(PBSService):
             self.logger.info(self.logprefix + 'stopping Scheduler on host ' +
                              self.hostname)
             return super(Scheduler, self)._stop(sig, inst=self)
+        elif self.attributes['id'] != 'default':
+            self.logger.info(self.logprefix + 'stopping MultiSched ' +
+                             self.attributes['id'] + ' on host ' +
+                             self.hostname)
+            return super(Scheduler, self)._stop(inst=self)
         else:
             try:
                 self.pi.stop_sched()

--- a/test/tests/functional/pbs_multi_sched.py
+++ b/test/tests/functional/pbs_multi_sched.py
@@ -796,24 +796,24 @@ class TestMultipleSchedulers(TestFunctional):
         self.server.expect(JOB, {'job_state': 'R'}, id=sc1_jid1)
         self.server.expect(JOB, {'job_state': 'Q'}, id=sc1_jid3)
         self.server.expect(JOB, {'job_state': 'Q'}, id=sc1_jid2)
-        self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': 'True'},
-                            id='sc1')
         # need to delete the running job because PBS has only 1 ncpu and
         # our work is also done with the job.
         # this step will decrease the execution time as well
+        self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': 'True'},
+                            id='sc1')
         self.server.delete(sc1_jid1, wait=True)
         # pbsuser3 job will run after pbsuser1
         self.server.expect(JOB, {'job_state': 'R'}, id=sc1_jid3)
         self.server.expect(JOB, {'job_state': 'Q'}, id=sc1_jid2)
+        # deleting the currently running job
         self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': 'True'},
                             id='sc1')
-        # deleting the currently running job
         self.server.delete(sc1_jid3, wait=True)
         # pbsuser2 job will run in the end
         self.server.expect(JOB, {'job_state': 'R'}, id=sc1_jid2)
+        # deleting the currently running job
         self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': 'True'},
                             id='sc1')
-        # deleting the currently running job
         self.server.delete(sc1_jid2, wait=True)
         # query fairshare and check usage
         sc1_fs_user1 = self.scheds['sc1'].query_fairshare(name=str(TEST_USER1))
@@ -825,8 +825,13 @@ class TestMultipleSchedulers(TestFunctional):
         sc1_fs_user4 = self.scheds['sc1'].query_fairshare(name=str(TEST_USER4))
         self.assertEqual(sc1_fs_user4.usage, 1)
         # Restart the scheduler
+        t = time.time()
         self.scheds['sc1'].restart()
         # Check the multisched 'sc1' usage file whether it's updating or not
+        self.assertTrue(self.scheds['sc1'].isUp())
+        self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': 'True'},
+                            id='sc1')
+        self.scheds['sc1'].log_match("Scheduler is reconfiguring", starttime=t)
         self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': 'False'},
                             id='sc1')
         sc1_J1 = Job(TEST_USER1, attrs=sc1_attr)
@@ -841,22 +846,22 @@ class TestMultipleSchedulers(TestFunctional):
         self.server.expect(JOB, {'job_state': 'R'}, id=sc1_jid4)
         self.server.expect(JOB, {'job_state': 'Q'}, id=sc1_jid1)
         self.server.expect(JOB, {'job_state': 'Q'}, id=sc1_jid2)
+        # deleting the currently running job
         self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': 'True'},
                             id='sc1')
-        # deleting the currently running job
         self.server.delete(sc1_jid4, wait=True)
         # pbsuser1 job will run after pbsuser4
         self.server.expect(JOB, {'job_state': 'R'}, id=sc1_jid1)
         self.server.expect(JOB, {'job_state': 'Q'}, id=sc1_jid2)
+        # deleting the currently running job
         self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': 'True'},
                             id='sc1')
-        # deleting the currently running job
         self.server.delete(sc1_jid1, wait=True)
         # pbsuser2 job will run in the end
         self.server.expect(JOB, {'job_state': 'R'}, id=sc1_jid2)
+        # deleting the currently running job
         self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': 'True'},
                             id='sc1')
-        # deleting the currently running job
         self.server.delete(sc1_jid2, wait=True)
         # query fairshare and check usage
         sc1_fs_user1 = self.scheds['sc1'].query_fairshare(name=str(TEST_USER1))

--- a/test/tests/functional/pbs_multi_sched.py
+++ b/test/tests/functional/pbs_multi_sched.py
@@ -811,9 +811,9 @@ class TestMultipleSchedulers(TestFunctional):
         self.server.delete(sc1_jid3, wait=True)
         # pbsuser2 job will run in the end
         self.server.expect(JOB, {'job_state': 'R'}, id=sc1_jid2)
-        # deleting the currently running job
         self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': 'True'},
                             id='sc1')
+        # deleting the currently running job
         self.server.delete(sc1_jid2, wait=True)
         # query fairshare and check usage
         sc1_fs_user1 = self.scheds['sc1'].query_fairshare(name=str(TEST_USER1))
@@ -829,6 +829,9 @@ class TestMultipleSchedulers(TestFunctional):
         self.scheds['sc1'].restart()
         # Check the multisched 'sc1' usage file whether it's updating or not
         self.assertTrue(self.scheds['sc1'].isUp())
+        # The scheduler will set scheduler attributes on the first scheduling
+        # cycle, so we need to trigger a cycle, have the scheduler configure,
+        # then turn it off again
         self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': 'True'},
                             id='sc1')
         self.scheds['sc1'].log_match("Scheduler is reconfiguring", starttime=t)
@@ -846,22 +849,22 @@ class TestMultipleSchedulers(TestFunctional):
         self.server.expect(JOB, {'job_state': 'R'}, id=sc1_jid4)
         self.server.expect(JOB, {'job_state': 'Q'}, id=sc1_jid1)
         self.server.expect(JOB, {'job_state': 'Q'}, id=sc1_jid2)
-        # deleting the currently running job
         self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': 'True'},
                             id='sc1')
+        # deleting the currently running job
         self.server.delete(sc1_jid4, wait=True)
         # pbsuser1 job will run after pbsuser4
         self.server.expect(JOB, {'job_state': 'R'}, id=sc1_jid1)
         self.server.expect(JOB, {'job_state': 'Q'}, id=sc1_jid2)
-        # deleting the currently running job
         self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': 'True'},
                             id='sc1')
+        # deleting the currently running job
         self.server.delete(sc1_jid1, wait=True)
         # pbsuser2 job will run in the end
         self.server.expect(JOB, {'job_state': 'R'}, id=sc1_jid2)
-        # deleting the currently running job
         self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': 'True'},
                             id='sc1')
+        # deleting the currently running job
         self.server.delete(sc1_jid2, wait=True)
         # query fairshare and check usage
         sc1_fs_user1 = self.scheds['sc1'].query_fairshare(name=str(TEST_USER1))

--- a/test/tests/functional/pbs_multi_sched.py
+++ b/test/tests/functional/pbs_multi_sched.py
@@ -805,9 +805,9 @@ class TestMultipleSchedulers(TestFunctional):
         # pbsuser3 job will run after pbsuser1
         self.server.expect(JOB, {'job_state': 'R'}, id=sc1_jid3)
         self.server.expect(JOB, {'job_state': 'Q'}, id=sc1_jid2)
-        # deleting the currently running job
         self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': 'True'},
                             id='sc1')
+        # deleting the currently running job
         self.server.delete(sc1_jid3, wait=True)
         # pbsuser2 job will run in the end
         self.server.expect(JOB, {'job_state': 'R'}, id=sc1_jid2)


### PR DESCRIPTION
#### Describe Bug or Feature
Multisched fairshare test was failing

#### Describe Your Change
Fix the multisched fairshare test.
Also, now when a scheduler's `scheduling` attribute is changed, do not send SCH_CONFIGURE.


#### Attach Test and Valgrind Logs/Output
[after-fix.txt](https://github.com/openpbs/openpbs/files/5152861/after-fix.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
