### PR TITLE
scheduler does not update node partitions properly

### DIFF
--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -1733,7 +1733,7 @@ run_update_resresv(status *policy, int pbs_sd, server_info *sinfo,
 						if (!ns[i]->ninfo->is_free)
 							npar[j]->free_nodes--;
 						sort_nodepart = 1;
-						update_buckets_for_node_array(npar[j]->bkts, npar[j]->ninfo_arr);
+						update_buckets_for_node(npar[j]->bkts, ns[i]->ninfo);
 					}
 				}
 				/* if the node is being provisioned, it's brought down in

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -1727,11 +1727,13 @@ run_update_resresv(status *policy, int pbs_sd, server_info *sinfo,
 				int j;
 				update_node_on_run(ns[i], rr, &old_state);
 				if (ns[i]->ninfo->np_arr != NULL) {
-					for (j = 0; ns[i]->ninfo->np_arr[j] != NULL; j++) {
-						modify_resource_list(ns[i]->ninfo->np_arr[j]->res, ns[i]->resreq, SCHD_INCR);
+					node_partition **npar = ns[i]->ninfo->np_arr;
+					for (j = 0; npar[j] != NULL; j++) {
+						modify_resource_list(npar[j]->res, ns[i]->resreq, SCHD_INCR);
 						if (!ns[i]->ninfo->is_free)
-							ns[i]->ninfo->np_arr[j]->free_nodes--;
+							npar[j]->free_nodes--;
 						sort_nodepart = 1;
+						update_buckets_for_node_array(npar[j]->bkts, npar[j]->ninfo_arr);
 					}
 				}
 				/* if the node is being provisioned, it's brought down in

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -1974,8 +1974,6 @@ update_node_on_run(nspec *ns, resource_resv *resresv, char *job_state)
 		pbs_bitmap_bit_on(bkt->busy_pool->truth, ind);
 		bkt->busy_pool->truth_ct++;
 	}
-
-
 }
 
 /**

--- a/src/scheduler/node_partition.c
+++ b/src/scheduler/node_partition.c
@@ -603,6 +603,49 @@ create_node_partitions(status *policy, node_info **nodes, char **resnames, unsig
 }
 
 /**
+ * @brief update the node buckets associated with a node
+ *
+ *  @param[in] bkts - the buckets to update
+ *  @param[in] ninfo - the node of the job/resv
+ */
+void
+update_buckets_for_node(node_bucket **bkts, node_info *ninfo) {
+	int i;
+	for (i = 0; bkts[i] != NULL; i++) {
+		int node_ind = ninfo->node_ind;
+
+		/* Is this node in the bucket? */
+		if (pbs_bitmap_get_bit(bkts[i]->bkt_nodes, node_ind)) {
+			/* First turn off the current bit */
+			if (pbs_bitmap_get_bit(bkts[i]->free_pool->truth, node_ind)) {
+				pbs_bitmap_bit_off(bkts[i]->free_pool->truth, node_ind);
+				bkts[i]->free_pool->truth_ct--;
+				} else if (pbs_bitmap_get_bit(bkts[i]->busy_later_pool->truth, node_ind)) {
+				pbs_bitmap_bit_off(bkts[i]->busy_later_pool->truth, node_ind);
+				bkts[i]->busy_later_pool->truth_ct--;
+			}  else if (pbs_bitmap_get_bit(bkts[i]->busy_pool->truth, node_ind)) {
+				pbs_bitmap_bit_off(bkts[i]->busy_pool->truth, node_ind);
+				bkts[i]->busy_pool->truth_ct--;
+			}
+
+			/* Next, turn on the correct bit */
+			if (ninfo->num_jobs > 0 || ninfo->num_run_resv > 0) {
+				pbs_bitmap_bit_on(bkts[i]->busy_pool->truth, node_ind);
+				bkts[i]->busy_pool->truth_ct++;
+			} else {
+				if (ninfo->node_events != NULL) {
+					pbs_bitmap_bit_on(bkts[i]->busy_later_pool->truth, node_ind);
+					bkts[i]->busy_later_pool->truth_ct++;
+				} else {
+					pbs_bitmap_bit_on(bkts[i]->free_pool->truth, node_ind);
+					bkts[i]->free_pool->truth_ct++;
+				}
+			}
+		}
+	}
+}
+
+/**
  * @brief update the node buckets associated with a node partition on
  *        job/resv run/end
  *
@@ -611,45 +654,13 @@ create_node_partitions(status *policy, node_info **nodes, char **resnames, unsig
  */
 void
 update_buckets_for_node_array(node_bucket **bkts, node_info **ninfo_arr) {
-	int i, j;
+	int i;
 
 	if (bkts == NULL || ninfo_arr == NULL)
 		return;
 
-	for (i = 0; ninfo_arr[i] != NULL; i++) {
-		for (j = 0; bkts[j] != NULL; j++) {
-			int node_ind = ninfo_arr[i]->node_ind;
-
-			/* Is this node in the bucket? */
-			if (pbs_bitmap_get_bit(bkts[j]->bkt_nodes, node_ind)) {
-				/* First turn off the current bit */
-				if (pbs_bitmap_get_bit(bkts[j]->free_pool->truth, node_ind)) {
-					pbs_bitmap_bit_off(bkts[j]->free_pool->truth, node_ind);
-					bkts[j]->free_pool->truth_ct--;
-				} else if (pbs_bitmap_get_bit(bkts[j]->busy_later_pool->truth, node_ind)) {
-					pbs_bitmap_bit_off(bkts[j]->busy_later_pool->truth, node_ind);
-					bkts[j]->busy_later_pool->truth_ct--;
-				}  else if (pbs_bitmap_get_bit(bkts[j]->busy_pool->truth, node_ind)) {
-					pbs_bitmap_bit_off(bkts[j]->busy_pool->truth, node_ind);
-					bkts[j]->busy_pool->truth_ct--;
-				}
-
-				/* Next, turn on the correct bit */
-				if (ninfo_arr[i]->num_jobs > 0 || ninfo_arr[i]->num_run_resv > 0) {
-					pbs_bitmap_bit_on(bkts[j]->busy_pool->truth, node_ind);
-					bkts[j]->busy_pool->truth_ct++;
-				} else {
-					if (ninfo_arr[i]->node_events != NULL) {
-						pbs_bitmap_bit_on(bkts[j]->busy_later_pool->truth, node_ind);
-						bkts[j]->busy_later_pool->truth_ct++;
-					} else {
-						pbs_bitmap_bit_on(bkts[j]->free_pool->truth, node_ind);
-						bkts[j]->free_pool->truth_ct++;
-					}
-				}
-			}
-		}
-	}
+	for (i = 0; ninfo_arr[i] != NULL; i++)
+		update_buckets_for_node(bkts, ninfo_arr[i]);
 }
 
 /**

--- a/src/scheduler/node_partition.c
+++ b/src/scheduler/node_partition.c
@@ -611,6 +611,10 @@ create_node_partitions(status *policy, node_info **nodes, char **resnames, unsig
 void
 update_buckets_for_node(node_bucket **bkts, node_info *ninfo) {
 	int i;
+
+	if (bkts == NULL || ninfo == NULL)
+		return;
+
 	for (i = 0; bkts[i] != NULL; i++) {
 		int node_ind = ninfo->node_ind;
 
@@ -620,7 +624,7 @@ update_buckets_for_node(node_bucket **bkts, node_info *ninfo) {
 			if (pbs_bitmap_get_bit(bkts[i]->free_pool->truth, node_ind)) {
 				pbs_bitmap_bit_off(bkts[i]->free_pool->truth, node_ind);
 				bkts[i]->free_pool->truth_ct--;
-				} else if (pbs_bitmap_get_bit(bkts[i]->busy_later_pool->truth, node_ind)) {
+			} else if (pbs_bitmap_get_bit(bkts[i]->busy_later_pool->truth, node_ind)) {
 				pbs_bitmap_bit_off(bkts[i]->busy_later_pool->truth, node_ind);
 				bkts[i]->busy_later_pool->truth_ct--;
 			}  else if (pbs_bitmap_get_bit(bkts[i]->busy_pool->truth, node_ind)) {

--- a/src/scheduler/node_partition.h
+++ b/src/scheduler/node_partition.h
@@ -228,6 +228,11 @@ void update_all_nodepart(status *policy, server_info *sinfo, unsigned int flags)
 void sort_all_nodepart(status *policy, server_info *sinfo);
 
 /*
+ * update the node buckets associated with a node
+ */
+void update_buckets_for_node(node_bucket **bkts, node_info *ninfo);
+
+/*
  * update the node buckets associated with a node partition on
  * job/resv run/end
  */

--- a/src/scheduler/node_partition.h
+++ b/src/scheduler/node_partition.h
@@ -227,6 +227,12 @@ void update_all_nodepart(status *policy, server_info *sinfo, unsigned int flags)
 /* Sort all placement sets (server's psets, queue's psets, and hostsets) */
 void sort_all_nodepart(status *policy, server_info *sinfo);
 
+/*
+ * update the node buckets associated with a node partition on
+ * job/resv run/end
+ */
+void update_buckets_for_node_array(node_bucket **bkts, node_info **ninfo_arr);
+
 #ifdef	__cplusplus
 }
 #endif


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
When a job runs, the scheduler does not update the buckets in node partitions.
TestNodeBuckets.test_psets_calendaring is failing because of this issue.


#### Describe Your Change
When a job runs, the scheduler will update buckets of node partitions of each node the job runs on.

#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
Description: Rerun All Tests From #3452
Platforms: UBUNTU1804,SUSE15,CENTOS8
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|3471|1726|3|2|0|0|1721|

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
