### PR TITLE
Deprecate skipOnCpuset decorator

### DIFF
--- a/test/tests/functional/pbs_Rrecord_resources_used.py
+++ b/test/tests/functional/pbs_Rrecord_resources_used.py
@@ -186,7 +186,6 @@ class Test_Rrecord_with_resources_used(TestFunctional):
 
         return jid1, jid2, jid3s1
 
-    @skipOnCpuSet
     def test_Rrecord_with_nodefailrequeue(self):
         """
         Scenario: The node on which the job was running goes down and
@@ -205,7 +204,6 @@ class Test_Rrecord_with_resources_used(TestFunctional):
             msg='.*R;' + re.escape(jid3s1) + '.*resources_used.*',
             id=jid3s1, regexp=True)
 
-    @skipOnCpuSet
     def test_Rrecord_when_mom_restarted_with_r(self):
         """
         Scenario: The node on which the job was running goes down and
@@ -227,7 +225,6 @@ class Test_Rrecord_with_resources_used(TestFunctional):
             msg='.*R;' + re.escape(jid3s1) + '.*resources_used.*run_count=1',
             id=jid3s1, regexp=True)
 
-    @skipOnCpuSet
     def test_Rrecord_for_nonrerunnable_jobs(self):
         """
         Scenario: One non-rerunnable job. The node on which the job was
@@ -250,7 +247,6 @@ class Test_Rrecord_with_resources_used(TestFunctional):
             msg='.*R;' + re.escape(jid3s1) + '.*resources_used.*run_count=1',
             id=jid3s1, regexp=True)
 
-    @skipOnCpuSet
     def test_Rrecord_when_mom_restarted_without_r(self):
         """
         Scenario: Mom restarted without '-r' option and jobs are requeued
@@ -296,7 +292,6 @@ class Test_Rrecord_with_resources_used(TestFunctional):
             regexp=True)
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
 
-    @skipOnCpuSet
     def test_Rrecord_with_multiple_reruns(self):
         """
         Scenario: Job is rerun multiple times.
@@ -398,7 +393,6 @@ class Test_Rrecord_with_resources_used(TestFunctional):
             '.*Exit_status=-11.*.*resources_used.*.*run_count=1.*',
             id=jid3s1, regexp=True)
 
-    @skipOnCpuSet
     def test_Rrecord_with_multiple_reruns_case2(self):
         """
         Scenario: Jobs submitted with select cput and ncpus. Job is rerun
@@ -474,7 +468,6 @@ class Test_Rrecord_with_resources_used(TestFunctional):
             '.*.*resources_used.cput=[0-9]*:[0-9]*:[0-9]*.*.*run_count=2.*',
             id=jid2, regexp=True)
 
-    @skipOnCpuSet
     def test_Rrecord_job_rerun_forcefully(self):
         """
         Scenario: Job is forcefully rerun.

--- a/test/tests/functional/pbs_accumulate_resc_used.py
+++ b/test/tests/functional/pbs_accumulate_resc_used.py
@@ -492,7 +492,6 @@ else:
         self.server.accounting_match(
             "E;%s;.*%s.*" % (jid, acctlog_match), regexp=True, n=100)
 
-    @skipOnCpuSet
     def test_periodic(self):
         """
         Test accumulatinon of resources from an exechost_periodic hook.

--- a/test/tests/functional/pbs_admin_suspend.py
+++ b/test/tests/functional/pbs_admin_suspend.py
@@ -53,7 +53,6 @@ class TestAdminSuspend(TestFunctional):
         a = {'resources_available.ncpus': 4, 'resources_available.mem': '4gb'}
         self.mom.create_vnodes(a, 1)
 
-    @skipOnCpuSet
     def test_basic(self):
         """
         Test basic admin-suspend functionality
@@ -89,7 +88,6 @@ class TestAdminSuspend(TestFunctional):
         self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
         self.server.expect(NODE, {'state': 'free'}, id=vnode)
 
-    @skipOnCpuSet
     def test_basic_ja(self):
         """
         Test basic admin-suspend functionality for job arrays
@@ -131,7 +129,6 @@ class TestAdminSuspend(TestFunctional):
         self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
         self.server.expect(NODE, {'state': 'free'}, id=vnode)
 
-    @skipOnCpuSet
     def test_basic_restart(self):
         """
         Test basic admin-suspend functionality with server restart
@@ -164,7 +161,6 @@ class TestAdminSuspend(TestFunctional):
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
         self.server.expect(NODE, {'state': 'free'}, id=vnode)
 
-    @skipOnCpuSet
     def test_cmd_perm(self):
         """
         Test permissions on admin-suspend, admin-resume, maintenance_jobs
@@ -217,7 +213,6 @@ class TestAdminSuspend(TestFunctional):
 
         self.server.expect(JOB, {'job_state': 'S'}, id=jid)
 
-    @skipOnCpuSet
     def test_wrong_state1(self):
         """
         Test using wrong resume signal is correctly rejected
@@ -239,7 +234,6 @@ class TestAdminSuspend(TestFunctional):
 
         self.server.expect(JOB, {'job_state': 'S'}, id=jid1)
 
-    @skipOnCpuSet
     def test_wrong_state2(self):
         """
         Test using wrong resume signal is correctly rejected
@@ -263,7 +257,6 @@ class TestAdminSuspend(TestFunctional):
         # If resume had worked, the job would be in substate 45
         self.server.expect(JOB, {'substate': 43}, id=jid1)
 
-    @skipOnCpuSet
     def test_deljob(self):
         """
         Test whether a node leaves the maintenance state when
@@ -281,7 +274,6 @@ class TestAdminSuspend(TestFunctional):
         self.server.deljob(jid, wait=True)
         self.server.expect(NODE, {'state': 'free'}, id=vnode)
 
-    @skipOnCpuSet
     def test_deljob_force(self):
         """
         Test whether a node leaves the maintenance state when
@@ -299,7 +291,6 @@ class TestAdminSuspend(TestFunctional):
         self.server.deljob(jid, extend='force', wait=True)
         self.server.expect(NODE, {'state': 'free'}, id=vnode)
 
-    @skipOnCpuSet
     def test_rerunjob(self):
         """
         Test whether a node leaves the maintenance state when
@@ -319,7 +310,6 @@ class TestAdminSuspend(TestFunctional):
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
         self.server.expect(NODE, {'state': 'free'}, id=vnode)
 
-    @skipOnCpuSet
     def test_multivnode(self):
         """
         Submit a job to multiple vnodes.  Send an admin-suspend signal
@@ -341,7 +331,6 @@ class TestAdminSuspend(TestFunctional):
         self.server.sigjob(jid, 'admin-resume', runas=ROOT_USER)
         self.server.expect(NODE, {'state=free': 3})
 
-    @skipOnCpuSet
     def test_multivnode2(self):
         """
         Submit a job to multiple vnodes.  Send an admin-suspend signal
@@ -380,7 +369,6 @@ class TestAdminSuspend(TestFunctional):
         self.server.expect(NODE, {'state=free': 2})
         self.server.expect(NODE, {'state': 'maintenance'}, id=vnode)
 
-    @skipOnCpuSet
     def test_multivnode_excl(self):
         """
         Submit an excl job to multiple vnodes.  Send an admin-suspend
@@ -403,7 +391,6 @@ class TestAdminSuspend(TestFunctional):
         self.server.sigjob(jid, 'admin-resume', runas=ROOT_USER)
         self.server.expect(NODE, {'state=job-exclusive': 3})
 
-    @skipOnCpuSet
     def test_degraded_resv(self):
         """
         Test if a reservation goes into the degraded state after its node is
@@ -436,7 +423,6 @@ class TestAdminSuspend(TestFunctional):
         a = {'reserve_state': (MATCH_RE, 'RESV_DEGRADED|10')}
         d = self.server.expect(RESV, a, rid)
 
-    @skipOnCpuSet
     def test_resv_jobend(self):
         """
         Test if a node goes back to free state when reservation ends and
@@ -487,7 +473,6 @@ class TestAdminSuspend(TestFunctional):
         # job2 starts running
         self.server.expect(JOB, {'job_state': 'R'}, id=jid2, max_attempts=60)
 
-    @skipOnCpuSet
     def test_que(self):
         """
         Test to check that job gets suspended on non-default queue
@@ -545,7 +530,6 @@ class TestAdminSuspend(TestFunctional):
         self.server.expect(
             NODE, {'state': (MATCH_RE, 'free|job-exclusive')}, id=vnode)
 
-    @skipOnCpuSet
     def test_resume(self):
         """
         Test node state remains in maintenance until
@@ -593,7 +577,6 @@ class TestAdminSuspend(TestFunctional):
         self.server.expect(NODE, {'state=free': 3})
         self.server.expect(JOB, {'job_state=R': 4})
 
-    @skipOnCpuSet
     def test_admin_resume_loop(self):
         """
         Test that running admin-resume in a loop will have no impact on PBS
@@ -619,7 +602,6 @@ class TestAdminSuspend(TestFunctional):
             self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
             self.server.expect(NODE, {'state': 'free'}, id=vnode)
 
-    @skipOnCpuSet
     def test_custom_res(self):
         """
         Test that job will not run on a node in
@@ -681,7 +663,6 @@ class TestAdminSuspend(TestFunctional):
             msg = "jid3 and jid4 not running on " + vnode + " as expected"
             self.logger.info(msg)
 
-    @skipOnCpuSet
     def test_list_jobs_1(self):
         """
         Test to list and set maintenance_jobs as various users
@@ -753,7 +734,6 @@ class TestAdminSuspend(TestFunctional):
             self.assertFalse(e.rv)
             self.assertTrue("Unauthorized Request" in e.msg[0])
 
-    @skipOnCpuSet
     def test_list_jobs_2(self):
         """
         Test to list maintenance_jobs when no job is admin-suspended
@@ -777,7 +757,6 @@ class TestAdminSuspend(TestFunctional):
         # List maintenance_jobs again
         self.server.expect(NODE, 'maintenance_jobs', op=UNSET, id=vnode)
 
-    @skipOnCpuSet
     def test_preempt_order(self):
         """
         Test that scheduler preempt_order has no impact
@@ -826,7 +805,6 @@ class TestAdminSuspend(TestFunctional):
         self.server.expect(JOB, {'job_state': 'R', 'substate': 42}, id=jid2)
         self.server.expect(JOB, {'job_state': 'Q'}, id=jid1)
 
-    @skipOnCpuSet
     def test_hook(self):
         """
         List maintenance_jobs via hook
@@ -875,7 +853,6 @@ pbs.logmsg(pbs.LOG_DEBUG,\
         self.mom.log_match(
             "list of maintenance_jobs are %s" % (jid2,))
 
-    @skipOnCpuSet
     def test_offline(self):
         """
         Test that if a node is put to offline

--- a/test/tests/functional/pbs_allpart.py
+++ b/test/tests/functional/pbs_allpart.py
@@ -51,7 +51,6 @@ class TestSchedAllPart(TestFunctional):
         a = {'resources_available.ncpus': 1, 'resources_available.mem': '1gb'}
         self.mom.create_vnodes(a, 2, usenatvnode=True)
 
-    @skipOnCpuSet
     def test_free_nodes(self):
         """
         Test that if there aren't enough free nodes available, it is reported
@@ -69,7 +68,6 @@ class TestSchedAllPart(TestFunctional):
              'Not Running: Not enough free nodes available'}
         self.server.expect(JOB, a, id=jid2)
 
-    @skipOnCpuSet
     def test_vscatter(self):
         """
         Test that we determine we can't run a job when there aren't enough
@@ -91,7 +89,6 @@ class TestSchedAllPart(TestFunctional):
              'Not Running: Not enough free nodes available'}
         self.server.expect(JOB, a, id=jid2)
 
-    @skipOnCpuSet
     def test_vscatter2(self):
         """
         Test that we can determine a job can never run if it is requesting
@@ -108,7 +105,6 @@ class TestSchedAllPart(TestFunctional):
              'Can Never Run: Not enough total nodes available'}
         self.server.expect(JOB, a, id=jid)
 
-    @skipOnCpuSet
     def test_rassn(self):
         """
         Test rassn resource (ncpus) is unavailable and the comment is shown
@@ -130,7 +126,6 @@ class TestSchedAllPart(TestFunctional):
         a = {'job_state': 'Q', 'comment': m}
         self.server.expect(JOB, a, id=jid2)
 
-    @skipOnCpuSet
     def test_nonexistent_non_consumable(self):
         """
         Test that a nonexistent non-consumable value is caught as 'Never Run'
@@ -143,7 +138,6 @@ class TestSchedAllPart(TestFunctional):
         a = {'job_state': 'Q', 'comment': (MATCH_RE, m)}
         self.server.expect(JOB, a, id=jid)
 
-    @skipOnCpuSet
     def test_too_many_ncpus(self):
         """
         test that a job is marked as can never run if it requests more cpus

--- a/test/tests/functional/pbs_calendaring.py
+++ b/test/tests/functional/pbs_calendaring.py
@@ -49,7 +49,6 @@ class TestCalendaring(TestFunctional):
     This test suite tests if PBS scheduler calendars events correctly
     """
 
-    @skipOnCpuSet
     def test_topjob_start_time(self):
         """
         In this test we test that the top job which gets added to the
@@ -107,7 +106,6 @@ class TestCalendaring(TestFunctional):
         # Third subjob should set estimated.start_time in future.
         self.assertGreater(est_epoch1, time_now)
 
-    @skipOnCpuSet
     def test_topjob_start_time_of_subjob(self):
         """
         In this test we test that the subjob which gets added to the
@@ -144,7 +142,6 @@ class TestCalendaring(TestFunctional):
         errmsg = jid + ";Error in calculation of start time of top job"
         self.scheduler.log_match(errmsg, existence=False, max_attempts=10)
 
-    @skipOnCpuSet
     def test_topjob_fail(self):
         """
         Test that when we fail to add a job to the calendar it doesn't

--- a/test/tests/functional/pbs_conf_resv_stale_vnode.py
+++ b/test/tests/functional/pbs_conf_resv_stale_vnode.py
@@ -66,7 +66,6 @@ class TestResvStaleVnode(TestFunctional):
         self.scheduler.set_sched_config({'node_sort_key':
                                          '\"sort_priority HIGH\"'})
 
-    @skipOnCpuSet
     def test_conf_resv_stale_vnode(self):
         """
         Test that the scheduler won't confirm a reservation on a stale node.
@@ -99,7 +98,6 @@ class TestResvStaleVnode(TestFunctional):
         self.server.expect(RESV, a, id=rid)
         self.server.expect(RESV, a2, id=rid)
 
-    @skipOnCpuSet
     def test_stale_degraded(self):
         """
         Test that a reservation goes into the degraded state

--- a/test/tests/functional/pbs_eligible_time.py
+++ b/test/tests/functional/pbs_eligible_time.py
@@ -95,7 +95,6 @@ class TestEligibleTime(TestFunctional):
         # lag on some slow systems, add a little leeway.
         self.server.expect(JOB, {'eligible_time': 10}, op=LT)
 
-    @skipOnCpuSet
     def test_job_array(self):
         """
         Test that a job array switches from accruing eligible time
@@ -174,7 +173,6 @@ class TestEligibleTime(TestFunctional):
             else:
                 raise PtlLogMatchError(rc=1, rv=False, msg=e.msg)
 
-    @skipOnCpuSet
     def test_after_depend(self):
         """
         Make sure jobs accrue eligible time (or not) approprately with an

--- a/test/tests/functional/pbs_equiv_classes.py
+++ b/test/tests/functional/pbs_equiv_classes.py
@@ -70,7 +70,6 @@ class TestEquivClass(TestFunctional):
 
         return ret_jids
 
-    @skipOnCpuSet
     def test_basic(self):
         """
         Test the basic behavior of job equivalence classes: submit two
@@ -95,7 +94,6 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 2",
                                  starttime=self.t)
 
-    @skipOnCpuSet
     def test_select(self):
         """
         Test to see if jobs with select resources not in the resources line
@@ -124,7 +122,6 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 2",
                                  starttime=self.t)
 
-    @skipOnCpuSet
     def test_place(self):
         """
         Test to see if jobs with different place statements
@@ -151,7 +148,6 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 3",
                                  starttime=self.t)
 
-    @skipOnCpuSet
     def test_reslist1(self):
         """
         Test to see if jobs with resources in Resource_List that are not in
@@ -188,7 +184,6 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 2",
                                  starttime=self.t)
 
-    @skipOnCpuSet
     def test_reslist2(self):
         """
         Test to see if jobs with resources in Resource_List that are in the
@@ -227,7 +222,6 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 5",
                                  starttime=self.t)
 
-    @skipOnCpuSet
     def test_nolimits(self):
         """
         Test to see that jobs from different users, groups, and projects
@@ -265,7 +259,6 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 2",
                                  starttime=self.t)
 
-    @skipOnCpuSet
     def test_user(self):
         """
         Test to see that jobs from different users fall into the same
@@ -291,7 +284,6 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 2",
                                  starttime=self.t)
 
-    @skipOnCpuSet
     def test_user_old(self):
         """
         Test to see that jobs from different users fall into different
@@ -319,7 +311,6 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 3",
                                  starttime=self.t)
 
-    @skipOnCpuSet
     def test_user_server(self):
         """
         Test to see that jobs from different users fall into different
@@ -347,7 +338,6 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 3",
                                  starttime=self.t)
 
-    @skipOnCpuSet
     def test_user_server_soft(self):
         """
         Test to see that jobs from different users fall into different
@@ -375,7 +365,6 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 3",
                                  starttime=self.t)
 
-    @skipOnCpuSet
     def test_user_queue(self):
         """
         Test to see that jobs from different users fall into different
@@ -404,7 +393,6 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 3",
                                  starttime=self.t)
 
-    @skipOnCpuSet
     def test_user_queue_without_limits(self):
         """
         Test that jobs from different users submitted to a queue without
@@ -441,7 +429,6 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 3",
                                  starttime=self.t)
 
-    @skipOnCpuSet
     def test_user_queue_soft(self):
         """
         Test to see that jobs from different users fall into different
@@ -470,7 +457,6 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 3",
                                  starttime=self.t)
 
-    @skipOnCpuSet
     def test_user_queue_without_soft_limits(self):
         """
         Test that jobs from different users submitted to a queue without
@@ -504,7 +490,6 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 2",
                                  starttime=self.t)
 
-    @skipOnCpuSet
     def test_group(self):
         """
         Test to see that jobs from different groups fall into the same
@@ -534,7 +519,6 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 2",
                                  starttime=self.t)
 
-    @skipOnCpuSet
     @skipOnShasta
     def test_group_old(self):
         """
@@ -568,7 +552,6 @@ class TestEquivClass(TestFunctional):
                                  starttime=self.t)
 
     @skipOnShasta
-    @skipOnCpuSet
     def test_group_server(self):
         """
         Test to see that jobs from different groups fall into different
@@ -601,7 +584,6 @@ class TestEquivClass(TestFunctional):
                                  starttime=self.t)
 
     @skipOnShasta
-    @skipOnCpuSet
     def test_group_server_soft(self):
         """
         Test to see that jobs from different groups fall into different
@@ -634,7 +616,6 @@ class TestEquivClass(TestFunctional):
                                  starttime=self.t)
 
     @skipOnShasta
-    @skipOnCpuSet
     def test_group_queue(self):
         """
         Test to see that jobs from different groups fall into different
@@ -670,7 +651,6 @@ class TestEquivClass(TestFunctional):
                                  starttime=self.t)
 
     @skipOnShasta
-    @skipOnCpuSet
     def test_group_queue_soft(self):
         """
         Test to see that jobs from different groups fall into different
@@ -705,7 +685,6 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 3",
                                  starttime=self.t)
 
-    @skipOnCpuSet
     def test_proj(self):
         """
         Test to see that jobs from different projects fall into the same
@@ -735,7 +714,6 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 2",
                                  starttime=self.t)
 
-    @skipOnCpuSet
     def test_proj_server(self):
         """
         Test to see that jobs from different projects fall into different
@@ -767,7 +745,6 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 3",
                                  starttime=self.t)
 
-    @skipOnCpuSet
     def test_proj_server_soft(self):
         """
         Test to see that jobs from different projects fall into different
@@ -799,7 +776,6 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 3",
                                  starttime=self.t)
 
-    @skipOnCpuSet
     def test_proj_queue(self):
         """
         Test to see that jobs from different groups fall into different
@@ -831,7 +807,6 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 3",
                                  starttime=self.t)
 
-    @skipOnCpuSet
     def test_proj_queue_soft(self):
         """
         Test to see that jobs from different groups fall into different
@@ -863,7 +838,6 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 3",
                                  starttime=self.t)
 
-    @skipOnCpuSet
     def test_queue(self):
         """
         Test to see that jobs from different generic queues fall into
@@ -900,7 +874,6 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 2",
                                  starttime=self.t)
 
-    @skipOnCpuSet
     def test_queue_limits(self):
         """
         Test to see if jobs in a queue with limits use their queue as part
@@ -957,7 +930,6 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 4",
                                  starttime=self.t)
 
-    @skipOnCpuSet
     def test_queue_nodes(self):
         """
         Test to see if jobs that are submitted into a queue with nodes
@@ -1012,7 +984,6 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 3",
                                  starttime=self.t)
 
-    @skipOnCpuSet
     def test_prime_queue(self):
         """
         Test to see if a job in a primetime queue has its queue be part of
@@ -1075,7 +1046,6 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 4",
                                  starttime=self.t)
 
-    @skipOnCpuSet
     def test_non_prime_queue(self):
         """
         Test to see if a job in a non-primetime queue has its queue be part of
@@ -1139,7 +1109,6 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 4",
                                  starttime=self.t)
 
-    @skipOnCpuSet
     def test_ded_time_queue(self):
         """
         Test to see if a job in a dedicated time queue has its queue be part
@@ -1188,7 +1157,6 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 3",
                                  starttime=self.t)
 
-    @skipOnCpuSet
     def test_job_array(self):
         """
         Test that various job types will fall into single equivalence
@@ -1215,7 +1183,6 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 1",
                                  starttime=self.t)
 
-    @skipOnCpuSet
     def test_reservation(self):
         """
         Test that similar jobs inside reservations falls under same
@@ -1247,7 +1214,6 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 2",
                                  starttime=self.t)
 
-    @skipOnCpuSet
     def test_time_limit(self):
         """
         Test that various time limits will have their own
@@ -1286,7 +1252,6 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 3",
                                  starttime=self.t)
 
-    @skipOnCpuSet
     def test_fairshare(self):
         """
         Test that scheduler do not create any equiv classes
@@ -1320,7 +1285,6 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 1",
                                  starttime=self.t)
 
-    @skipOnCpuSet
     def test_server_hook(self):
         """
         Test that job equivalence classes are updated
@@ -1390,7 +1354,6 @@ e.job.Resource_List["cput"] = 20
         self.scheduler.log_match("Number of job equivalence classes: 3",
                                  starttime=self.t)
 
-    @skipOnCpuSet
     def test_mom_hook(self):
         """
         Test for job equivalence classes with mom hooks.
@@ -1448,7 +1411,6 @@ else:
         self.scheduler.log_match("Number of job equivalence classes: 3",
                                  starttime=self.t)
 
-    @skipOnCpuSet
     def test_incr_decr(self):
         """
         Test for varying job equivalence class values
@@ -1527,7 +1489,6 @@ else:
             "Number of job equivalence classes message " +
             "not present when there are no jobs as expected")
 
-    @skipOnCpuSet
     def test_server_queue_limit(self):
         """
         Test with mix of hard and soft limits
@@ -1627,7 +1588,6 @@ else:
         self.scheduler.log_match("Number of job equivalence classes: 8",
                                  starttime=self.t)
 
-    @skipOnCpuSet
     def test_preemption(self):
         """
         Suspended jobs are placed into their own equivalence class.  If
@@ -1680,7 +1640,6 @@ else:
 
         self.server.expect(JOB, {'job_state': 'R'}, id=jid4)
 
-    @skipOnCpuSet
     def test_preemption2(self):
         """
         Suspended jobs are placed into their own equivalence class.  If
@@ -1739,7 +1698,6 @@ else:
 
         self.server.expect(JOB, {'job_state': 'R'}, id=jid5)
 
-    @skipOnCpuSet
     def test_multiple_job_preemption_order(self):
         """
         Test that when multiple jobs from same eqivalence class are
@@ -1863,7 +1821,6 @@ else:
         self.server.expect(JOB, {'job_state': 'R'}, id=jid3)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid6)
 
-    @skipOnCpuSet
     def test_multiple_equivalence_class_preemption(self):
         """
         This test is to test that -
@@ -1959,7 +1916,6 @@ else:
         self.scheduler.log_match("Number of job equivalence classes: 2",
                                  starttime=self.t)
 
-    @skipOnCpuSet
     def test_held_jobs_equiv_class(self):
         """
         1) Test that held jobs do not go into another equivalence class.
@@ -1983,7 +1939,6 @@ else:
         self.scheduler.log_match("Number of job equivalence classes: 1",
                                  starttime=self.t)
 
-    @skipOnCpuSet
     def test_queue_resav(self):
         """
         Test that jobs in queues with resources_available limits use queue as
@@ -2022,7 +1977,6 @@ else:
         self.scheduler.log_match("Number of job equivalence classes: 2",
                                  starttime=self.t)
 
-    @skipOnCpuSet
     def test_overlap_resv(self):
         """
         Test that 2 overlapping reservation creates 2 different
@@ -2077,7 +2031,6 @@ else:
         self.server.expect(JOB, {"job_state": 'R'}, id=jid1)
         self.server.expect(JOB, {"job_state": 'R'}, id=jid3)
 
-    @skipOnCpuSet
     def test_limit_res(self):
         """
         Test when resources are being limited on, but those resources are not
@@ -2125,7 +2078,6 @@ else:
             attribs['resource_available.mem'] = '4gb'
         return attribs
 
-    @skipOnCpuSet
     def test_equiv_class_not_marked_on_suspend(self):
         """
         Test that if a job is suspended then scheduler does not mark its

--- a/test/tests/functional/pbs_hook_execjob_prologue.py
+++ b/test/tests/functional/pbs_hook_execjob_prologue.py
@@ -118,7 +118,6 @@ class TestPbsExecutePrologue(TestFunctional):
 
         self.server.expect(NODE, {'state': 'free'}, id=self.hostA, offset=1)
 
-    @skipOnCpuSet
     def test_prologue_internal_error_offline_vnodes(self):
         """
         Test a prologue hook with an internal error and

--- a/test/tests/functional/pbs_indirect_resources.py
+++ b/test/tests/functional/pbs_indirect_resources.py
@@ -43,7 +43,6 @@ from tests.functional import *
 
 class TestHostResources(TestFunctional):
 
-    @skipOnCpuSet
     def test_set_direct_on_indirect_resc(self):
         """
         Set a direct resource on indirect resource and make sure
@@ -65,7 +64,6 @@ class TestHostResources(TestFunctional):
         self.server.expect(NODE, {'resources_assigned.fooi': ''},
                            id=vnode1, op=UNSET, max_attempts=1)
 
-    @skipOnCpuSet
     def test_set_direct_on_indirect_resc_busy(self):
         """
         Set a direct resource on indirect resource
@@ -100,7 +98,6 @@ class TestHostResources(TestFunctional):
             self.server.expect(NODE, {'resources_available.fooi': 100},
                                id=vnode1, op=UNSET, max_attempts=1)
 
-    @skipOnCpuSet
     def test_set_direct_on_target_node(self):
         """
         Set a direct resource on target node which should
@@ -133,7 +130,6 @@ class TestHostResources(TestFunctional):
             _msg = "Setting indirect resources on a target object should fail"
             self.assertTrue(False, _msg)
 
-    @skipOnCpuSet
     def test_create_node_without_resc_set(self):
         """
         Create a consumable resource then create a new node.

--- a/test/tests/functional/pbs_job_array.py
+++ b/test/tests/functional/pbs_job_array.py
@@ -134,7 +134,6 @@ e.accept()
         _msg = 'No license found on server %s' % (self.server.shortname)
         self.assertTrue(rv, _msg)
 
-    @skipOnCpuSet
     def test_running_subjob_survive_restart(self):
         """
         Test to check if a running subjob of an array job survive a
@@ -182,7 +181,6 @@ e.accept()
         self.server.manager(MGR_CMD_SET, SERVER, attr)
         self.test_running_subjob_survive_restart()
 
-    @skipOnCpuSet
     def test_suspended_subjob_survive_restart(self):
         """
         Test to check if a suspended subjob of an array job survive a
@@ -234,7 +232,6 @@ e.accept()
         self.server.manager(MGR_CMD_SET, SERVER, attr)
         self.test_suspended_subjob_survive_restart()
 
-    @skipOnCpuSet
     def test_deleted_q_subjob_survive_restart(self):
         """
         Test to check if a deleted queued subjob of an array job survive a
@@ -268,7 +265,6 @@ e.accept()
         self.server.manager(MGR_CMD_SET, SERVER, attr)
         self.test_deleted_q_subjob_survive_restart()
 
-    @skipOnCpuSet
     def test_deleted_r_subjob_survive_restart(self):
         """
         Test to check if a deleted running subjob of an array job survive a
@@ -303,7 +299,6 @@ e.accept()
         self.server.manager(MGR_CMD_SET, SERVER, attr)
         self.test_deleted_q_subjob_survive_restart()
 
-    @skipOnCpuSet
     def test_qdel_expired_subjob(self):
         """
         Test to check if qdel of a subjob is disallowed
@@ -344,7 +339,6 @@ e.accept()
         else:
             raise self.failureException("subjob in X state can be deleted")
 
-    @skipOnCpuSet
     def test_subjob_comments(self):
         """
         Test subjob comments for finished and terminated subjobs
@@ -365,7 +359,6 @@ e.accept()
         self.server.expect(
             JOB, {'comment': 'Subjob finished'}, subjid_1, max_attempts=1)
 
-    @skipOnCpuSet
     def test_subjob_comments_with_history(self):
         """
         Test subjob comments for finished, failed and terminated subjobs
@@ -411,7 +404,6 @@ e.accept()
             JOB, {'comment': (MATCH_RE, 'Job run at.*and failed')}, subjid_2,
             extend='x')
 
-    @skipOnCpuSet
     def test_multiple_server_restarts(self):
         """
         Test subjobs wont rerun after multiple server restarts
@@ -431,7 +423,6 @@ e.accept()
             self.server.expect(
                 JOB, a, subjid_1, attrop=PTL_AND)
 
-    @skipOnCpuSet
     def test_job_array_history_duration(self):
         """
         Test that job array and subjobs are purged after history duration
@@ -462,7 +453,6 @@ e.accept()
         self.server.expect(JOB, 'job_state', op=UNSET,
                            id=subjid_2, extend='x')
 
-    @skipOnCpuSet
     def test_queue_deletion_after_terminated_subjob(self):
         """
         Test that queue can be deleted after the job array is
@@ -481,7 +471,6 @@ e.accept()
         self.server.delete(j_id, wait=True)
         self.server.manager(MGR_CMD_DELETE, QUEUE, id='workq')
 
-    @skipOnCpuSet
     def test_held_job_array_survive_server_restart(self):
         """
         Test held job array can be released after server restart
@@ -515,7 +504,6 @@ e.accept()
         self.server.manager(MGR_CMD_SET, SERVER, a)
         self.test_held_job_array_survive_server_restart()
 
-    @skipOnCpuSet
     def test_subjobs_qrun(self):
         """
         Test that job array's subjobs can be qrun
@@ -533,7 +521,6 @@ e.accept()
         self.server.expect(JOB, {'job_state': 'B'}, j_id)
         self.server.expect(JOB, {'job_state': 'R'}, subjid_1)
 
-    @skipOnCpuSet
     def test_dependent_job_array_server_restart(self):
         """
         Check Job array dependency is not released after server restart
@@ -562,7 +549,6 @@ e.accept()
                            j_id, extend='x', interval=5)
         self.server.expect(JOB, {'job_state': 'B'}, j_id2, interval=5)
 
-    @skipOnCpuSet
     def test_rerun_subjobs_server_restart(self):
         """
         Test that subjobs which are requeued remain queued after server restart
@@ -588,7 +574,6 @@ e.accept()
         a = {'job_state': 'R'}
         self.server.expect(JOB, a, subjid_1)
 
-    @skipOnCpuSet
     def test_rerun_node_fail_requeue(self):
         """
         Test sub jobs gets requeued after node_fail_requeue time
@@ -606,7 +591,6 @@ e.accept()
         self.mom.stop()
         self.server.expect(JOB, {'job_state': 'Q'}, subjid_1, offset=5)
 
-    @skipOnCpuSet
     def test_qmove_job_array(self):
         """
         Test job array's can be qmoved to a high priority queue
@@ -635,7 +619,6 @@ e.accept()
         self.server.expect(JOB, {'job_state': 'S'}, subjid_1)
         self.server.expect(JOB, {'job_state': 'R'}, subjid_3)
 
-    @skipOnCpuSet
     def test_delete_history_subjob_server_restart(self):
         """
         Test that subjobs can be deleted from history
@@ -656,7 +639,6 @@ e.accept()
         self.kill_and_restart_svr()
         self.server.expect(JOB, 'job_state', op=UNSET, extend='x', id=j_id)
 
-    @skipOnCpuSet
     def test_job_id_duplicate_server_restart(self):
         """
         Test that after server restart there is no duplication
@@ -727,7 +709,6 @@ e.accept()
                     raise self.failureException("std file " + f_name +
                                                 " not found")
 
-    @skipOnCpuSet
     @skipOnCray
     def test_subjob_wrong_state(self):
         """
@@ -752,7 +733,6 @@ e.accept()
         # ensure all the subjobs are running
         self.server.expect(JOB, {'job_state=R': 200}, extend='t')
 
-    @skipOnCpuSet
     def test_recover_big_array_job(self):
         """
         Test that during server restart, server is able to recover valid

--- a/test/tests/functional/pbs_job_array_comment.py
+++ b/test/tests/functional/pbs_job_array_comment.py
@@ -46,7 +46,6 @@ class TestJobArrayComment(TestFunctional):
     Testing job array comment is accurate
     """
 
-    @skipOnCpuSet
     def test_job_array_comment(self):
         """
         Testing job array comment is correct when one or more sub jobs

--- a/test/tests/functional/pbs_job_comment_on_resume.py
+++ b/test/tests/functional/pbs_job_comment_on_resume.py
@@ -47,7 +47,6 @@ class TestJobComment(TestFunctional):
     Testing job comment is accurate
     """
 
-    @skipOnCpuSet
     def test_job_comment_on_resume(self):
         """
         Testing whether job comment is accurate

--- a/test/tests/functional/pbs_job_dependency.py
+++ b/test/tests/functional/pbs_job_dependency.py
@@ -84,7 +84,6 @@ e.accept()
             for job_list in check_dl:
                 self.assertIn(job, job_list)
 
-    @skipOnCpuSet
     def test_runone_depend_basic(self):
         """
         Test basic runone dependency tests
@@ -143,7 +142,6 @@ e.accept()
         self.server.expect(JOB, {ATTR_state: 'H', ATTR_h: 's'}, id=j3)
         self.assert_dependency(j1, j2, j3)
 
-    @skipOnCpuSet
     def test_runone_depend_basic_on_job_array(self):
         """
         Test basic runone dependency tests on job arrays

--- a/test/tests/functional/pbs_job_purge.py
+++ b/test/tests/functional/pbs_job_purge.py
@@ -46,7 +46,6 @@ class TestJobPurge(TestFunctional):
     This test suite tests the Job purge process
     """
 
-    @skipOnCpuSet
     def test_job_files_after_execution(self):
         """
         Checks the job related files and ensures that files are

--- a/test/tests/functional/pbs_job_routing.py
+++ b/test/tests/functional/pbs_job_routing.py
@@ -54,7 +54,6 @@ class TestJobRouting(TestFunctional):
 
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'false'})
 
-    @skipOnCpuSet
     def test_t1(self):
         """
         This test case validates Job array state when one
@@ -113,7 +112,6 @@ class TestJobRouting(TestFunctional):
         self.server.expect(JOB, {ATTR_queue + '=' + dflt_q: 3}, count=True,
                            id=jid, extend='t')
 
-    @skipOnCpuSet
     def test_t2(self):
         """
         This test case validates Job array state when running subjobs

--- a/test/tests/functional/pbs_job_script.py
+++ b/test/tests/functional/pbs_job_script.py
@@ -65,7 +65,6 @@ class TestPbsJobScript(TestFunctional):
         jid = self.server.submit(j)
         return jid
 
-    @skipOnCpuSet
     def test_long_select_spec(self):
         """
         Test that PBS is able to accept jobs scripts with very long select
@@ -79,7 +78,6 @@ class TestPbsJobScript(TestFunctional):
         self.server.expect(JOB, {'job_state': 'R', 'exec_vnode': execvnode},
                            id=jid)
 
-    @skipOnCpuSet
     def test_long_select_spec_extend(self):
         """
         Test that PBS is able to accept jobs scripts with very long select

--- a/test/tests/functional/pbs_job_sort_formula.py
+++ b/test/tests/functional/pbs_job_sort_formula.py
@@ -46,7 +46,6 @@ class TestJobSortFormula(TestFunctional):
     Tests for the job_sort_formula
     """
 
-    @skipOnCpuSet
     def test_job_sort_formula_negative_value(self):
         """
         Test to see that negative values in the

--- a/test/tests/functional/pbs_maintenance_reservations.py
+++ b/test/tests/functional/pbs_maintenance_reservations.py
@@ -201,7 +201,6 @@ class TestMaintenanceReservations(TestFunctional):
 
         self.assertEqual("pbs_rsub: Duplicate host: foo", msg)
 
-    @skipOnCpuSet
     def test_maintenance_confirm(self):
         """
         Test if the maintenance (prefixed with 'M') is immediately

--- a/test/tests/functional/pbs_mom_mock_run.py
+++ b/test/tests/functional/pbs_mom_mock_run.py
@@ -42,7 +42,7 @@ from tests.functional import *
 
 
 class TestMomMockRun(TestFunctional):
-    @skipOnCpuSet
+
     def test_rsc_used(self):
         """
         Test that resources_used are set correctly by mom under mock run

--- a/test/tests/functional/pbs_multi_sched.py
+++ b/test/tests/functional/pbs_multi_sched.py
@@ -136,7 +136,6 @@ class TestMultipleSchedulers(TestFunctional):
                 self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': op},
                                     id=each)
 
-    @skipOnCpuSet
     def test_job_sort_formula_multisched(self):
         """
         Test that job_sort_formula can be set for each sched
@@ -204,7 +203,6 @@ class TestMultipleSchedulers(TestFunctional):
                 self.server.expect(JOB, {'job_state': 'Q'}, id=jid2)
                 self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
 
-    @skipOnCpuSet
     def test_set_sched_priv(self):
         """
         Test sched_priv can be only set to valid paths
@@ -264,7 +262,6 @@ class TestMultipleSchedulers(TestFunctional):
         # Blocked by PP-1202 will revisit once its fixed
         # self.server.expect(SCHED, 'comment', id='sc1', op=UNSET)
 
-    @skipOnCpuSet
     def test_start_scheduler(self):
         """
         Test that scheduler wont start without appropriate folders created.
@@ -316,7 +313,6 @@ class TestMultipleSchedulers(TestFunctional):
         self.server.expect(SCHED, {'state': 'scheduling'},
                            id='sc5', max_attempts=10)
 
-    @skipOnCpuSet
     def test_resource_sched_reconfigure(self):
         """
         Test all schedulers will reconfigure while creating,
@@ -365,7 +361,6 @@ class TestMultipleSchedulers(TestFunctional):
         # Blocked by PP-1202 will revisit once its fixed
         # self.server.manager(MGR_CMD_UNSET, SCHED, 'partition', id="sc2")
 
-    @skipOnCpuSet
     def test_job_queue_partition(self):
         """
         Test job submitted to a queue associated to a partition will land
@@ -398,7 +393,6 @@ class TestMultipleSchedulers(TestFunctional):
             jid + ';Job run', max_attempts=10,
             starttime=self.server.ctime)
 
-    @skipOnCpuSet
     def test_multiple_queue_same_partition(self):
         """
         Test multiple queue associated with same partition
@@ -426,7 +420,6 @@ class TestMultipleSchedulers(TestFunctional):
             jid + ';Job run', max_attempts=10,
             starttime=self.server.ctime)
 
-    @skipOnCpuSet
     def test_preemption_highp_queue(self):
         """
         Test preemption occures only within queues which are assigned
@@ -456,7 +449,6 @@ class TestMultipleSchedulers(TestFunctional):
             jid1 + ';Job preempted by suspension',
             max_attempts=10, starttime=t)
 
-    @skipOnCpuSet
     def test_preemption_two_sched(self):
         """
         Test two schedulers preempting jobs at the same time
@@ -516,7 +508,6 @@ class TestMultipleSchedulers(TestFunctional):
         self.server.expect(JOB, {'job_state': 'R'}, id=hj1_jid)
         self.server.expect(JOB, {'job_state': 'R'}, id=hj2_jid)
 
-    @skipOnCpuSet
     def test_backfill_per_scheduler(self):
         """
         Test backfilling is applicable only per scheduler
@@ -548,7 +539,6 @@ class TestMultipleSchedulers(TestFunctional):
             jid4 + ';Job is a top job and will run at',
             max_attempts=5, starttime=t, existence=False)
 
-    @skipOnCpuSet
     def test_resource_per_scheduler(self):
         """
         Test resources will be considered only by scheduler
@@ -610,7 +600,6 @@ class TestMultipleSchedulers(TestFunctional):
         self.server.expect(SCHED, a, id='sc1',
                            attrop=PTL_AND, max_attempts=10)
 
-    @skipOnCpuSet
     def test_job_sorted_per_scheduler(self):
         """
         Test jobs are sorted as per job_sort_formula
@@ -644,7 +633,6 @@ class TestMultipleSchedulers(TestFunctional):
                             {'scheduling': 'True'}, id="sc3")
         self.server.expect(JOB, {'job_state': 'R'}, id=jid4)
 
-    @skipOnCpuSet
     def test_qrun_job(self):
         """
         Test jobs can be run by qrun by a newly created scheduler.
@@ -660,7 +648,6 @@ class TestMultipleSchedulers(TestFunctional):
         self.server.runjob(jid1)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
 
-    @skipOnCpuSet
     def test_run_limts_per_scheduler(self):
         """
         Test run_limits applied at server level is
@@ -689,7 +676,6 @@ class TestMultipleSchedulers(TestFunctional):
         jc = "Not Running: User has reached server running job limit."
         self.server.expect(JOB, {'comment': jc}, id=jid4)
 
-    @skipOnCpuSet
     def test_multi_fairshare(self):
         """
         Test different schedulers have their own fairshare trees with
@@ -746,7 +732,6 @@ class TestMultipleSchedulers(TestFunctional):
         self.assertEqual(n.nshares, sc3_shares)
         self.assertEqual(n.usage, sc3_usage)
 
-    @skipOnCpuSet
     def test_fairshare_usage(self):
         """
         Test the schedulers fairshare usage file and
@@ -982,7 +967,6 @@ class TestMultipleSchedulers(TestFunctional):
         n = self.scheds['sc1'].query_fairshare().get_node(name=str(TEST_USER))
         self.assertTrue(n.usage, 25)
 
-    @skipOnCpuSet
     def test_pbsfs_revert_to_defaults(self):
         """
         Test if revert_to_defaults() works properly with multi scheds.
@@ -1079,7 +1063,6 @@ class TestMultipleSchedulers(TestFunctional):
 
         return ret_jids
 
-    @skipOnCpuSet
     def test_equiv_multisched(self):
         """
         Test the basic behavior of job equivalence classes: submit two
@@ -1116,7 +1099,6 @@ class TestMultipleSchedulers(TestFunctional):
         self.scheds['sc2'].log_match("Number of job equivalence classes: 2",
                                      max_attempts=10, starttime=t)
 
-    @skipOnCpuSet
     def test_limits_queues(self):
         """
         Test to see that jobs from different users fall into different
@@ -1216,7 +1198,6 @@ class TestMultipleSchedulers(TestFunctional):
             self.assertTrue(err_msg in e.msg[0],
                             "Error message is not expected")
 
-    @skipOnCpuSet
     def test_job_sort_formula_threshold(self):
         """
         Test the scheduler attribute job_sort_formula_threshold for multisched
@@ -1276,7 +1257,6 @@ class TestMultipleSchedulers(TestFunctional):
         self.server.manager(MGR_CMD_SET, SERVER, {'node_group_key': 'switch'})
         self.server.manager(MGR_CMD_SET, SERVER, {'node_group_enable': 't'})
 
-    @skipOnCpuSet
     def test_multi_sched_explicit_ps(self):
         """
         Test only_explicit_ps set to sched attr will be in affect
@@ -1328,7 +1308,6 @@ class TestMultipleSchedulers(TestFunctional):
                            'comment': 'Not Running: Placement set switch=A'
                            ' has too few free resources'}, id=j6id)
 
-    @skipOnCpuSet
     def test_jobs_do_not_span_ps(self):
         """
         Test do_not_span_psets set to sched attr will be in affect
@@ -1358,7 +1337,6 @@ class TestMultipleSchedulers(TestFunctional):
         j2id = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=j2id)
 
-    @skipOnCpuSet
     def test_sched_preempt_enforce_resumption(self):
         """
         Test sched_preempt_enforce_resumption can be set to a multi sched
@@ -1443,7 +1421,6 @@ class TestMultipleSchedulers(TestFunctional):
         p_day = 'sunday'
         self.scheds[scid].holidays_set_day(p_day, p_hhmm, np_hhmm)
 
-    @skipOnCpuSet
     def test_prime_time_backfill(self):
         """
         Test opt_backfill_fuzzy can be set to a multi sched and
@@ -1487,7 +1464,6 @@ class TestMultipleSchedulers(TestFunctional):
         prime_mod = prime_start % 60  # ignoring the seconds
         self.assertEqual((prime_start - prime_mod), est_epoch)
 
-    @skipOnCpuSet
     def test_prime_time_multisched(self):
         """
         Test prime time queue can be set partition and multi sched
@@ -1516,7 +1492,6 @@ class TestMultipleSchedulers(TestFunctional):
         self.scheds['sc2'].log_match(jid2 + ";Job only runs in primetime",
                                      starttime=self.server.ctime)
 
-    @skipOnCpuSet
     def test_dedicated_time_multisched(self):
         """
         Test dedicated time queue can be set partition and multi sched
@@ -1658,7 +1633,6 @@ class TestMultipleSchedulers(TestFunctional):
             "scheduler priv directory has changed to " + new_sched_priv,
             max_attempts=10, starttime=self.server.ctime)
 
-    @skipOnCpuSet
     def test_set_msched_update_inbuilt_attrs_accrue_type(self):
         """
         Test to make sure Multisched is able to update any one of the builtin
@@ -1690,7 +1664,6 @@ class TestMultipleSchedulers(TestFunctional):
         # This makes sure that accrue_type is indeed getting changed
         self.server.expect(JOB, {ATTR_accrue_type: 3}, id=jid2)
 
-    @skipOnCpuSet
     def test_multisched_not_crash(self):
         """
         Test to make sure Multisched does not crash when all nodes in partition
@@ -1720,7 +1693,6 @@ class TestMultipleSchedulers(TestFunctional):
         # If job goes to R state means scheduler is still alive.
         self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
 
-    @skipOnCpuSet
     def test_multi_sched_job_sort_key(self):
         """
         Test to make sure that jobs are sorted as per
@@ -1743,7 +1715,6 @@ class TestMultipleSchedulers(TestFunctional):
         self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
         self.server.expect(JOB, {'job_state': 'Q'}, id=jid1)
 
-    @skipOnCpuSet
     def test_multi_sched_node_sort_key(self):
         """
         Test to make sure nodes are sorted in the order
@@ -1785,7 +1756,6 @@ class TestMultipleSchedulers(TestFunctional):
         self.server.expect(JOB, {'job_state': 'R'}, id=jid4)
         self.check_vnodes(j, [vn[0]], jid4)
 
-    @skipOnCpuSet
     def test_multi_sched_priority_sockets(self):
         """
         Test scheduler socket connections from all the schedulers
@@ -1815,7 +1785,6 @@ class TestMultipleSchedulers(TestFunctional):
                             {'scheduling': 'True'}, id='sc2')
         self.server.log_match("processing priority socket", starttime=t)
 
-    @skipOnCpuSet
     def test_advance_resv_in_multi_sched(self):
         """
         Test that advance reservations in a multi-sched environment can be
@@ -1867,7 +1836,6 @@ class TestMultipleSchedulers(TestFunctional):
         result = {'job_state': 'R', 'exec_vnode': '(' + vn1 + ':ncpus=1)'}
         self.server.expect(JOB, result, id=jid4)
 
-    @skipOnCpuSet
     def test_resv_in_empty_multi_sched_env(self):
         """
         Test that advance reservations gets confirmed by all the schedulers
@@ -1894,7 +1862,6 @@ class TestMultipleSchedulers(TestFunctional):
         msg = "Resv;" + rid + ";Reservation denied"
         self.server.log_match(msg)
 
-    @skipOnCpuSet
     def test_asap_resv(self):
         """
         Test ASAP reservation in multisched environment. It should not
@@ -2026,7 +1993,6 @@ e.accept()
         self.assertIn("hook 'h1' encountered an exception",
                       e.exception.msg[0])
 
-    @skipOnCpuSet
     def test_resv_alter(self):
         """
         Test if a reservation confirmed by a multi-sched can be altered by the
@@ -2186,7 +2152,6 @@ e.accept()
         self.degraded_resv_reconfirm(start=now + 20, end=now + 200, run=True,
                                      rrule='FREQ=HOURLY;COUNT=2')
 
-    @skipOnCpuSet
     def test_resv_from_job_in_multi_sched_using_qsub(self):
         """
         Test that a user is able to create a reservation out of a job using
@@ -2209,7 +2174,6 @@ e.accept()
              'partition': 'P1'}
         self.server.expect(RESV, a, id=rid)
 
-    @skipOnCpuSet
     def test_resv_from_job_in_multi_sched_using_rsub(self):
         """
         Test that a user is able to create a reservation out of a job using

--- a/test/tests/functional/pbs_node_buckets.py
+++ b/test/tests/functional/pbs_node_buckets.py
@@ -116,7 +116,6 @@ class TestNodeBuckets(TestFunctional):
 
         self.server.delete(jid, wait=True)
 
-    @skipOnCpuSet
     def test_basic(self):
         """
         Request nodes of a specific color and make sure they are correctly
@@ -137,7 +136,6 @@ class TestNodeBuckets(TestFunctional):
             self.assertTrue('yellow' in
                             n[0]['resources_available.color'])
 
-    @skipOnCpuSet
     def test_multi_bucket(self):
         """
         Request two different chunk types which need to be allocated from
@@ -162,7 +160,6 @@ class TestNodeBuckets(TestFunctional):
             n = self.server.status(NODE, id=nodes[i])
             self.assertTrue('blue' in n[0]['resources_available.color'])
 
-    @skipOnCpuSet
     def test_multi_bucket2(self):
         """
         Request nodes from all 7 different buckets and see them allocated
@@ -190,7 +187,6 @@ class TestNodeBuckets(TestFunctional):
             self.assertTrue(self.colors[i] in
                             n[0]['resources_available.color'])
 
-    @skipOnCpuSet
     def test_not_run(self):
         """
         Request more nodes of one color that is available to make sure
@@ -206,7 +202,6 @@ class TestNodeBuckets(TestFunctional):
         self.server.expect(JOB, a, attrop=PTL_AND, id=jid)
         self.scheduler.log_match(jid + ';Chunk: ' + chunk, n=10000)
 
-    @skipOnCpuSet
     def test_calendaring1(self):
         """
         Test to see that nodes that are used in the future for
@@ -252,7 +247,6 @@ class TestNodeBuckets(TestFunctional):
         self.server.expect(JOB, 'comment', op=SET, id=jid4, interval=1)
         self.scheduler.log_match(jid4 + ';Chunk: ' + chunk3, n=10000)
 
-    @skipOnCpuSet
     def test_calendaring2(self):
         """
         Test that nodes that a reservation calendared on them later on
@@ -288,7 +282,6 @@ class TestNodeBuckets(TestFunctional):
         self.assertTrue(vnode + '[2865]' in n, msg)
         self.assertTrue(vnode + '[2870]' in n, msg)
 
-    @skipOnCpuSet
     def test_calendaring3(self):
         """
         Test that a future reservation's nodes are used first for a job
@@ -332,7 +325,6 @@ class TestNodeBuckets(TestFunctional):
         self.assertTrue(vnode + '[2865]' in n, msg)
         self.assertTrue(vnode + '[2870]' in n, msg)
 
-    @skipOnCpuSet
     def test_buckets_and_non(self):
         """
         Test that jobs requesting buckets and not requesting buckets
@@ -366,7 +358,6 @@ class TestNodeBuckets(TestFunctional):
         for n in nodes2:
             self.assertNotEqual(n, nodes1[0], msg)
 
-    @skipOnCpuSet
     def test_not_buckets(self):
         """
         Test to make sure the jobs that should use the standard node searching
@@ -493,7 +484,6 @@ class TestNodeBuckets(TestFunctional):
                                vnodes_per_host=4)
         self.check_normal_path(sel='2:ncpus=8')
 
-    @skipOnCpuSet
     def test_multi_vnode_resv(self):
         """
         Test that node buckets do not get in the way of running jobs on
@@ -538,7 +528,6 @@ class TestNodeBuckets(TestFunctional):
         self.assertEqual(len(set(s)), 1,
                          "Job1 ran in more than one placement set")
 
-    @skipOnCpuSet
     def test_bucket_sort(self):
         """
         Test if buckets are sorted properly: all of the yellow bucket
@@ -566,7 +555,6 @@ class TestNodeBuckets(TestFunctional):
         self.assertEqual(c1, 'yellow', "Job didn't run on yellow nodes")
         self.assertEqual(c2, 'yellow', "Job didn't run on yellow nodes")
 
-    @skipOnCpuSet
     def test_psets(self):
         """
         Test placement sets with node buckets
@@ -611,7 +599,6 @@ class TestNodeBuckets(TestFunctional):
         for node in used_nodes1:
             self.assertNotIn(node, used_nodes2, 'Jobs share nodes: ' + node)
 
-    @skipOnCpuSet
     def test_psets_calendaring(self):
         """
         Test that jobs in the calendar fit within a placement set
@@ -675,7 +662,6 @@ class TestNodeBuckets(TestFunctional):
             self.assertNotIn(node, used_nodes3,
                              'Jobs will share nodes: ' + node)
 
-    @skipOnCpuSet
     def test_psets_calendaring_resv(self):
         """
         Test that jobs do not run into a reservation and will correctly
@@ -712,7 +698,6 @@ class TestNodeBuckets(TestFunctional):
         self.assertEqual(len(set(s)), 1,
                          "Job will run in more than one placement set")
 
-    @skipOnCpuSet
     def test_place_group(self):
         """
         Test node buckets with place=group
@@ -735,7 +720,6 @@ class TestNodeBuckets(TestFunctional):
         self.assertEqual(len(set(s)), 1,
                          "Job ran in more than one placement set")
 
-    @skipOnCpuSet
     def test_psets_spanning(self):
         """
         Request more nodes than available in one placement set and see
@@ -784,7 +768,6 @@ class TestNodeBuckets(TestFunctional):
         self.assertGreater(len(set(s)), 1,
                            "Job did not span properly")
 
-    @skipOnCpuSet
     def test_psets_queue(self):
         """
         Test that placement sets work for nodes associated with queues
@@ -846,7 +829,6 @@ class TestNodeBuckets(TestFunctional):
         self.assertGreater(len(set(s)), 1,
                            "Job did not span properly")
 
-    @skipOnCpuSet
     def test_free(self):
         """
         Test that free placement works with the bucket code path
@@ -882,7 +864,6 @@ class TestNodeBuckets(TestFunctional):
         for node in n1:
             self.assertTrue(node not in n2, 'Jobs share nodes: ' + node)
 
-    @skipOnCpuSet
     def test_queue_nodes(self):
         """
         Test that buckets work with nodes associated to a queue
@@ -922,7 +903,6 @@ class TestNodeBuckets(TestFunctional):
         self.assertIn(v1, ev, msg)
         self.assertIn(v2, ev, msg)
 
-    @skipOnCpuSet
     def test_booleans(self):
         """
         Test that booleans are correctly handled if not in the sched_config
@@ -958,7 +938,6 @@ class TestNodeBuckets(TestFunctional):
             self.server.expect(
                 NODE, 'resources_available.bool', op=UNSET, id=n)
 
-    @skipOnCpuSet
     def test_last_pset_can_never_run(self):
         """
         Test that the job does not retain the error value of last placement

--- a/test/tests/functional/pbs_node_rampdown_keep_select.py
+++ b/test/tests/functional/pbs_node_rampdown_keep_select.py
@@ -381,7 +381,6 @@ class TestPbsNodeRampDownKeepSelect(TestFunctional):
         # 16. validate PBS_NODEFILE again
         self.pbs_nodefile_match_exec_host(jid, mlist_new, tc.sched_sel_after)
 
-    @skipOnCpuSet
     def test_basic_use_case_ncpus(self, rel_user=TEST_USER, use_script=False):
         """
         submit job with below select string
@@ -433,7 +432,6 @@ class TestPbsNodeRampDownKeepSelect(TestFunctional):
         tc = test_config(**args)
         self.common_tc_flow(tc)
 
-    @skipOnCpuSet
     def test_basic_use_case_ncpus_as_root(self):
         """
         submit job with below select string
@@ -443,7 +441,6 @@ class TestPbsNodeRampDownKeepSelect(TestFunctional):
         """
         self.test_basic_use_case_ncpus(rel_user=ROOT_USER)
 
-    @skipOnCpuSet
     def test_basic_use_case_ncpus_using_script(self):
         """
         Like test_basic_use_case_ncpus test except instead of calling
@@ -458,7 +455,6 @@ class TestPbsNodeRampDownKeepSelect(TestFunctional):
             "exit 0"
         self.test_basic_use_case_ncpus(use_script=True)
 
-    @skipOnCpuSet
     def test_with_a_custom_str_res(self, partial_res_list=False):
         """
         submit job with select string containing a custom string resource
@@ -533,7 +529,6 @@ class TestPbsNodeRampDownKeepSelect(TestFunctional):
         tc = test_config(**args)
         self.common_tc_flow(tc)
 
-    @skipOnCpuSet
     def test_with_a_custom_str_res_partial_list(self, partial_res_list=False):
         """
         submit job with select string containing a custom string resource
@@ -545,7 +540,6 @@ class TestPbsNodeRampDownKeepSelect(TestFunctional):
         """
         self.test_with_a_custom_str_res(partial_res_list=True)
 
-    @skipOnCpuSet
     def test_with_a_custom_bool_res(self, partial_res_list=False):
         """
         submit job with select string containing a custom boolean resource
@@ -611,7 +605,6 @@ class TestPbsNodeRampDownKeepSelect(TestFunctional):
         tc = test_config(**args)
         self.common_tc_flow(tc)
 
-    @skipOnCpuSet
     def test_with_a_custom_bool_res_partial_list(self,
                                                  partial_res_list=False):
         """
@@ -624,7 +617,6 @@ class TestPbsNodeRampDownKeepSelect(TestFunctional):
         """
         self.test_with_a_custom_bool_res(partial_res_list=True)
 
-    @skipOnCpuSet
     def test_with_a_custom_long_res(self, partial_res_list=False):
         """
         submit job with select string containing a custom long resource
@@ -697,7 +689,6 @@ class TestPbsNodeRampDownKeepSelect(TestFunctional):
         tc = test_config(**args)
         self.common_tc_flow(tc)
 
-    @skipOnCpuSet
     def test_with_a_custom_long_partial_list(self, partial_res_list=False):
         """
         submit job with select string containing a custom long resource
@@ -709,7 +700,6 @@ class TestPbsNodeRampDownKeepSelect(TestFunctional):
         """
         self.test_with_a_custom_long_res(partial_res_list=True)
 
-    @skipOnCpuSet
     def test_with_a_custom_size_res(self, partial_res_list=False):
         """
         submit job with select string containing a custom size resource
@@ -783,7 +773,6 @@ class TestPbsNodeRampDownKeepSelect(TestFunctional):
         tc = test_config(**args)
         self.common_tc_flow(tc)
 
-    @skipOnCpuSet
     def test_with_a_custom_size_partial_list(self, partial_res_list=False):
         """
         submit job with select string containing a custom size resource
@@ -795,7 +784,6 @@ class TestPbsNodeRampDownKeepSelect(TestFunctional):
         """
         self.test_with_a_custom_size_res(partial_res_list=True)
 
-    @skipOnCpuSet
     def test_with_a_custom_float_res(self, partial_res_list=False):
         """
         submit job with select string containing a custom float resource
@@ -870,7 +858,6 @@ class TestPbsNodeRampDownKeepSelect(TestFunctional):
         tc = test_config(**args)
         self.common_tc_flow(tc)
 
-    @skipOnCpuSet
     def test_with_a_custom_float_partial_list(self, partial_res_list=False):
         """
         submit job with select string containing a custom float resource
@@ -882,7 +869,6 @@ class TestPbsNodeRampDownKeepSelect(TestFunctional):
         """
         self.test_with_a_custom_float_res(partial_res_list=True)
 
-    @skipOnCpuSet
     def test_with_mixed_custom_res(self, partial_res_list=False):
         """
         submit job with select string containing a mix of all types of
@@ -1011,7 +997,6 @@ class TestPbsNodeRampDownKeepSelect(TestFunctional):
         tc = test_config(**args)
         self.common_tc_flow(tc)
 
-    @skipOnCpuSet
     def test_with_mixed_custom_res_partial_list(self, partial_res_list=False):
         """
         submit job with select string containing a mix of all types of
@@ -1026,7 +1011,6 @@ class TestPbsNodeRampDownKeepSelect(TestFunctional):
         """
         self.test_with_mixed_custom_res(partial_res_list=True)
 
-    @skipOnCpuSet
     def test_schunk_use_case(self, release_partial_schunk=False):
         """
         submit job with below select string
@@ -1088,7 +1072,6 @@ class TestPbsNodeRampDownKeepSelect(TestFunctional):
         tc = test_config(**args)
         self.common_tc_flow(tc)
 
-    @skipOnCpuSet
     def test_schunk_partial_release_use_case(self):
         """
         submit job with below select string
@@ -1100,7 +1083,6 @@ class TestPbsNodeRampDownKeepSelect(TestFunctional):
         """
         self.test_schunk_use_case(release_partial_schunk=True)
 
-    @skipOnCpuSet
     def test_release_nodes_error(self):
         """
         Tests erroneous cases:
@@ -1182,7 +1164,6 @@ class TestPbsNodeRampDownKeepSelect(TestFunctional):
         self.assertTrue(ret['err'][0].startswith(
             'pbs_release_nodes: Server returned error 15010 for job'))
 
-    @skipOnCpuSet
     def test_node_count(self, rel_user=TEST_USER, use_script=False):
         """
         submit job with below select string
@@ -1232,7 +1213,6 @@ class TestPbsNodeRampDownKeepSelect(TestFunctional):
         tc = test_config(**args)
         self.common_tc_flow(tc)
 
-    @skipOnCpuSet
     def test_node_count_as_root(self):
         """
         submit job with below select string
@@ -1241,7 +1221,6 @@ class TestPbsNodeRampDownKeepSelect(TestFunctional):
         """
         self.test_node_count(rel_user=ROOT_USER)
 
-    @skipOnCpuSet
     def test_node_count_using_script(self):
         """
         Like test_node_count test except instead of calling
@@ -1256,7 +1235,6 @@ class TestPbsNodeRampDownKeepSelect(TestFunctional):
             "exit 0"
         self.test_node_count(use_script=True)
 
-    @skipOnCpuSet
     def test_node_count_with_mixed_custom_res(self):
         """
         submit job with select string containing a mix of all types of
@@ -1373,7 +1351,6 @@ class TestPbsNodeRampDownKeepSelect(TestFunctional):
         tc = test_config(**args)
         self.common_tc_flow(tc)
 
-    @skipOnCpuSet
     def test_node_count_schunk_use_case(self):
         """
         submit job with below select string

--- a/test/tests/functional/pbs_pbsnodes.py
+++ b/test/tests/functional/pbs_pbsnodes.py
@@ -189,7 +189,6 @@ class TestPbsnodes(TestFunctional):
         self.assertEqual(prev.strip(), now.strip(),
                          'Last used time mismatch after server restart')
 
-    @skipOnCpuSet
     @skipOnCray
     def test_pbsnodes_as_user(self):
         """
@@ -219,7 +218,6 @@ class TestPbsnodes(TestFunctional):
                                      attr_dict['resources_available.mem'])
 
     @tags('smoke')
-    @skipOnCpuSet
     @skipOnCray
     def test_pbsnodes_as_root(self):
         """

--- a/test/tests/functional/pbs_preemption.py
+++ b/test/tests/functional/pbs_preemption.py
@@ -166,21 +166,18 @@ exit 1
 
         self.scheduler.log_match(jid + ";Job preempted by " + preempted_by)
 
-    @skipOnCpuSet
     def test_preempt_suspend(self):
         """
         Test that a job is preempted by suspension
         """
         self.submit_and_preempt_jobs(preempt_order='S')
 
-    @skipOnCpuSet
     def test_preempt_suspend_ja(self):
         """
         Test that a subjob is preempted by suspension
         """
         self.submit_and_preempt_jobs(preempt_order='S', job_array=True)
 
-    @skipOnCpuSet
     def test_preempt_checkpoint(self):
         """
         Test that a job is preempted with checkpoint
@@ -188,7 +185,6 @@ exit 1
         self.mom.add_checkpoint_abort_script(body=self.chk_script)
         self.submit_and_preempt_jobs(preempt_order='C')
 
-    @skipOnCpuSet
     def test_preempt_checkpoint_requeue(self):
         """
         Test that when checkpoint fails, a job is correctly requeued
@@ -196,14 +192,12 @@ exit 1
         self.mom.add_checkpoint_abort_script(body=self.chk_script_fail)
         self.submit_and_preempt_jobs(preempt_order='CR')
 
-    @skipOnCpuSet
     def test_preempt_requeue(self):
         """
         Test that a job is preempted by requeue
         """
         self.submit_and_preempt_jobs(preempt_order='R')
 
-    @skipOnCpuSet
     def test_preempt_requeue_exclhost(self):
         """
         Test that a job is preempted by requeue on node
@@ -220,21 +214,18 @@ exit 1
             existence=False, starttime=start_time,
             max_attempts=5)
 
-    @skipOnCpuSet
     def test_preempt_requeue_ja(self):
         """
         Test that a subjob is preempted by requeue
         """
         self.submit_and_preempt_jobs(preempt_order='R', job_array=True)
 
-    @skipOnCpuSet
     def test_preempt_delete(self):
         """
         Test preempt via delete correctly deletes a job
         """
         self.submit_and_preempt_jobs(preempt_order='D')
 
-    @skipOnCpuSet
     def test_preempt_delete_ja(self):
         """
         Test preempt via delete correctly deletes a subjob
@@ -242,7 +233,6 @@ exit 1
 
         self.submit_and_preempt_jobs(preempt_order='D', job_array=True)
 
-    @skipOnCpuSet
     def test_preempt_checkpoint_delete(self):
         """
         Test that when checkpoint fails, a job is correctly deleted
@@ -250,7 +240,6 @@ exit 1
         self.mom.add_checkpoint_abort_script(body=self.chk_script_fail)
         self.submit_and_preempt_jobs(preempt_order='CD')
 
-    @skipOnCpuSet
     def test_preempt_rerunable_false(self):
         # in CLI mode Rerunnable requires a 'n' value.  It's different with API
         m = self.server.get_op_mode()
@@ -261,7 +250,6 @@ exit 1
 
         self.server.set_op_mode(m)
 
-    @skipOnCpuSet
     def test_preempt_checkpoint_false(self):
         # in CLI mode Checkpoint requires a 'n' value.  It's different with API
         m = self.server.get_op_mode()
@@ -272,7 +260,6 @@ exit 1
 
         self.server.set_op_mode(m)
 
-    @skipOnCpuSet
     def test_preempt_order_requeue_first(self):
         """
         Test that a low priority job is requeued if preempt_order is in
@@ -280,7 +267,6 @@ exit 1
         """
         self.submit_and_preempt_jobs(preempt_order='R', order=1)
 
-    @skipOnCpuSet
     def test_preempt_order_requeue_second(self):
         """
         Test that a low priority job is requeued if preempt_order is in
@@ -288,7 +274,6 @@ exit 1
         """
         self.submit_and_preempt_jobs(preempt_order='R', order=2)
 
-    @skipOnCpuSet
     def test_preempt_requeue_never_run(self):
         """
         Test that a job is preempted by requeue and the scheduler does not
@@ -300,7 +285,6 @@ exit 1
             ";Job will never run", existence=False, starttime=start_time,
             max_attempts=5)
 
-    @skipOnCpuSet
     def test_preempt_multiple_jobs(self):
         """
         Test that multiple jobs are preempted by one large high priority job
@@ -324,7 +308,6 @@ exit 1
         self.server.expect(JOB, {'job_state=S': 10})
         self.server.expect(JOB, {'job_state': 'R'}, id=hjid)
 
-    @skipOnCpuSet
     def test_qalter_preempt_targets_to_none(self):
         """
         Test that a job requesting preempt targets set to two different queues
@@ -348,7 +331,6 @@ exit 1
         self.server.expect(JOB, id=jid,
                            attrib={'Resource_List.preempt_targets': 'None'})
 
-    @skipOnCpuSet
     def test_preempt_sort_when_set(self):
         """
         This test is for preempt_sort when it is set to min_time_since_start
@@ -364,7 +346,6 @@ exit 1
         self.server.expect(JOB, {ATTR_state: 'S'}, id=jid2)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid3)
 
-    @skipOnCpuSet
     def test_preempt_retry(self):
         """
         Test that jobs can be successfully preempted after a previously failed
@@ -420,7 +401,6 @@ exit 3
         self.server.expect(JOB, {'job_state': 'R'}, id=jid3)
         self.server.set_op_mode(m)
 
-    @skipOnCpuSet
     def test_vnode_resource_contention(self):
         """
         Test to make sure that preemption happens when the resource in
@@ -450,7 +430,6 @@ exit 3
         self.server.expect(NODE, {'state': 'free'}, id=vn4)
 
     @requirements(num_moms=2)
-    @skipOnCpuSet
     def test_host_resource_contention(self):
         """
         Test to make sure that preemption happens when the resource in
@@ -500,7 +479,6 @@ exit 3
         comment = "Not Running: Insufficient amount of resource: host"
         self.server.expect(JOB, {'comment': comment}, id=hjid2)
 
-    @skipOnCpuSet
     def test_preempt_queue_restart(self):
         """
         Test that a queue which has preempt_targets set to another queue
@@ -535,7 +513,6 @@ exit 3
             self.du.run_cmd(cmd=reset_db, sudo=True, as_script=True)
             self.fail('TC failed as workq2 recovery failed')
 
-    @skipOnCpuSet
     def test_insufficient_server_rassn_select_resc(self):
         """
         Set a rassn_select resource (like ncpus or mem) ons server and
@@ -561,7 +538,6 @@ exit 3
 
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid_high)
 
-    @skipOnCpuSet
     def test_preemption_priority_escalation(self):
         """
         Test that scheduler does not try preempting a job that escalates its
@@ -621,7 +597,6 @@ exit 3
         for job_id in jid_list[0:-2]:
             self.scheduler.log_match(job_id + msg)
 
-    @skipOnCpuSet
     def test_preemption_priority_escalation_2(self):
         """
         Test that scheduler does not try preempting a job that escalates its
@@ -691,7 +666,6 @@ exit 3
         self.server.expect(JOB, {'job_state': 'S'}, id=jid_list[3])
         self.server.expect(JOB, {'job_state': 'S'}, id=jid_list[4])
 
-    @skipOnCpuSet
     def test_preempt_requeue_resc(self):
         """
         Test that scheduler will preempt jobs for resources with rrtros

--- a/test/tests/functional/pbs_provisioning.py
+++ b/test/tests/functional/pbs_provisioning.py
@@ -120,7 +120,6 @@ class TestProvisioningJob(TestFunctional):
             self.hook_list[1], a, hook_provision, overwrite=True)
         self.assertTrue(rv)
 
-    @skipOnCpuSet
     def test_execjob_begin_hook_on_os_provisioned_job(self):
         """
         Test the execjob_begin hook is seen by OS provisioned job.
@@ -161,7 +160,6 @@ class TestProvisioningJob(TestFunctional):
                                 interval=1)
         self.assertTrue(rv)
 
-    @skipOnCpuSet
     def test_app_provisioning(self):
         """
         Test application provisioning
@@ -178,7 +176,6 @@ class TestProvisioningJob(TestFunctional):
             max_attempts=20,
             interval=1)
 
-    @skipOnCpuSet
     def test_os_provisioning_pending_hook_copy(self):
         """
         Test that job still runs after:

--- a/test/tests/functional/pbs_provisioning_enhancement.py
+++ b/test/tests/functional/pbs_provisioning_enhancement.py
@@ -127,7 +127,6 @@ e.reject()
 
         self.server.manager(MGR_CMD_SET, SERVER, {'log_events': 2047})
 
-    @skipOnCpuSet
     def test_app_provisioning(self):
         """
         Test application provisioning
@@ -151,7 +150,6 @@ e.reject()
             max_attempts=20,
             interval=1)
 
-    @skipOnCpuSet
     def test_os_provisioning(self):
         """
         Test os provisioning
@@ -181,7 +179,6 @@ e.reject()
         # OS provisioining completes affer mom restart.
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid)
 
-    @skipOnCpuSet
     def test_subchunk_application_provisioning(self):
         """
         Test application provisioning job request consist of subchunks
@@ -207,7 +204,6 @@ e.reject()
         # Current aoe on momA, should be set to the requested aoe in job.
         self.server.expect(NODE, {'current_aoe': 'App1'}, id=self.hostA)
 
-    @skipOnCpuSet
     def test_subchunk_os_provisioning(self):
         """
         Test os provisioning job request consist of subchunks
@@ -233,7 +229,6 @@ e.reject()
         # Current aoe on momA, should be set to the requested aoe in job.
         self.server.expect(NODE, {'current_aoe': 'osimage1'}, id=self.hostA)
 
-    @skipOnCpuSet
     def test_job_wide_provisioining_request(self):
         """
         Test jobs with jobwide aoe resource request.
@@ -261,7 +256,6 @@ e.reject()
         # Current aoe on momA, should be set to the requested aoe in job.
         self.server.expect(NODE, {'current_aoe': 'App1'}, id=self.hostA)
 
-    @skipOnCpuSet
     def test_multiple_aoe_request(self):
         """
         Test jobs with multiple similar/various aoe request in subchunks.
@@ -304,7 +298,6 @@ e.reject()
                         'when it should have succeeded')
         self.logger.info("Job submission succeeded, as expected")
 
-    @skipOnCpuSet
     def test_provisioning_with_placement(self):
         """
         Test provisioining job with various placement options.
@@ -366,7 +359,6 @@ e.reject()
         # Current aoe on momA, should be set to the requested aoe in job.
         self.server.expect(NODE, {'current_aoe': 'App1'}, id=self.hostA)
 
-    @skipOnCpuSet
     def test_sched_provisioning_response_with_runjob(self):
         """
         Test that if one provisioning job fails to run then scheduler
@@ -405,7 +397,6 @@ e.reject()
         self.server.log_match(job1_msg)
         self.server.log_match(job2_msg)
 
-    @skipOnCpuSet
     def test_sched_provisioning_response(self):
         """
         Test that if scheduler could not find node solution for one
@@ -451,7 +442,6 @@ e.reject()
         job_state = self.server.status(JOB, id=jid3)
         self.assertEqual(job_state[0]['exec_vnode'], solution)
 
-    @skipOnCpuSet
     def test_multinode_provisioning(self):
         """
         Test the effect of max_concurrent_provision

--- a/test/tests/functional/pbs_qrun.py
+++ b/test/tests/functional/pbs_qrun.py
@@ -53,7 +53,6 @@ class TestQrun(TestFunctional):
         self.pbs_exec = self.server.pbs_conf['PBS_EXEC']
         self.qrun = os.path.join(self.pbs_exec, 'bin', 'qrun')
 
-    @skipOnCpuSet
     def test_invalid_host_val(self):
         """
         Tests that pbs_server should not crash when the node list in
@@ -63,7 +62,7 @@ class TestQrun(TestFunctional):
         # submit a multi-chunk job
         j1 = Job(attrs={'Resource_List.select':
                         'ncpus=2:host=%s+ncpus=2:host=%s' %
-                 (self.mom.shortname, self.mom.shortname)})
+                        (self.mom.shortname, self.mom.shortname)})
         jid1 = self.server.submit(j1)
         self.server.expect(JOB, {ATTR_state: 'Q'}, jid1)
         exec_vnode = '"\'(%s)+(%s)\'"' % \
@@ -98,7 +97,6 @@ class TestQrun(TestFunctional):
         self.assertTrue(self.server.isUp(), msg)
         self.logger.info("As expected server is up and running")
 
-    @skipOnCpuSet
     def test_qrun_hangs(self):
         """
         This test submit 500 jobs with differnt equivalence class,
@@ -144,7 +142,6 @@ class TestQrun(TestFunctional):
                 self.logger.info("Runjob hung. Child process exit.")
                 self.fail("Qrun didn't start another sched cycle")
 
-    @skipOnCpuSet
     def test_qrun_subjob(self):
         """
         This test tests if PBS is able to qrun an array subjob

--- a/test/tests/functional/pbs_qstat.py
+++ b/test/tests/functional/pbs_qstat.py
@@ -45,7 +45,7 @@ class TestQstat(TestFunctional):
     """
     This test suite validates output of qstat with various options
     """
-    @skipOnCpuSet
+
     def test_qstat_pt(self):
         """
         Test that checks correct output for qstat -pt
@@ -152,6 +152,6 @@ class TestQstat(TestFunctional):
                          'Qstat returned with non-zero exit status')
         qstat_out = '\n'.join(ret['out'])
         self.assertNotEqual(re.search(r"%s/([0-9]+)"
-                            % re.escape(self.mom.shortname),
-                            qstat_out), None, "The exec host does not"
-                            " contain the task slot number")
+                                      % re.escape(self.mom.shortname),
+                                      qstat_out), None, "The exec host does"
+                            " not contain the task slot number")

--- a/test/tests/functional/pbs_qstat_count.py
+++ b/test/tests/functional/pbs_qstat_count.py
@@ -103,7 +103,6 @@ class TestqstatStateCount(TestFunctional):
         self.assertEqual(counts['expected_queued_count'], counts['Queued'],
                          'Queued count incorrect')
 
-    @skipOnCpuSet
     def test_queued_no_restart(self):
         """
         The test case verifies that the reported queued_count in qstat -Bf
@@ -128,7 +127,6 @@ class TestqstatStateCount(TestFunctional):
         self.server.expect(JOB, {'job_state': 'R'}, id=jid[1])
         self.verify_count()
 
-    @skipOnCpuSet
     def test_queued_restart(self):
         """
         The test case verifies that the reported queued_count in qstat -Bf
@@ -154,7 +152,6 @@ class TestqstatStateCount(TestFunctional):
         self.server.restart()
         self.verify_count()
 
-    @skipOnCpuSet
     def test_queued_no_restart_multiple_queue(self):
         """
         The test case verifies that the queued_count reported in the output
@@ -190,7 +187,6 @@ class TestqstatStateCount(TestFunctional):
 
         self.verify_count()
 
-    @skipOnCpuSet
     def test_queued_restart_multiple_queue(self):
         """
         The test case verifies that the queued_count reported in the output
@@ -226,7 +222,6 @@ class TestqstatStateCount(TestFunctional):
         self.server.restart()
         self.verify_count()
 
-    @skipOnCpuSet
     def test_queued_sched_false(self):
         """
         This test case verifies that the value of queued_count in the output
@@ -241,7 +236,6 @@ class TestqstatStateCount(TestFunctional):
         self.server.restart()
         self.verify_count()
 
-    @skipOnCpuSet
     def test_wait_to_queued(self):
         """
         This test case verifies that when a job state changes from W to Q after
@@ -268,7 +262,6 @@ class TestqstatStateCount(TestFunctional):
         self.server.restart()
         self.verify_count()
 
-    @skipOnCpuSet
     def test_job_state_count(self):
         """
         Testing if jobs in the 'W' state will cause

--- a/test/tests/functional/pbs_qstat_formats.py
+++ b/test/tests/functional/pbs_qstat_formats.py
@@ -309,7 +309,7 @@ class TestQstatFormats(TestFunctional):
         oneline_attr_count = sum(1 for line in open(
             qstat_oneline_out) if not line.isspace())
         map(os.remove, [qstat_dsv_script, qstat_dsv_out,
-            qstat_oneline_script, qstat_oneline_out])
+                        qstat_oneline_script, qstat_oneline_out])
         self.assertEqual(dsv_attr_count, oneline_attr_count)
 
     def test_json(self):
@@ -412,7 +412,6 @@ class TestQstatFormats(TestFunctional):
         except ValueError:
             self.assertTrue(False)
 
-    @skipOnCpuSet
     def test_qstat_json_valid_multiple_jobs_p(self):
         """
         Test json output of qstat -f is in valid format when multiple jobs are

--- a/test/tests/functional/pbs_qsub_opts_args.py
+++ b/test/tests/functional/pbs_qsub_opts_args.py
@@ -159,7 +159,6 @@ bhtiusabsdlg' % (os.environ['HOME'])
         rv = self.du.run_cmd(self.server.hostname, cmd=cmd)
         self.assertEqual(rv['rc'], 0, 'qsub failed')
 
-    @skipOnCpuSet
     def test_qsub_with_option_a(self):
         """
         Test submission of job with execution time(future and past)

--- a/test/tests/functional/pbs_que_resc_usage.py
+++ b/test/tests/functional/pbs_que_resc_usage.py
@@ -63,7 +63,6 @@ class TestQueRescUsage(TestFunctional):
         self.server.manager(MGR_CMD_SET, QUEUE, {
                             'resources_available.foo': 6}, id='workq')
 
-    @skipOnCpuSet
     def test_resc_assigned_set_unset(self):
         """
         Test "resources_assigned" attribute of the resource and it's behavior
@@ -131,7 +130,6 @@ class TestQueRescUsage(TestFunctional):
         self.assertNotIn('resources_assigned.ncpus',
                          q_status[0], self.err_msg)
 
-    @skipOnCpuSet
     def test_resources_assigned_with_zero_val(self):
         """
         In PBS we can request +ve or -ve values so sometimes resources_assigned
@@ -172,7 +170,6 @@ class TestQueRescUsage(TestFunctional):
         self.assertNotIn('resources_assigned.foo',
                          q_status[0], self.err_msg)
 
-    @skipOnCpuSet
     def test_resources_assigned_deletion(self):
         """
         Test resources_assigned.<resc_name> deletion from the system

--- a/test/tests/functional/pbs_ralter.py
+++ b/test/tests/functional/pbs_ralter.py
@@ -525,7 +525,6 @@ class TestPbsResvAlter(TestFunctional):
                                                    ['reserve_start'])
         return t_duration, t_start, t_end
 
-    @skipOnCpuSet
     def test_alter_advance_resv_start_time_before_run(self):
         """
         This test case covers the below scenarios for an advance reservation
@@ -557,7 +556,6 @@ class TestPbsResvAlter(TestFunctional):
                                                       -shift, alter_s=True,
                                                       sequence=3)
 
-    @skipOnCpuSet
     def test_alter_advance_resv_start_time_after_run(self):
         """
         This test case covers the below scenarios for an advance reservation
@@ -589,7 +587,6 @@ class TestPbsResvAlter(TestFunctional):
         self.alter_a_reservation(rid, start, end, shift, alter_s=True,
                                  whichMessage=0)
 
-    @skipOnCpuSet
     def test_alter_advance_resv_end_time_before_run(self):
         """
         This test case covers the below scenarios for an advance reservation
@@ -620,7 +617,6 @@ class TestPbsResvAlter(TestFunctional):
                                                       shift, alter_e=True,
                                                       sequence=3)
 
-    @skipOnCpuSet
     def test_alter_advance_resv_end_time_after_run(self):
         """
         This test case covers the below scenarios for an advance reservation
@@ -648,7 +644,6 @@ class TestPbsResvAlter(TestFunctional):
         self.check_resv_running(rid, duration, 0)
         self.server.expect(JOB, {'job_state': "R"}, id=jid)
 
-    @skipOnCpuSet
     def test_alter_advance_resv_both_times_before_run(self):
         """
         This test case covers the below scenarios for an advance reservation
@@ -680,7 +675,6 @@ class TestPbsResvAlter(TestFunctional):
                                                       -shift, alter_s=True,
                                                       alter_e=True, sequence=3)
 
-    @skipOnCpuSet
     def test_alter_advance_resv_both_times_after_run(self):
         """
         This test case covers the below scenarios for an advance reservation
@@ -715,7 +709,6 @@ class TestPbsResvAlter(TestFunctional):
                                  shift, alter_s=True,
                                  alter_e=True, whichMessage=0)
 
-    @skipOnCpuSet
     def test_alter_standing_resv_start_time_before_run(self):
         """
         This test case covers the below scenarios for a standing reservation
@@ -763,7 +756,6 @@ class TestPbsResvAlter(TestFunctional):
         # Check that duration of the second occurrence is not altered.
         self.check_standing_resv_second_occurrence(rid, start, end)
 
-    @skipOnCpuSet
     def test_alter_standing_resv_start_time_after_run(self):
         """
         This test case covers the below scenarios for a standing reservation
@@ -808,7 +800,6 @@ class TestPbsResvAlter(TestFunctional):
         # Check that duration of the second occurrence is not altered.
         self.check_standing_resv_second_occurrence(rid, start, end)
 
-    @skipOnCpuSet
     def test_alter_standing_resv_end_time_before_run(self):
         """
         This test case covers the below scenarios for a standing reservation
@@ -863,7 +854,6 @@ class TestPbsResvAlter(TestFunctional):
         # Check that duration of the second occurrence is not altered.
         self.check_standing_resv_second_occurrence(rid, start, end)
 
-    @skipOnCpuSet
     def test_alter_standing_resv_end_time_after_run(self):
         """
         This test case covers the below scenarios for a standing reservation
@@ -907,7 +897,6 @@ class TestPbsResvAlter(TestFunctional):
         # Check that duration of the second occurrence is not altered.
         self.check_standing_resv_second_occurrence(rid, start, end)
 
-    @skipOnCpuSet
     def test_alter_standing_resv_both_times_before_run(self):
         """
         This test case covers the below scenarios for a standing reservation
@@ -956,7 +945,6 @@ class TestPbsResvAlter(TestFunctional):
         # Check that duration of the second occurrence is not altered.
         self.check_standing_resv_second_occurrence(rid, start, end)
 
-    @skipOnCpuSet
     def test_alter_standing_resv_both_times_after_run(self):
         """
         This test case covers the below scenarios for a standing reservation
@@ -1005,7 +993,6 @@ class TestPbsResvAlter(TestFunctional):
         # Check that duration of the second occurrence is not altered.
         self.check_standing_resv_second_occurrence(rid, start, end)
 
-    @skipOnCpuSet
     def test_conflict_two_advance_resvs(self):
         """
         This test confirms that an advance reservation cannot be extended
@@ -1036,7 +1023,6 @@ class TestPbsResvAlter(TestFunctional):
         self.alter_a_reservation(rid2, start2, end2, -shift, alter_s=True,
                                  whichMessage=3, interactive=5, sequence=2)
 
-    @skipOnCpuSet
     def test_conflict_two_standing_resvs(self):
         """
         This test confirms that an occurrence of a standing reservation cannot
@@ -1067,7 +1053,6 @@ class TestPbsResvAlter(TestFunctional):
         self.alter_a_reservation(rid2, start2, end2, -shift, alter_s=True,
                                  whichMessage=3, interactive=5, sequence=2)
 
-    @skipOnCpuSet
     def test_check_alternate_nodes_advance_resv_endtime(self):
         """
         This test confirms that an advance reservation can be extended even if
@@ -1102,7 +1087,6 @@ class TestPbsResvAlter(TestFunctional):
         attrs = {'resv_nodes': (MATCH_RE, re.escape(free_node))}
         self.server.expect(RESV, attrs, id=rid1)
 
-    @skipOnCpuSet
     def test_check_alternate_nodes_advance_resv_starttime(self):
         """
         This test confirms that an advance reservation can be extended even if
@@ -1138,7 +1122,6 @@ class TestPbsResvAlter(TestFunctional):
         attrs = {'resv_nodes': (MATCH_RE, re.escape(free_node))}
         self.server.expect(RESV, attrs, id=rid1)
 
-    @skipOnCpuSet
     def test_check_alternate_nodes_standing_resv_endtime(self):
         """
         This test confirms that an occurrence of a standing reservation can be
@@ -1176,7 +1159,6 @@ class TestPbsResvAlter(TestFunctional):
         attrs = {'resv_nodes': (MATCH_RE, re.escape(free_node))}
         self.server.expect(RESV, attrs, id=rid1)
 
-    @skipOnCpuSet
     def test_check_alternate_nodes_standing_resv_starttime(self):
         """
         This test confirms that an advance reservation can be extended even if
@@ -1213,7 +1195,6 @@ class TestPbsResvAlter(TestFunctional):
         attrs = {'resv_nodes': (MATCH_RE, re.escape(free_node))}
         self.server.expect(RESV, attrs, id=rid1)
 
-    @skipOnCpuSet
     def test_conflict_standing_resv_occurrence(self):
         """
         This test confirms that if the requested time while altering an
@@ -1232,7 +1213,6 @@ class TestPbsResvAlter(TestFunctional):
         self.alter_a_reservation(rid, start, end, shift, alter_e=True,
                                  whichMessage=0)
 
-    @skipOnCpuSet
     def test_large_resv_nodes_server_crash(self):
         """
         This test is to test whether the server crashes or not when a very
@@ -1253,7 +1233,6 @@ class TestPbsResvAlter(TestFunctional):
 
         self.alter_a_reservation(rid, start, end, shift, alter_s=True)
 
-    @skipOnCpuSet
     def test_alter_advance_resv_boundary_values(self):
         """
         This test checks the alter of start and end times at the boundary
@@ -1275,7 +1254,6 @@ class TestPbsResvAlter(TestFunctional):
         self.alter_a_reservation(
             rid, start, end, -shift, alter_s=True, sequence=4)
 
-    @skipOnCpuSet
     def test_alter_standing_resv_boundary_values(self):
         """
         This test checks the alter of start and end times at the boundary
@@ -1297,7 +1275,6 @@ class TestPbsResvAlter(TestFunctional):
         self.alter_a_reservation(
             rid, start, end, -shift, alter_s=True, sequence=4)
 
-    @skipOnCpuSet
     def test_alter_degraded_resv_mom_down(self):
         """
         This test checks the alter of start and end times of reservations
@@ -1366,7 +1343,6 @@ class TestPbsResvAlter(TestFunctional):
                                  alter_e=True, whichMessage=mtype,
                                  interactive=2, sequence=seq + 1)
 
-    @skipOnCpuSet
     def test_alter_resv_name(self):
         """
         This test checks the alter of reservation name.
@@ -1387,7 +1363,6 @@ class TestPbsResvAlter(TestFunctional):
         self.server.expect(RESV, attr1, id=rid1[0])
         self.server.expect(RESV, attr2, id=rid2[0])
 
-    @skipOnCpuSet
     def test_alter_user_permission(self):
         """
         This test checks the user permissions for pbs_ralter.
@@ -1531,7 +1506,6 @@ class TestPbsResvAlter(TestFunctional):
         self.server.expect(RESV, attr, op=UNSET, id=rid, max_attempts=5)
         self.server.expect(QUEUE, attr2, op=UNSET, id=qid, max_attempts=5)
 
-    @skipOnCpuSet
     def test_ralter_psets(self):
         """
         Test that PBS will not place a job across placement sets after
@@ -1585,7 +1559,6 @@ class TestPbsResvAlter(TestFunctional):
         self.alter_a_reservation(rid1, start1, end1, shift=300,
                                  alter_e=True, sequence=2, whichMessage=3)
 
-    @skipOnCpuSet
     def test_failed_ralter(self):
         """
         Test that a failed ralter does not allow jobs to interfere with
@@ -1620,7 +1593,6 @@ class TestPbsResvAlter(TestFunctional):
                                  alter_e=True, sequence=2, whichMessage=3)
         self.server.expect(JOB, {'job_state': 'Q'}, id=jid)
 
-    @skipOnCpuSet
     def test_adv_resv_duration_before_start(self):
         """
         Test duration of reservation can be changed. In this case end
@@ -1663,7 +1635,6 @@ class TestPbsResvAlter(TestFunctional):
                            {'reserve_state': (MATCH_RE, 'RESV_RUNNING|5')},
                            id=rid, max_attempts=5, offset=sleepdur)
 
-    @skipOnCpuSet
     def test_adv_resv_dur_and_endtime_before_start(self):
         """
         Test that duration and end time of reservation can be changed together.
@@ -1700,7 +1671,6 @@ class TestPbsResvAlter(TestFunctional):
         self.assertEqual(t_start, t_end - t_duration)
         self.assertEqual(t_duration, new_duration2)
 
-    @skipOnCpuSet
     def test_adv_resv_dur_and_starttime_before_start(self):
         """
         Test duration and starttime of reservation can be changed together.
@@ -1910,7 +1880,6 @@ class TestPbsResvAlter(TestFunctional):
         # Check that duration of the second occurrence is not altered.
         self.check_standing_resv_second_occurrence(rid, start, end)
 
-    @skipOnCpuSet
     def test_conflict_standing_resv_occurrence_duration(self):
         """
         This test confirms that if the requested duration while altering an
@@ -1938,7 +1907,6 @@ class TestPbsResvAlter(TestFunctional):
         self.assertEqual(int(t_duration), duration)
         self.assertEqual(int(t_end), end)
 
-    @skipOnCpuSet
     def test_alter_empty_fail(self):
         """
         This test confirms that if a requested ralter fails due to the
@@ -1997,7 +1965,6 @@ class TestPbsResvAlter(TestFunctional):
         self.assertEqual(int(t_duration), new_duration_in_sec)
         self.assertEqual(int(t_end), new_end)
 
-    @skipOnCpuSet
     def test_adv_resv_dur_and_endtime_with_running_jobs(self):
         """
         Test that duration and end time of reservation cannot be changed
@@ -2035,7 +2002,6 @@ class TestPbsResvAlter(TestFunctional):
         self.assertEqual(t_start, start)
         self.assertEqual(t_duration, duration)
 
-    @skipOnCpuSet
     def test_standing_resv_dur_and_endtime_with_running_jobs(self):
         """
         Change duration and endtime of standing reservation with

--- a/test/tests/functional/pbs_release_limited_res_suspend.py
+++ b/test/tests/functional/pbs_release_limited_res_suspend.py
@@ -58,7 +58,6 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
              ATTR_start: 'True', ATTR_p: '200'}
         self.server.manager(MGR_CMD_CREATE, QUEUE, b, "expressq")
 
-    @skipOnCpuSet
     def test_do_not_release_mem_sched_susp(self):
         """
         During preemption by suspension test that only ncpus are released from
@@ -96,7 +95,6 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
         self.assertEqual(rv[0][ras_ncpus], "2",
                          msg="pbs did not release ncpus")
 
-    @skipOnCpuSet
     def test_do_not_release_mem_qsig_susp(self):
         """
         If a running job is suspended using qsig, test that only ncpus are
@@ -128,7 +126,6 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
         self.assertEqual(rv[0][ras_ncpus], "0",
                          msg="pbs did not release ncpus")
 
-    @skipOnCpuSet
     def test_change_in_res_to_release_on_suspend(self):
         """
         set restrict_res_to_release_on_suspend to only ncpus and then suspend
@@ -179,7 +176,6 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
         self.assertEqual(rv[0][ras_ncpus], "4",
                          msg="pbs did not account for ncpus correctly")
 
-    @skipOnCpuSet
     def test_res_released_sched_susp(self):
         """
         Test if job's resources_released attribute is correctly set when
@@ -211,7 +207,6 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
         self.assertEqual(job[0][ATTR_released], rr,
                          msg="resources_released incorrect")
 
-    @skipOnCpuSet
     def test_res_released_sched_susp_multi_vnode(self):
         """
         Test if job's resources_released attribute is correctly set when
@@ -255,7 +250,6 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
         self.assertEqual(job[0][ATTR_released], rr,
                          msg="resources_released incorrect")
 
-    @skipOnCpuSet
     def test_res_released_sched_susp_arrayjob(self):
         """
         Test if array subjob's resources_released attribute is correctly
@@ -291,7 +285,6 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
         self.assertEqual(job[0][ATTR_released], rr,
                          msg="resources_released incorrect")
 
-    @skipOnCpuSet
     def test_res_released_list_sched_susp_arrayjob(self):
         """
         Test if array subjob's resources_released_list attribute is correctly
@@ -328,7 +321,6 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
         rr_l_mem = job[0][ATTR_rel_list + ".mem"]
         self.assertEqual(rr_l_mem, "524288kb", msg="memory not released")
 
-    @skipOnCpuSet
     def test_res_released_list_sched_susp(self):
         """
         Test if job's resources_released_list attribute is correctly set when
@@ -361,7 +353,6 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
         rr_l_mem = job[0][ATTR_rel_list + ".mem"]
         self.assertEqual(rr_l_mem, "524288kb", msg="memory not released")
 
-    @skipOnCpuSet
     def test_res_released_list_sched_susp_multi_vnode(self):
         """
         Test if job's resources_released_list attribute is correctly set when
@@ -405,7 +396,6 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
         rr_l_mem = job[0][ATTR_rel_list + ".mem"]
         self.assertNotEqual(rr_l_mem, "2097152kb", msg="memory not released")
 
-    @skipOnCpuSet
     def test_node_res_after_deleting_suspended_job(self):
         """
         Test that once a suspended job is deleted node's resources assigned
@@ -457,7 +447,6 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
             rv[0][ras_ncpus], "0",
             msg="pbs did not reassign ncpus correctly on the node")
 
-    @skipOnCpuSet
     def test_default_restrict_res_released_on_suspend(self):
         """
         Test the default value of restrict_res_to_release_on_suspend.
@@ -490,7 +479,6 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
         self.assertEqual(rv[0][ras_ncpus], "2",
                          msg="pbs did not release ncpus")
 
-    @skipOnCpuSet
     def test_setting_unknown_resc(self):
         """
         Set a non existing resource in restrict_res_to_release_on_suspend
@@ -504,7 +492,6 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
         except PbsManagerError as e:
             self.assertTrue("Unknown resource" in e.msg[0])
 
-    @skipOnCpuSet
     def test_delete_res_busy_on_res_to_release_list(self):
         """
         Create a resource, set it in restrict_res_to_release_on_suspend
@@ -531,7 +518,6 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
         except PbsManagerError as e:
             self.assertTrue("Resource busy on server" in e.msg[0])
 
-    @skipOnCpuSet
     def test_queue_res_release_upon_suspension(self):
         """
         Create 2 consumable resources and set it on queue,
@@ -578,7 +564,6 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
         self.assertEqual(rv[0][ras_bar], "40",
                          msg="pbs should not release resource bar")
 
-    @skipOnCpuSet
     def test_server_res_release_upon_suspension_using_qsig(self):
         """
         Create 2 consumable resources and set it on server,
@@ -625,7 +610,6 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
         self.assertEqual(rv[0][ras_bar], "40",
                          msg="pbs should not release resource bar")
 
-    @skipOnCpuSet
     def test_server_res_release_upon_suspension_using_preemption(self):
         """
         Create 2 consumable resources and set it on server,
@@ -692,7 +676,6 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
         self.assertEqual(rv[0][ras_bar], "60",
                          msg="pbs should not release resource bar")
 
-    @skipOnCpuSet
     def test_node_custom_res_release_upon_suspension(self):
         """
         Create 2 consumable resources and set it on node,
@@ -740,7 +723,6 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
         self.assertEqual(rv[0][ras_bar], "40",
                          msg="pbs should not release resource bar")
 
-    @skipOnCpuSet
     def test_resuming_with_no_res_released(self):
         """
         Set restrict_res_to_release_on_suspend to a resource that a job
@@ -769,7 +751,6 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
         self.server.sigjob(jobid=jid1, signal="resume")
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
 
-    @skipOnCpuSet
     def test_resuming_with_no_res_released_multi_vnode(self):
         """
         Set restrict_res_to_release_on_suspend to a resource that multi-vnode
@@ -809,7 +790,6 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
         self.server.sigjob(jobid=jid1, signal="resume")
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
 
-    @skipOnCpuSet
     def test_resuming_excljob_with_no_res_released(self):
         """
         Set restrict_res_to_release_on_suspend to a resource that an node excl
@@ -845,7 +825,6 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
         self.server.deljob(jid2, wait=True)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
 
-    @skipOnCpuSet
     def test_normal_user_unable_to_see_res_released(self):
         """
         Check if normal user (non-operator, non-manager) has privileges to see
@@ -873,7 +852,6 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
                          "Normal user can see resources_released_list "
                          "which is not expected")
 
-    @skipOnCpuSet
     def test_if_node_gets_oversubscribed(self):
         """
         Check if the node gets oversubscribed if a filler job runs
@@ -920,7 +898,6 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
         # suspended job did not release any ncpus
         self.server.expect(JOB, {ATTR_state: 'Q'}, id=jid2)
 
-    @skipOnCpuSet
     def test_suspended_job_gets_calendered(self):
         """
         Check if a job which releases limited amount of resources gets
@@ -956,7 +933,6 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
             jid1 + ";Can't find start time estimate", existence=False,
             max_attempts=2)
 
-    @skipOnCpuSet
     def helper_test_preempt_release_all(self, preempt_method):
         """
         Helper function to test that when preempting jobs, all resources
@@ -998,7 +974,6 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid2)
         self.scheduler.log_match(jid1 + ";" + schedlog_msg)
 
-    @skipOnCpuSet
     def test_preempt_requeue_release_all(self):
         """
         Test that when preempting jobs via Requeue, all resources
@@ -1006,7 +981,6 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
         """
         self.helper_test_preempt_release_all("R")
 
-    @skipOnCpuSet
     def test_preempt_checkpoint_release_all(self):
         """
         Test that when preempting jobs via Checkpointing, all resources
@@ -1021,7 +995,6 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
         self.mom.add_checkpoint_abort_script(body=chk_script)
         self.helper_test_preempt_release_all("C")
 
-    @skipOnCpuSet
     def test_server_restart_with_suspened_job(self):
         """
         Test that when a job releases limited resources on a node and then

--- a/test/tests/functional/pbs_reservations.py
+++ b/test/tests/functional/pbs_reservations.py
@@ -253,7 +253,6 @@ class TestReservations(TestFunctional):
 
         self.server.expect(RESV, resv_state, id=rid)
 
-    @skipOnCpuSet
     def test_degraded_standing_reservations(self):
         """
         Verify that degraded standing reservations are reconfirmed
@@ -263,7 +262,6 @@ class TestReservations(TestFunctional):
         self.degraded_resv_reconfirm(start=t + 25, end=t + 625,
                                      rrule='freq=HOURLY;count=5')
 
-    @skipOnCpuSet
     def test_degraded_advance_reservations(self):
         """
         Verify that degraded advance reservations are reconfirmed
@@ -272,7 +270,6 @@ class TestReservations(TestFunctional):
         t = int(time.time())
         self.degraded_resv_reconfirm(start=t + 25, end=t + 625)
 
-    @skipOnCpuSet
     def test_degraded_standing_running_reservations(self):
         """
         Verify that degraded standing reservations are reconfirmed
@@ -282,7 +279,6 @@ class TestReservations(TestFunctional):
         self.degraded_resv_reconfirm(start=t + 25, end=t + 625,
                                      rrule='freq=HOURLY;count=5', run=True)
 
-    @skipOnCpuSet
     def test_degraded_advance_running_reservations(self):
         """
         Verify that degraded advance reservations are not reconfirmed
@@ -292,7 +288,6 @@ class TestReservations(TestFunctional):
         self.degraded_resv_reconfirm(
             start=t + 25, end=t + 625, run=True)
 
-    @skipOnCpuSet
     def test_degraded_standing_reservations_fail(self):
         """
         Verify that degraded standing reservations are not
@@ -302,7 +297,6 @@ class TestReservations(TestFunctional):
         self.degraded_resv_failed_reconfirm(start=t + 120, end=t + 720,
                                             rrule='freq=HOURLY;count=5')
 
-    @skipOnCpuSet
     def test_degraded_advance_reservations_fail(self):
         """
         Verify that advance reservations are not reconfirmed if there
@@ -311,7 +305,6 @@ class TestReservations(TestFunctional):
         t = int(time.time())
         self.degraded_resv_failed_reconfirm(start=t + 120, end=t + 720)
 
-    @skipOnCpuSet
     def test_degraded_standing_running_reservations_fail(self):
         """
         Verify that degraded running standing reservations are not
@@ -322,7 +315,6 @@ class TestReservations(TestFunctional):
                                             rrule='freq=HOURLY;count=5',
                                             run=True)
 
-    @skipOnCpuSet
     def test_degraded_advance_running_reservations_fail(self):
         """
         Verify that advance running reservations are not reconfirmed if there
@@ -332,7 +324,6 @@ class TestReservations(TestFunctional):
         self.degraded_resv_failed_reconfirm(
             start=t + 25, end=t + 625, run=True)
 
-    @skipOnCpuSet
     def test_degraded_advanced_reservation_superchunk(self):
         """
         Verify that an advanced reservation requesting a superchunk is
@@ -377,7 +368,6 @@ class TestReservations(TestFunctional):
         self.assertNotEqual(nds1, nds2)
         self.assertEquals(sc, nds1.split('+')[0])
 
-    @skipOnCpuSet
     def test_degraded_running_only_replace(self):
         """
         Test that when a running degraded reservation is reconfirmed,
@@ -434,7 +424,6 @@ class TestReservations(TestFunctional):
         rnodes2 = self.server.reservations[rid].get_vnodes()
         self.assertIn(jnode, rnodes2, 'Reservation not on job node')
 
-    @skipOnCpuSet
     def test_standing_reservation_occurrence_two_not_degraded(self):
         """
         Test that when a standing reservation's occurrence 1 is on an offline
@@ -496,7 +485,6 @@ class TestReservations(TestFunctional):
         a = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
         self.server.expect(RESV, a, id=rid2, offset=end - int(time.time()))
 
-    @skipOnCpuSet
     def test_degraded_reservation_reconfirm_running_job(self):
         """
         Test that a reservation isn't reconfirmed if there is a running job
@@ -541,7 +529,6 @@ class TestReservations(TestFunctional):
 
         self.server.expect(RESV, {'reserve_substate': 5}, id=rid)
 
-    @skipOnCpuSet
     def test_not_honoring_resvs(self):
         """
         PBS schedules jobs on nodes without accounting
@@ -604,7 +591,6 @@ class TestReservations(TestFunctional):
         self.server.expect(JOB, {'job_state': 'Q'}, id=j1id)
         self.server.expect(JOB, {'job_state': 'Q'}, id=j2id)
 
-    @skipOnCpuSet
     def test_sched_cycle_starts_on_resv_end(self):
         """
         This test checks whether the sched cycle gets started
@@ -645,7 +631,6 @@ class TestReservations(TestFunctional):
                               id=resid, interval=5)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid)
 
-    @skipOnCpuSet
     def test_exclusive_state(self):
         """
         Test that the resv-exclusive and job-exclusive
@@ -683,7 +668,6 @@ class TestReservations(TestFunctional):
         self.assertIn('resv-exclusive', states)
         self.assertIn('job-exclusive', states)
 
-    @skipOnCpuSet
     def test_resv_excl_future_resv(self):
         """
         Test to see that exclusive reservations in the near term do not
@@ -710,7 +694,6 @@ class TestReservations(TestFunctional):
 
         self.server.expect(RESV, exp_attr, id=rid2)
 
-    @skipOnCpuSet
     def test_job_exceed_resv_end(self):
         """
         Test to see that a job when submitted to a reservation without the
@@ -788,7 +771,6 @@ class TestReservations(TestFunctional):
         self.server.log_match(rid1 + ";Reservation denied",
                               id=rid1, interval=5)
 
-    @skipOnCpuSet
     def test_future_resv_confirms_after_running_job(self):
         """
         Test if a future reservation gets confirmed if its start time starts
@@ -833,7 +815,6 @@ class TestReservations(TestFunctional):
         exp_attr = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
         self.server.expect(RESV, exp_attr, id=rid2)
 
-    @skipOnCpuSet
     def test_future_resv_confirms_before_non_excl_job(self):
         """
         Test if a future reservation gets confirmed if its start time starts
@@ -879,7 +860,6 @@ class TestReservations(TestFunctional):
         exp_attr = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
         self.server.expect(RESV, exp_attr, id=rid2)
 
-    @skipOnCpuSet
     def test_future_resv_with_non_excl_jobs(self):
         """
         Test if future reservations with/without exclusive placement are
@@ -938,7 +918,6 @@ class TestReservations(TestFunctional):
         exp_attr = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
         self.server.expect(RESV, exp_attr, id=rid3)
 
-    @skipOnCpuSet
     def test_resv_excl_with_jobs(self):
         """
         Test to see that exclusive reservations in the near term do not
@@ -1014,7 +993,6 @@ class TestReservations(TestFunctional):
         self.server.expect(NODE, {'state': 'resv-exclusive'},
                            id=mom_name)
 
-    @skipOnCpuSet
     def test_multiple_asap_resv(self):
         """
         Test that multiple ASAP reservations are scheduled one after another
@@ -1060,7 +1038,6 @@ class TestReservations(TestFunctional):
         msg = 'ASAP reservation has incorrect start time'
         self.assertEqual(resv2_stime, resv1_stime + 3600, msg)
 
-    @skipOnCpuSet
     def test_excl_asap_resv_before_longterm_resvs(self):
         """
         Test if an ASAP reservation created from an exclusive
@@ -1124,7 +1101,6 @@ class TestReservations(TestFunctional):
         exp_attr = {'reserve_state': (MATCH_RE, "RESV_CONFIRMED|2")}
         self.server.expect(RESV, exp_attr, id=rid3)
 
-    @skipOnCpuSet
     def test_excl_asap_resv_after_longterm_resvs(self):
         """
         Test if an exclusive ASAP reservation created from an exclusive
@@ -1200,7 +1176,6 @@ class TestReservations(TestFunctional):
         exp_attr = {'reserve_state': (MATCH_RE, "RESV_CONFIRMED|2")}
         self.server.expect(RESV, exp_attr, id=rid3)
 
-    @skipOnCpuSet
     def test_multi_vnode_excl_advance_resvs(self):
         """
         Test if long term exclusive reservations do not interfere
@@ -1247,7 +1222,6 @@ class TestReservations(TestFunctional):
         exp_attr['reserve_state'] = (MATCH_RE, 'RESV_RUNNING|5')
         self.server.expect(RESV, exp_attr, id=rid3, offset=30)
 
-    @skipOnCpuSet
     def test_multi_vnode_excl_asap_resv(self):
         """
         Test if an ASAP reservation created from a excl placement
@@ -1305,7 +1279,6 @@ class TestReservations(TestFunctional):
         exp_attr = {'reserve_state': (MATCH_RE, "RESV_CONFIRMED|2")}
         self.server.expect(RESV, exp_attr, id=rid2)
 
-    @skipOnCpuSet
     def test_fail_confirm_resv_message(self):
         """
         Test if the scheduler fails to reserve a
@@ -1335,7 +1308,6 @@ class TestReservations(TestFunctional):
         self.server.manager(MGR_CMD_SET, SERVER, {
             'job_history_enable': 'True'})
 
-    @skipOnCpuSet
     def test_advance_reservation_with_job_array(self):
         """
         Test to submit a job array within a advance reservation
@@ -1449,7 +1421,6 @@ class TestReservations(TestFunctional):
                            extend='x', attrop=PTL_AND, id=jid3)
 
     @requirements(num_moms=2)
-    @skipOnCpuSet
     def test_advance_resv_with_multinode_job_array(self):
         """
         Test multinode job array with advance reservation
@@ -1534,7 +1505,6 @@ class TestReservations(TestFunctional):
         self.server.expect(JOB, {'job_state': 'F'},
                            id=jid2, extend='x', interval=10, offset=120)
 
-    @skipOnCpuSet
     def test_reservations_with_expired_subjobs(self):
         """
         Test that an array job submitted to a reservation ends when
@@ -1572,7 +1542,6 @@ class TestReservations(TestFunctional):
         self.server.expect(JOB, {'job_state': 'F', 'substate': '91'},
                            extend='x', id=jid)
 
-    @skipOnCpuSet
     def test_ASAP_resv_request_same_time(self):
         """
         Test two jobs converted in two ASAP reservation
@@ -1653,7 +1622,6 @@ class TestReservations(TestFunctional):
         if not self.scheduler.isUp():
             self.fail("Scheduler is not up")
 
-    @skipOnCpuSet
     def test_standing_resv_with_job_array(self):
         """
         Test job-array with standing reservation
@@ -1769,7 +1737,6 @@ class TestReservations(TestFunctional):
         self.server.expect(JOB, {'job_state': 'F',  'queue': rid_q},
                            id=jid, extend='x')
 
-    @skipOnCpuSet
     def test_multiple_job_array_within_standing_reservation(self):
         """
         Test multiple job-array submitted to a standing reservations
@@ -2058,7 +2025,6 @@ class TestReservations(TestFunctional):
         self.server.manager(MGR_CMD_SET, SERVER,
                             {'job_history_enable': 'True'})
 
-    @skipOnCpuSet
     def test_ASAP_resv_with_multivnode_job(self):
         """
         Test 2 multivnode jobs converted to ASAP resv
@@ -2117,7 +2083,6 @@ class TestReservations(TestFunctional):
         self.mom.isUp()
         self.scheduler.isUp()
 
-    @skipOnCpuSet
     def test_standing_resv_with_multivnode_job_array(self):
         """
         Test multivnode job array with standing reservation. Also
@@ -2248,7 +2213,6 @@ class TestReservations(TestFunctional):
 
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid)
 
-    @skipOnCpuSet
     def test_resv_job_hard_walltime(self):
         """
         Test that a job with hard walltime will not conflict with

--- a/test/tests/functional/pbs_resource_multichunk.py
+++ b/test/tests/functional/pbs_resource_multichunk.py
@@ -47,6 +47,7 @@ class TestResourceMultiChunk(TestFunctional):
     Test suite to test value of custom resource
     in a multi chunk job request
     """
+
     def setUp(self):
         TestFunctional.setUp(self)
         attr = {}
@@ -59,7 +60,6 @@ class TestResourceMultiChunk(TestFunctional):
              'resources_available.ncpus': 2}
         self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
 
-    @skipOnCpuSet
     def test_resource_float_type(self):
         """
         Test to check the value of custom resource

--- a/test/tests/functional/pbs_resource_usage_log.py
+++ b/test/tests/functional/pbs_resource_usage_log.py
@@ -55,7 +55,6 @@ class TestResourceUsageLog(TestFunctional):
         attr2 = {'resources_available.mem': '200gb'}
         self.server.manager(MGR_CMD_SET, NODE, attr2, id=self.mom.shortname)
 
-    @skipOnCpuSet
     def test_acclog_for_job_states(self):
         """
         Check accounting logs when a job completes successfully and when
@@ -110,7 +109,6 @@ class TestResourceUsageLog(TestFunctional):
             '.*Exit_status=271.*resources_used.*run_count=1', id=jid3,
             regexp=True)
 
-    @skipOnCpuSet
     def test_acclog_mom_down(self):
         """
         Check accounting logs when node is down and MoM is restarted
@@ -200,7 +198,6 @@ class TestResourceUsageLog(TestFunctional):
             msg='E;' + re.escape(jid_a) +
             '.*Exit_status=1.*run_count=0', id=jid_a, regexp=True)
 
-    @skipOnCpuSet
     def test_acclog_job_multiple_qrerun(self):
         """
         Check for R record in accounting logs when job is
@@ -291,7 +288,6 @@ class TestResourceUsageLog(TestFunctional):
             '.*Exit_status=1.*run_count=0',
             id=jid_a, regexp=True)
 
-    @skipOnCpuSet
     def test_acclog_force_requeue(self):
         """
         Check for resource usage when job is force requeued
@@ -318,7 +314,6 @@ class TestResourceUsageLog(TestFunctional):
             id=jid1,
             regexp=True)
 
-    @skipOnCpuSet
     def test_acclog_services_restart(self):
         """
         Check for resource usage in accounting logs after
@@ -344,7 +339,6 @@ class TestResourceUsageLog(TestFunctional):
             msg='R;' + jid1 + '.*resources_used.*run_count=1', id=jid1,
             regexp=True)
 
-    @skipOnCpuSet
     def test_acclog_preempt_order(self):
         """
         Check for R record when editing preempt order to "R" and requeuing job

--- a/test/tests/functional/pbs_runjob_hook.py
+++ b/test/tests/functional/pbs_runjob_hook.py
@@ -78,7 +78,6 @@ else:
     j.Resource_List['foo_str'] = "foo_value"
 """
 
-    @skipOnCpuSet
     def test_array_sub_job_index(self):
         """
         Submit a job array. Check the array sub-job index value
@@ -100,7 +99,6 @@ else:
             self.server.log_match("sub_job_array_index=%d" % (i),
                                   starttime=self.server.ctime)
 
-    @skipOnCpuSet
     def test_array_sub_new_res_in_hook(self):
         """
         Insert site resource in runjob hook. Submit a job array.
@@ -130,7 +128,6 @@ else:
             m = 'E;' + re.escape(sid) + ';.*Resource_List.site=site_value'
             self.server.accounting_match(m, regexp=True)
 
-    @skipOnCpuSet
     def test_array_sub_res_persist_in_hook_forcereque(self):
         """
         set custom resource in runjob hook. Submit a job array.
@@ -191,7 +188,6 @@ else:
         for i in range(lower, upper + 1):
             self.server.log_match(m % (sid[i]), start_time)
 
-    @skipOnCpuSet
     def test_array_sub_res_persist_in_hook_qrerun(self):
         """
         set custom resource in runjob hook. Submit a job array.
@@ -259,7 +255,6 @@ else:
         self.server.log_match("sub_job_array_index=None",
                               starttime=self.server.ctime)
 
-    @skipOnCpuSet
     def test_reject_array_sub_job(self):
         """
         Test to check array subjobs,

--- a/test/tests/functional/pbs_sched_attr_updates.py
+++ b/test/tests/functional/pbs_sched_attr_updates.py
@@ -41,7 +41,7 @@ from tests.functional import *
 
 
 class TestSchedAttrUpdates(TestFunctional):
-    @skipOnCpuSet
+
     def test_basic_throttling(self):
         """
         Test the behavior of sched's 'attr_update_period' attribute
@@ -96,7 +96,6 @@ class TestSchedAttrUpdates(TestFunctional):
         self.server.expect(JOB, "comment", op=SET, id=jid8)
         self.server.log_match("Type 96 request received", starttime=t)
 
-    @skipOnCpuSet
     def test_accrue_type(self):
         """
         Test that accrue_type updates are sent immediately

--- a/test/tests/functional/pbs_sched_badstate.py
+++ b/test/tests/functional/pbs_sched_badstate.py
@@ -44,7 +44,6 @@ from tests.functional import *
 
 class TestSchedBadstate(TestFunctional):
 
-    @skipOnCpuSet
     def test_sched_badstate_subjob(self):
         """
         This test case tests if scheduler goes into infinite loop

--- a/test/tests/functional/pbs_sched_fifo.py
+++ b/test/tests/functional/pbs_sched_fifo.py
@@ -45,7 +45,7 @@ class TestSchedFifo(TestFunctional):
     """
     Test suite for FIFO scheduling
     """
-    @skipOnCpuSet
+
     def test_sched_fifo(self):
         """
         Check that FIFO works.

--- a/test/tests/functional/pbs_sched_preempt_enforce_resumption.py
+++ b/test/tests/functional/pbs_sched_preempt_enforce_resumption.py
@@ -59,7 +59,6 @@ class TestSchedPreemptEnforceResumption(TestFunctional):
         a = {'job_history_enable': 'True'}
         self.server.manager(MGR_CMD_SET, SERVER, a)
 
-    @skipOnCpuSet
     def test_filler_job_higher_walltime(self):
         """
         This test confirms that the filler job does not run if it conflicts
@@ -90,7 +89,6 @@ class TestSchedPreemptEnforceResumption(TestFunctional):
         self.scheduler.log_match(jid3 + logmsg)
         self.server.expect(JOB, {ATTR_state: 'Q'}, id=jid3)
 
-    @skipOnCpuSet
     def test_suspended_job_ded_time_calendared(self):
         """
         This test confirms that a suspended job becomes top job when unable to
@@ -106,8 +104,9 @@ class TestSchedPreemptEnforceResumption(TestFunctional):
         self.scheduler.add_dedicated_time(start=start, end=end)
 
         j1 = Job(TEST_USER)
+        jtime = int(time.time())
         j1.set_attributes({ATTR_l + '.select': '1:ncpus=2',
-                           ATTR_l + '.walltime': start-int(time.time())-10})
+                           ATTR_l + '.walltime': start - jtime - 10})
         jid1 = self.server.submit(j1)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
 
@@ -131,7 +130,6 @@ class TestSchedPreemptEnforceResumption(TestFunctional):
 
         self.assertGreaterEqual(est_start_time, end)
 
-    @skipOnCpuSet
     def test_filler_job_lesser_walltime(self):
         """
         This test confirms that the filler job does run when the walltime does
@@ -179,7 +177,6 @@ class TestSchedPreemptEnforceResumption(TestFunctional):
         logmsg = ";Job would conflict with reservation or top job"
         self.scheduler.log_match(jid4 + logmsg)
 
-    @skipOnCpuSet
     def test_filler_job_suspend(self):
         """
         This test confirms that the filler gets suspended by a high
@@ -240,7 +237,6 @@ class TestSchedPreemptEnforceResumption(TestFunctional):
                            offset=30, interval=2)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid2)
 
-    @skipOnCpuSet
     def test_preempted_job_server_soft_limits(self):
         """
         This test confirms that a preempted job remains suspended if it has
@@ -287,7 +283,6 @@ class TestSchedPreemptEnforceResumption(TestFunctional):
                            offset=30, interval=2)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
 
-    @skipOnCpuSet
     def test_preempted_job_queue_soft_limits(self):
         """
         This test confirms that a preempted job remains suspended if it has
@@ -334,7 +329,6 @@ class TestSchedPreemptEnforceResumption(TestFunctional):
                            offset=30, interval=2)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
 
-    @skipOnCpuSet
     def test_filler_jobs_with_no_walltime(self):
         """
         This test confirms that filler jobs with no walltime remain queued
@@ -369,7 +363,6 @@ class TestSchedPreemptEnforceResumption(TestFunctional):
         self.server.expect(JOB, {ATTR_state: 'Q'}, id=jid3)
         self.server.expect(JOB, {ATTR_state: 'Q'}, id=jid4)
 
-    @skipOnCpuSet
     def test_filler_stf(self):
         """
         Test that confirms filler shrink to fit jobs will shrink correctly

--- a/test/tests/functional/pbs_schedule_indirect_resources.py
+++ b/test/tests/functional/pbs_schedule_indirect_resources.py
@@ -70,7 +70,6 @@ class TestIndirectResources(TestFunctional):
 
         return (jobid, job)
 
-    @skipOnCpuSet
     def test_node_grouping_with_indirect_res(self):
         """
         Test node grouping with indirect resources set on some nodes

--- a/test/tests/functional/pbs_soft_walltime.py
+++ b/test/tests/functional/pbs_soft_walltime.py
@@ -462,7 +462,6 @@ e.accept()
         self.server.expect(JOB, {'estimated.soft_walltime': 65}, op=GE,
                            id=jid)
 
-    @skipOnCpuSet
     def test_resv_conf_soft(self):
         """
         Test that there is no change in the reservation behavior with
@@ -485,7 +484,6 @@ e.accept()
         rid = self.server.submit(R)
         self.server.log_match(rid + ';reservation deleted', max_attempts=5)
 
-    @skipOnCpuSet
     def test_resv_conf_soft_with_hard(self):
         """
         Test that there is no change in the reservation behavior with
@@ -510,7 +508,6 @@ e.accept()
         rid = self.server.submit(R)
         self.server.log_match(rid + ';reservation deleted', max_attempts=5)
 
-    @skipOnCpuSet
     def test_resv_job_soft(self):
         """
         Test to see that a job with a soft walltime which would "end" before
@@ -539,7 +536,6 @@ e.accept()
              'Not Running: Job would conflict with reservation or top job'}
         self.server.expect(JOB, a, id=jid, attrop=PTL_AND)
 
-    @skipOnCpuSet
     def test_resv_job_soft_hard(self):
         """
         Test to see that a job with a soft walltime and a hard walltime does
@@ -570,7 +566,6 @@ e.accept()
              'Not Running: Job would conflict with reservation or top job'}
         self.server.expect(JOB, a, id=jid, attrop=PTL_AND)
 
-    @skipOnCpuSet
     def test_topjob(self):
         """
         Test that soft_walltime is used for calendaring of topjobs
@@ -612,7 +607,6 @@ e.accept()
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
         self.compare_estimates(jid2, [jid3, jid4])
 
-    @skipOnCpuSet
     def test_topjob2(self):
         """
         Test a mixture of soft_walltime and walltime used in the calendar
@@ -656,7 +650,6 @@ e.accept()
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
         self.compare_estimates(jid2, [jid3, jid4, jid5])
 
-    @skipOnCpuSet
     def test_filler_job(self):
         """
         Test to see if filler jobs will run based on their soft_walltime
@@ -691,7 +684,6 @@ e.accept()
         self.server.expect(JOB, {ATTR_state: 'Q'}, id=jid2)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid3)
 
-    @skipOnCpuSet
     def test_preempt_order(self):
         """
         Test if soft_walltime is used for preempt_order.  It should be used
@@ -1031,7 +1023,6 @@ e.accept()
                             est_soft_walltime}, op=GE,
                            extend='x', attrop=PTL_AND, id=jid)
 
-    @skipOnCpuSet
     def test_soft_job_array(self):
         """
         Test that soft walltime works similar way with subjobs as

--- a/test/tests/functional/pbs_stf.py
+++ b/test/tests/functional/pbs_stf.py
@@ -111,7 +111,6 @@ class TestSTF(TestFunctional):
         self.server.expect(JOB, ATTR_comment, op=SET)
         self.server.expect(JOB, {ATTR_state: 'Q'}, id=jid)
 
-    @skipOnCpuSet
     def test_t_4_1_3(self):
         """
         Test shrink to fit by setting a dedicated time that started 20 minutes
@@ -162,7 +161,6 @@ class TestSTF(TestFunctional):
         msg = "Job;%s;Job will run for duration=[%s|%s]" % (j2id, wt, wt2)
         self.scheduler.log_match(msg, regexp=True, max_attempts=5, interval=2)
 
-    @skipOnCpuSet
     def test_t_4_1_1(self):
         """
         Test shrink to fit by setting a dedicated time that starts 1 hour
@@ -186,7 +184,6 @@ class TestSTF(TestFunctional):
         attr = {'Resource_List.walltime': (GE, '00:10:00')}
         self.server.expect(JOB, attr, id=jid)
 
-    @skipOnCpuSet
     def test_t_4_2_1(self):
         """
         Test shrink to fit by setting primetime that starts 4 hours from now
@@ -221,7 +218,6 @@ class TestSTF(TestFunctional):
         attr = {'Resource_List.walltime': (GE, '00:10:00')}
         self.server.expect(JOB, attr, id=j2id)
 
-    @skipOnCpuSet
     def test_t_4_2_3(self):
         """
         Test shrink to fit by setting primetime that starts 4 hours from now
@@ -251,7 +247,6 @@ class TestSTF(TestFunctional):
         attr = {'Resource_List.walltime': (GE, '00:10:00')}
         self.server.expect(JOB, attr, id=jid)
 
-    @skipOnCpuSet
     def test_t_4_2_4(self):
         """
         Test shrink to fit by setting primetime that started 22 minutes ago
@@ -281,7 +276,6 @@ class TestSTF(TestFunctional):
         attr = {'Resource_List.walltime': (GE, '00:01:00')}
         self.server.expect(JOB, attr, id=jid)
 
-    @skipOnCpuSet
     def test_t_4_3_1(self):
         """
         Test shrink to fit by creating 16 reservations, say from R110 to R125,
@@ -333,7 +327,6 @@ class TestSTF(TestFunctional):
         attr = {'Resource_List.walltime': (GE, '00:10:00')}
         self.server.expect(JOB, attr, id=jid)
 
-    @skipOnCpuSet
     def test_t_4_3_6(self):
         """
         Test shrink to fit by creating one reservation having ncpus=1,
@@ -391,7 +384,6 @@ class TestSTF(TestFunctional):
                                  max_attempts=5)
         self.server.expect(JOB, {'job_state': 'S'}, id=jid)
 
-    @skipOnCpuSet
     def test_t_4_3_8(self):
         """
         Test shrink to fit by submitting a STF job and then creating a
@@ -437,7 +429,6 @@ class TestSTF(TestFunctional):
 
         self.server.log_match(rid2 + ";reservation deleted", max_attempts=10)
 
-    @skipOnCpuSet
     def test_t_4_4_1(self):
         """
         Test shrink to fit by submitting top jobs as barrier.
@@ -487,7 +478,6 @@ class TestSTF(TestFunctional):
         attr = {'Resource_List.walltime': (LE, '05:00:00')}
         self.server.expect(JOB, attr, id=jid)
 
-    @skipOnCpuSet
     def test_t_4_5_1(self):
         """
         Test shrink to fit by setting primetime that started 45 minutes ago
@@ -522,7 +512,6 @@ class TestSTF(TestFunctional):
         attr = {'Resource_List.walltime': (LE, '00:05:00')}
         self.server.expect(JOB, attr, id=j2id)
 
-    @skipOnCpuSet
     def test_t_4_6_1(self):
         """
         Test shrink to fit by submitting a reservation and top jobs as
@@ -563,7 +552,6 @@ class TestSTF(TestFunctional):
         attr = {'Resource_List.walltime': (LE, '00:15:00')}
         self.server.expect(JOB, attr, id=jid3)
 
-    @skipOnCpuSet
     def test_t_5_1_1(self):
         """
         STF job's min/max_walltime relative to resources_min/max.walltime
@@ -636,7 +624,6 @@ class TestSTF(TestFunctional):
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
 
-    @skipOnCpuSet
     def test_t_5_1_2(self):
         """
         STF job's max_walltime relative to resources_max.walltime
@@ -671,7 +658,6 @@ class TestSTF(TestFunctional):
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
 
-    @skipOnCpuSet
     def test_t_5_2_1(self):
         """
         Setting resources_max.min_walltime on a queue.
@@ -683,7 +669,6 @@ class TestSTF(TestFunctional):
             self.assertTrue('Resource limits can not be set for the resource'
                             in e.msg[0])
 
-    @skipOnCpuSet
     def test_t_5_2_2(self):
         """
         Setting resources_max.min_walltime on the server.
@@ -695,7 +680,6 @@ class TestSTF(TestFunctional):
             self.assertTrue('Resource limits can not be set for the resource'
                             in e.msg[0])
 
-    @skipOnCpuSet
     def test_t_6(self):
         """
         Test to see that the min_walltime is not unset if the max_walltime

--- a/test/tests/functional/pbs_strict_ordering.py
+++ b/test/tests/functional/pbs_strict_ordering.py
@@ -51,7 +51,6 @@ class TestStrictOrderingAndBackfilling(TestFunctional):
     Test strict ordering when backfilling is truned off
     """
     @timeout(1800)
-    @skipOnCpuSet
     def test_t1(self):
 
         a = {'resources_available.ncpus': 4}
@@ -99,7 +98,6 @@ class TestStrictOrderingAndBackfilling(TestFunctional):
     backfilling is off
     """
 
-    @skipOnCpuSet
     def test_t2(self):
         rv = self.scheduler.set_sched_config(
             {'by_queue': 'false prime', 'strict_ordering': 'true all'})
@@ -160,7 +158,6 @@ class TestStrictOrderingAndBackfilling(TestFunctional):
                            max_attempts=30,
                            interval=2)
 
-    @skipOnCpuSet
     def test_zero_backfill_depth_on_queue(self):
         """
         Test if scheduler tries to run a job when strict ordering is enabled
@@ -239,7 +236,6 @@ class TestStrictOrderingAndBackfilling(TestFunctional):
         self.server.expect(JOB, {'job_state': 'R'}, id=jid6)
         self.scheduler.log_match(jid5 + ";Job is a top job")
 
-    @skipOnCpuSet
     def test_zero_backfill_depth_on_one_queue(self):
         """
         Test if scheduler tries to run a job when strict ordering is enabled

--- a/test/tests/functional/pbs_suspend_resume_accounting.py
+++ b/test/tests/functional/pbs_suspend_resume_accounting.py
@@ -72,7 +72,6 @@ class TestSuspendResumeAccounting(TestFunctional):
         record = 'r;%s;' % jid
         self.server.accounting_match(msg=record, id=jid)
 
-    @skipOnCpuSet
     def test_suspend_resume_job_array_signal(self):
         """
         Test case to verify accounting suspend
@@ -134,7 +133,6 @@ class TestSuspendResumeAccounting(TestFunctional):
         record = 'r;%s;' % jid
         self.server.accounting_match(msg=record, id=jid)
 
-    @skipOnCpuSet
     def test_suspend_resume_job_scheduler(self):
         """
         Test case to verify accounting suspend
@@ -233,7 +231,6 @@ class TestSuspendResumeAccounting(TestFunctional):
         record = 'r;%s;' % jid
         self.server.accounting_match(msg=record, id=jid)
 
-    @skipOnCpuSet
     def test_resc_released_susp_resume_multi_vnode(self):
         """
         Test case to verify accounting of suspend/resume
@@ -282,7 +279,6 @@ class TestSuspendResumeAccounting(TestFunctional):
         line = self.server.accounting_match(msg=record, id=jid1)[1]
         self.assertIn(resc_released, line)
 
-    @skipOnCpuSet
     def test_higher_priority_job_hook_reject(self):
         """
         Test case to verify accounting of suspend/resume

--- a/test/tests/functional/pbs_test_entity_limits.py
+++ b/test/tests/functional/pbs_test_entity_limits.py
@@ -136,7 +136,6 @@ class TestEntityLimits(TestFunctional):
             self.assertFalse(True, "Job violating limits got submitted after "
                              "server restart.")
 
-    @skipOnCpuSet
     def test_server_generic_user_limits_queued(self):
         """
         Test queued_jobs_threshold for any user at the server level.
@@ -146,7 +145,6 @@ class TestEntityLimits(TestFunctional):
         m = "qsub: would exceed complex's per-user limit of jobs in 'Q' state"
         self.common_limit_test(True, a, queued=True, exp_err=m)
 
-    @skipOnCpuSet
     def test_server_user_limits_queued(self):
         """
         Test queued_jobs_threshold for user TEST_USER at the server level.
@@ -157,7 +155,6 @@ class TestEntityLimits(TestFunctional):
             str(TEST_USER) + ' already in complex'
         self.common_limit_test(True, a, queued=True, exp_err=errmsg)
 
-    @skipOnCpuSet
     def test_server_project_limits_queued(self):
         """
         Test queued_jobs_threshold for project p1 at the server level.
@@ -168,7 +165,6 @@ class TestEntityLimits(TestFunctional):
             + "already in complex"
         self.common_limit_test(True, a, attrs, queued=True, exp_err=errmsg)
 
-    @skipOnCpuSet
     def test_server_generic_project_limits_queued(self):
         """
         Test queued_jobs_threshold for any project at the server level.
@@ -179,7 +175,6 @@ class TestEntityLimits(TestFunctional):
             + "'Q' state"
         self.common_limit_test(True, a, queued=True, exp_err=errmsg)
 
-    @skipOnCpuSet
     @skipOnShasta
     def test_server_group_limits_queued(self):
         """
@@ -191,7 +186,6 @@ class TestEntityLimits(TestFunctional):
             str(TSTGRP0) + ' already in complex'
         self.common_limit_test(True, a, queued=True, exp_err=errmsg)
 
-    @skipOnCpuSet
     @skipOnShasta
     def test_server_generic_group_limits_queued(self):
         """
@@ -202,7 +196,6 @@ class TestEntityLimits(TestFunctional):
         m = "qsub: would exceed complex's per-group limit of jobs in 'Q' state"
         self.common_limit_test(True, a, queued=True, exp_err=m)
 
-    @skipOnCpuSet
     def test_server_overall_limits_queued(self):
         """
         Test queued_jobs_threshold for any entity at the server level.
@@ -211,7 +204,6 @@ class TestEntityLimits(TestFunctional):
         errmsg = "qsub: Maximum number of jobs in 'Q' state already in complex"
         self.common_limit_test(True, a, queued=True, exp_err=errmsg)
 
-    @skipOnCpuSet
     def test_queue_generic_user_limits_queued(self):
         """
         Test queued_jobs_threshold for any user for the default queue.
@@ -223,7 +215,6 @@ class TestEntityLimits(TestFunctional):
             + "jobs in 'Q' state"
         self.common_limit_test(False, a, attrs, queued=True, exp_err=errmsg)
 
-    @skipOnCpuSet
     def test_queue_user_limits_queued(self):
         """
         Test queued_jobs_threshold for user pbsuser1 for the default queue.
@@ -236,7 +227,6 @@ class TestEntityLimits(TestFunctional):
         self.common_limit_test(False, a, attrs, queued=True, exp_err=errmsg)
 
     @skipOnShasta
-    @skipOnCpuSet
     def test_queue_group_limits_queued(self):
         """
         Test queued_jobs_threshold for group TSTGRP0 for the default queue.
@@ -248,7 +238,6 @@ class TestEntityLimits(TestFunctional):
             str(TSTGRP0) + ' already in queue ' + self.server.default_queue
         self.common_limit_test(False, a, attrs, queued=True, exp_err=errmsg)
 
-    @skipOnCpuSet
     def test_queue_project_limits_queued(self):
         """
         Test queued_jobs_threshold for project p1 for the default queue.
@@ -259,7 +248,6 @@ class TestEntityLimits(TestFunctional):
             'already in queue ' + self.server.default_queue
         self.common_limit_test(False, a, attrs, queued=True, exp_err=errmsg)
 
-    @skipOnCpuSet
     def test_queue_generic_project_limits_queued(self):
         """
         Test queued_jobs_threshold for any project for the default queue.
@@ -271,7 +259,6 @@ class TestEntityLimits(TestFunctional):
             "'s per-project limit of jobs in 'Q' state"
         self.common_limit_test(False, a, attrs, queued=True, exp_err=errmsg)
 
-    @skipOnCpuSet
     @skipOnShasta
     def test_queue_generic_group_limits_queued(self):
         """
@@ -284,7 +271,6 @@ class TestEntityLimits(TestFunctional):
             "'s per-group limit of jobs in 'Q' state"
         self.common_limit_test(False, a, attrs, queued=True, exp_err=errmsg)
 
-    @skipOnCpuSet
     def test_queue_overall_limits_queued(self):
         """
         Test queued_jobs_threshold for all entities for the default queue.
@@ -295,7 +281,6 @@ class TestEntityLimits(TestFunctional):
             + self.server.default_queue
         self.common_limit_test(False, a, attrs, queued=True, exp_err=emsg)
 
-    @skipOnCpuSet
     def test_server_generic_user_limits_res_queued(self):
         """
         Test queued_jobs_threshold_res for any user at the server level.
@@ -307,7 +292,6 @@ class TestEntityLimits(TestFunctional):
             + "complex for jobs in 'Q' state"
         self.common_limit_test(True, a, attrs, queued=True, exp_err=errmsg)
 
-    @skipOnCpuSet
     def test_server_user_limits_res_queued(self):
         """
         Test queued_jobs_threshold_res for user pbsuser1 at the server level.
@@ -320,7 +304,6 @@ class TestEntityLimits(TestFunctional):
         self.common_limit_test(True, a, attrs, queued=True, exp_err=errmsg)
 
     @skipOnShasta
-    @skipOnCpuSet
     def test_server_generic_group_limits_res_queued(self):
         """
         Test queued_jobs_threshold_res for any group at the server level.
@@ -332,7 +315,6 @@ class TestEntityLimits(TestFunctional):
             + "complex for jobs in 'Q' state"
         self.common_limit_test(True, a, attrs, queued=True, exp_err=errmsg)
 
-    @skipOnCpuSet
     def test_server_project_limits_res_queued(self):
         """
         Test queued_jobs_threshold_res for project p1 at the server level.
@@ -344,7 +326,6 @@ class TestEntityLimits(TestFunctional):
             + " complex for jobs in 'Q' state"
         self.common_limit_test(True, a, attrs, queued=True, exp_err=errmsg)
 
-    @skipOnCpuSet
     def test_server_generic_project_limits_res_queued(self):
         """
         Test queued_jobs_threshold_res for any project at the server level.
@@ -357,7 +338,6 @@ class TestEntityLimits(TestFunctional):
         self.common_limit_test(True, a, attrs, queued=True, exp_err=errmsg)
 
     @skipOnShasta
-    @skipOnCpuSet
     def test_server_group_limits_res_queued(self):
         """
         Test queued_jobs_threshold_res for group pbsuser1 at the server level.
@@ -369,7 +349,6 @@ class TestEntityLimits(TestFunctional):
             "'s limit on resource ncpus in complex for jobs in 'Q' state"
         self.common_limit_test(True, a, attrs, queued=True, exp_err=errmsg)
 
-    @skipOnCpuSet
     def test_server_overall_limits_res_queued(self):
         """
         Test queued_jobs_threshold_res for all entities at the server level.
@@ -381,7 +360,6 @@ class TestEntityLimits(TestFunctional):
             + "jobs in 'Q' state"
         self.common_limit_test(True, a, attrs, queued=True, exp_err=errmsg)
 
-    @skipOnCpuSet
     def test_queue_generic_user_limits_res_queued(self):
         """
         Test queued_jobs_threshold_res for all users for the default queue.
@@ -394,7 +372,6 @@ class TestEntityLimits(TestFunctional):
             + self.server.default_queue + " for jobs in 'Q' state"
         self.common_limit_test(False, a, attrs, queued=True, exp_err=emsg)
 
-    @skipOnCpuSet
     def test_queue_user_limits_res_queued(self):
         """
         Test queued_jobs_threshold_res for user pbsuser1 for the default queue.
@@ -409,7 +386,6 @@ class TestEntityLimits(TestFunctional):
         self.common_limit_test(False, a, attrs, queued=True, exp_err=errmsg)
 
     @skipOnShasta
-    @skipOnCpuSet
     def test_queue_group_limits_res_queued(self):
         """
         Test queued_jobs_threshold_res for group pbsuser1 for the default queue
@@ -424,7 +400,6 @@ class TestEntityLimits(TestFunctional):
         self.common_limit_test(False, a, attrs, queued=True, exp_err=errmsg)
 
     @skipOnShasta
-    @skipOnCpuSet
     def test_queue_generic_group_limits_res_queued(self):
         """
         Test queued_jobs_threshold_res for any group for the default queue.
@@ -437,7 +412,6 @@ class TestEntityLimits(TestFunctional):
             + 'queue ' + self.server.default_queue + " for jobs in 'Q' state"
         self.common_limit_test(False, a, attrs, queued=True, exp_err=errmsg)
 
-    @skipOnCpuSet
     def test_queue_project_limits_res_queued(self):
         """
         Test queued_jobs_threshold_res for project p1 for the default queue.
@@ -450,7 +424,6 @@ class TestEntityLimits(TestFunctional):
             'in queue ' + self.server.default_queue + " for jobs in 'Q' state"
         self.common_limit_test(False, a, attrs, queued=True, exp_err=errmsg)
 
-    @skipOnCpuSet
     def test_queue_generic_project_limits_res_queued(self):
         """
         Test queued_jobs_threshold_res for any project for the default queue.
@@ -463,7 +436,6 @@ class TestEntityLimits(TestFunctional):
             + ' queue ' + self.server.default_queue + " for jobs in 'Q' state"
         self.common_limit_test(False, a, attrs, queued=True, exp_err=errmsg)
 
-    @skipOnCpuSet
     def test_queue_overall_limits_res_queued(self):
         """
         Test queued_jobs_threshold_res for any entity for the default queue.
@@ -476,7 +448,6 @@ class TestEntityLimits(TestFunctional):
             self.server.default_queue + " for jobs in 'Q' state"
         self.common_limit_test(False, a, attrs, queued=True, exp_err=errmsg)
 
-    @skipOnCpuSet
     def test_server_generic_user_limits_max(self):
         """
         Test max_queued for any user at the server level.
@@ -486,7 +457,6 @@ class TestEntityLimits(TestFunctional):
         errmsg = "qsub: would exceed complex's per-user limit"
         self.common_limit_test(True, a, exp_err=errmsg)
 
-    @skipOnCpuSet
     def test_server_user_limits_max(self):
         """
         Test max_queued for user pbsuser1 at the server level.
@@ -497,7 +467,6 @@ class TestEntityLimits(TestFunctional):
             ' already in complex'
         self.common_limit_test(True, a, exp_err=errmsg)
 
-    @skipOnCpuSet
     def test_server_project_limits_max(self):
         """
         Test max_queued for project p1 at the server level.
@@ -507,7 +476,6 @@ class TestEntityLimits(TestFunctional):
         msg = 'qsub: Maximum number of jobs for project p1 already in complex'
         self.common_limit_test(True, a, attrs, exp_err=msg)
 
-    @skipOnCpuSet
     def test_server_generic_project_limits_max(self):
         """
         Test max_queued for any project at the server level.
@@ -518,7 +486,6 @@ class TestEntityLimits(TestFunctional):
         self.common_limit_test(True, a, exp_err=errmsg)
 
     @skipOnShasta
-    @skipOnCpuSet
     def test_server_group_limits_max(self):
         """
         Test max_queued for group TSTGRP0 at the server level.
@@ -530,7 +497,6 @@ class TestEntityLimits(TestFunctional):
         self.common_limit_test(True, a, exp_err=errmsg)
 
     @skipOnShasta
-    @skipOnCpuSet
     def test_server_generic_group_limits_max(self):
         """
         Test max_queued for any group at the server level.
@@ -540,7 +506,6 @@ class TestEntityLimits(TestFunctional):
         errmsg = "qsub: would exceed complex's per-group limit"
         self.common_limit_test(True, a, exp_err=errmsg)
 
-    @skipOnCpuSet
     def test_server_overall_limits_max(self):
         """
         Test max_queued for any entity at the server level.
@@ -549,7 +514,6 @@ class TestEntityLimits(TestFunctional):
         errmsg = 'qsub: Maximum number of jobs already in complex'
         self.common_limit_test(True, a, exp_err=errmsg)
 
-    @skipOnCpuSet
     def test_queue_generic_user_limits_max(self):
         """
         Test max_queued for any user for the default queue.
@@ -560,7 +524,6 @@ class TestEntityLimits(TestFunctional):
         errmsg = "qsub: would exceed queue generic's per-user limit"
         self.common_limit_test(False, a, attrs, exp_err=errmsg)
 
-    @skipOnCpuSet
     def test_queue_user_limits_max(self):
         """
         Test max_queued for user pbsuser1 for the default queue.
@@ -573,7 +536,6 @@ class TestEntityLimits(TestFunctional):
         self.common_limit_test(False, a, attrs, exp_err=errmsg)
 
     @skipOnShasta
-    @skipOnCpuSet
     def test_queue_group_limits_max(self):
         """
         Test max_queued for group pbsuser1 for the default queue.
@@ -585,7 +547,6 @@ class TestEntityLimits(TestFunctional):
             ' already in queue ' + self.server.default_queue
         self.common_limit_test(False, a, attrs, exp_err=errmsg)
 
-    @skipOnCpuSet
     def test_queue_project_limits_max(self):
         """
         Test max_queued for project p1 for the default queue.
@@ -596,7 +557,6 @@ class TestEntityLimits(TestFunctional):
             + self.server.default_queue
         self.common_limit_test(False, a, attrs, exp_err=msg)
 
-    @skipOnCpuSet
     def test_queue_generic_project_limits_max(self):
         """
         Test max_queued for any project for the default queue.
@@ -609,7 +569,6 @@ class TestEntityLimits(TestFunctional):
         self.common_limit_test(False, a, attrs, exp_err=errmsg)
 
     @skipOnShasta
-    @skipOnCpuSet
     def test_queue_generic_group_limits_max(self):
         """
         Test max_queued for any group for the default queue.
@@ -621,7 +580,6 @@ class TestEntityLimits(TestFunctional):
             "'s per-group limit"
         self.common_limit_test(False, a, attrs, exp_err=errmsg)
 
-    @skipOnCpuSet
     def test_queue_overall_limits_max(self):
         """
         Test max_queued for all entities for the default queue.
@@ -632,7 +590,6 @@ class TestEntityLimits(TestFunctional):
             self.server.default_queue
         self.common_limit_test(False, a, attrs, exp_err=errmsg)
 
-    @skipOnCpuSet
     def test_server_generic_user_limits_res_max(self):
         """
         Test max_queued_res for any user at the server level.
@@ -643,7 +600,6 @@ class TestEntityLimits(TestFunctional):
         emsg = 'qsub: would exceed per-user limit on resource ncpus in complex'
         self.common_limit_test(True, a, attrs, exp_err=emsg)
 
-    @skipOnCpuSet
     def test_server_user_limits_res_max(self):
         """
         Test max_queued_res for user pbsuser1 at the server level.
@@ -656,7 +612,6 @@ class TestEntityLimits(TestFunctional):
         self.common_limit_test(True, a, attrs, exp_err=errmsg)
 
     @skipOnShasta
-    @skipOnCpuSet
     def test_server_generic_group_limits_res_max(self):
         """
         Test max_queued_res for any group at the server level.
@@ -667,7 +622,6 @@ class TestEntityLimits(TestFunctional):
         msg = 'qsub: would exceed per-group limit on resource ncpus in complex'
         self.common_limit_test(True, a, attrs, exp_err=msg)
 
-    @skipOnCpuSet
     def test_server_project_limits_res_max(self):
         """
         Test max_queued_res for project p1 at the server level.
@@ -679,7 +633,6 @@ class TestEntityLimits(TestFunctional):
             + " complex"
         self.common_limit_test(True, a, attrs, exp_err=errmsg)
 
-    @skipOnCpuSet
     def test_server_generic_project_limits_res_max(self):
         """
         Test max_queued_res for any project at the server level.
@@ -691,7 +644,6 @@ class TestEntityLimits(TestFunctional):
         self.common_limit_test(True, a, attrs, exp_err=m)
 
     @skipOnShasta
-    @skipOnCpuSet
     def test_server_group_limits_res_max(self):
         """
         Test max_queued_res for group pbsuser1 at the server level.
@@ -703,7 +655,6 @@ class TestEntityLimits(TestFunctional):
             "'s limit on resource ncpus in complex"
         self.common_limit_test(True, a, attrs, exp_err=errmsg)
 
-    @skipOnCpuSet
     def test_server_overall_limits_res_max(self):
         """
         Test max_queued_res for all entities at the server level.
@@ -714,7 +665,6 @@ class TestEntityLimits(TestFunctional):
         errmsg = 'qsub: would exceed limit on resource ncpus in complex'
         self.common_limit_test(True, a, attrs, exp_err=errmsg)
 
-    @skipOnCpuSet
     def test_queue_generic_user_limits_res_max(self):
         """
         Test max_queued_res for all users for the default queue.
@@ -727,7 +677,6 @@ class TestEntityLimits(TestFunctional):
             + ' queue ' + self.server.default_queue
         self.common_limit_test(False, a, attrs, exp_err=errmsg)
 
-    @skipOnCpuSet
     def test_queue_user_limits_res_max(self):
         """
         Test max_queued_res for user pbsuser1 for the default queue.
@@ -742,7 +691,6 @@ class TestEntityLimits(TestFunctional):
         self.common_limit_test(False, a, attrs, exp_err=errmsg)
 
     @skipOnShasta
-    @skipOnCpuSet
     def test_queue_group_limits_res_max(self):
         """
         Test max_queued_res for group pbsuser1 for the default queue
@@ -756,7 +704,6 @@ class TestEntityLimits(TestFunctional):
         self.common_limit_test(False, a, attrs, exp_err=errmsg)
 
     @skipOnShasta
-    @skipOnCpuSet
     def test_queue_generic_group_limits_res_max(self):
         """
         Test max_queued_res for any group for the default queue.
@@ -769,7 +716,6 @@ class TestEntityLimits(TestFunctional):
             + ' queue ' + self.server.default_queue
         self.common_limit_test(False, a, attrs, exp_err=errmsg)
 
-    @skipOnCpuSet
     def test_queue_project_limits_res_max(self):
         """
         Test max_queued_res for project p1 for the default queue.
@@ -782,7 +728,6 @@ class TestEntityLimits(TestFunctional):
             ' in queue ' + self.server.default_queue
         self.common_limit_test(False, a, attrs, exp_err=errmsg)
 
-    @skipOnCpuSet
     def test_queue_generic_project_limits_res_max(self):
         """
         Test max_queued_res for any project for the default queue.
@@ -795,7 +740,6 @@ class TestEntityLimits(TestFunctional):
             + ' queue ' + self.server.default_queue
         self.common_limit_test(False, a, attrs, exp_err=errmsg)
 
-    @skipOnCpuSet
     def test_queue_overall_limits_res_max(self):
         """
         Test max_queued_res for any entity for the default queue.
@@ -808,7 +752,6 @@ class TestEntityLimits(TestFunctional):
                  + self.server.default_queue
         self.common_limit_test(False, a, attrs, exp_err=errmsg)
 
-    @skipOnCpuSet
     def test_qalter_resource(self):
         """
         Test that qaltering a job's resource list is accounted
@@ -856,7 +799,6 @@ class TestEntityLimits(TestFunctional):
                 raise self.failureException("rcvd unexpected err message: " +
                                             e.msg[0])
 
-    @skipOnCpuSet
     def test_multiple_queued_limits(self):
         defqname = self.server.default_queue
         q2name = 'q2'
@@ -907,7 +849,6 @@ class TestEntityLimits(TestFunctional):
         else:
             self.assertFalse(True, "Job violating limits got submitted.")
 
-    @skipOnCpuSet
     def test_pbs_all_soft_limits(self):
         """
         Set resource soft limit on server for PBS_ALL and see that the job
@@ -953,7 +894,6 @@ class TestEntityLimits(TestFunctional):
         self.server.expect(JOB, {'job_state': 'S'}, id=jid1)
         self.server.expect(JOB, {'job_state': 'Q'}, id=jid4)
 
-    @skipOnCpuSet
     def test_user_soft_limits(self):
         """
         Set resource soft limit on server for a user and see that the job
@@ -1000,7 +940,6 @@ class TestEntityLimits(TestFunctional):
         self.server.expect(JOB, {'job_state': 'S'}, id=jid1)
         self.server.expect(JOB, {'job_state': 'Q'}, id=jid4)
 
-    @skipOnCpuSet
     def test_group_soft_limits(self):
         """
         Set resource soft limit on server for a group and see that the job
@@ -1049,7 +988,6 @@ class TestEntityLimits(TestFunctional):
         self.server.expect(JOB, {'job_state': 'S'}, id=jid1)
         self.server.expect(JOB, {'job_state': 'Q'}, id=jid4)
 
-    @skipOnCpuSet
     def test_project_soft_limits(self):
         """
         Set resource soft limit on server for a project and see that the job

--- a/test/tests/functional/pbs_test_run_count.py
+++ b/test/tests/functional/pbs_test_run_count.py
@@ -119,14 +119,16 @@ class Test_run_count(TestFunctional):
         self.server.expect(JOB, {ATTR_state: "H", ATTR_runcount: maxruncount},
                            attrop=PTL_AND, id=sjid)
         ja_comment = "Job Array Held, too many failed attempts to run subjob"
-        self.server.expect(JOB, {ATTR_state: "H", ATTR_comment: (MATCH_RE,
-                           ja_comment)}, attrop=PTL_AND, id=jid)
+        self.server.expect(JOB, {ATTR_state: "H",
+                                 ATTR_comment: (MATCH_RE, ja_comment)},
+                           attrop=PTL_AND, id=jid)
         self.disable_reject_begin_hook()
         self.server.rlsjob(jid, 's')
         self.server.expect(JOB, {ATTR_state: "R"}, id=sjid)
         ja_comment = "Job Array Began at"
-        self.server.expect(JOB, {ATTR_state: "B", ATTR_comment: (MATCH_RE,
-                           ja_comment)}, attrop=PTL_AND, id=jid)
+        self.server.expect(JOB, {ATTR_state: "B",
+                                 ATTR_comment: (MATCH_RE, ja_comment)},
+                           attrop=PTL_AND, id=jid)
 
     def test_run_count_subjob(self):
         """
@@ -141,7 +143,6 @@ class Test_run_count(TestFunctional):
         jid = self.server.submit(j)
         self.subjob_check(jid=jid, sjid=j.create_subjob_id(jid, 1))
 
-    @skipOnCpuSet
     def test_run_count_subjob_in_x(self):
         """
         Submit a job array and check if the subjob and the parent are getting
@@ -182,7 +183,6 @@ class Test_run_count(TestFunctional):
         self.subjob_check(jid, sjid, maxruncount="40")
         return sjid
 
-    @skipOnCpuSet
     def test_large_run_count_subjob_in_x(self):
         """
         Submit a job array and check if the subjob and the parent are getting

--- a/test/tests/functional/pbs_trillion_jobid.py
+++ b/test/tests/functional/pbs_trillion_jobid.py
@@ -307,7 +307,6 @@ exit 0
             seq_id = {ATTR_max_job_sequence_id: val}
             self.server.manager(MGR_CMD_SET, SERVER, seq_id, runas=ROOT_USER)
 
-    @skipOnCpuSet
     def test_max_job_sequence_id_wrap(self):
         """
         Test to check the jobid's/resvid's are wrapping it to zero or not,

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -57,7 +57,6 @@ class SmokeTest(PBSTestSuite):
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
 
-    @skipOnCpuSet
     def test_submit_job_array(self):
         """
         Test to submit a job array
@@ -71,7 +70,6 @@ class SmokeTest(PBSTestSuite):
         self.server.expect(JOB, {'job_state=R': 3}, count=True,
                            id=jid, extend='t')
 
-    @skipOnCpuSet
     def test_advance_reservation(self):
         """
         Test to submit an advanced reservation and submit jobs to that
@@ -140,7 +138,6 @@ class SmokeTest(PBSTestSuite):
         if _m == PTL_API:
             self.server.set_op_mode(PTL_API)
 
-    @skipOnCpuSet
     def test_degraded_advance_reservation(self):
         """
         Make reservations more fault tolerant
@@ -207,7 +204,6 @@ class SmokeTest(PBSTestSuite):
         self.server.sigjob(jid, 'resume')
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
 
-    @skipOnCpuSet
     def test_backfilling(self):
         """
         Test for backfilling
@@ -245,7 +241,6 @@ class SmokeTest(PBSTestSuite):
         self.server.rlsjob(jid, USER_HOLD)
         self.server.expect(JOB, {'Hold_Types': 'n'}, jid)
 
-    @skipOnCpuSet
     def test_create_vnode(self):
         """
         Test to create vnodes
@@ -285,7 +280,6 @@ class SmokeTest(PBSTestSuite):
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, qname)
         self.server.manager(MGR_CMD_DELETE, QUEUE, id=qname)
 
-    @skipOnCpuSet
     def test_fgc_limits(self):
         """
         Test for limits
@@ -306,7 +300,6 @@ class SmokeTest(PBSTestSuite):
         self.server.expect(JOB, 'comment', op=SET, id=j3id)
         self.server.expect(JOB, {'job_state': 'Q'}, id=j3id)
 
-    @skipOnCpuSet
     def test_limits(self):
         """
         Test for limits
@@ -337,7 +330,6 @@ class SmokeTest(PBSTestSuite):
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
 
-    @skipOnCpuSet
     def test_finished_jobs(self):
         """
         Test for finished jobs and resource used for jobs.
@@ -379,7 +371,6 @@ class SmokeTest(PBSTestSuite):
         self.server.expect(SERVER, {'server_state': 'Scheduling'}, op=NE)
         self.server.expect(JOB, {'job_state=R': 1})
 
-    @skipOnCpuSet
     def test_job_scheduling_order(self):
         """
         Test for job scheduling order
@@ -404,7 +395,6 @@ class SmokeTest(PBSTestSuite):
         self.server.expect(JOB, {'estimated.start_time': 5},
                            count=True, op=SET)
 
-    @skipOnCpuSet
     def test_preemption(self):
         """
         Test for preemption
@@ -429,7 +419,6 @@ class SmokeTest(PBSTestSuite):
         self.server.expect(JOB, {'job_state': 'R'}, id=j2id)
         self.server.expect(JOB, {'job_state': 'S'}, id=jid)
 
-    @skipOnCpuSet
     def test_preemption_qrun(self):
         """
         Test that a job is preempted when a high priority job is run via qrun
@@ -455,7 +444,6 @@ class SmokeTest(PBSTestSuite):
 
         self.scheduler.log_match(jid1 + ";Job preempted by suspension")
 
-    @skipOnCpuSet
     def test_fairshare(self):
         """
         Test for fairshare
@@ -534,7 +522,6 @@ class SmokeTest(PBSTestSuite):
         self.mom.log_match("my custom message", starttime=self.server.ctime,
                            interval=1)
 
-    @skipOnCpuSet
     def test_shrink_to_fit(self):
         """
         Smoke test shrink to fit by setting a dedicated time to start in an
@@ -573,7 +560,6 @@ class SmokeTest(PBSTestSuite):
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
         self.logger.info('Job submitted successfully: ' + jid)
 
-    @skipOnCpuSet
     def test_formula_match(self):
         """
         Test for job sort formula
@@ -651,7 +637,6 @@ class SmokeTest(PBSTestSuite):
         self.server.expect(JOB, {ATTR_queue: 'solverq', 'job_state': 'R'},
                            attrop=PTL_AND)
 
-    @skipOnCpuSet
     def test_by_queue(self):
         """
         Test by_queue scheduling policy
@@ -710,7 +695,6 @@ class SmokeTest(PBSTestSuite):
             self.logger.info('Expected order: ' + ','.join(job_order))
             self.assertTrue(cycle.political_order == job_order)
 
-    @skipOnCpuSet
     def test_round_robin(self):
         """
         Test round_robin scheduling policy
@@ -820,7 +804,6 @@ class SmokeTest(PBSTestSuite):
              'comment': msg}
         self.server.expect(JOB, a, id=j1id)
 
-    @skipOnCpuSet
     def test_schedlog_preempted_info(self):
         """
         Demonstrate how to retrieve a list of jobs that had to be preempted in
@@ -837,7 +820,6 @@ class SmokeTest(PBSTestSuite):
                 self.logger.info('Preemption info: ' +
                                  str(cycle.preempted_jobs))
 
-    @skipOnCpuSet
     def test_basic(self):
         """
         basic express queue preemption test
@@ -871,7 +853,6 @@ class SmokeTest(PBSTestSuite):
         self.server.expect(SERVER, {'total_jobs': 0})
         self.server.manager(MGR_CMD_DELETE, QUEUE, id="expressq")
 
-    @skipOnCpuSet
     def test_basic_ja(self):
         """
         basic express queue preemption test with job array
@@ -920,7 +901,6 @@ class SmokeTest(PBSTestSuite):
             d = e.rv
         return d
 
-    @skipOnCpuSet
     def test_shrink_to_fit_resv_barrier(self):
         """
         Test shrink to fit by creating one reservation having ncpus=1,
@@ -952,7 +932,6 @@ class SmokeTest(PBSTestSuite):
         attr = {'Resource_List.walltime': (GE, '00:10:00')}
         self.server.expect(JOB, attr, id=jid2)
 
-    @skipOnCpuSet
     def test_job_sort_formula_threshold(self):
         """
         Test job_sort_formula_threshold basic behavior
@@ -1123,14 +1102,12 @@ class SmokeTest(PBSTestSuite):
         else:
             return j1id
 
-    @skipOnCpuSet
     def test_suspend_job_with_preempt(self):
         """
         Test Suspend of Job using Scheduler Preemption
         """
         self.common_stuff(isWithPreempt=True)
 
-    @skipOnCpuSet
     def test_resume_job_with_preempt(self):
         """
         Test Resume of Job using Scheduler Preemption
@@ -1146,14 +1123,12 @@ class SmokeTest(PBSTestSuite):
                                    {'session_id': (NOT, self.isSuspended)},
                                    id=job['id'])
 
-    @skipOnCpuSet
     def test_suspend_job_array_with_preempt(self):
         """
         Test Suspend of Job array using Scheduler Preemption
         """
         self.common_stuff(isJobArray=True, isWithPreempt=True)
 
-    @skipOnCpuSet
     def test_resume_job_array_with_preempt(self):
         """
         Test Resume of Job array using Scheduler Preemption
@@ -1272,7 +1247,6 @@ class SmokeTest(PBSTestSuite):
         self.scheduler.set_sched_config(a)
         self.server.manager(MGR_CMD_SET, SCHED, {'log_events': 4095})
 
-    @skipOnCpuSet
     def test_fairshare_enhanced(self):
         """
         Test the basic fairshare behavior with custom resources for math module
@@ -1418,7 +1392,6 @@ class SmokeTest(PBSTestSuite):
             msg += " %s command" % pbs_cmd
             self.logger.info(msg)
 
-    @skipOnCpuSet
     def test_exclhost(self):
         """
         Test that a job requesting exclhost is not placed on another host


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Deprecate skipOnCpuset decorator from tests.


#### Describe Your Change
Deprecate skipOnCpuset decorator from tests and skip tests directly from library if tried to create more vnodes or set ncpus more than available or if tried to set mem.

Once all tests are fixed. cpuset decorator will be removed.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

skipcpuset branch:

Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, WIN2K16
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|4100|2677|26|2|3|3|2643|

mainline : 
Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, WIN2K16
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|4131|2677|25|2|9|3|2638|
<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
