### PR TITLE
Fix build on macOS

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -51,6 +51,12 @@ How to install PBS using the configure script.
       libexpat-dev libssl-dev libxext-dev libxft-dev autoconf \
       automake
 
+  For macOS systems using MacPorts you should run the following command as root:
+
+    port install autoconf automake libtool pkgconfig \
+      expat hwloc libedit libical openssl postgresql12 python38 \
+      swig-python tcl tk xorg-libX11 xorg-libXt
+
 2. Install the prerequisite packages for running PBS. In addition
   to the commands below, you should also install a text editor of
   your choosing (vim, emacs, gedit, etc.).
@@ -85,6 +91,11 @@ How to install PBS using the configure script.
     apt install expat libedit2 postgresql python3 postgresql-contrib sendmail-bin \
       sudo tcl tk libical3 postgresql-server-dev-all
 
+  For macOS systems using MacPorts you should run the following command as root:
+
+    port install expat libedit libical openssl postgresql12-server python38 \
+      tcl tk
+
 3. Open a terminal as a normal (non-root) user, unpack the PBS
   tarball, and cd to the package directory.
 
@@ -111,6 +122,12 @@ How to install PBS using the configure script.
   following command:
 
     ./configure --prefix=/opt/pbs --libexecdir=/opt/pbs/libexec
+
+  For macOS systems using MacPorts you should run the following commands:
+
+    export CPATH=/opt/local/include/postgresql12:/opt/local/include
+    export LIBRARY_PATH=/opt/local/lib/postgresql12:/opt/local/lib
+    ./configure --with-swig=/opt/local --with-tcl=/opt/local
 
   If PTL needs to be installed along with PBS use the option
   "--enable-ptl" (see note 5 below)

--- a/configure.ac
+++ b/configure.ac
@@ -127,25 +127,20 @@ AC_CHECK_HEADERS([ \
 	stdio.h \
 	alloca.h \
 	arpa/inet.h \
-	asm/types.h \
 	assert.h \
-	crypt.h \
 	ctype.h \
 	dirent.h \
 	dlfcn.h \
 	execinfo.h \
 	fcntl.h \
-	features.h \
 	float.h \
 	fstab.h \
 	ftw.h \
 	grp.h \
 	libgen.h \
 	limits.h \
-	malloc.h \
 	math.h \
 	memory.h \
-	mntent.h \
 	netdb.h \
 	netinet/in.h \
 	netinet/in_systm.h \
@@ -168,9 +163,7 @@ AC_CHECK_HEADERS([ \
 	stdlib.h \
 	string.h \
 	strings.h \
-	syscall.h \
 	syslog.h \
-	sys/epoll.h \
 	sys/fcntl.h \
 	sys/file.h \
 	sys/ioctl.h \
@@ -178,18 +171,13 @@ AC_CHECK_HEADERS([ \
 	sys/mount.h \
 	sys/param.h \
 	sys/poll.h \
-	sys/prctl.h \
-	sys/procfs.h \
 	sys/quota.h \
 	sys/resource.h \
 	sys/select.h \
 	sys/signal.h \
 	sys/socket.h \
-	sys/statfs.h \
 	sys/stat.h \
 	sys/statvfs.h \
-	sys/sysinfo.h \
-	sys/sysmacros.h \
 	sys/time.h \
 	sys/timeb.h \
 	sys/times.h \
@@ -199,7 +187,6 @@ AC_CHECK_HEADERS([ \
 	sys/unistd.h \
 	sys/user.h \
 	sys/utsname.h \
-	sys/vfs.h \
 	sys/wait.h \
 	termios.h \
 	time.h \

--- a/m4/with_database_dir.m4
+++ b/m4/with_database_dir.m4
@@ -81,6 +81,5 @@ AC_DEFUN([PBS_AC_WITH_DATABASE_DIR],
   AC_SUBST([database_dir])
   AC_SUBST([database_inc])
   AC_SUBST([database_lib])
-  AC_SUBST([database_ldflags])
   AC_DEFINE([DATABASE], [], [Defined when PBS database is available])
 ])

--- a/m4/with_database_dir.m4
+++ b/m4/with_database_dir.m4
@@ -47,31 +47,35 @@ AC_DEFUN([PBS_AC_WITH_DATABASE_DIR],
       [Specify the directory where the PBS database is installed.]
     )
   )
-  AS_IF([test "x$with_database_dir" != "x"],
-    [database_dir="$with_database_dir"],
-    [database_dir="/usr"]
+  [database_dir="$with_database_dir"]
+  AS_IF(
+    [test "$database_dir" = ""],
+    AC_CHECK_HEADER([libpq-fe.h], [], [database_dir="/usr"])
   )
-  AS_IF([test -r "$database_dir/include/libpq-fe.h"],
-    AS_IF([test "$database_dir" != "/usr"],
-      [database_inc="-I$database_dir/include"]),
-    AS_IF([test -r "$database_dir/include/pgsql/libpq-fe.h"],
+  AS_IF(
+    [test "$database_dir" != ""],
+    AS_IF(
+      [test -r "$database_dir/include/libpq-fe.h"],
+      [database_inc="-I$database_dir/include"],
+      [test -r "$database_dir/include/pgsql/libpq-fe.h"],
       [database_inc="-I$database_dir/include/pgsql"],
-      AS_IF([test -r "$database_dir/include/postgresql/libpq-fe.h"],
-        [database_inc="-I$database_dir/include/postgresql"],
-        AC_MSG_ERROR([Database headers not found.]))))
-  AS_IF([test "$database_dir" = "/usr"],
+      [test -r "$database_dir/include/postgresql/libpq-fe.h"],
+      [database_inc="-I$database_dir/include/postgresql"],
+      AC_MSG_ERROR([Database headers not found.])
+    )
+  )
+  AS_IF(
     # Using system installed PostgreSQL
-    AS_IF([test -r "/usr/lib64/libpq.so" -o -r "/usr/lib/libpq.so" -o -r "/usr/lib/x86_64-linux-gnu/libpq.so"],
+    [test "$with_database_dir" = ""],
+    AC_CHECK_LIB([pq], [PQconnectdb],
       [database_lib="-lpq"],
       AC_MSG_ERROR([PBS database shared object library not found.])),
     # Using developer installed PostgreSQL
-      AS_IF([test -r "$database_dir/lib64/libpq.a"],
-        [database_lib="$database_dir/lib64/libpq.a"],
-        AS_IF([test -r "$database_dir/lib/libpq.a"],
-          [database_lib="$database_dir/lib/libpq.a"],
-          AC_MSG_ERROR([PBS database library not found.])
-        )
-      )
+    [test -r "$database_dir/lib64/libpq.a"],
+    [database_lib="$database_dir/lib64/libpq.a"],
+    [test -r "$database_dir/lib/libpq.a"],
+    [database_lib="$database_dir/lib/libpq.a"],
+    AC_MSG_ERROR([PBS database library not found.])
   )
   AC_MSG_RESULT([$database_dir])
   AC_SUBST([database_dir])

--- a/m4/with_editline.m4
+++ b/m4/with_editline.m4
@@ -46,32 +46,27 @@ AC_DEFUN([PBS_AC_WITH_EDITLINE],
       [Specify the directory where editline is installed.]
     )
   )
-  AS_IF([test "x$with_editline" != "x"],
-    editline_dir=["$with_editline"],
-    editline_dir=["/usr"]
-  )
+  [editline_dir="$with_editline"]
   AC_MSG_CHECKING([for editline])
-  AS_IF([test -r "$editline_dir/include/histedit.h"],
-    AS_IF([test "$editline_dir" != "/usr"],
-      [editline_inc="-I$editline_dir/include"]),
-    AC_MSG_ERROR([editline headers not found.]))
-  AS_IF([test "$editline_dir" = "/usr"],
+  AS_IF(
+    [test "$editline_dir" = ""],
+    AC_CHECK_HEADER([histedit.h], [], AC_MSG_ERROR([editline headers not found.])),
+    [test -r "$editline_dir/include/histedit.h"],
+    [editline_inc="-I$editline_dir/include"],
+    AC_MSG_ERROR([editline headers not found.])
+  )
+  AS_IF(
     # Using system installed editline
-    AS_IF([test -r /usr/lib64/libedit.so],
+    [test "$editline_dir" = ""],
+    AC_CHECK_LIB([edit], [el_init],
       [editline_lib="-ledit"],
-      AS_IF([test -r /usr/lib/libedit.so],
-        [editline_lib="-ledit"],
-        AS_IF([test -r /usr/lib/x86_64-linux-gnu/libedit.so],
-          [editline_lib="-ledit"],
-          AC_MSG_ERROR([editline shared object library not found.])))),
+      AC_MSG_ERROR([editline shared object library not found.])),
     # Using developer installed editline
-    AS_IF([test -r "${editline_dir}/lib64/libedit.a"],
-      [editline_lib="${editline_dir}/lib64/libedit.a"],
-      AS_IF([test -r "${editline_dir}/lib/libedit.a"],
-        [editline_lib="${editline_dir}/lib/libedit.a"],
-        AC_MSG_ERROR([editline library not found.])
-      )
-    )
+    [test -r "${editline_dir}/lib64/libedit.a"],
+    [editline_lib="${editline_dir}/lib64/libedit.a"],
+    [test -r "${editline_dir}/lib/libedit.a"],
+    [editline_lib="${editline_dir}/lib/libedit.a"],
+    AC_MSG_ERROR([editline library not found.])
   )
   AC_MSG_RESULT([$editline_dir])
   AC_CHECK_LIB([ncurses], [tgetent],

--- a/m4/with_expat.m4
+++ b/m4/with_expat.m4
@@ -46,28 +46,27 @@ AC_DEFUN([PBS_AC_WITH_EXPAT],
       [Specify the directory where expat is installed.]
     )
   )
-  AS_IF([test "x$with_expat" != "x"],
-    expat_dir=["$with_expat"],
-    expat_dir=["/usr"]
-  )
+  [expat_dir="$with_expat"]
   AC_MSG_CHECKING([for expat])
-  AS_IF([test -r "$expat_dir/include/expat.h"],
-    AS_IF([test "$expat_dir" != "/usr"],
-      [expat_inc="-I$expat_dir/include"]),
-    AC_MSG_ERROR([expat headers not found.]))
-  AS_IF([test "$expat_dir" = "/usr"],
+  AS_IF(
+    [test "$expat_dir" = ""],
+    AC_CHECK_HEADER([expat.h], [], AC_MSG_ERROR([expat headers not found.])),
+    [test -r "$expat_dir/include/expat.h"],
+    [expat_inc="-I$expat_dir/include"],
+    AC_MSG_ERROR([expat headers not found.])
+  )
+  AS_IF(
+    [test "$expat_dir" = ""],
     # Using system installed expat
-    AS_IF([test -r "/usr/lib64/libexpat.so" -o -r "/usr/lib/libexpat.so" -o -r "/usr/lib/x86_64-linux-gnu/libexpat.so"],
+    AC_CHECK_LIB([expat], [XML_Parse],
       [expat_lib="-lexpat"],
       AC_MSG_ERROR([expat shared object library not found.])),
     # Using developer installed expat
-    AS_IF([test -r "${expat_dir}/lib64/libexpat.a"],
-      [expat_lib="${expat_dir}/lib64/libexpat.a"],
-      AS_IF([test -r "${expat_dir}/lib/libexpat.a"],
-        [expat_lib="${expat_dir}/lib/libexpat.a"],
-        AC_MSG_ERROR([expat library not found.])
-      )
-    )
+    [test -r "${expat_dir}/lib64/libexpat.a"],
+    [expat_lib="${expat_dir}/lib64/libexpat.a"],
+    [test -r "${expat_dir}/lib/libexpat.a"],
+    [expat_lib="${expat_dir}/lib/libexpat.a"],
+    AC_MSG_ERROR([expat library not found.])
   )
   AC_MSG_RESULT([$expat_dir])
   AC_SUBST(expat_inc)

--- a/m4/with_hwloc.m4
+++ b/m4/with_hwloc.m4
@@ -46,33 +46,31 @@ AC_DEFUN([PBS_AC_WITH_HWLOC],
       [Specify the directory where hwloc is installed.]
     )
   )
-  AS_IF([test "x$with_hwloc" != "x"],
-    hwloc_dir=["$with_hwloc"],
-    hwloc_dir=["/usr"]
-  )
+  hwloc_dir=["$with_hwloc"]
   AC_MSG_CHECKING([for hwloc])
   [hwloc_flags=""]
   [hwloc_inc=""]
   [hwloc_lib=""]
-  AS_IF([test -r "$hwloc_dir/include/hwloc.h"],
-    AS_IF([test "$hwloc_dir" != "/usr"],
-      [hwloc_inc="-I$hwloc_dir/include"]),
-      AC_MSG_ERROR([hwloc headers not found.])
+  AS_IF(
+    [test "$hwloc_dir" = ""],
+    AC_CHECK_HEADER([hwloc.h], [], AC_MSG_ERROR([hwloc headers not found.])),
+    [test -r "$hwloc_dir/include/hwloc.h"],
+    [hwloc_inc="-I$hwloc_dir/include"],
+    AC_MSG_ERROR([hwloc headers not found.])
   )
-  AS_IF([test "$hwloc_dir" = "/usr"],
+  AS_IF(
     # Using system installed hwloc
-    AS_IF([test -r "/usr/lib64/libhwloc.so" -o -r "/usr/lib/libhwloc.so" -o -r "/usr/lib/x86_64-linux-gnu/libhwloc.so"],
+    [test "$hwloc_dir" = ""],
+    AC_CHECK_LIB([hwloc], [hwloc_topology_init],
       [hwloc_lib="-lhwloc"],
       AC_MSG_ERROR([hwloc shared object library not found.])
     ),
     # Using developer installed hwloc
-    AS_IF([test -r "${hwloc_dir}/lib64/libhwloc_embedded.a"],
-      [hwloc_lib="${hwloc_dir}/lib64/libhwloc_embedded.a"],
-      AS_IF([test -r "${hwloc_dir}/lib/libhwloc_embedded.a"],
-        [hwloc_lib="${hwloc_dir}/lib/libhwloc_embedded.a"],
-        AC_MSG_ERROR([hwloc library not found.])
-      )
-    )
+    [test -r "${hwloc_dir}/lib64/libhwloc_embedded.a"],
+    [hwloc_lib="${hwloc_dir}/lib64/libhwloc_embedded.a"],
+    [test -r "${hwloc_dir}/lib/libhwloc_embedded.a"],
+    [hwloc_lib="${hwloc_dir}/lib/libhwloc_embedded.a"],
+    AC_MSG_ERROR([hwloc library not found.])
   )
   AC_MSG_RESULT([$hwloc_dir])
   AS_CASE([x$target_os],

--- a/m4/with_krbauth.m4
+++ b/m4/with_krbauth.m4
@@ -88,7 +88,7 @@ AC_DEFUN([KRB5_CONFIG],
   LDFLAGS="$ac_save_ldflags"],
   [])
 
-  AS_IF([test "x$_KRB5_KAFS_LIBS" == "x"],
+  AS_IF([test "x$_KRB5_KAFS_LIBS" = "x"],
     [
     AC_CHECK_LIB([kafs],[k_hasafs],
       [_KRB5_KAFS_LIBS="-lkafs"],

--- a/m4/with_libz.m4
+++ b/m4/with_libz.m4
@@ -46,32 +46,27 @@ AC_DEFUN([PBS_AC_WITH_LIBZ],
       [Specify the directory where libz is installed.]
     )
   )
-  AS_IF([test "x$with_libz" != "x"],
-    libz_dir=["$with_libz"],
-    libz_dir=["/lib64"]
-  )
+  [libz_dir="$with_libz"]
   AC_MSG_CHECKING([for libz])
-  AS_IF([test "$libz_dir" = "/lib64"],
+  AS_IF(
+    [test "$libz_dir" = ""],
+    AC_CHECK_HEADER([zlib.h], [], AC_MSG_ERROR([libz headers not found.])),
+    [test -r "$libz_dir/include/zlib.h"],
+    [libz_inc="-I$libz_dir/include"],
+    AC_MSG_ERROR([libz headers not found.])
+  )
+  AS_IF(
     # Using system installed libz
-	libz_inc=""
-	AS_IF([test -r "/lib64/libz.so" -o -r "/usr/lib64/libz.so" -o -r "/usr/lib/x86_64-linux-gnu/libz.so" -o -r "/usr/lib/aarch64-linux-gnu/libz.so"],
-    	[libz_lib="-lz"],
-      AC_MSG_ERROR([libz shared object library not found.])
-	),
-
-	# Using developer installed libz
-    AS_IF([test -r "$libz_dir/include/zlib.h"],
-      [libz_include="$libz_dir/include"],
-      AC_MSG_ERROR([libz headers not found.])
-    )
-	libz_inc="-I$libz_include"
-    AS_IF([test -r "${libz_dir}/lib64/libz.a"],
-      [libz_lib="${libz_dir}/lib64/libz.a"],
-      AS_IF([test -r "${libz_dir}/lib/libz.a"],
-        [libz_lib="${libz_dir}/lib/libz.a"],
-        AC_MSG_ERROR([libz not found.])
-      )
-    )
+    [test "$libz_dir" = ""],
+    AC_CHECK_LIB([z], [deflateInit_],
+      [libz_lib="-lz"],
+      AC_MSG_ERROR([libz shared object library not found.])),
+	  # Using developer installed libz
+    [test -r "${libz_dir}/lib64/libz.a"],
+    [libz_lib="${libz_dir}/lib64/libz.a"],
+    [test -r "${libz_dir}/lib/libz.a"],
+    [libz_lib="${libz_dir}/lib/libz.a"],
+    AC_MSG_ERROR([libz not found.])
   )
   AC_MSG_RESULT([$libz_dir])
   AC_SUBST(libz_inc)

--- a/m4/with_python.m4
+++ b/m4/with_python.m4
@@ -56,7 +56,7 @@ AC_DEFUN([PBS_AC_WITH_PYTHON],
           -a "$PYTHON_VERSION" != "3.7" \
           -a "$PYTHON_VERSION" != "3.8" ],
     AC_MSG_ERROR([Python must be version 3.5, 3.6, 3.7 or 3.8]))
-  AS_IF([test "$PYTHON_VERSION" == "3.8"], [_extra_arg="--embed"], [_extra_arg=""])
+  AS_IF([test "$PYTHON_VERSION" = "3.8"], [_extra_arg="--embed"], [_extra_arg=""])
   [PYTHON_INCLUDES=`$PYTHON_CONFIG --includes ${_extra_arg}`]
   AC_SUBST(PYTHON_INCLUDES)
   [PYTHON_CFLAGS=`$PYTHON_CONFIG --cflags ${_extra_arg}`]

--- a/m4/with_swig.m4
+++ b/m4/with_swig.m4
@@ -56,9 +56,9 @@ AC_DEFUN([PBS_AC_WITH_SWIG],
     AC_DEFINE([SWIG], [], [Defined when swig is available]),
     AC_MSG_RESULT([not found])
     AC_MSG_WARN([swig command not found.]))
-  AS_IF([test "x`ls -d ${swig_dir}/share/swig/* 2>/dev/null`" == "x" ],
-          [swig_py_inc="-I`ls -d ${swig_dir}/share/swig*` -I`ls -d ${swig_dir}/share/swig*/python`"],
-          [swig_py_inc="-I`ls -d ${swig_dir}/share/swig/*` -I`ls -d ${swig_dir}/share/swig/*/python`"])
+  AS_IF([test "x`ls -d ${swig_dir}/share/swig/* 2>/dev/null`" = "x" ],
+          [swig_py_inc="-I`ls -d ${swig_dir}/share/swig* | tail -n 1` -I`ls -d ${swig_dir}/share/swig*/python | tail -n 1`"],
+          [swig_py_inc="-I`ls -d ${swig_dir}/share/swig/* | tail -n 1` -I`ls -d ${swig_dir}/share/swig/*/python | tail -n 1`"])
   AC_SUBST([swig_dir])
   AC_SUBST([swig_py_inc])
 ])

--- a/src/cmds/Makefile.am
+++ b/src/cmds/Makefile.am
@@ -124,7 +124,7 @@ pbs_dataservice_bin_CPPFLAGS = \
 	@database_inc@
 pbs_dataservice_bin_LDFLAGS = "-Wl,-rpath,$(DESTDIR)$(libdir)"
 pbs_dataservice_bin_LDADD = \
-	$(top_builddir)/src/lib/Libdb/libdb.so \
+	$(top_builddir)/src/lib/Libdb/libpbsdb.la \
 	${common_libs} \
 	@database_lib@ \
 	-lssl \
@@ -136,7 +136,7 @@ pbs_ds_password_bin_CPPFLAGS = \
 	@database_inc@
 pbs_ds_password_bin_LDFLAGS = "-Wl,-rpath,$(DESTDIR)$(libdir)"
 pbs_ds_password_bin_LDADD = \
-	$(top_builddir)/src/lib/Libdb/libdb.so \
+	$(top_builddir)/src/lib/Libdb/libpbsdb.la \
 	${common_libs} \
 	@database_lib@ \
 	-lssl \

--- a/src/cmds/Makefile.am
+++ b/src/cmds/Makefile.am
@@ -120,25 +120,21 @@ pbs_demux_LDADD = ${common_libs}
 pbs_demux_SOURCES = pbs_demux.c
 
 pbs_dataservice_bin_CPPFLAGS = \
-	${common_cflags} \
-	@database_inc@
+	${common_cflags}
 pbs_dataservice_bin_LDFLAGS = "-Wl,-rpath,$(DESTDIR)$(libdir)"
 pbs_dataservice_bin_LDADD = \
 	$(top_builddir)/src/lib/Libdb/libpbsdb.la \
 	${common_libs} \
-	@database_lib@ \
 	-lssl \
 	-lcrypto
 pbs_dataservice_bin_SOURCES = pbs_dataservice.c ${common_sources}
 
 pbs_ds_password_bin_CPPFLAGS = \
-	${common_cflags} \
-	@database_inc@
+	${common_cflags}
 pbs_ds_password_bin_LDFLAGS = "-Wl,-rpath,$(DESTDIR)$(libdir)"
 pbs_ds_password_bin_LDADD = \
 	$(top_builddir)/src/lib/Libdb/libpbsdb.la \
 	${common_libs} \
-	@database_lib@ \
 	-lssl \
 	-lcrypto
 pbs_ds_password_bin_SOURCES = pbs_ds_password.c ${common_sources}

--- a/src/cmds/Makefile.am
+++ b/src/cmds/Makefile.am
@@ -121,7 +121,6 @@ pbs_demux_SOURCES = pbs_demux.c
 
 pbs_dataservice_bin_CPPFLAGS = \
 	${common_cflags}
-pbs_dataservice_bin_LDFLAGS = "-Wl,-rpath,$(DESTDIR)$(libdir)"
 pbs_dataservice_bin_LDADD = \
 	$(top_builddir)/src/lib/Libdb/libpbsdb.la \
 	${common_libs} \
@@ -131,7 +130,6 @@ pbs_dataservice_bin_SOURCES = pbs_dataservice.c ${common_sources}
 
 pbs_ds_password_bin_CPPFLAGS = \
 	${common_cflags}
-pbs_ds_password_bin_LDFLAGS = "-Wl,-rpath,$(DESTDIR)$(libdir)"
 pbs_ds_password_bin_LDADD = \
 	$(top_builddir)/src/lib/Libdb/libpbsdb.la \
 	${common_libs} \

--- a/src/cmds/qsub.c
+++ b/src/cmds/qsub.c
@@ -321,6 +321,8 @@ static int block_opt_o = FALSE;
 static int relnodes_on_stageout_opt_o = FALSE;
 static int tolerate_node_failures_opt_o = FALSE;
 
+extern char **environ;
+
 /* The following are "Utility" functions. */
 
 /**

--- a/src/include/dis.h
+++ b/src/include/dis.h
@@ -247,10 +247,10 @@ auth_def_t * transport_chan_get_authdef(int, int);
 int transport_send_pkt(int, int, void *, size_t);
 int transport_recv_pkt(int, int *, void **, size_t *);
 
-pbs_tcp_chan_t * (*pfn_transport_get_chan)(int);
-int (*pfn_transport_set_chan)(int, pbs_tcp_chan_t *);
-int (*pfn_transport_recv)(int, void *, int);
-int (*pfn_transport_send)(int, void *, int);
+extern pbs_tcp_chan_t * (*pfn_transport_get_chan)(int);
+extern int (*pfn_transport_set_chan)(int, pbs_tcp_chan_t *);
+extern int (*pfn_transport_recv)(int, void *, int);
+extern int (*pfn_transport_send)(int, void *, int);
 
 #define transport_recv(x, y, z) (*pfn_transport_recv)(x, y, z)
 #define transport_send(x, y, z) (*pfn_transport_send)(x, y, z)

--- a/src/lib/Libattr/attr_fn_acl.c
+++ b/src/lib/Libattr/attr_fn_acl.c
@@ -49,6 +49,7 @@
 #include <string.h>
 #include <pwd.h>
 #include <grp.h>
+#include <unistd.h>
 #include "pbs_ifl.h"
 #include "list_link.h"
 #include "attribute.h"

--- a/src/lib/Libdb/Makefile.am
+++ b/src/lib/Libdb/Makefile.am
@@ -42,8 +42,7 @@
 SUBDIRS = \
 	pgsql
 
-all-local:
-	cp -p $(top_builddir)/src/lib/Libdb/pgsql/.libs/libdb.so.0.0.0 $(top_builddir)/src/lib/Libdb/libdb.so
-
-clean-local:
-	rm -f $(top_builddir)/src/lib/Libdb/libdb.so
+lib_LTLIBRARIES = libpbsdb.la
+libpbsdb_la_LDFLAGS = -version-info 0:0:0
+libpbsdb_la_LIBADD = pgsql/libpbsdbpg.la
+libpbsdb_la_SOURCES =

--- a/src/lib/Libdb/Makefile.am
+++ b/src/lib/Libdb/Makefile.am
@@ -44,5 +44,5 @@ SUBDIRS = \
 
 lib_LTLIBRARIES = libpbsdb.la
 libpbsdb_la_LDFLAGS = -version-info 0:0:0
-libpbsdb_la_LIBADD = pgsql/libpbsdbpg.la
+libpbsdb_la_LIBADD = pgsql/libpbsdbpg.la @database_lib@
 libpbsdb_la_SOURCES =

--- a/src/lib/Libdb/pgsql/Makefile.am
+++ b/src/lib/Libdb/pgsql/Makefile.am
@@ -36,18 +36,16 @@
 # "OpenPBS®", "PBS Professional®", and "PBS Pro™" and Altair's logos is
 # subject to Altair's trademark licensing policies.
 
-lib_LTLIBRARIES = libdb.la
+noinst_LTLIBRARIES = libpbsdbpg.la
 
-libdb_la_CPPFLAGS = \
+libpbsdbpg_la_CPPFLAGS = \
 	-I$(top_srcdir)/src/include \
 	@database_inc@
 
-libdb_la_LDFLAGS = -version-info 0:0:0
-
-libdb_la_LIBADD = \
+libpbsdbpg_la_LIBADD = \
 	@database_lib@
 
-libdb_la_SOURCES = \
+libpbsdbpg_la_SOURCES = \
 	db_postgres.h \
 	db_common.c \
 	db_attr.c \
@@ -66,8 +64,3 @@ dist_libexec_SCRIPTS = \
 
 dist_sbin_SCRIPTS = \
 	pbs_ds_systemd
-
-install-exec-hook:
-	install -D $(DESTDIR)$(libdir)/libdb.so.0.0.0 $(DESTDIR)$(libdir)/libdb_pg.so
-uninstall:
-	rm -f $(DESTDIR)$(libdir)/libdb_pg.so

--- a/src/lib/Libdis/dis.c
+++ b/src/lib/Libdis/dis.c
@@ -54,6 +54,11 @@ const char *dis_emsg[] = {"No error",
 	"Protocol failure in commit",
 	"End of File"};
 
+pbs_tcp_chan_t * (*pfn_transport_get_chan)(int);
+int (*pfn_transport_set_chan)(int, pbs_tcp_chan_t *);
+int (*pfn_transport_recv)(int, void *, int);
+int (*pfn_transport_send)(int, void *, int);
+
 /* this is for our client threading functionlity to get the DIS_BUFSZ */
 long dis_buffsize = DIS_BUFSIZ;
 

--- a/src/lib/Libnet/hnls.c
+++ b/src/lib/Libnet/hnls.c
@@ -72,7 +72,6 @@
 #include <sys/socketvar.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
-#include <stropts.h>
 #include <netdb.h>
 
 #endif

--- a/src/resmom/linux/mom_mach.c
+++ b/src/resmom/linux/mom_mach.c
@@ -54,21 +54,20 @@
 #include <string.h>
 #include <pwd.h>
 #include <time.h>
-#include <mntent.h>
 #include <ftw.h>
 #include <dlfcn.h>
-#include <asm/types.h>
 #include <sys/types.h>
 #include <sys/time.h>
-#include <sys/procfs.h>
 #include <sys/param.h>
 #include <sys/stat.h>
+#ifdef __linux__
 #include <sys/vfs.h>
-#include <sys/sysmacros.h>
+#else
+#include <sys/mount.h>
+#endif
 #include <sys/resource.h>
 #include <sys/utsname.h>
 #include <sys/wait.h>
-#include <syscall.h>
 #include <signal.h>
 
 #include "pbs_error.h"

--- a/src/resmom/linux/mom_mach.h
+++ b/src/resmom/linux/mom_mach.h
@@ -48,6 +48,9 @@ extern "C" {
  * Target System: linux
  */
 
+#ifndef __linux__
+typedef unsigned long ulong;
+#endif
 
 #ifndef PBS_MACH
 #define PBS_MACH "linux"

--- a/src/resmom/linux/mom_start.c
+++ b/src/resmom/linux/mom_start.c
@@ -895,7 +895,9 @@ struct sig_tbl sig_tbl[] = {
 	{ "TTIN", SIGTTIN },
 	{ "TTOU", SIGTTOU },
 	{ "IO", SIGIO },
+#ifdef __linux__
 	{ "POLL", SIGPOLL },
+#endif
 	{ "XCPU", SIGXCPU },
 	{ "XFSZ", SIGXFSZ },
 	{ "VTALRM", SIGVTALRM },

--- a/src/resmom/mom_hook_func.c
+++ b/src/resmom/mom_hook_func.c
@@ -151,6 +151,7 @@ extern	int		internal_state_update; /* flag for sending mom information update to
 
 extern int		server_stream;
 
+extern char **environ;
 
 /**
  * @brief
@@ -1347,7 +1348,7 @@ run_hook_exit:
 		    event_type == HOOK_EVENT_EXECJOB_PRETERM) {
 			int ret = 0;
 			if ( ret != 0 ) {
-				snprintf(log_buffer, LOG_BUF_SIZE, "Unable to set the environment for the job: %s", 
+				snprintf(log_buffer, LOG_BUF_SIZE, "Unable to set the environment for the job: %s",
 					pjob->ji_qs.ji_jobid);
 				log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_JOB, LOG_ERR,
 					__func__, log_buffer);
@@ -1361,7 +1362,7 @@ run_hook_exit:
 		char *pbs_hook_conf = NULL;
 
 		if ((pjob->ji_env.v_envp != NULL) && (phook->user == HOOK_PBSUSER)) {
-			/* Duplicate only when the hook user is pbsuser */ 
+			/* Duplicate only when the hook user is pbsuser */
 			hook_env.v_envp = dup_string_arr(pjob->ji_env.v_envp);
 			if (hook_env.v_envp == NULL) {
 				log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_JOB, LOG_ERR,

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -153,6 +153,7 @@
 #include "site_code.h"
 #endif
 
+extern char **environ;
 
 /**
  *	@brief

--- a/src/server/Makefile.am
+++ b/src/server/Makefile.am
@@ -43,7 +43,6 @@ sbin_PROGRAMS = pbs_server.bin pbs_comm
 
 pbs_server_bin_CPPFLAGS = \
 	-I$(top_srcdir)/src/include \
-	@database_inc@ \
 	@expat_inc@ \
 	@libical_inc@ \
 	@libz_inc@ \

--- a/src/server/Makefile.am
+++ b/src/server/Makefile.am
@@ -60,7 +60,6 @@ pbs_server_bin_LDADD = \
 	$(top_builddir)/src/lib/Libpython/libpbspython_svr.a \
 	$(top_builddir)/src/lib/Libdb/libpbsdb.la \
 	$(top_builddir)/src/lib/Libpbs/.libs/libpbs.a \
-	@database_ldflags@ \
 	@expat_lib@ \
 	@libz_lib@ \
 	@libical_lib@ \

--- a/src/server/Makefile.am
+++ b/src/server/Makefile.am
@@ -61,7 +61,7 @@ pbs_server_bin_LDADD = \
 	$(top_builddir)/src/lib/Libsec/libsec.a \
 	$(top_builddir)/src/lib/Libsite/libsite.a \
 	$(top_builddir)/src/lib/Libpython/libpbspython_svr.a \
-	$(top_builddir)/src/lib/Libdb/libdb.so \
+	$(top_builddir)/src/lib/Libdb/libpbsdb.la \
 	$(top_builddir)/src/lib/Libpbs/.libs/libpbs.a \
 	@database_ldflags@ \
 	@expat_lib@ \

--- a/src/server/Makefile.am
+++ b/src/server/Makefile.am
@@ -49,8 +49,6 @@ pbs_server_bin_CPPFLAGS = \
 	@PYTHON_INCLUDES@ \
 	@KRB5_CFLAGS@
 
-pbs_server_bin_LDFLAGS = "-Wl,-rpath,$(DESTDIR)$(libdir)"
-
 pbs_server_bin_LDADD = \
 	$(top_builddir)/src/lib/Libtpp/libtpp.a \
 	$(top_builddir)/src/lib/Libattr/libattr.a \

--- a/src/server/job_func.c
+++ b/src/server/job_func.c
@@ -49,9 +49,7 @@
 #include <errno.h>
 #include <assert.h>
 
-#ifndef SIGKILL
 #include <signal.h>
-#endif
 #include <memory.h>
 #include <fcntl.h>
 #include <stdio.h>

--- a/src/server/pbsd_init.c
+++ b/src/server/pbsd_init.c
@@ -402,35 +402,35 @@ pbsd_init(int type)
 
 
 	{
-		struct rlimit64 rlimit;
+		struct rlimit rlimit;
 
-		rlimit.rlim_cur = RLIM64_INFINITY;
-		rlimit.rlim_max = RLIM64_INFINITY;
+		rlimit.rlim_cur = RLIM_INFINITY;
+		rlimit.rlim_max = RLIM_INFINITY;
 
-		(void)setrlimit64(RLIMIT_CPU,   &rlimit);
-		(void)setrlimit64(RLIMIT_FSIZE, &rlimit);
-		(void)setrlimit64(RLIMIT_DATA,  &rlimit);
-		(void)setrlimit64(RLIMIT_STACK, &rlimit);
+		(void)setrlimit(RLIMIT_CPU,   &rlimit);
+		(void)setrlimit(RLIMIT_FSIZE, &rlimit);
+		(void)setrlimit(RLIMIT_DATA,  &rlimit);
+		(void)setrlimit(RLIMIT_STACK, &rlimit);
 #ifdef	RLIMIT_RSS
-		(void)setrlimit64(RLIMIT_RSS  , &rlimit);
+		(void)setrlimit(RLIMIT_RSS  , &rlimit);
 #endif	/* RLIMIT_RSS */
 #ifdef	RLIMIT_VMEM
-		(void)setrlimit64(RLIMIT_VMEM  , &rlimit);
+		(void)setrlimit(RLIMIT_VMEM  , &rlimit);
 #endif	/* RLIMIT_VMEM */
 #ifdef	RLIMIT_CORE
 		if (pbs_conf.pbs_core_limit) {
-			struct rlimit64 corelimit;
-			corelimit.rlim_max = RLIM64_INFINITY;
+			struct rlimit corelimit;
+			corelimit.rlim_max = RLIM_INFINITY;
 			if (strcmp("unlimited", pbs_conf.pbs_core_limit) == 0)
-				corelimit.rlim_cur = RLIM64_INFINITY;
+				corelimit.rlim_cur = RLIM_INFINITY;
 			else if (char_in_cname == 1) {
 				log_record(PBSEVENT_ERROR, PBS_EVENTCLASS_SERVER, LOG_WARNING,
 					__func__, msg_corelimit);
-				corelimit.rlim_cur = RLIM64_INFINITY;
+				corelimit.rlim_cur = RLIM_INFINITY;
 			} else
 				corelimit.rlim_cur =
-					(rlim64_t)atol(pbs_conf.pbs_core_limit);
-			(void)setrlimit64(RLIMIT_CORE, &corelimit);
+					(rlim_t)atol(pbs_conf.pbs_core_limit);
+			(void)setrlimit(RLIMIT_CORE, &corelimit);
 		}
 #endif	/* RLIMIT_CORE */
 	}

--- a/src/server/svr_func.c
+++ b/src/server/svr_func.c
@@ -61,9 +61,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 #include <fcntl.h>
-#ifndef SIGKILL
 #include <signal.h>
-#endif
 #include "server_limits.h"
 #include "list_link.h"
 #include "log.h"

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -195,7 +195,6 @@ printjob_bin_SOURCES = printjob.c $(top_srcdir)/src/lib/Libcmds/cmds_common.c
 printjob_svr_bin_CPPFLAGS = \
 	${common_cflags} \
 	-I$(top_srcdir)/src/lib/Libdb \
-	@database_inc@ \
 	-DPRINTJOBSVR
 
 printjob_svr_bin_LDFLAGS = "-Wl,-rpath,$(DESTDIR)$(libdir)"

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -84,7 +84,6 @@ pbs_ds_monitor_CPPFLAGS = ${common_cflags}
 pbs_ds_monitor_LDADD = \
 	$(top_builddir)/src/lib/Libdb/libpbsdb.la \
 	${common_libs} \
-	@database_ldflags@ \
 	-lssl \
 	-lcrypto
 
@@ -199,7 +198,6 @@ printjob_svr_bin_CPPFLAGS = \
 printjob_svr_bin_LDADD = \
 	$(top_builddir)/src/lib/Libdb/libpbsdb.la \
 	${common_libs} \
-	@database_ldflags@ \
 	-lssl \
 	-lcrypto
 

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -83,7 +83,7 @@ chk_tree_SOURCES = chk_tree.c
 pbs_ds_monitor_CPPFLAGS = ${common_cflags}
 pbs_ds_monitor_LDFLAGS = "-Wl,-rpath,$(DESTDIR)$(libdir)"
 pbs_ds_monitor_LDADD = \
-	$(top_builddir)/src/lib/Libdb/libdb.so \
+	$(top_builddir)/src/lib/Libdb/libpbsdb.la \
 	${common_libs} \
 	@database_ldflags@ \
 	-lssl \
@@ -201,7 +201,7 @@ printjob_svr_bin_CPPFLAGS = \
 printjob_svr_bin_LDFLAGS = "-Wl,-rpath,$(DESTDIR)$(libdir)"
 
 printjob_svr_bin_LDADD = \
-	$(top_builddir)/src/lib/Libdb/libdb.so \
+	$(top_builddir)/src/lib/Libdb/libpbsdb.la \
 	${common_libs} \
 	@database_ldflags@ \
 	-lssl \

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -81,7 +81,6 @@ chk_tree_LDADD = ${common_libs}
 chk_tree_SOURCES = chk_tree.c
 
 pbs_ds_monitor_CPPFLAGS = ${common_cflags}
-pbs_ds_monitor_LDFLAGS = "-Wl,-rpath,$(DESTDIR)$(libdir)"
 pbs_ds_monitor_LDADD = \
 	$(top_builddir)/src/lib/Libdb/libpbsdb.la \
 	${common_libs} \
@@ -196,8 +195,6 @@ printjob_svr_bin_CPPFLAGS = \
 	${common_cflags} \
 	-I$(top_srcdir)/src/lib/Libdb \
 	-DPRINTJOBSVR
-
-printjob_svr_bin_LDFLAGS = "-Wl,-rpath,$(DESTDIR)$(libdir)"
 
 printjob_svr_bin_LDADD = \
 	$(top_builddir)/src/lib/Libdb/libpbsdb.la \


### PR DESCRIPTION
#### Describe Bug or Feature
OpenPBS doesn't build on macOS.


#### Describe Your Change
Removed unused Linux-specific headers, added ifdefs for required ones. Replaced Linux-specific versions of rlimit with portable ones. Modified autoconf scripts to not hardcode Linux-specific include/lib dirs, and generally cleaned them up. Fixed compile errors due to missing declarations and duplicate symbols. Renamed `libdb` to `libpbsdb` to not conflict with the common [libdb](https://web.stanford.edu/class/cs276a/projects/docs/berkeleydb/ref/build_unix/shlib.html).

#### Attach Test and Valgrind Logs/Output
