### PR TITLE
Race condition in receiving resources_used from sister MoM and sending to server

### DIFF
--- a/src/resmom/requests.c
+++ b/src/resmom/requests.c
@@ -1862,7 +1862,7 @@ terminate_job(job *pjob, int internal)
 			next_sample_time = min_check_poll;
 		}
 		if (kill_job(pjob, s) == 0) {
-			/* no processes around, force into exiting */
+			/* no processes around, time to exit */
 			exiting_tasks = 1;
 		}
 		i = -2;

--- a/src/resmom/requests.c
+++ b/src/resmom/requests.c
@@ -1863,7 +1863,6 @@ terminate_job(job *pjob, int internal)
 		}
 		if (kill_job(pjob, s) == 0) {
 			/* no processes around, force into exiting */
-			pjob->ji_qs.ji_substate = JOB_SUBSTATE_EXITING;
 			exiting_tasks = 1;
 		}
 		i = -2;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
The resources_used reported in the accounting logs could (infrequently) be less than actual amount of resources used.

There is a race condition that causes the main mom not to wait for the resources_used info from the sister moms before sending the job information to the server.  The race happens when the job ends on the main mom just before the reservation the job was in is ending.  
In req_signaljob, because there are no tasks to kill (because they already ended) kill_job would return a tasks killed count of 0.  The job substate would be set to JOB_SUBSTATE_EXITING which would cause main mom to ultimately proceed to sending the job's resources_used info and obit, even if not all of the sisters have reported back yet.
#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
In terminate_job which is called by req_signaljob, removed setting the job substate to JOB_SUBSTATE_EXITING.
This leaves the job substate as JOB_SUBSTATE_KILLSIS until all the sisters have reported in.  Then JOB_SUBSTATE_EXITING will be set in im_request (IM_KILL_JOB).  And all of the moms' job resources_used info will be sent to the server.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

Extra debug statements show the same race condition is being hit, but with the fix the outcome is the desired outcome.
[before.txt](https://github.com/openpbs/openpbs/files/5171889/before.txt)
[fixed.txt](https://github.com/openpbs/openpbs/files/5171890/fixed.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
