### PR TITLE
Update tests of pbs_test_tpp to skip if exact num of moms and comms are not specified

### DIFF
--- a/test/tests/functional/pbs_test_tpp.py
+++ b/test/tests/functional/pbs_test_tpp.py
@@ -281,8 +281,7 @@ class TestTPP(TestFunctional):
         self.hostA = self.momA.shortname
         self.hostB = self.momB.shortname
         self.hostC = self.server.client
-        nodes = [self.hostA, self.hostB, self.hostC]
-        self.node_list.extend(nodes)
+        self.node_list = [self.hostA, self.hostB, self.hostC]
         self.server.manager(MGR_CMD_SET, SERVER, {'flatuid': True})
         self.common_steps(job=True, interactive=True)
         self.common_steps(resv=True, resv_job=True, client=self.hostB)
@@ -309,8 +308,8 @@ class TestTPP(TestFunctional):
         self.hostB = self.server.client
         self.hostC = self.momB.shortname
         self.hostD = self.comm1.shortname
-        nodes = [self.hostA, self.hostB, self.hostC, self.hostD]
-        self.node_list.extend(nodes)
+        self.node_list = [self.hostA, self.hostB,
+                          self.hostC, self.hostD]
         a = {'PBS_START_COMM': '0', 'PBS_START_MOM': '1',
              'PBS_LEAF_ROUTERS': self.hostD}
         b = {'PBS_LEAF_ROUTERS': self.hostD}
@@ -345,8 +344,7 @@ class TestTPP(TestFunctional):
         self.momB = self.moms.values()[1]
         self.hostA = self.momA.shortname
         self.hostB = self.momB.shortname
-        nodes = [self.hostA, self.hostB]
-        self.node_list.extend(nodes)
+        self.node_list = [self.hostA, self.hostB]
         self.common_steps(job=True, resv=True,
                           resv_job=True, client=self.hostA)
         self.common_steps(job=True, interactive=True,
@@ -412,7 +410,9 @@ class TestTPP(TestFunctional):
                 self.skipTest("Mom and comm should be on server host")
         if num_moms == 2 and num_comms == 2:
             self.hostA = self.server.shortname
+            self.momB = self.moms.values()[1]
             self.hostB = mom_list[1]
+            self.comm2 = self.comms.values()[1]
             self.hostC = comm_list[1]
             self.node_list = [self.hostA, self.hostB, self.hostC]
         elif num_moms == 3 and num_comms == 3:
@@ -448,8 +448,10 @@ class TestTPP(TestFunctional):
             self.hostC = mom_list[1]
             self.hostD = mom_list[2]
             self.hostE = mom_list[3]
+            self.comm2 = self.comms.values()[1]
             self.hostF = comm_list[1]
             self.hostG = comm_list[2]
+            self.comm4 = self.comms.values()[3]
             self.hostH = comm_list[3]
             self.hostI = comm_list[4]
             self.node_list = [

--- a/test/tests/functional/pbs_test_tpp.py
+++ b/test/tests/functional/pbs_test_tpp.py
@@ -1054,7 +1054,7 @@ class TestTPP(TestFunctional):
         Node 8 : Mom (self.hostE)
         Node 9 : Comm (self.hostI)
         """
-        self.common_setup(no_mom_on_comm=True,req_moms=4, req_comms=5)
+        self.common_setup(no_mom_on_comm=True, req_moms=4, req_comms=5)
         a = {'PBS_COMM_ROUTERS': self.hostA}
         comm_hosts = [self.hostF, self.hostG, self.hostH, self.hostI]
         for host in comm_hosts:

--- a/test/tests/functional/pbs_test_tpp.py
+++ b/test/tests/functional/pbs_test_tpp.py
@@ -401,8 +401,8 @@ class TestTPP(TestFunctional):
         """
         mom_list = [x.shortname for x in self.moms.values()]
         comm_list = [y.shortname for y in self.comms.values()]
-        num_moms = len(self.moms)
-        num_comms = len(self.comms)
+        num_moms = len(mom_list)
+        num_comms = len(comm_list)
         if (req_moms != num_moms) and (req_comms != num_comms):
             msg = "Test requires exact %s moms and %s" % (req_moms, req_comms)
             msg += " comms as input"
@@ -412,21 +412,15 @@ class TestTPP(TestFunctional):
                 self.skipTest("Mom and comm should be on server host")
         if num_moms == 2 and num_comms == 2:
             self.hostA = self.server.shortname
-            self.momB = self.moms.values()[1]
-            self.hostB = self.momB.shortname
-            self.comm2 = self.comms.values()[1]
-            self.hostC = self.comm2.shortname
+            self.hostB = mom_list[1]
+            self.hostC = comm_list[1]
             self.node_list = [self.hostA, self.hostB, self.hostC]
         elif num_moms == 3 and num_comms == 3:
             self.hostA = self.server.shortname
-            self.momB = self.moms.values()[1]
-            self.hostB = self.momB.shortname
-            self.momC = self.moms.values()[2]
-            self.hostD = self.momC.shortname
-            self.comm2 = self.comms.values()[1]
-            self.hostC = self.comm2.shortname
-            self.comm3 = self.comms.values()[2]
-            self.hostE = self.comm3.shortname
+            self.hostB = mom_list[1]
+            self.hostC = comm_list[1]
+            self.hostD = mom_list[2]
+            self.hostE = comm_list[2]
             self.node_list = [
                 self.hostA,
                 self.hostB,
@@ -435,18 +429,13 @@ class TestTPP(TestFunctional):
                 self.hostE]
         elif num_moms == 2 and num_comms == 3:
             if self.server.shortname not in comm_list:
-                self.comm1 = self.comms.values()[0]
-                self.hostA = self.comm1.shortname
+                self.hostA = comm_list[0]
             else:
                 self.hostA = self.server.shortname
-            self.momB = self.moms.values()[0]
-            self.hostB = self.momB.shortname
-            self.momC = self.moms.values()[1]
-            self.hostC = self.momC.shortname
-            self.comm2 = self.comms.values()[1]
-            self.hostD = self.comm2.shortname
-            self.comm3 = self.comms.values()[2]
-            self.hostE = self.comm3.shortname
+            self.hostB = mom_list[0]
+            self.hostD = comm_list[1]
+            self.hostC = mom_list[1]
+            self.hostE = comm_list[2]
             self.node_list = [
                 self.hostA,
                 self.hostB,
@@ -455,22 +444,14 @@ class TestTPP(TestFunctional):
                 self.hostE]
         elif num_moms == 4 and num_comms == 5:
             self.hostA = self.server.shortname
-            self.momB = self.moms.values()[0]
-            self.hostB = self.momB.shortname
-            self.momC = self.moms.values()[1]
-            self.hostC = self.momC.shortname
-            self.momD = self.moms.values()[2]
-            self.hostD = self.momD.shortname
-            self.momE = self.moms.values()[3]
-            self.hostE = self.momE.shortname
-            self.comm2 = self.comms.values()[1]
-            self.hostF = self.comm2.shortname
-            self.comm3 = self.comms.values()[2]
-            self.hostG = self.comm3.shortname
-            self.comm4 = self.comms.values()[3]
-            self.hostH = self.comm4.shortname
-            self.comm5 = self.comms.values()[4]
-            self.hostI = self.comm5.shortname
+            self.hostB = mom_list[0]
+            self.hostC = mom_list[1]
+            self.hostD = mom_list[2]
+            self.hostE = mom_list[3]
+            self.hostF = comm_list[1]
+            self.hostG = comm_list[2]
+            self.hostH = comm_list[3]
+            self.hostI = comm_list[4]
             self.node_list = [
                 self.hostA,
                 self.hostB,

--- a/test/tests/functional/pbs_test_tpp.py
+++ b/test/tests/functional/pbs_test_tpp.py
@@ -381,7 +381,8 @@ class TestTPP(TestFunctional):
         for vnode in vnode_list:
             self.server.expect(VNODE, a, id=vnode)
 
-    def common_setup(self, no_mom_on_comm=False, no_comm_on_server=False):
+    def common_setup(self, no_mom_on_comm=False, no_comm_on_server=False,
+                     req_moms=2, req_comms=2):
         """
         This function sets the shortnames of moms and comms in the cluster
         accordingly.
@@ -393,20 +394,30 @@ class TestTPP(TestFunctional):
         :type no_mom_on_comm: Bool. Defaults to False
         :param no_comm_on_server: Flag, True if no comm is present on server
         :type no_comm_on_server: Bool. Defaults to False
+        :param req_moms: No of required moms
+        :type req_moms: Integer. Defaults to 2
+        :param req_comms: No of required comms
+        :type req_comms: Integer. Defaults to 2
         """
         mom_list = [x.shortname for x in self.moms.values()]
         comm_list = [y.shortname for y in self.comms.values()]
+        num_moms = len(self.moms)
+        num_comms = len(self.comms)
+        if (req_moms != num_moms) and (req_comms != num_comms):
+            msg = "Test requires exact %s moms and %s" % (req_moms, req_comms)
+            msg += " comms as input"
+            self.skipTest(msg)
         if not no_mom_on_comm and not no_comm_on_server:
             if self.server.shortname not in mom_list:
                 self.skipTest("Mom and comm should be on server host")
-        if len(self.moms.values()) == 2 and len(self.comms.values()) == 2:
+        if num_moms == 2 and num_comms == 2:
             self.hostA = self.server.shortname
             self.momB = self.moms.values()[1]
             self.hostB = self.momB.shortname
             self.comm2 = self.comms.values()[1]
             self.hostC = self.comm2.shortname
-            nodes = [self.hostA, self.hostB, self.hostC]
-        elif len(self.moms.values()) == 3 and len(self.comms.values()) == 3:
+            self.node_list = [self.hostA, self.hostB, self.hostC]
+        elif num_moms == 3 and num_comms == 3:
             self.hostA = self.server.shortname
             self.momB = self.moms.values()[1]
             self.hostB = self.momB.shortname
@@ -416,13 +427,13 @@ class TestTPP(TestFunctional):
             self.hostC = self.comm2.shortname
             self.comm3 = self.comms.values()[2]
             self.hostE = self.comm3.shortname
-            nodes = [
+            self.node_list = [
                 self.hostA,
                 self.hostB,
                 self.hostC,
                 self.hostD,
                 self.hostE]
-        elif len(self.moms.values()) == 2 and len(self.comms.values()) == 3:
+        elif num_moms == 2 and num_comms == 3:
             if self.server.shortname not in comm_list:
                 self.comm1 = self.comms.values()[0]
                 self.hostA = self.comm1.shortname
@@ -436,13 +447,13 @@ class TestTPP(TestFunctional):
             self.hostD = self.comm2.shortname
             self.comm3 = self.comms.values()[2]
             self.hostE = self.comm3.shortname
-            nodes = [
+            self.node_list = [
                 self.hostA,
                 self.hostB,
                 self.hostC,
                 self.hostD,
                 self.hostE]
-        elif len(self.moms.values()) == 4 and len(self.comms.values()) == 5:
+        elif num_moms == 4 and num_comms == 5:
             self.hostA = self.server.shortname
             self.momB = self.moms.values()[0]
             self.hostB = self.momB.shortname
@@ -460,14 +471,13 @@ class TestTPP(TestFunctional):
             self.hostH = self.comm4.shortname
             self.comm5 = self.comms.values()[4]
             self.hostI = self.comm5.shortname
-            nodes = [
+            self.node_list = [
                 self.hostA,
                 self.hostB,
                 self.hostC,
                 self.hostD,
                 self.hostE, self.hostF, self.hostG, self.hostH,
                 self.hostI]
-        self.node_list.extend(nodes)
 
     @requirements(num_moms=2, num_comms=2)
     def test_multiple_comm_with_mom(self):
@@ -727,7 +737,7 @@ class TestTPP(TestFunctional):
         Node 4 : Mom (self.hostD)
         Node 5 : Comm (self.hostE)
         """
-        self.common_setup()
+        self.common_setup(req_moms=3, req_comms=3)
         a = {'PBS_COMM_ROUTERS': self.hostA}
         self.set_pbs_conf(host_name=self.hostC, conf_param=a)
         comm_val = self.hostA + "," + self.hostC
@@ -766,7 +776,7 @@ class TestTPP(TestFunctional):
         Node 4 : Mom (self.hostD)
         Node 5 : Comm (self.hostE)
         """
-        self.common_setup()
+        self.common_setup(req_moms=3, req_comms=3)
         hostA_ip = socket.gethostbyname(self.hostA)
         hostC_ip = socket.gethostbyname(self.hostC)
         a = {'PBS_COMM_ROUTERS': hostA_ip}
@@ -807,7 +817,7 @@ class TestTPP(TestFunctional):
         Node 4 : Mom (self.hostD)
         Node 5 : Comm (self.hostE)
         """
-        self.common_setup()
+        self.common_setup(req_moms=3, req_comms=3)
         hostA_ip = socket.gethostbyname(self.hostA)
         comm_val = self.hostA + ":17001"
         a = {'PBS_COMM_ROUTERS': comm_val}
@@ -848,7 +858,7 @@ class TestTPP(TestFunctional):
         Node 4 : Mom (self.hostD)
         Node 5 : Comm (self.hostE)
         """
-        self.common_setup()
+        self.common_setup(req_moms=3, req_comms=3)
         hostA_ip = socket.gethostbyname(self.hostA)
         comm_val = self.hostA + ":17001"
         a = {'PBS_COMM_ROUTERS': self.hostA}
@@ -991,7 +1001,7 @@ class TestTPP(TestFunctional):
         Node 4 : Mom (self.hostC)
         Node 5 : Comm (self.hostE)
         """
-        self.common_setup(no_mom_on_comm=True)
+        self.common_setup(no_mom_on_comm=True, req_comms=3)
         a = {'PBS_COMM_ROUTERS': self.hostA}
         hosts = [self.hostD, self.hostE]
         for host in hosts:
@@ -1015,7 +1025,8 @@ class TestTPP(TestFunctional):
         Node 5 : Comm (self.hostE)
         Node 6 : Comm (self.hostA)
         """
-        self.common_setup(no_mom_on_comm=True, no_comm_on_server=True)
+        self.common_setup(no_mom_on_comm=True, no_comm_on_server=True,
+                          req_comms=3)
         a = {'PBS_COMM_ROUTERS': self.hostA}
         hosts = [self.hostD, self.hostE]
         for host in hosts:
@@ -1043,20 +1054,20 @@ class TestTPP(TestFunctional):
         Node 8 : Mom (self.hostE)
         Node 9 : Comm (self.hostI)
         """
-        self.common_setup(no_mom_on_comm=True)
+        self.common_setup(no_mom_on_comm=True,req_moms=4, req_comms=5)
         a = {'PBS_COMM_ROUTERS': self.hostA}
         comm_hosts = [self.hostF, self.hostG, self.hostH, self.hostI]
         for host in comm_hosts:
             self.set_pbs_conf(host_name=host, conf_param=a)
         mom_hosts = [self.hostB, self.hostC, self.hostD, self.hostE]
         for host in mom_hosts:
-            if hosts == self.hostB:
+            if host == self.hostB:
                 leaf_val = self.hostF + "," + self.hostG
-            elif hosts == self.hostC:
+            elif host == self.hostC:
                 leaf_val = self.hostG + "," + self.hostF
-            elif hosts == self.hostD:
+            elif host == self.hostD:
                 leaf_val = self.hostH + "," + self.hostI
-            elif hosts == self.hostE:
+            elif host == self.hostE:
                 leaf_val = self.hostI + "," + self.hostH
             b = {'PBS_LEAF_ROUTERS': leaf_val}
             self.set_pbs_conf(host_name=host, conf_param=b)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature

- Update tests of pbs_test_tpp to skip if exact num of moms and comms are not specified

#### Describe Your Change

- Added skip code and updated tests accordingly


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
[TPP_2moms_2comms.txt](https://github.com/openpbs/openpbs/files/5173269/TPP_2moms_2comms.txt)
[TPP_3moms_3comms.txt](https://github.com/openpbs/openpbs/files/5173277/TPP_3moms_3comms.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
