### PR TITLE
Fixing test test_res_string

### DIFF
--- a/test/tests/functional/pbs_svr_dyn_res.py
+++ b/test/tests/functional/pbs_svr_dyn_res.py
@@ -293,6 +293,8 @@ class TestServerDynRes(TestFunctional):
         a = {'job_state': 'R', 'Resource_List.foobar': 'abc'}
         self.server.expect(JOB, a, id=jid)
 
+        self.server.delete(jid, wait=True)
+
         # Submit job
         a = {'Resource_List.foobar': 'xyz'}
         j = Job(TEST_USER, attrs=a)

--- a/test/tests/functional/pbs_svr_dyn_res.py
+++ b/test/tests/functional/pbs_svr_dyn_res.py
@@ -287,7 +287,6 @@ class TestServerDynRes(TestFunctional):
         # Submit job
         a = {'Resource_List.foobar': 'abc'}
         j = Job(TEST_USER, attrs=a)
-        j.set_sleep_time(5)
         jid = self.server.submit(j)
 
         # Job must run successfully

--- a/test/tests/functional/pbs_svr_dyn_res.py
+++ b/test/tests/functional/pbs_svr_dyn_res.py
@@ -244,22 +244,24 @@ class TestServerDynRes(TestFunctional):
         a = {'Resource_List.foobar_small': '4'}
         # Submit job
         j = Job(TEST_USER, attrs=a)
-        j.set_sleep_time(5)
         jid = self.server.submit(j)
 
         # Job must run successfully
         a = {'job_state': 'R', 'Resource_List.foobar_small': 4}
         self.server.expect(JOB, a, id=jid)
 
+        self.server.delete(jid, wait=True)
+
         a = {'Resource_List.foobar_medium': '10'}
         # Submit job
         j = Job(TEST_USER, attrs=a)
-        j.set_sleep_time(5)
         jid = self.server.submit(j)
 
         # Job must run successfully
         a = {'job_state': 'R', 'Resource_List.foobar_medium': 10}
         self.server.expect(JOB, a, id=jid)
+
+        self.server.delete(jid, wait=True)
 
         a = {'Resource_List.foobar_large': '18'}
         # Submit job
@@ -325,12 +327,13 @@ class TestServerDynRes(TestFunctional):
         # Submit job
         a = {'Resource_List.foobar': 'red'}
         j = Job(TEST_USER, attrs=a)
-        j.set_sleep_time(5)
         jid = self.server.submit(j)
 
         # Job must run successfully
         a = {'job_state': 'R', 'Resource_List.foobar': 'red'}
         self.server.expect(JOB, a, id=jid)
+
+        self.server.delete(jid, wait=True)
 
         # Submit job
         a = {'Resource_List.foobar': 'green'}
@@ -362,12 +365,13 @@ class TestServerDynRes(TestFunctional):
         # Submit job
         a = {'Resource_List.foobar': '95gb'}
         j1 = Job(TEST_USER, attrs=a)
-        j1.set_sleep_time(5)
         jid1 = self.server.submit(j1)
 
         # Job must run successfully
         a = {'job_state': 'R', 'Resource_List.foobar': '95gb'}
         self.server.expect(JOB, a, id=jid1)
+
+        self.server.delete(jid1, wait=True)
 
         # Submit job
         a = {'Resource_List.foobar': '101gb'}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
The job sleep time is set to 5 seconds. This sometimes fails on slower machines because the job ends before the expect can check if the job is in R state. Removing the custom added sleep time for the job and keeping it to default sleep time.

#### Attach Test and Valgrind Logs/Output
[test_res_string.txt](https://github.com/openpbs/openpbs/files/5177188/test_res_string.txt)
[test_res_string_array.txt](https://github.com/openpbs/openpbs/files/5177189/test_res_string_array.txt)
[test_res_size.txt](https://github.com/openpbs/openpbs/files/5177190/test_res_size.txt)
[test_multiple_res.txt](https://github.com/openpbs/openpbs/files/5177191/test_multiple_res.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
