### PR TITLE
scheduler fails to calendar a job

### DIFF
--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -765,6 +765,7 @@ struct resv_info
 	node_info **resv_nodes;		/* node universe for reservation */
 	char *partition;		/* name of the partition in which the reservation was confirmed */
 	selspec *select_orig;		/* original schedselect pre-alter */
+	nspec **orig_nspec_arr;		/* original non-shrunk exec_vnode with exec_vnode chunk mapped to select chunk */
 };
 
 /* resource reservation - used for both jobs and advanced reservations */
@@ -809,7 +810,6 @@ struct resource_resv
 	server_info *server;		/* pointer to server which owns res resv */
 	node_info **ninfo_arr; 		/* nodes belonging to res resv */
 	nspec **nspec_arr;		/* exec vnode of object in internal sched form (one nspec per node) */
-	nspec **orig_nspec_arr;		/* original non-shrunk exec_vnode with exec_vnode chunk mapped to select chunk */
 
 	job_info *job;			/* pointer to job specific structure */
 	resv_info *resv;		/* pointer to reservation specific structure */

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -1680,8 +1680,13 @@ run_update_resresv(status *policy, int pbs_sd, server_info *sinfo,
 		 */
 		rr->can_not_run = 1;
 
-		if (rr->nspec_arr != NULL && rr->nspec_arr != ns && rr->nspec_arr != ns_arr)
+		if (rr->nspec_arr != NULL && rr->nspec_arr != ns && rr->nspec_arr != ns_arr && rr->nspec_arr != orig_ns)
 			free_nspecs(rr->nspec_arr);
+
+		if (orig_ns != ns_arr) {
+			free_nspecs(ns_arr);
+			ns_arr= NULL;
+		}
 		/* The nspec array coming out of the node selection code could
 		 * have a node appear multiple times.  This is how we need to
 		 * send the execvnode to the server.  We now need to combine
@@ -1692,6 +1697,9 @@ run_update_resresv(status *policy, int pbs_sd, server_info *sinfo,
 
 		if (rr->resv != NULL)
 			rr->resv->orig_nspec_arr = orig_ns;
+		else
+			free_nspecs(orig_ns);
+
 		rr->nspec_arr = ns;
 
 		if (rr->is_job && !(flags & RURR_NOPRINT)) {

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -1685,7 +1685,7 @@ run_update_resresv(status *policy, int pbs_sd, server_info *sinfo,
 
 		if (orig_ns != ns_arr) {
 			free_nspecs(ns_arr);
-			ns_arr= NULL;
+			ns_arr = NULL;
 		}
 		/* The nspec array coming out of the node selection code could
 		 * have a node appear multiple times.  This is how we need to

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -1567,8 +1567,12 @@ run_update_resresv(status *policy, int pbs_sd, server_info *sinfo,
 		/* Where should we run our resresv? */
 
 		/* 1) if the resresv knows where it should be run, run it there */
-		if (rr->orig_nspec_arr != NULL) {
-			orig_ns = rr->orig_nspec_arr;
+		if (((rr->resv == NULL) && (rr->nspec_arr != NULL)) ||
+		    ((rr->resv != NULL) && (rr->resv->orig_nspec_arr != NULL))) {
+			if (rr->resv != NULL)
+				orig_ns = rr->resv->orig_nspec_arr;
+			else
+				orig_ns = rr->nspec_arr;
 			/* we didn't use nspec_arr, we need to free it */
 			free_nspecs(ns_arr);
 			ns_arr = NULL;
@@ -1685,7 +1689,9 @@ run_update_resresv(status *policy, int pbs_sd, server_info *sinfo,
 		 */
 		if (ns == NULL)
 			ns = combine_nspec_array(orig_ns);
-		rr->orig_nspec_arr = orig_ns;
+
+		if (rr->resv != NULL)
+			rr->resv->orig_nspec_arr = orig_ns;
 		rr->nspec_arr = ns;
 
 		if (rr->is_job && !(flags & RURR_NOPRINT)) {

--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -1315,7 +1315,7 @@ query_job(struct batch_status *job, server_info *sinfo, schd_error *err)
 			resresv->job->queued_subjobs = range_parse(attrp->value);
 		else if (!strcmp(attrp->name, ATTR_execvnode)) {
 			nspec **tmp_nspec_arr;
-			tmp_nspec_arr = parse_execvnode(attrp->value, sinfo, resresv->select);
+			tmp_nspec_arr = parse_execvnode(attrp->value, sinfo, NULL);
 			resresv->nspec_arr = combine_nspec_array(tmp_nspec_arr);
 			free_nspecs(tmp_nspec_arr);
 

--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -1147,7 +1147,6 @@ query_job(struct batch_status *job, server_info *sinfo, schd_error *err)
 	long count;			/* long used in string->long conversion */
 	char *endp;			/* used for strtol() */
 	resource_req *resreq;		/* resource_req list for resources requested  */
-	char *execvnode = NULL;		/* Hold the exec_vnode until the end of the parsing */
 
 	if ((resresv = new_resource_resv()) == NULL)
 		return NULL;
@@ -1314,9 +1313,15 @@ query_job(struct batch_status *job, server_info *sinfo, schd_error *err)
 		/* array_indices_remaining */
 		else if (!strcmp(attrp->name, ATTR_array_indices_remaining))
 			resresv->job->queued_subjobs = range_parse(attrp->value);
-		else if (!strcmp(attrp->name, ATTR_execvnode))
-			execvnode = attrp->value;
-		else if (!strcmp(attrp->name, ATTR_l)) { /* resources requested*/
+		else if (!strcmp(attrp->name, ATTR_execvnode)) {
+			nspec **tmp_nspec_arr;
+			tmp_nspec_arr = parse_execvnode(attrp->value, sinfo, resresv->select);
+			resresv->nspec_arr = combine_nspec_array(tmp_nspec_arr);
+			free_nspecs(tmp_nspec_arr);
+
+			if (resresv->nspec_arr != NULL)
+				resresv->ninfo_arr = create_node_array_from_nspec(resresv->nspec_arr);
+		} else if (!strcmp(attrp->name, ATTR_l)) { /* resources requested*/
 			resreq = find_alloc_resource_req_by_str(resresv->resreq, attrp->resource);
 			if (resreq == NULL) {
 				free_resource_resv(resresv);
@@ -1394,14 +1399,6 @@ query_job(struct batch_status *job, server_info *sinfo, schd_error *err)
 		}
 
 		attrp = attrp->next;
-	}
-
-	if (execvnode != NULL) {
-		resresv->orig_nspec_arr = parse_execvnode(execvnode, sinfo, resresv->select);
-		resresv->nspec_arr = combine_nspec_array(resresv->orig_nspec_arr);
-
-		if (resresv->nspec_arr != NULL)
-			resresv->ninfo_arr = create_node_array_from_nspec(resresv->nspec_arr);
 	}
 
 	return resresv;

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -3993,15 +3993,7 @@ check_resources_for_node(resource_req *resreq, node_info *ninfo,
 
 				is_run_event = (event->event_type == TIMED_RUN_EVENT);
 
-
-				/* Normally when one job starts immediately after another (J1 end time == J2 start time)
-				 * we have no conflict between the two jobs.  When jobs do not request walltime,
-				 * they all have the same (5yr) walltime and fall one after another.
-				 * Using <= instead of < has the same effect as the jobs having a 1 second overlap.
-				 * Now all non-walltime jobs will overlap with the job before it and cause calendaring to occur.
-				 */
-				if (((resresv->duration == FIVE_YRS)?(event_time <= end_time):(event_time < end_time))
-					&& resresv != resc_resv && ns != NULL) {
+				if ((event_time < end_time) && resresv != resc_resv && ns != NULL) {
 					/* One event will need provisioning while the other will not,
 					 * they cannot co exist at same time.
 					 */

--- a/src/scheduler/resource_resv.c
+++ b/src/scheduler/resource_resv.c
@@ -179,7 +179,6 @@ new_resource_resv()
 	resresv->server = NULL;
 	resresv->ninfo_arr = NULL;
 	resresv->nspec_arr = NULL;
-	resresv->orig_nspec_arr = NULL;
 
 	resresv->job = NULL;
 	resresv->resv = NULL;
@@ -372,9 +371,6 @@ free_resource_resv(resource_resv *resresv)
 
 	if (resresv->nspec_arr != NULL)
 		free_nspecs(resresv->nspec_arr);
-
-	if (resresv->orig_nspec_arr != NULL)
-		free_nspecs(resresv->orig_nspec_arr);
 
 	if (resresv->job != NULL)
 		free_job_info(resresv->job);
@@ -667,15 +663,11 @@ dup_resource_resv(resource_resv *oresresv, server_info *nsinfo, queue_info *nqin
 					nresresv->job->resv->resv->resv_nodes);
 				nresresv->nspec_arr = dup_nspecs(oresresv->nspec_arr,
 					nresresv->job->resv->ninfo_arr, NULL);
-				nresresv->orig_nspec_arr = dup_nspecs(oresresv->orig_nspec_arr,
-					nresresv->job->resv->ninfo_arr, nresresv->select);
 
 			}
 			else {
 				nresresv->ninfo_arr = copy_node_ptr_array(oresresv->ninfo_arr,
 					nsinfo->nodes);
-				nresresv->orig_nspec_arr = dup_nspecs(oresresv->orig_nspec_arr,
-					nsinfo->nodes, nresresv->select);
 				nresresv->nspec_arr = dup_nspecs(oresresv->nspec_arr,
 					nsinfo->nodes, NULL);
 			}
@@ -685,13 +677,12 @@ dup_resource_resv(resource_resv *oresresv, server_info *nsinfo, queue_info *nqin
 		selspec *sel;
 		nresresv->is_resv = 1;
 		nresresv->resv = dup_resv_info(oresresv->resv, nsinfo);
-
-		nresresv->ninfo_arr = copy_node_ptr_array(oresresv->ninfo_arr, nsinfo->nodes);
 		if (nresresv->resv->select_orig != NULL)
 			sel = nresresv->resv->select_orig;
 		else
 			sel = nresresv->select;
-		nresresv->orig_nspec_arr = dup_nspecs(oresresv->orig_nspec_arr, nsinfo->nodes, sel);
+		nresresv->resv->orig_nspec_arr = dup_nspecs(oresresv->resv->orig_nspec_arr, nsinfo->nodes, sel);
+		nresresv->ninfo_arr = copy_node_ptr_array(oresresv->ninfo_arr, nsinfo->nodes);
 		nresresv->nspec_arr = dup_nspecs(oresresv->nspec_arr, nsinfo->nodes, NULL);
 	}
 	else  { /* error */

--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -535,9 +535,9 @@ query_reservations(int pbs_sd, server_info *sinfo, struct batch_status *resvs)
 					 */
 					release_nodes(resresv_ocr);
 
-					resresv_ocr->orig_nspec_arr = parse_execvnode(
+					resresv_ocr->resv->orig_nspec_arr = parse_execvnode(
 						execvnode_ptr[degraded_idx - 1], sinfo, resresv_ocr->select);
-					resresv_ocr->nspec_arr = combine_nspec_array(resresv_ocr->orig_nspec_arr);
+					resresv_ocr->nspec_arr = combine_nspec_array(resresv_ocr->resv->orig_nspec_arr);
 					resresv_ocr->ninfo_arr = create_node_array_from_nspec(resresv_ocr->nspec_arr);
 					resresv_ocr->resv->resv_nodes = create_resv_nodes(
 						resresv_ocr->nspec_arr, sinfo);
@@ -781,15 +781,15 @@ query_resv(struct batch_status *resv, server_info *sinfo)
 			sel = advresv->resv->select_orig;
 		else
 			sel = advresv->select;
-		advresv->orig_nspec_arr = parse_execvnode(resv_nodes, sinfo, sel);
-		advresv->nspec_arr = combine_nspec_array(advresv->orig_nspec_arr);
+		advresv->resv->orig_nspec_arr = parse_execvnode(resv_nodes, sinfo, sel);
+		advresv->nspec_arr = combine_nspec_array(advresv->resv->orig_nspec_arr);
 		advresv->ninfo_arr = create_node_array_from_nspec(advresv->nspec_arr);
 
 		/* create a node info array by copying the nodes and setting
 		 * available resources to only the ones assigned to the reservation
 		 */
 		advresv->resv->resv_nodes = create_resv_nodes(advresv->nspec_arr, sinfo);
-		selectspec = create_select_from_nspec(advresv->orig_nspec_arr);
+		selectspec = create_select_from_nspec(advresv->resv->orig_nspec_arr);
 		advresv->execselect = parse_selspec(selectspec);
 		free(selectspec);
 	}
@@ -867,6 +867,7 @@ new_resv_info()
 	rinfo->occr_start_arr = NULL;
 	rinfo->partition = NULL;
 	rinfo->select_orig = NULL;
+	rinfo->orig_nspec_arr = NULL;
 
 	return rinfo;
 }
@@ -906,6 +907,9 @@ free_resv_info(resv_info *rinfo)
 
 	if (rinfo->select_orig != NULL)
 		free_selspec(rinfo->select_orig);
+
+	if (rinfo->orig_nspec_arr != NULL)
+		free_nspecs(rinfo->orig_nspec_arr);
 
 	free(rinfo);
 
@@ -1159,9 +1163,9 @@ check_new_reservations(status *policy, int pbs_sd, resource_resv **resvs, server
 						 * the required fields.
 						 */
 						release_nodes(nresv_copy);
-						nresv_copy->orig_nspec_arr = parse_execvnode(occr_execvnodes_arr[j], sinfo, nresv_copy->select);
+						nresv_copy->resv->orig_nspec_arr = parse_execvnode(occr_execvnodes_arr[j], sinfo, nresv_copy->select);
 						nresv_copy->ninfo_arr = create_node_array_from_nspec(nresv_copy->nspec_arr);
-						nresv_copy->nspec_arr = combine_nspec_array(nresv_copy->orig_nspec_arr);
+						nresv_copy->nspec_arr = combine_nspec_array(nresv_copy->resv->orig_nspec_arr);
 						nresv_copy->resv->resv_nodes = create_resv_nodes(nresv_copy->nspec_arr, sinfo);
 					}
 
@@ -1518,14 +1522,14 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 					char *sel;
 					int ind;
 					free_selspec(nresv->execselect);
-					/* Use orig_nspec_arr over nspec_arr because
+					/* Use resv->orig_nspec_arr over nspec_arr because
 					 * A) we modified it above in check_vnodes_unavailable() for reconfirmation
 					 * B) it will allow us to map the original select back to the new resv_nodes
 					 */
-					sel = create_select_from_nspec(nresv->orig_nspec_arr);
+					sel = create_select_from_nspec(nresv->resv->orig_nspec_arr);
 					nresv->execselect = parse_selspec(sel);
-					for (ind = 0; nresv->orig_nspec_arr[ind] != NULL; ind++) {
-					    nresv->execselect->chunks[ind]->seq_num = nresv->orig_nspec_arr[ind]->seq_num;
+					for (ind = 0; nresv->resv->orig_nspec_arr[ind] != NULL; ind++) {
+					    nresv->execselect->chunks[ind]->seq_num = nresv->resv->orig_nspec_arr[ind]->seq_num;
 					}
 
 					free(sel);
@@ -1538,7 +1542,7 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 				 * this occurrence's execvnodes to the sequence of execvnodes
 				 */
 				confirmd_occr++;
-				tmp = create_execvnode(nresv->orig_nspec_arr);
+				tmp = create_execvnode(nresv->resv->orig_nspec_arr);
 				if (j == 0)
 					execvnodes = string_dup(tmp);
 				else  { /* subsequent occurrences */
@@ -1779,8 +1783,8 @@ check_down_running(resource_resv *resv, int chunk_ind)
 	if (resv == NULL || chunk_ind < 0 || !resv->is_resv)
 		return -3;
 
-	for (i = chunk_ind; resv->orig_nspec_arr[i] != NULL && ret != -2; i++) {
-		nspec *ns = resv->orig_nspec_arr[i];
+	for (i = chunk_ind; resv->resv->orig_nspec_arr[i] != NULL && ret != -2; i++) {
+		nspec *ns = resv->resv->orig_nspec_arr[i];
 		node_info *ninfo = ns->ninfo;
 
 		if (ninfo != NULL) {
@@ -1817,7 +1821,7 @@ check_down_running(resource_resv *resv, int chunk_ind)
  * 	we are removing unavailable nodes or available nodes
  *
  * @param[in] resv - reservation to remove nodes from
- * @param[in] start_of_chk - index into orig_nspec_arr of where to start
+ * @param[in] start_of_chk - index into resv->orig_nspec_arr of where to start
  * @param[in] chk_seq_num - sequence number of chunk to remove nodes from
  * @param[in] num_chks - number of nodes to remove.  Depending on node_type, it is OK to remove less than this
  * @param[in] node_type - type of node to remove: -1 unavailable, 0 normal, 1 either all with no running jobs
@@ -1835,7 +1839,7 @@ int ralter_remove_nodes(resource_resv *resv, int start_of_chk, int chk_seq_num, 
 	cur_chks = num_chks;
 	nspec **nspec_arr;
 
-	nspec_arr = resv->orig_nspec_arr;
+	nspec_arr = resv->resv->orig_nspec_arr;
 
 	for (i = start_of_chk; nspec_arr[i] != NULL && cur_chks; i++) {
 		int ret;
@@ -1890,7 +1894,7 @@ ralter_reduce_chunks(resource_resv *resv)
 	if (resv->resv->select_orig == NULL)
 		return 0;
 
-	cnt = count_array(resv->orig_nspec_arr);
+	cnt = count_array(resv->resv->orig_nspec_arr);
 	j = 0;
 	chks_orig = resv->resv->select_orig->chunks;
 	chks = resv->select->chunks;
@@ -1928,21 +1932,21 @@ ralter_reduce_chunks(resource_resv *resv)
 
 			j++;
 		}
-		for (k = start_of_chunk; k < cnt && resv->orig_nspec_arr[k]->chk->seq_num == chks_orig[i]->seq_num; k++)
+		for (k = start_of_chunk; k < cnt && resv->resv->orig_nspec_arr[k]->chk->seq_num == chks_orig[i]->seq_num; k++)
 			;
 		start_of_chunk = k;
 	}
 	i = 0;
-	while (resv->orig_nspec_arr[i] != NULL) {
-		if (resv->orig_nspec_arr[i]->ninfo == NULL) {
-			free_nspec(resv->orig_nspec_arr[i]);
-			for (j = i; resv->orig_nspec_arr[j] != NULL; j++)
-				resv->orig_nspec_arr[j] = resv->orig_nspec_arr[j + 1];
+	while (resv->resv->orig_nspec_arr[i] != NULL) {
+		if (resv->resv->orig_nspec_arr[i]->ninfo == NULL) {
+			free_nspec(resv->resv->orig_nspec_arr[i]);
+			for (j = i; resv->resv->orig_nspec_arr[j] != NULL; j++)
+				resv->resv->orig_nspec_arr[j] = resv->resv->orig_nspec_arr[j + 1];
 		} else
 			i++;
 	}
 	free_nspecs(resv->nspec_arr);
-	resv->nspec_arr = combine_nspec_array(resv->orig_nspec_arr);
+	resv->nspec_arr = combine_nspec_array(resv->resv->orig_nspec_arr);
 
 	return 1;
 }
@@ -1975,8 +1979,8 @@ check_vnodes_unavailable(resource_resv *resv)
 	if (resv == NULL || resv->nspec_arr == NULL)
 		return -3;
 
-	for (i = 0; resv->orig_nspec_arr[i] != NULL; i++) {
-		if (!resv->orig_nspec_arr[i]->end_of_chunk)
+	for (i = 0; resv->resv->orig_nspec_arr[i] != NULL; i++) {
+		if (!resv->resv->orig_nspec_arr[i]->end_of_chunk)
 			has_superchunk = 1;
 		num_chunks++;
 	}
@@ -1988,16 +1992,16 @@ check_vnodes_unavailable(resource_resv *resv)
 		}
 	}
 
-	for (i = 0; resv->orig_nspec_arr[i] != NULL; i++) {
+	for (i = 0; resv->resv->orig_nspec_arr[i] != NULL; i++) {
 
 		/* If the original select chunks haven't been mapped to the resv_nodes and the reservation is running, we can't continue */
-		if (resv->resv->is_running && resv->orig_nspec_arr[i]->chk == NULL) {
+		if (resv->resv->is_running && resv->resv->orig_nspec_arr[i]->chk == NULL) {
 			free(chunks_to_remove);
 			return -2;
 		}
 
 		/* Part of a superchunk we've already handled */
-		if (resv->orig_nspec_arr[i]->ninfo == NULL)
+		if (resv->resv->orig_nspec_arr[i]->ninfo == NULL)
 			continue;
 
 		ret = check_down_running(resv, i);
@@ -2010,27 +2014,27 @@ check_vnodes_unavailable(resource_resv *resv)
 		else if (ret == -1) {
 			int j;
 			has_down_node = 1;
-			for (j = i; resv->orig_nspec_arr[j] != NULL && !resv->orig_nspec_arr[j]->end_of_chunk; j++) {
-				resv->orig_nspec_arr[j]->ninfo = NULL;
+			for (j = i; resv->resv->orig_nspec_arr[j] != NULL && !resv->resv->orig_nspec_arr[j]->end_of_chunk; j++) {
+				resv->resv->orig_nspec_arr[j]->ninfo = NULL;
 				if (has_superchunk)
-					chunks_to_remove[del_i++] = resv->orig_nspec_arr[j];
+					chunks_to_remove[del_i++] = resv->resv->orig_nspec_arr[j];
 			}
 			/* We ran into an error where we ran into the end of the array before the end of the chunk
 			 * The entire chunk is in chunks_to_remove, so we'll just remove it.
 			 */
-			if (resv->orig_nspec_arr[j] == NULL)
+			if (resv->resv->orig_nspec_arr[j] == NULL)
 				break;
 
-			resv->orig_nspec_arr[j]->ninfo = NULL;
+			resv->resv->orig_nspec_arr[j]->ninfo = NULL;
 			/*
 			 * The nspec_arr only has consumable resources.  When replacing a vnode we need
 			 * to make sure to replace it with the right type of node matching the non-consumables
 			 */
-			free_resource_req_list(resv->orig_nspec_arr[j]->resreq);
-			resv->orig_nspec_arr[j]->resreq = dup_resource_req_list(resv->orig_nspec_arr[j]->chk->req);
-			resv->orig_nspec_arr[j]->sub_seq_num = 1;
+			free_resource_req_list(resv->resv->orig_nspec_arr[j]->resreq);
+			resv->resv->orig_nspec_arr[j]->resreq = dup_resource_req_list(resv->resv->orig_nspec_arr[j]->chk->req);
+			resv->resv->orig_nspec_arr[j]->sub_seq_num = 1;
 		} else /* Node is available for use */
-			resv->orig_nspec_arr[i]->sub_seq_num = 0;
+			resv->resv->orig_nspec_arr[i]->sub_seq_num = 0;
 	}
 
 	if (has_superchunk) {
@@ -2038,7 +2042,7 @@ check_vnodes_unavailable(resource_resv *resv)
 
 		for(i = 0; chunks_to_remove[i] != NULL; i++) {
 			free_nspec(chunks_to_remove[i]);
-			remove_ptr_from_array(resv->orig_nspec_arr, chunks_to_remove[i]);
+			remove_ptr_from_array(resv->resv->orig_nspec_arr, chunks_to_remove[i]);
 		}
 	}
 	if (has_down_node == 1)
@@ -2046,7 +2050,7 @@ check_vnodes_unavailable(resource_resv *resv)
 		 * This will ensure that we get all the nodes back we need to,
 		 * before we start looking for replacements
 		 */
-		qsort(resv->orig_nspec_arr, count_array(resv->orig_nspec_arr), sizeof(nspec *), cmp_nspec_by_sub_seq);
+		qsort(resv->resv->orig_nspec_arr, count_array(resv->resv->orig_nspec_arr), sizeof(nspec *), cmp_nspec_by_sub_seq);
 
 	free(chunks_to_remove);
 
@@ -2073,8 +2077,8 @@ release_nodes(resource_resv *resresv)
 	free_nspecs(resresv->nspec_arr);
 	resresv->nspec_arr = NULL;
 
-	free_nspecs(resresv->orig_nspec_arr);
-	resresv->orig_nspec_arr = NULL;
+	free_nspecs(resresv->resv->orig_nspec_arr);
+	resresv->resv->orig_nspec_arr = NULL;
 
 	if (resresv->nodepart_name != NULL) {
 		free(resresv->nodepart_name);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Due to a bug in #1936 scheduler, while performing a run event scheduler tries to calendar a job, the scheduler tries to find the node solution of the job present in the run event even when that job already has a node solution associated with it.
This makes the scheduler look into events it is not supposed to and fails perform_event call, eventually resulting in failure to add a job to the calendar.

#### Describe Your Change
in run_update_resresv scheduler checks for orig_nspec_arr on the job and if not found it tries to find a node solution for the job by calling check_nodes. Orig_nspec_arr is only set for reservations and not for jobs. 
This change moves orig_nspec_arr inside the resv_info structure and also checks for orig_nspec_arr only when the scheduler is trying to run reservations.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
[test_reservation.txt](https://github.com/openpbs/openpbs/files/5177103/test_reservation.txt)
[pbs_ralter.txt](https://github.com/openpbs/openpbs/files/5177104/pbs_ralter.txt)
Description: Rerun All Tests From #3614
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|3621|3478|4|0|0|2|3472|

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
