### PR TITLE
Fix mom hooks debug=True raising exception

### DIFF
--- a/src/include/pbs_python.h
+++ b/src/include/pbs_python.h
@@ -398,6 +398,7 @@ extern int get_py_progname(char **);
 #define PY_GET_VNODE_STATIC_METHOD	"get_vnode_static"
 #define PY_GET_QUEUE_STATIC_METHOD	"get_queue_static"
 #define PY_GET_SERVER_DATA_FP_METHOD	"get_server_data_fp"
+#define PY_GET_SERVER_DATA_FILE_METHOD	"get_server_data_file"
 #define PY_USE_STATIC_DATA_METHOD	"use_static_data"
 
 /* Event parameter names */

--- a/src/lib/Libpython/module_pbs_v1.c
+++ b/src/lib/Libpython/module_pbs_v1.c
@@ -242,6 +242,9 @@ extern PyObject * pbsv1mod_meth_get_queue_static(PyObject *self,
 extern char pbsv1mod_meth_get_server_data_fp_doc[];
 extern PyObject *pbsv1mod_meth_get_server_data_fp(void);
 
+extern char pbsv1mod_meth_get_server_data_file_doc[];
+extern PyObject *pbsv1mod_meth_get_server_data_file(void);
+
 extern char pbsv1mod_meth_use_static_data_doc[];
 extern PyObject *pbsv1mod_meth_use_static_data(void);
 
@@ -590,6 +593,8 @@ static PyMethodDef pbs_v1_module_methods[] = {
 		METH_VARARGS | METH_KEYWORDS, pbsv1mod_meth_get_vnode_static_doc},
 	{PY_GET_SERVER_DATA_FP_METHOD, (PyCFunction) pbsv1mod_meth_get_server_data_fp,
 		METH_NOARGS, pbsv1mod_meth_get_server_data_fp_doc},
+	{PY_GET_SERVER_DATA_FILE_METHOD, (PyCFunction) pbsv1mod_meth_get_server_data_file,
+		METH_NOARGS, pbsv1mod_meth_get_server_data_file_doc},
 	{PY_USE_STATIC_DATA_METHOD,
 		(PyCFunction) pbsv1mod_meth_use_static_data,
 		METH_NOARGS, pbsv1mod_meth_use_static_data_doc},

--- a/src/lib/Libpython/pbs_python_svr_internal.c
+++ b/src/lib/Libpython/pbs_python_svr_internal.c
@@ -11779,6 +11779,26 @@ pbsv1mod_meth_get_server_data_fp(void)
 	return (fp_obj);
 }
 
+const char pbsv1mod_meth_get_server_data_file_doc[] =
+"server_data_fp()\n\
+\n\
+   Returns the Python string representing the pathname to the hook data file.\n\
+\n\
+";
+
+/**
+ * @brief
+ *	Returns the Python string representing the pathname to the hook data file.
+ */
+PyObject *
+pbsv1mod_meth_get_server_data_file(void)
+{
+	if ((hook_debug.data_file == NULL) || (hook_debug.data_file[0] == '\0')) {
+		Py_RETURN_NONE;
+	}
+	return (PyUnicode_FromString(hook_debug.data_file));
+}
+
 const char pbsv1mod_meth_use_static_data_doc[] =
 "use_static_data()\n\
 \n\

--- a/src/modules/python/pbs/v1/_svr_types.py
+++ b/src/modules/python/pbs/v1/_svr_types.py
@@ -78,6 +78,21 @@ except:
 # Set global pbs_conf parameter.
 pbs_conf = _pbs_v1.get_pbs_conf()
 
+
+#
+# get_server_data_fp: returns the file object representing the
+#                     hook debug data file.
+def get_server_data_fp():
+    data_file = _pbs_v1.get_server_data_file()
+    if data_file is None:
+        return None
+    try:
+        return open(data_file, "a+");
+    except:
+        _pbs_v1.logmsg(_pbs_v1.LOG_WARNING,
+                       "warning: error opening debug data file %s" % data_file)
+        return None
+
 #
 # get_local_nodename: returns the name of the current host as it would appear
 #                      as a vnode name. This is usually the short form of the
@@ -118,8 +133,6 @@ def pbs_statobj(objtype, name=None, connect_server=None, filter_queue=None):
 
     _pbs_v1.set_c_mode()
 
-    server_data_fp = _pbs_v1.get_server_data_fp()
-
     if(connect_server == None):
         con = pbs_connect("localhost")
     else:
@@ -154,6 +167,8 @@ def pbs_statobj(objtype, name=None, connect_server=None, filter_queue=None):
         _pbs_v1.set_python_mode()
         return None
 
+    server_data_fp = get_server_data_fp()
+
     b = bs
     obj = None
     while(b):
@@ -171,6 +186,8 @@ def pbs_statobj(objtype, name=None, connect_server=None, filter_queue=None):
             _pbs_v1.logmsg(_pbs_v1.LOG_DEBUG,
                            "pbs_statobj: Bad object type %s" % (objtype))
             pbs_disconnect(con)
+            if server_data_fp:
+                server_data_fp.close()
             _pbs_v1.set_python_mode()
             return None
 
@@ -193,6 +210,8 @@ def pbs_statobj(objtype, name=None, connect_server=None, filter_queue=None):
                 if((filter_queue != None) and (n == ATTR_queue) and
                         (filter_queue != v)):
                     pbs_disconnect(con)
+                    if server_data_fp:
+                        server_data_fp.close()
                     _pbs_v1.set_python_mode()
                     return None
                 if n == ATTR_inter or n == ATTR_block or n == ATTR_X11_port:
@@ -247,6 +266,8 @@ def pbs_statobj(objtype, name=None, connect_server=None, filter_queue=None):
         b = b.next
 
     pbs_disconnect(con)
+    if server_data_fp:
+        server_data_fp.close()
     _pbs_v1.set_python_mode()
     return obj
 
@@ -1123,14 +1144,15 @@ class pbs_iter():
                 job = None
 
                 _pbs_v1.set_c_mode()
-
-                server_data_fp = _pbs_v1.get_server_data_fp()
+                server_data_fp = get_server_data_fp()
                 if(b):
                     if(self.type == "jobs"):
                         _pbs_v1.logmsg(_pbs_v1.LOG_DEBUG,
                                        "pbs_iter/next: pbs_python mode not"
                                        " supported by NAS local mod")
                         pbs_disconnect(self.con)
+                        if server_data_fp:
+                            server_data_fp.close()
                         self.con = -1
                         _pbs_v1.set_python_mode()
                         raise StopIteration
@@ -1149,6 +1171,8 @@ class pbs_iter():
                                        "type %s"
                                        % (self.type))
                         pbs_disconnect(self.con)
+                        if server_data_fp:
+                            server_data_fp.close()
                         self.con = -1
                         _pbs_v1.set_python_mode()
                         raise StopIteration
@@ -1223,6 +1247,8 @@ class pbs_iter():
 
                 self.bs = b.next
 
+                if server_data_fp:
+                    server_data_fp.close()
                 _pbs_v1.set_python_mode()
                 return obj
             else:
@@ -1267,7 +1293,7 @@ class pbs_iter():
 
                 _pbs_v1.set_c_mode()
 
-                server_data_fp = _pbs_v1.get_server_data_fp()
+                server_data_fp = get_server_data_fp()
                 if(b):
                     if(self.type == "jobs"):
                         obj = _job(b.name, self._connect_server)
@@ -1287,6 +1313,8 @@ class pbs_iter():
                                        " iterator type %s"
                                        % (self.type))
                         pbs_disconnect(self.con)
+                        if server_data_fp:
+                            server_data_fp.close()
                         self.con = -1
                         _pbs_v1.set_python_mode()
                         raise StopIteration
@@ -1362,6 +1390,8 @@ class pbs_iter():
                 self.bs = b.next
 
                 _pbs_v1.set_python_mode()
+                if server_data_fp:
+                    server_data_fp.close()
                 return obj
             else:
                 # argument 0 below tells C function we're inside next

--- a/src/tools/pbs_python.c
+++ b/src/tools/pbs_python.c
@@ -2775,11 +2775,16 @@ main(int argc, char *argv[], char *envp[])
 				fp_server_out = fopen(the_server_output,
 					"w");
 				if (fp_server_out == NULL) {
-					fprintf(stderr,
-						"warning: open of server output %s failed!",
+					log_eventf(PBSEVENT_DEBUG,
+						PBS_EVENTCLASS_HOOK, LOG_WARNING,
+						__func__,
+						"warning: error opening debug data file %s",
 						the_server_output);
+					pbs_python_set_hook_debug_data_fp(NULL);
+					pbs_python_set_hook_debug_data_file("");
 				} else {
 					pbs_python_set_hook_debug_data_fp(fp_server_out);
+					pbs_python_set_hook_debug_data_file(the_server_output);
 				}
 			} else if ((strcmp(plist->al_name, HOOKATT_USER) != 0) &&
 				(strcmp(plist->al_name, HOOKATT_FREQ) != 0) &&

--- a/test/tests/functional/pbs_hook_debug_input.py
+++ b/test/tests/functional/pbs_hook_debug_input.py
@@ -156,7 +156,7 @@ q = s.queue("%s")
 for vn in s.vnodes():
     pbs.logmsg(pbs.LOG_DEBUG, "found vn=" + vn.name)
 pbs.event().accept()
-""" % (def_que,)
+""" % def_que
         attr = {'enabled': 'true', 'event': 'execjob_begin', 'debug': 'true'}
         self.server.create_import_hook(hname, attr, hook_body)
 

--- a/test/tests/functional/pbs_hook_debug_input.py
+++ b/test/tests/functional/pbs_hook_debug_input.py
@@ -54,13 +54,21 @@ class TestHookDebugInput(TestFunctional):
             self.server_hooks_tmp_dir = \
                 os.path.join(self.server.pbs_conf['PBS_HOME'],
                              'server_priv', 'hooks', 'tmp')
+        if not hasattr(self, 'mom_hooks_tmp_dir'):
+            self.mom_hooks_tmp_dir = \
+                os.path.join(self.mom.pbs_conf['PBS_HOME'],
+                             'mom_priv', 'hooks', 'tmp')
 
-    def remove_files_match(self, pattern):
+    def remove_files_match(self, pattern, mom=False):
         """
         Remove hook debug files in hooks/tmp folder that
         match pattern
         """
-        for item in self.du.listdir(path=self.server_hooks_tmp_dir, sudo=True):
+        if mom:
+            hooks_tmp_dir = self.mom_hooks_tmp_dir
+        else:
+            hooks_tmp_dir = self.server_hooks_tmp_dir
+        for item in self.du.listdir(path=hooks_tmp_dir, sudo=True):
             if fnmatch.fnmatch(item, pattern):
                 self.du.rm(path=item, sudo=True)
 
@@ -83,6 +91,27 @@ class TestHookDebugInput(TestFunctional):
             search_str = 'pbs.event().job.queue=%s' % qname
             self.assertTrue(search_str in f.read().decode())
         self.remove_files_match(input_file_pattern)
+
+    def match_in_debug_file(self, input_file_pattern, search_list, mom=False):
+        """
+        Assert that all the strings in 'search_list' appears in the hook
+        debug file that matches input_file_pattern
+        """
+        input_file = None
+        if mom:
+            hooks_tmp_dir = self.mom_hooks_tmp_dir
+        else:
+            hooks_tmp_dir = self.server_hooks_tmp_dir
+        for item in self.du.listdir(path=hooks_tmp_dir, sudo=True):
+            if fnmatch.fnmatch(item, input_file_pattern):
+                input_file = item
+                break
+        self.assertTrue(input_file is not None)
+        with PBSLogUtils().open_log(input_file, sudo=True) as f:
+            content = f.read().decode()
+            for entry in search_list:
+                self.assertTrue(entry in content)
+        self.remove_files_match(input_file_pattern, mom)
 
     def test_queuejob_hook_debug_input_has_queue_name(self):
         """
@@ -113,3 +142,34 @@ class TestHookDebugInput(TestFunctional):
         j2 = Job(TEST_USER, attrs=attr)
         self.server.submit(j2)
         self.match_queue_name_in_input_file(input_file_pattern, new_queue)
+
+    def test_mom_hook_debug_data(self):
+        """
+        Test that a debug enabled mom hook produces expected debug data.
+        """
+        def_que = self.server.default_queue
+        hname = "debug"
+        hook_body = """
+import pbs
+s = pbs.server()
+q = s.queue("%s")
+for vn in s.vnodes():
+    pbs.logmsg(pbs.LOG_DEBUG, "found vn=" + vn.name)
+pbs.event().accept()
+""" % (def_que,)
+        attr = {'enabled': 'true', 'event': 'execjob_begin', 'debug': 'true'}
+        self.server.create_import_hook(hname, attr, hook_body)
+
+        data_file_pattern = os.path.join(self.mom_hooks_tmp_dir,
+                                         'hook_execjob_begin_%s*.data' % hname)
+        self.remove_files_match(data_file_pattern, mom=True)
+
+        j1 = Job(TEST_USER)
+        j1.set_sleep_time(5)
+        jid = self.server.submit(j1)
+        self.server.expect(JOB, 'queue', op=UNSET, id=jid)
+
+        search = ["pbs.server().queue(%s).queue_type=Execution" % def_que]
+        search.append("pbs.server().vnode(%s).ntype=0" % self.mom.shortname)
+        self.logger.info(search)
+        self.match_in_debug_file(data_file_pattern, search, mom=True)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* A mom hook with debug=true with "pbs.server()" content raises the following exception:
```
02/18/2020 22:30:05;0001;pbs_python;Svr;pbs_python;PBS server internal error (15011) in Error evaluating Python script, <class 'SystemError'>
02/18/2020 22:30:05;0001;pbs_python;Svr;pbs_python;PBS server internal error (15011) in Error evaluating Python script, <built-in function get_server_data_fp> returned a result with an error set

 ```


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* A mom hook is executed by pbs_python.
* Upon detecting the hook to be debug=true, pbs_python opens the hook debug file inside C code, passes the file pointer to the Python world via PyFile_FromFd() as called in Libpython/pbs_python_svr_internal.c:meth_get_server_data_fp(). pbs.server()* data are appended using the file pointer.
* Problem happens as under Python3 where current PBS is linked under, PyFile_fromFd() raises an OSerror exception, even though the file pointer is perfectly valid. This does not happen on older version of PBS running Python2. I've not seen any patch yet to fix PyFile_fromFd() in Python3.
* Fix is to just let the Python world open the file and manage its pointer accordingly, bypassing the need to call PyFile_FromFd().
* This required introducing a new function meth_get_server_data_file() that will return the pathname of the hook debug file of the job.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

* [ptl.mom_hook_debug_data.PASS.txt](https://github.com/openpbs/openpbs/files/5211767/ptl.mom_hook_debug_data.PASS.txt)
* [ptl.mom_hook_debug_data.FAIL.txt](https://github.com/openpbs/openpbs/files/5211769/ptl.mom_hook_debug_data.FAIL.txt)
* [ptl.hook_debug_nocrash.txt](https://github.com/openpbs/openpbs/files/5221424/ptl.hook_debug_nocrash.txt)
* [ptl.hook_debug_input.txt](https://github.com/openpbs/openpbs/files/5221421/ptl.hook_debug_input.txt)
* [ptl.hook_set_jobenv.txt](https://github.com/openpbs/openpbs/files/5221430/ptl.hook_set_jobenv.txt)
* [ptl.crosslink.txt](https://github.com/openpbs/openpbs/files/5221434/ptl.crosslink.txt)
* Regression test results:

3757 | hirenk | regression | Rerun All Tests From #3755 | bayucan/openpbs@hook-debug | 17th Sep 2020 01:39:27.451 AM -07:00 | 01:27:16.917 | 1837 | 0 | 0 | 4 | 2 | 0 | 1 | 1830
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --

Info about the 6 failing tests: 
-- PTL TestPbsExecutePrologue.test_prologue_exception_sisters failure looks like a known test problem.
-- Perl 230362_mom_hooks_smoke_test.t14.t, smoketest.t6.t, smoketest.t7.t failed but they don't look like related to my fix. I've seen other builds of openpbs@master to be failing as well on the  same tests.
-- PTL TestPbsJobCleanup.test_del_queued_jobs is erroring out, but seemed to happen as well on other builds.
-- PTL TestTrillionJobId.test_verify_sequence_id erroring out looks like a known test issue.

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
