### PR TITLE
Move PTL create_vnodes method from class Server to Mom

### DIFF
--- a/test/fw/bin/pbs_config
+++ b/test/fw/bin/pbs_config
@@ -489,7 +489,7 @@ if __name__ == '__main__':
             for hostname in hosts:
                 s = Server(hostname)
                 m = MoM(hostname, pbsconf_file=conf_file)
-                s.create_vnodes(vnodeprefix, nattrs, num_vnodes, m,
+                m.create_vnodes(nattrs, num_vnodes,
                                 additive, sharedhost, restart, delall,
                                 natvnode, usenatvnode, fname=vdefname,
                                 vnodes_per_host=vnodes_per_host)

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -13494,6 +13494,7 @@ class MoM(PBSService):
         helper function to create vnodes.
 
         :param attrib: attributes to assign to each node
+        :type attrib: dict
         :param num: the number of vnodes to create. Defaults to 1
         :type num: int
         :param additive: If True, vnodes are added to the existing

--- a/test/tests/functional/pbs_admin_suspend.py
+++ b/test/tests/functional/pbs_admin_suspend.py
@@ -837,12 +837,12 @@ class TestAdminSuspend(TestFunctional):
         hook_body = """
 import pbs
 
-vname = str(pbs.server().name) + '[0]'
-vn = pbs.server().vnode(vname)
+vn = pbs.server().vnode('vn[0]')
 pbs.logmsg(pbs.LOG_DEBUG,\
 "list of maintenance_jobs are %s" % vn.maintenance_jobs)
 """
-
+        a = {'resources_available.ncpus': 4, 'resources_available.mem': '4gb'}
+        self.mom.create_vnodes(a, 1, vname='vn')
         a = {'event': 'exechost_periodic', 'enabled': 'True', 'freq': 5}
         self.server.create_import_hook(hook_name, a, hook_body)
 

--- a/test/tests/functional/pbs_admin_suspend.py
+++ b/test/tests/functional/pbs_admin_suspend.py
@@ -51,7 +51,7 @@ class TestAdminSuspend(TestFunctional):
     def setUp(self):
         TestFunctional.setUp(self)
         a = {'resources_available.ncpus': 4, 'resources_available.mem': '4gb'}
-        self.server.create_vnodes('vn', a, 1, self.mom)
+        self.mom.create_vnodes(a, 1)
 
     @skipOnCpuSet
     def test_basic(self):
@@ -65,29 +65,29 @@ class TestAdminSuspend(TestFunctional):
         j2 = Job(TEST_USER)
         jid2 = self.server.submit(j2)
         self.server.expect(JOB, {'job_state': 'R', 'substate': 42}, id=jid2)
-
+        vnode = self.mom.shortname + '[0]'
         # admin-suspend job 1.
         self.server.sigjob(jid1, 'admin-suspend', runas=ROOT_USER)
         self.server.expect(JOB, {'job_state': 'S'}, id=jid1)
-        self.server.expect(NODE, {'state': 'maintenance'}, id='vn[0]')
+        self.server.expect(NODE, {'state': 'maintenance'}, id=vnode)
         self.server.expect(NODE, {'maintenance_jobs': jid1})
 
         # admin-suspend job 2
         self.server.sigjob(jid2, 'admin-suspend', runas=ROOT_USER)
         self.server.expect(JOB, {'job_state': 'S'}, id=jid2)
-        self.server.expect(NODE, {'state': 'maintenance'}, id='vn[0]')
+        self.server.expect(NODE, {'state': 'maintenance'}, id=vnode)
         self.server.expect(NODE, {'maintenance_jobs': jid1 + "," + jid2})
 
         # admin-resume job 1.  Make sure the node is still in state maintenance
         self.server.sigjob(jid1, 'admin-resume', runas=ROOT_USER)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
-        self.server.expect(NODE, {'state': 'maintenance'}, id='vn[0]')
+        self.server.expect(NODE, {'state': 'maintenance'}, id=vnode)
         self.server.expect(NODE, {'maintenance_jobs': jid2})
 
         # admin-resume job 2.  Make sure the node retuns to state free
         self.server.sigjob(jid2, 'admin-resume', runas=ROOT_USER)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
-        self.server.expect(NODE, {'state': 'free'}, id='vn[0]')
+        self.server.expect(NODE, {'state': 'free'}, id=vnode)
 
     @skipOnCpuSet
     def test_basic_ja(self):
@@ -106,29 +106,30 @@ class TestAdminSuspend(TestFunctional):
 
         self.server.expect(JOB, {'job_state': 'R', 'substate': 42}, id=jid1)
         self.server.expect(JOB, {'job_state': 'R', 'substate': 42}, id=jid2)
+        vnode = self.mom.shortname + '[0]'
 
         # admin-suspend job 1.
         self.server.sigjob(jid1, 'admin-suspend', runas=ROOT_USER)
         self.server.expect(JOB, {'job_state': 'S'}, id=jid1)
-        self.server.expect(NODE, {'state': 'maintenance'}, id='vn[0]')
+        self.server.expect(NODE, {'state': 'maintenance'}, id=vnode)
         self.server.expect(NODE, {'maintenance_jobs': jid1})
 
         # admin-suspend job 2
         self.server.sigjob(jid2, 'admin-suspend', runas=ROOT_USER)
         self.server.expect(JOB, {'job_state': 'S'}, id=jid2)
-        self.server.expect(NODE, {'state': 'maintenance'}, id='vn[0]')
+        self.server.expect(NODE, {'state': 'maintenance'}, id=vnode)
         self.server.expect(NODE, {'maintenance_jobs': jid1 + "," + jid2})
 
         # admin-resume job 1.  Make sure the node is still in state maintenance
         self.server.sigjob(jid1, 'admin-resume', runas=ROOT_USER)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
-        self.server.expect(NODE, {'state': 'maintenance'}, id='vn[0]')
+        self.server.expect(NODE, {'state': 'maintenance'}, id=vnode)
         self.server.expect(NODE, {'maintenance_jobs': jid2})
 
         # admin-resume job 2.  Make sure the node retuns to state free
         self.server.sigjob(jid2, 'admin-resume', runas=ROOT_USER)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
-        self.server.expect(NODE, {'state': 'free'}, id='vn[0]')
+        self.server.expect(NODE, {'state': 'free'}, id=vnode)
 
     @skipOnCpuSet
     def test_basic_restart(self):
@@ -140,16 +141,16 @@ class TestAdminSuspend(TestFunctional):
         jid = self.server.submit(j1)
         self.server.expect(
             JOB, {'job_state': 'R', 'substate': 42}, attrop=PTL_AND, id=jid)
-
+        vnode = self.mom.shortname + '[0]'
         # admin-suspend job
         self.server.sigjob(jid, 'admin-suspend', runas=ROOT_USER)
         self.server.expect(JOB, {'job_state': 'S'}, id=jid)
-        self.server.expect(NODE, {'state': 'maintenance'}, id='vn[0]')
+        self.server.expect(NODE, {'state': 'maintenance'}, id=vnode)
         self.server.expect(NODE, {'maintenance_jobs': jid})
 
         self.server.restart()
 
-        self.server.expect(NODE, {'state': 'maintenance'}, id='vn[0]')
+        self.server.expect(NODE, {'state': 'maintenance'}, id=vnode)
         self.server.expect(NODE, {'maintenance_jobs': jid})
 
         # Checking licenses to avoid failure at resume since PBS licenses
@@ -161,7 +162,7 @@ class TestAdminSuspend(TestFunctional):
         # admin-resume job
         self.server.sigjob(jid, 'admin-resume', runas=ROOT_USER)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
-        self.server.expect(NODE, {'state': 'free'}, id='vn[0]')
+        self.server.expect(NODE, {'state': 'free'}, id=vnode)
 
     @skipOnCpuSet
     def test_cmd_perm(self):
@@ -169,28 +170,28 @@ class TestAdminSuspend(TestFunctional):
         Test permissions on admin-suspend, admin-resume, maintenance_jobs
         and the maintenace node state.
         """
-
+        vnode = self.mom.shortname + '[0]'
         # Test to make sure we can't set the maintenance node state
         try:
             self.server.manager(
                 MGR_CMD_SET, NODE,
-                {'state': 'maintenance'}, id='vn[0]', runas=ROOT_USER)
+                {'state': 'maintenance'}, id=vnode, runas=ROOT_USER)
         except PbsManagerError as e:
             self.assertTrue('Illegal value for node state' in e.msg[0])
 
-        self.server.expect(NODE, {'state': 'free'}, id='vn[0]')
+        self.server.expect(NODE, {'state': 'free'}, id=vnode)
 
         # Test to make sure we can't set the 'maintenance_jobs' attribute
         try:
             self.server.manager(
                 MGR_CMD_SET, NODE,
-                {'maintenance_jobs': 'foo'}, id='vn[0]', runas=ROOT_USER)
+                {'maintenance_jobs': 'foo'}, id=vnode, runas=ROOT_USER)
         except PbsManagerError as e:
             self.assertTrue(
                 'Cannot set attribute, read only or insufficient permission'
                 in e.msg[0])
 
-        self.server.expect(NODE, 'maintenance_jobs', op=UNSET, id='vn[0]')
+        self.server.expect(NODE, 'maintenance_jobs', op=UNSET, id=vnode)
 
         # Test to make sure regular users can't admin-suspend jobs
         j = Job(TEST_USER)
@@ -272,12 +273,13 @@ class TestAdminSuspend(TestFunctional):
         j = Job(TEST_USER)
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R', 'substate': 42}, id=jid)
+        vnode = self.mom.shortname + '[0]'
 
         self.server.sigjob(jid, 'admin-suspend', runas=ROOT_USER)
-        self.server.expect(NODE, {'state': 'maintenance'}, id='vn[0]')
+        self.server.expect(NODE, {'state': 'maintenance'}, id=vnode)
 
         self.server.deljob(jid, wait=True)
-        self.server.expect(NODE, {'state': 'free'}, id='vn[0]')
+        self.server.expect(NODE, {'state': 'free'}, id=vnode)
 
     @skipOnCpuSet
     def test_deljob_force(self):
@@ -289,12 +291,13 @@ class TestAdminSuspend(TestFunctional):
         j = Job(TEST_USER)
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R', 'substate': 42}, id=jid)
+        vnode = self.mom.shortname + '[0]'
 
         self.server.sigjob(jid, 'admin-suspend', runas=ROOT_USER)
-        self.server.expect(NODE, {'state': 'maintenance'}, id='vn[0]')
+        self.server.expect(NODE, {'state': 'maintenance'}, id=vnode)
 
         self.server.deljob(jid, extend='force', wait=True)
-        self.server.expect(NODE, {'state': 'free'}, id='vn[0]')
+        self.server.expect(NODE, {'state': 'free'}, id=vnode)
 
     @skipOnCpuSet
     def test_rerunjob(self):
@@ -306,14 +309,15 @@ class TestAdminSuspend(TestFunctional):
         j = Job(TEST_USER)
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R', 'substate': 42}, id=jid)
+        vnode = self.mom.shortname + '[0]'
 
         self.server.sigjob(jid, 'admin-suspend', runas=ROOT_USER)
-        self.server.expect(NODE, {'state': 'maintenance'}, id='vn[0]')
+        self.server.expect(NODE, {'state': 'maintenance'}, id=vnode)
 
         self.server.rerunjob(jid, extend='force')
         # Job eventually goes to R state after being requeued for short time
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
-        self.server.expect(NODE, {'state': 'free'}, id='vn[0]')
+        self.server.expect(NODE, {'state': 'free'}, id=vnode)
 
     @skipOnCpuSet
     def test_multivnode(self):
@@ -322,7 +326,7 @@ class TestAdminSuspend(TestFunctional):
         and see all nodes go into maintenance
         """
         a = {'resources_available.ncpus': 4, 'resources_available.mem': '4gb'}
-        self.server.create_vnodes('vn', a, 3, self.mom, usenatvnode=True)
+        self.mom.create_vnodes(a, 3, usenatvnode=True)
 
         j = Job(TEST_USER)
         j.set_attributes({'Resource_List.select': '3:ncpus=1',
@@ -346,7 +350,7 @@ class TestAdminSuspend(TestFunctional):
         Job and see the single node job's node stil in maintenance
         """
         a = {'resources_available.ncpus': 4, 'resources_available.mem': '4gb'}
-        self.server.create_vnodes('vn', a, 3, self.mom, usenatvnode=True)
+        self.mom.create_vnodes(a, 3, usenatvnode=True)
 
         # Submit multinode job 1
         j1 = Job(TEST_USER)
@@ -355,9 +359,10 @@ class TestAdminSuspend(TestFunctional):
         jid1 = self.server.submit(j1)
         self.server.expect(JOB, {'job_state': 'R', 'substate': 42}, id=jid1)
 
+        vnode = self.mom.shortname + '[0]'
         # Submit Job 2 to specific node
         j2 = Job(TEST_USER)
-        j2.set_attributes({'Resource_List.select': '1:ncpus=1:vnode=vn[0]'})
+        j2.set_attributes({'Resource_List.select': '1:ncpus=1:vnode=' + vnode})
         jid2 = self.server.submit(j2)
         self.server.expect(JOB, {'job_state': 'R', 'substate': 42}, id=jid2)
 
@@ -373,7 +378,7 @@ class TestAdminSuspend(TestFunctional):
         # admin-resume job1 and see one node stay in maintenance
         self.server.sigjob(jid1, 'admin-resume', runas=ROOT_USER)
         self.server.expect(NODE, {'state=free': 2})
-        self.server.expect(NODE, {'state': 'maintenance'}, id='vn[0]')
+        self.server.expect(NODE, {'state': 'maintenance'}, id=vnode)
 
     @skipOnCpuSet
     def test_multivnode_excl(self):
@@ -382,7 +387,7 @@ class TestAdminSuspend(TestFunctional):
         signal and see all nodes go into maintenance
         """
         a = {'resources_available.ncpus': 4, 'resources_available.mem': '4gb'}
-        self.server.create_vnodes('vn', a, 3, self.mom, usenatvnode=True)
+        self.mom.create_vnodes(a, 3, usenatvnode=True)
 
         j = Job(TEST_USER)
         j.set_attributes({'Resource_List.select': '3:ncpus=1',
@@ -422,10 +427,10 @@ class TestAdminSuspend(TestFunctional):
                           'Resource_List.walltime': 120})
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R', 'substate': 42}, id=jid)
-
+        vnode = self.mom.shortname + '[0]'
         # Admin-suspend job
         self.server.sigjob(jid, 'admin-suspend', runas=ROOT_USER)
-        self.server.expect(NODE, {'state': 'maintenance'}, id='vn[0]')
+        self.server.expect(NODE, {'state': 'maintenance'}, id=vnode)
 
         # See reservation in degreaded state
         a = {'reserve_state': (MATCH_RE, 'RESV_DEGRADED|10')}
@@ -464,10 +469,10 @@ class TestAdminSuspend(TestFunctional):
         self.server.expect(
             JOB, {'job_state': 'R', 'substate': 42},
             id=jid, max_attempts=30)
-
+        vnode = self.mom.shortname + '[0]'
         # Admin-suspend job
         self.server.sigjob(jid, 'admin-suspend', runas=ROOT_USER)
-        self.server.expect(NODE, {'state': 'maintenance'}, id='vn[0]')
+        self.server.expect(NODE, {'state': 'maintenance'}, id=vnode)
 
         # Submit another job outside of reservation
         j = Job(TEST_USER)
@@ -477,7 +482,7 @@ class TestAdminSuspend(TestFunctional):
         # Wait for the reservation to get over
         # Job also gets deleted and node state goes back to free
         self.server.expect(JOB, 'queue', op=UNSET, id=jid, offset=120)
-        self.server.expect(NODE, {'state': 'free'}, id='vn[0]')
+        self.server.expect(NODE, {'state': 'free'}, id=vnode)
 
         # job2 starts running
         self.server.expect(JOB, {'job_state': 'R'}, id=jid2, max_attempts=60)
@@ -511,33 +516,34 @@ class TestAdminSuspend(TestFunctional):
         self.server.expect(JOB, {'job_state': 'S'}, id=jid1)
 
         # Above will not cause node state to go to maintenance
+        vnode = self.mom.shortname + '[0]'
         self.server.expect(
-            NODE, {'state': (MATCH_RE, 'free|job-exclusive')}, id='vn[0]')
+            NODE, {'state': (MATCH_RE, 'free|job-exclusive')}, id=vnode)
 
         # admin suspend job2
         self.server.sigjob(jid2, 'admin-suspend', runas=ROOT_USER)
-        self.server.expect(NODE, {'state': 'maintenance'}, id='vn[0]')
+        self.server.expect(NODE, {'state': 'maintenance'}, id=vnode)
         self.server.expect(JOB, {'job_state=S': 2})
 
         # Releasing job1 will fail and not change node state
         rv = self.server.sigjob(jid1, 'resume', runas=ROOT_USER, logerr='True')
         self.assertFalse(rv)
-        self.server.expect(NODE, {'state': 'maintenance'}, id='vn[0]')
+        self.server.expect(NODE, {'state': 'maintenance'}, id=vnode)
 
         # deleting job1 will not change node state either
         self.server.deljob(jid1, wait=True)
-        self.server.expect(NODE, {'state': 'maintenance'}, id='vn[0]')
+        self.server.expect(NODE, {'state': 'maintenance'}, id=vnode)
 
         # Admin-resume job2
         self.server.sigjob(jid2, 'admin-resume', runas=ROOT_USER)
         self.server.expect(JOB, {'job_state': 'R', 'substate': 42}, id=jid2)
-        self.server.expect(NODE, {'state': 'free'}, id='vn[0]')
+        self.server.expect(NODE, {'state': 'free'}, id=vnode)
 
         # suspend the job
         self.server.sigjob(jid2, 'suspend', runas=ROOT_USER)
         self.server.expect(JOB, {'job_state': 'S'}, id=jid2)
         self.server.expect(
-            NODE, {'state': (MATCH_RE, 'free|job-exclusive')}, id='vn[0]')
+            NODE, {'state': (MATCH_RE, 'free|job-exclusive')}, id=vnode)
 
     @skipOnCpuSet
     def test_resume(self):
@@ -547,7 +553,7 @@ class TestAdminSuspend(TestFunctional):
         """
 
         a = {'resources_available.ncpus': 4, 'resources_available.mem': '4gb'}
-        self.server.create_vnodes('vn', a, 3, self.mom, usenatvnode=True)
+        self.mom.create_vnodes(a, 3, usenatvnode=True)
 
         j = Job(TEST_USER)
         j.set_attributes({'Resource_List.select': '3:ncpus=1',
@@ -598,12 +604,12 @@ class TestAdminSuspend(TestFunctional):
         j.set_sleep_time(300)
         jid1 = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R', 'substate': 42}, id=jid1)
-
+        vnode = self.mom.shortname + '[0]'
         # admin suspend and resume job in a loop
         for x in range(15):
             self.server.sigjob(jid1, 'admin-suspend', runas=ROOT_USER)
             self.server.expect(JOB, {'job_state': 'S'}, id=jid1)
-            self.server.expect(NODE, {'state': 'maintenance'}, id='vn[0]')
+            self.server.expect(NODE, {'state': 'maintenance'}, id=vnode)
 
             # sleep for sometime
             time.sleep(3)
@@ -611,7 +617,7 @@ class TestAdminSuspend(TestFunctional):
             # resume the job
             self.server.sigjob(jid1, 'admin-resume', runas=ROOT_USER)
             self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
-            self.server.expect(NODE, {'state': 'free'}, id='vn[0]')
+            self.server.expect(NODE, {'state': 'free'}, id=vnode)
 
     @skipOnCpuSet
     def test_custom_res(self):
@@ -623,16 +629,16 @@ class TestAdminSuspend(TestFunctional):
 
         # create multiple vnodes
         a = {'resources_available.ncpus': 4, 'resources_available.mem': '4gb'}
-        self.server.create_vnodes('vn', a, 3, self.mom, usenatvnode=True)
+        self.mom.create_vnodes(a, 3, usenatvnode=True)
 
         # create a node level resource
         self.server.manager(
             MGR_CMD_CREATE, RSC, {'type': 'float', 'flag': 'nh'}, id="foo",
             runas=ROOT_USER)
-
+        vnode = self.mom.shortname + '[1]'
         # set foo on vn[1]
         self.server.manager(
-            MGR_CMD_SET, NODE, {'resources_available.foo': 5}, id='vn[1]',
+            MGR_CMD_SET, NODE, {'resources_available.foo': 5}, id=vnode,
             runas=ROOT_USER)
 
         # set foo in sched_config
@@ -640,14 +646,14 @@ class TestAdminSuspend(TestFunctional):
 
         # submit a few jobs
         j = Job(TEST_USER)
-        j.set_attributes({'Resource_List.select': 'vnode=vn[1]'})
+        j.set_attributes({'Resource_List.select': 'vnode=' + vnode})
         jid1 = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R', 'substate': 42}, id=jid1)
 
         # admin suspend the job to put the node to maintenance
         self.server.sigjob(jid1, 'admin-suspend', runas=ROOT_USER)
         self.server.expect(JOB, {'job_state': 'S'}, id=jid1)
-        self.server.expect(NODE, {'state': 'maintenance'}, id='vn[1]')
+        self.server.expect(NODE, {'state': 'maintenance'}, id=vnode)
 
         # submit other jobs asking for specific resources on vn[1]
         j = Job(TEST_USER)
@@ -664,15 +670,16 @@ class TestAdminSuspend(TestFunctional):
 
         # verify that vn[1] is still in maintenance and
         # job3 and job4 not running on vn[1]
-        self.server.expect(NODE, {'state': 'maintenance'}, id='vn[1]')
+        self.server.expect(NODE, {'state': 'maintenance'}, id=vnode)
         try:
-            self.server.expect(JOB, {'exec_vnode': (MATCH_RE, 'vn[1]')},
+            self.server.expect(JOB, {'exec_vnode': (MATCH_RE, vnode)},
                                id=jid3, max_attempts=20)
-            self.server.expect(JOB, {'exec_vnode': (MATCH_RE, 'vn[1]')},
+            self.server.expect(JOB, {'exec_vnode': (MATCH_RE, vnode)},
                                id=jid4, max_attempts=20)
         except Exception as e:
             self.assertFalse(e.rv)
-            self.logger.info("jid3 and jid4 not running on vn[1] as expected")
+            msg = "jid3 and jid4 not running on " + vnode + " as expected"
+            self.logger.info(msg)
 
     @skipOnCpuSet
     def test_list_jobs_1(self):
@@ -696,9 +703,9 @@ class TestAdminSuspend(TestFunctional):
         # admin-suspend 2 of them
         self.server.sigjob(jid2, 'admin-suspend', runas=ROOT_USER)
         self.server.sigjob(jid3, 'admin-suspend', runas=ROOT_USER)
-
+        vnode = self.mom.shortname + '[0]'
         # node state is in maintenance
-        self.server.expect(NODE, {'state': 'maintenance'}, id='vn[0]')
+        self.server.expect(NODE, {'state': 'maintenance'}, id=vnode)
 
         # list maintenance_jobs as root
         self.server.expect(NODE, {'maintenance_jobs': jid2 + "," + jid3},
@@ -718,7 +725,7 @@ class TestAdminSuspend(TestFunctional):
         # set maintenance_jobs as root
         try:
             self.server.manager(MGR_CMD_SET, NODE,
-                                {'maintenance_jobs': jid1}, id='vn[0]',
+                                {'maintenance_jobs': jid1}, id=vnode,
                                 runas=ROOT_USER)
         except PbsManagerError as e:
             self.assertFalse(e.rv)
@@ -729,7 +736,7 @@ class TestAdminSuspend(TestFunctional):
         # Set maintenance_jobs as operator
         try:
             self.server.manager(MGR_CMD_SET, NODE,
-                                {'maintenance_jobs': jid1}, id='vn[0]',
+                                {'maintenance_jobs': jid1}, id=vnode,
                                 runas='pbsoper')
         except PbsManagerError as e:
             self.assertFalse(e.rv)
@@ -740,7 +747,7 @@ class TestAdminSuspend(TestFunctional):
         # Set maintenance_jobs as user
         try:
             self.server.manager(MGR_CMD_SET, NODE,
-                                {'maintenance_jobs': jid1}, id='vn[0]',
+                                {'maintenance_jobs': jid1}, id=vnode,
                                 runas=TEST_USER)
         except PbsManagerError as e:
             self.assertFalse(e.rv)
@@ -760,15 +767,15 @@ class TestAdminSuspend(TestFunctional):
 
         # verify that all are running
         self.server.expect(JOB, {'job_state=R': 3, 'substate=42': 3})
-
+        vnode = self.mom.shortname + '[0]'
         # list maintenance_jobs. It should be empty
-        self.server.expect(NODE, 'maintenance_jobs', op=UNSET, id='vn[0]')
+        self.server.expect(NODE, 'maintenance_jobs', op=UNSET, id=vnode)
 
         # Regular suspend a job
         self.server.sigjob(jid2, 'suspend', runas=ROOT_USER)
 
         # List maintenance_jobs again
-        self.server.expect(NODE, 'maintenance_jobs', op=UNSET, id='vn[0]')
+        self.server.expect(NODE, 'maintenance_jobs', op=UNSET, id=vnode)
 
     @skipOnCpuSet
     def test_preempt_order(self):
@@ -785,17 +792,17 @@ class TestAdminSuspend(TestFunctional):
         # set preempt_order to R
         self.server.manager(MGR_CMD_SET, SCHED, {'preempt_order': 'R'},
                             runas=ROOT_USER)
-
+        vnode = self.mom.shortname + '[0]'
         # submit a job
         j = Job(TEST_USER)
-        j.set_attributes({'Resource_List.select': 'vnode=vn[0]'})
+        j.set_attributes({'Resource_List.select': 'vnode=' + vnode})
         jid1 = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R', 'substate': 42}, id=jid1)
 
         # submit a high priority job
         j = Job(TEST_USER)
         j.set_attributes({'queue': 'highp', 'Resource_List.select':
-                          '1:ncpus=4:vnode=vn[0]'})
+                          '1:ncpus=4:vnode=' + vnode})
         jid2 = self.server.submit(j)
 
         # job2 is running and job1 is requeued
@@ -811,11 +818,11 @@ class TestAdminSuspend(TestFunctional):
         # admin suspend job2
         self.server.sigjob(jid2, 'admin-suspend')
         self.server.expect(JOB, {'job_state': 'S'}, id=jid2)
-        self.server.expect(NODE, {'state': 'maintenance'}, id='vn[0]')
+        self.server.expect(NODE, {'state': 'maintenance'}, id=vnode)
 
         # admin-resume job2. node state will become job-busy.
         self.server.sigjob(jid2, 'admin-resume')
-        self.server.expect(NODE, {'state': 'job-busy'}, id='vn[0]')
+        self.server.expect(NODE, {'state': 'job-busy'}, id=vnode)
         self.server.expect(JOB, {'job_state': 'R', 'substate': 42}, id=jid2)
         self.server.expect(JOB, {'job_state': 'Q'}, id=jid1)
 
@@ -830,7 +837,8 @@ class TestAdminSuspend(TestFunctional):
         hook_body = """
 import pbs
 
-vn = pbs.server().vnode('vn[0]')
+vname = str(pbs.server().name) + '[0]'
+vn = pbs.server().vnode(vname)
 pbs.logmsg(pbs.LOG_DEBUG,\
 "list of maintenance_jobs are %s" % vn.maintenance_jobs)
 """
@@ -885,8 +893,9 @@ pbs.logmsg(pbs.LOG_DEBUG,\
         self.server.sigjob(jid1, 'admin-suspend')
         self.server.sigjob(jid2, 'admin-suspend')
 
+        vnode = self.mom.shortname + '[0]'
         # node state is in maintenance
-        self.server.expect(NODE, {'state': 'maintenance'}, id='vn[0]')
+        self.server.expect(NODE, {'state': 'maintenance'}, id=vnode)
 
         # submit another job. It will be queued
         j3 = Job(TEST_USER)
@@ -895,7 +904,7 @@ pbs.logmsg(pbs.LOG_DEBUG,\
 
         # mark the node as offline too
         self.server.manager(MGR_CMD_SET, NODE, {'state': 'offline'},
-                            id='vn[0]')
+                            id=vnode)
 
         # delete job1 as user and resume job2
         self.server.deljob(jid1, wait=True, runas=TEST_USER)
@@ -903,6 +912,6 @@ pbs.logmsg(pbs.LOG_DEBUG,\
 
         # verify that node state is offline and
         # job3 is still queued
-        self.server.expect(NODE, {'state': 'offline'}, id='vn[0]')
+        self.server.expect(NODE, {'state': 'offline'}, id=vnode)
         self.server.expect(JOB, {'job_state': 'R', 'substate': 42}, id=jid2)
         self.server.expect(JOB, {'job_state': 'Q'}, id=jid3)

--- a/test/tests/functional/pbs_allpart.py
+++ b/test/tests/functional/pbs_allpart.py
@@ -49,7 +49,7 @@ class TestSchedAllPart(TestFunctional):
     def setUp(self):
         TestFunctional.setUp(self)
         a = {'resources_available.ncpus': 1, 'resources_available.mem': '1gb'}
-        self.server.create_vnodes('vn', a, 2, self.mom, usenatvnode=True)
+        self.mom.create_vnodes(a, 2, usenatvnode=True)
 
     @skipOnCpuSet
     def test_free_nodes(self):

--- a/test/tests/functional/pbs_calendaring.py
+++ b/test/tests/functional/pbs_calendaring.py
@@ -160,8 +160,8 @@ class TestCalendaring(TestFunctional):
         # it won't try and add it to the calendar.  To do this, we ask for
         # 1 node with 2 cpus.  There are 2 nodes with 1 cpu each.
         attrs = {'resources_available.ncpus': 1}
-        self.server.create_vnodes('vn', attrib=attrs, num=2,
-                                  mom=self.mom, sharednode=False)
+        self.mom.create_vnodes(attrib=attrs, num=2,
+                               sharednode=False)
 
         self.scheduler.set_sched_config({'strict_ordering': 'True ALL'})
 

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -2705,7 +2705,7 @@ if %s e.job.in_ms_mom():
         self.load_config(self.cfg4 % (self.mem, self.swapctl))
         self.server.expect(NODE, {ATTR_NODE_state: 'free'},
                            id=self.nodes_list[0])
-        self.moms.values()[0].create_vnodes('vn_attrs, 2')
+        self.moms.values()[0].create_vnodes(vn_attrs, 2)
         self.server.expect(NODE, {ATTR_NODE_state: 'free'},
                            id=self.nodes_list[0])
         a = {'Resource_List.select': '1:ncpus=1:mem=500mb'}

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -2705,8 +2705,7 @@ if %s e.job.in_ms_mom():
         self.load_config(self.cfg4 % (self.mem, self.swapctl))
         self.server.expect(NODE, {ATTR_NODE_state: 'free'},
                            id=self.nodes_list[0])
-        self.server.create_vnodes('vnode', vn_attrs, 2,
-                                  self.moms.values()[0])
+        self.moms.values()[0].create_vnodes('vn_attrs, 2')
         self.server.expect(NODE, {ATTR_NODE_state: 'free'},
                            id=self.nodes_list[0])
         a = {'Resource_List.select': '1:ncpus=1:mem=500mb'}

--- a/test/tests/functional/pbs_conf_resv_stale_vnode.py
+++ b/test/tests/functional/pbs_conf_resv_stale_vnode.py
@@ -54,17 +54,17 @@ class TestResvStaleVnode(TestFunctional):
         self.mom.add_config(conf={'$vnodedef_additive': 'False'})
         a = {'resources_available.ncpus': 1, 'priority': 100}
         self.mom.create_vnodes(a, 1, fname='nat', restart=False,
-                                  usenatvnode=True, expect=False, vname='foo')
+                               usenatvnode=True, expect=False, vname='foo')
         a['priority'] = 10
         self.mom.create_vnodes(a, 1, fname='fname1', delall=False,
-                                  restart=False, additive=True,
-                                  expect=False, vname='vn')
+                               restart=False, additive=True,
+                               expect=False, vname='vn')
         a['priority'] = 1
         self.mom.create_vnodes(a, 1, fname='fname2', delall=False,
-                                  additive=True, expect=False, vname='vnode')
+                               additive=True, expect=False, vname='vnode')
 
         self.scheduler.set_sched_config({'node_sort_key':
-                                        '\"sort_priority HIGH\"'})
+                                         '\"sort_priority HIGH\"'})
 
     @skipOnCpuSet
     def test_conf_resv_stale_vnode(self):

--- a/test/tests/functional/pbs_conf_resv_stale_vnode.py
+++ b/test/tests/functional/pbs_conf_resv_stale_vnode.py
@@ -53,15 +53,15 @@ class TestResvStaleVnode(TestFunctional):
         # This allows us to delete a vnodedef file and make that node stale
         self.mom.add_config(conf={'$vnodedef_additive': 'False'})
         a = {'resources_available.ncpus': 1, 'priority': 100}
-        self.server.create_vnodes('foo', a, 1, fname='nat', restart=False,
-                                  mom=self.mom, usenatvnode=True, expect=False)
+        self.mom.create_vnodes(a, 1, fname='nat', restart=False,
+                                  usenatvnode=True, expect=False, vname='foo')
         a['priority'] = 10
-        self.server.create_vnodes('vn', a, 1, fname='fname1', delall=False,
-                                  restart=False, additive=True, mom=self.mom,
-                                  expect=False)
+        self.mom.create_vnodes(a, 1, fname='fname1', delall=False,
+                                  restart=False, additive=True,
+                                  expect=False, vname='vn')
         a['priority'] = 1
-        self.server.create_vnodes('vnode', a, 1, fname='fname2', delall=False,
-                                  additive=True, mom=self.mom, expect=False)
+        self.mom.create_vnodes(a, 1, fname='fname2', delall=False,
+                                  additive=True, expect=False, vname='vnode')
 
         self.scheduler.set_sched_config({'node_sort_key':
                                         '\"sort_priority HIGH\"'})

--- a/test/tests/functional/pbs_config.py
+++ b/test/tests/functional/pbs_config.py
@@ -65,8 +65,8 @@ class TestPBSConfig(TestFunctional):
 
         # Create 4 vnodes
         a = {ATTR_rescavail + ".ncpus": 2}
-        self.server.create_vnodes(name='vnode', attrib=a, num=4, mom=self.mom,
-                                  usenatvnode=True)
+        self.mom.create_vnodes(attrib=a, num=4,
+                               usenatvnode=True)
         self.server.expect(VNODE, {'state=free': 4}, count=True)
 
         # Create a queue

--- a/test/tests/functional/pbs_cray_check_node_exclusivity.py
+++ b/test/tests/functional/pbs_cray_check_node_exclusivity.py
@@ -489,9 +489,9 @@ class TestCheckNodeExclusivity(TestFunctional):
         """
 
         a = {'sharing': 'ignore_excl'}
-        self.server.create_vnodes(self.mom.shortname, a, 1,
-                                  self.mom, createnode=False,
-                                  delall=False, usenatvnode=True)
+        self.mom.create_vnodes(a, 1,
+                               createnode=False,
+                               delall=False, usenatvnode=True)
         self.server.expect(NODE, {'state': 'free',
                                   'sharing': 'ignore_excl'},
                            id=self.mom.shortname)

--- a/test/tests/functional/pbs_equiv_classes.py
+++ b/test/tests/functional/pbs_equiv_classes.py
@@ -50,7 +50,7 @@ class TestEquivClass(TestFunctional):
     def setUp(self):
         TestFunctional.setUp(self)
         a = {'resources_available.ncpus': 8}
-        self.server.create_vnodes('vnode', a, 1, self.mom, usenatvnode=True)
+        self.mom.create_vnodes(a, 1, usenatvnode=True)
         self.server.manager(MGR_CMD_SET, SCHED, {'log_events': 2047})
         # capture the start time of the test for log matching
         self.t = time.time()
@@ -965,7 +965,7 @@ class TestEquivClass(TestFunctional):
         """
 
         a = {'resources_available.ncpus': 8}
-        self.server.create_vnodes('vnode', a, 2, self.mom, usenatvnode=True)
+        self.mom.create_vnodes(a, 2, usenatvnode=True)
 
         self.server.manager(MGR_CMD_CREATE, QUEUE,
                             {'queue_type': 'e', 'started': 'True',
@@ -974,9 +974,9 @@ class TestEquivClass(TestFunctional):
         self.server.manager(MGR_CMD_CREATE, QUEUE,
                             {'queue_type': 'e', 'started': 'True',
                              'enabled': 'True'}, id='nodes_queue')
-
+        vn = self.mom.shortname + '[0]'
         self.server.manager(MGR_CMD_SET, NODE,
-                            {'queue': 'nodes_queue'}, id='vnode[0]')
+                            {'queue': 'nodes_queue'}, id=vn)
 
         self.server.manager(MGR_CMD_SET, QUEUE,
                             {'Priority': 120}, id='workq')
@@ -1405,7 +1405,7 @@ e.job.Resource_List["cput"] = 20
         # Create vnodes
         a = {'resources_available.ncpus': 4,
              'resources_available.foo_str': "foo,bar,buba"}
-        self.server.create_vnodes('vnode', a, 4, self.mom)
+        self.mom.create_vnodes(a, 4)
 
         # Add resources to sched_config
         self.scheduler.add_resource("foo_str")
@@ -1640,7 +1640,7 @@ else:
         """
 
         a = {'resources_available.ncpus': 1}
-        self.server.create_vnodes('vnode', a, 4, self.mom, usenatvnode=True)
+        self.mom.create_vnodes(a, 4, usenatvnode=True)
 
         a = {'queue_type': 'e', 'started': 't',
              'enabled': 't', 'Priority': 150}
@@ -1693,7 +1693,7 @@ else:
         """
 
         a = {'resources_available.ncpus': 1}
-        self.server.create_vnodes('vnode', a, 4, self.mom, usenatvnode=True)
+        self.mom.create_vnodes(a, 4, usenatvnode=True)
 
         a = {'queue_type': 'e', 'started': 't',
              'enabled': 't', 'Priority': 150}
@@ -1753,7 +1753,7 @@ else:
 
         # Create 1 vnode with 3 ncpus
         a = {'resources_available.ncpus': 3}
-        self.server.create_vnodes('vnode', a, 1, self.mom, usenatvnode=True)
+        self.mom.create_vnodes(a, 1, usenatvnode=True)
 
         # Create expressq
         a = {'queue_type': 'execution', 'started': 'true',
@@ -1878,7 +1878,7 @@ else:
 
         # Create vnode with 4 ncpus
         a = {'resources_available.ncpus': 4}
-        self.server.create_vnodes('vnode', a, 1, self.mom, usenatvnode=True)
+        self.mom.create_vnodes(a, 1, usenatvnode=True)
 
         # Create a expressq
         a = {'queue_type': 'execution', 'started': 'true',
@@ -1967,7 +1967,7 @@ else:
         """
 
         a = {'resources_available.ncpus': 1}
-        self.server.create_vnodes('vnode', a, 1, self.mom, usenatvnode=True)
+        self.mom.create_vnodes(a, 1, usenatvnode=True)
 
         a = {'Resource_List.select': '1:ncpus=1', ATTR_h: None}
         J1 = Job(TEST_USER, attrs=a)
@@ -1991,7 +1991,7 @@ else:
         """
 
         a = {'resources_available.ncpus': 2}
-        self.server.create_vnodes('vnode', a, 1, self.mom, usenatvnode=True)
+        self.mom.create_vnodes(a, 1, usenatvnode=True)
 
         attrs = {'queue_type': 'Execution', 'started': 'True',
                  'enabled': 'True', 'resources_available.ncpus': 1,
@@ -2133,8 +2133,8 @@ else:
         suspended.
         """
         a = {'resources_available.ncpus': 2}
-        self.server.create_vnodes('vnode', a, 2, self.mom,
-                                  attrfunc=self.change_res)
+        self.mom.create_vnodes(a, 2,
+                               attrfunc=self.change_res)
 
         # Create an express queue
         a = {'queue_type': 'execution', 'started': 'true',

--- a/test/tests/functional/pbs_hook_execjob_prologue.py
+++ b/test/tests/functional/pbs_hook_execjob_prologue.py
@@ -126,8 +126,8 @@ class TestPbsExecutePrologue(TestFunctional):
         """
         attr = {'resources_available.mem': '2gb',
                 'resources_available.ncpus': '1'}
-        self.server.create_vnodes(self.hostC, attr, 3, self.momC,
-                                  delall=True, usenatvnode=True)
+        self.momC.create_vnodes(attr, 3,
+                                delall=True, usenatvnode=True)
         hook_name = "prologue_exception"
         hook_body = ("import pbs\n"
                      "e = pbs.event()\n"

--- a/test/tests/functional/pbs_indirect_resources.py
+++ b/test/tests/functional/pbs_indirect_resources.py
@@ -53,16 +53,17 @@ class TestHostResources(TestFunctional):
         self.server.add_resource('fooi', 'long', 'nh')
         # Create 2 vnodes with individual hosts
         attr = {'resources_available.ncpus': 1}
-        self.server.create_vnodes('vnode', attr, 2, sharednode=False,
-                                  mom=self.mom)
+        self.mom.create_vnodes(attr, 2, sharednode=False)
+        vnode0 = self.mom.shortname + '[0]'
+        vnode1 = self.mom.shortname + '[1]'
         self.server.manager(MGR_CMD_SET, NODE,
-                            {'resources_available.fooi': 100}, 'vnode[0]')
+                            {'resources_available.fooi': 100}, vnode0)
         self.server.manager(MGR_CMD_SET, NODE, {'resources_available.fooi':
-                                                '@vnode[0]'}, 'vnode[1]')
+                                                '@' + vnode0}, vnode1)
         self.server.manager(MGR_CMD_SET, NODE,
-                            {'resources_available.fooi': 100}, 'vnode[1]')
+                            {'resources_available.fooi': 100}, vnode1)
         self.server.expect(NODE, {'resources_assigned.fooi': ''},
-                           id='vnode[1]', op=UNSET, max_attempts=1)
+                           id=vnode1, op=UNSET, max_attempts=1)
 
     @skipOnCpuSet
     def test_set_direct_on_indirect_resc_busy(self):
@@ -72,31 +73,32 @@ class TestHostResources(TestFunctional):
         """
         # Create 2 vnodes with individual hosts
         attr = {'resources_available.ncpus': 1}
-        self.server.create_vnodes('vnode', attr, 2, sharednode=False,
-                                  mom=self.mom)
+        self.mom.create_vnodes(attr, 2, sharednode=False)
+        vnode0 = self.mom.shortname + '[0]'
+        vnode1 = self.mom.shortname + '[1]'
         # Create a consumable custom resources 'fooi'
         self.server.add_resource('fooi', 'long', 'nh')
         self.scheduler.add_resource("fooi")
         self.server.manager(MGR_CMD_SET, NODE,
-                            {'resources_available.fooi': 100}, 'vnode[0]')
+                            {'resources_available.fooi': 100}, vnode0)
         self.server.manager(MGR_CMD_SET, NODE, {'resources_available.fooi':
-                                                '@vnode[0]'}, 'vnode[1]')
+                                                '@' + vnode0}, vnode1)
         # Submit jobs.
         a = {'Resource_List.fooi': 50}
         J = Job(attrs=a)
         self.server.submit(J)
         j2 = self.server.submit(J)
         self.server.expect(JOB, {'job_state': 'R'}, id=j2)
-        self.server.expect(NODE, {'state': 'job-busy'}, id='vnode[1]')
+        self.server.expect(NODE, {'state': 'job-busy'}, id=vnode1)
         try:
             self.server.manager(MGR_CMD_SET, NODE,
                                 {'resources_available.fooi': 100},
-                                'vnode[1]')
+                                vnode1)
         except PbsManagerError:
             pass
         else:
             self.server.expect(NODE, {'resources_available.fooi': 100},
-                               id='vnode[1]', op=UNSET, max_attempts=1)
+                               id=vnode1, op=UNSET, max_attempts=1)
 
     @skipOnCpuSet
     def test_set_direct_on_target_node(self):
@@ -109,20 +111,22 @@ class TestHostResources(TestFunctional):
         """
         # Create 3 vnodes with individual hosts
         attr = {'resources_available.ncpus': 1}
-        self.server.create_vnodes('vnode', attr, 3, sharednode=False,
-                                  mom=self.mom)
+        self.mom.create_vnodes(attr, 3, sharednode=False)
         # Create a consumable custom resources 'fooi'
         self.server.add_resource('fooi', 'long', 'nh')
+        vnode0 = self.mom.shortname + '[0]'
+        vnode1 = self.mom.shortname + '[1]'
+        vnode2 = self.mom.shortname + '[2]'
         self.server.manager(MGR_CMD_SET, NODE,
-                            {'resources_available.fooi': 100}, 'vnode[0]')
+                            {'resources_available.fooi': 100}, vnode0)
         self.server.manager(MGR_CMD_SET, NODE,
-                            {'resources_available.fooi': 100}, 'vnode[1]')
+                            {'resources_available.fooi': 100}, vnode1)
         self.server.manager(MGR_CMD_SET, NODE, {'resources_available.fooi':
-                                                '@vnode[1]'}, 'vnode[2]')
+                                                '@' + vnode1}, vnode2)
         try:
             self.server.manager(MGR_CMD_SET, NODE,
-                                {'resources_available.fooi': '@vnode[0]'},
-                                'vnode[1]')
+                                {'resources_available.fooi': '@' + vnode0},
+                                vnode1)
         except PbsManagerError:
             pass
         else:

--- a/test/tests/functional/pbs_job_dependency.py
+++ b/test/tests/functional/pbs_job_dependency.py
@@ -61,8 +61,8 @@ e.accept()
         self.server.manager(MGR_CMD_CREATE, RSC, attr, id='NewRes')
         self.scheduler.add_resource('NewRes', apply=True)
         attr = {'resources_available.ncpus': 1}
-        self.server.create_vnodes('vnode', attr, 6, mom=self.mom,
-                                  attrfunc=self.cust_attr, usenatvnode=False)
+        self.mom.create_vnodes(attr, 6, attrfunc=self.cust_attr,
+                               usenatvnode=False)
 
     def cust_attr(self, name, totnodes, numnode, attrib):
         res_str = "ver" + str(numnode)

--- a/test/tests/functional/pbs_job_script.py
+++ b/test/tests/functional/pbs_job_script.py
@@ -47,7 +47,7 @@ class TestPbsJobScript(TestFunctional):
 
     def submit_job(self, addnewline=False):
         a = {'resources_available.ncpus': 2}
-        self.server.create_vnodes('Verylongvnodename', a, 500, self.mom)
+        self.mom.create_vnodes(a, 500, vname='Verylongvnodename')
 
         selstr = "#PBS -l select=1"
         for node in range(500):

--- a/test/tests/functional/pbs_maintenance_reservations.py
+++ b/test/tests/functional/pbs_maintenance_reservations.py
@@ -216,13 +216,14 @@ class TestMaintenanceReservations(TestFunctional):
                             {'managers': '%s@*' % TEST_USER})
 
         a = {'resources_available.ncpus': 2}
-        self.server.create_vnodes('vn', a, num=2, mom=self.mom)
+        self.mom.create_vnodes(a, num=2)
+        vn = self.mom.shortname
 
         a = {'resv_enable': False}
         self.server.manager(MGR_CMD_SET, NODE, a,
                             id=self.mom.shortname, runas=TEST_USER)
-        self.server.manager(MGR_CMD_SET, NODE, a, 'vn[0]', runas=TEST_USER)
-        self.server.manager(MGR_CMD_SET, NODE, a, 'vn[1]', runas=TEST_USER)
+        self.server.manager(MGR_CMD_SET, NODE, a, vn + '[0]', runas=TEST_USER)
+        self.server.manager(MGR_CMD_SET, NODE, a, vn + '[1]', runas=TEST_USER)
 
         a = {'reserve_start': now + 3600,
              'reserve_end': now + 7200}
@@ -232,12 +233,12 @@ class TestMaintenanceReservations(TestFunctional):
         rid = self.server.submit(r)
 
         self.assertTrue(rid.startswith('M'))
-
+        resv_vnodes = '(' + vn + '[0]:ncpus=2)+(' + vn + '[1]:ncpus=2)'
         exp_attr = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2'),
                     'Resource_List.select':
                     'host=%s:ncpus=4' % self.mom.shortname,
                     'Resource_List.place': 'exclhost',
-                    'resv_nodes': '(vn[0]:ncpus=2)+(vn[1]:ncpus=2)'}
+                    'resv_nodes': resv_vnodes}
         self.server.expect(RESV, exp_attr, id=rid)
 
     def test_maintenance_delete(self):

--- a/test/tests/functional/pbs_multi_sched.py
+++ b/test/tests/functional/pbs_multi_sched.py
@@ -475,8 +475,7 @@ class TestMultipleSchedulers(TestFunctional):
 
         n = {'resources_available.ncpus': 20}
         vn = ['%s[%d]' % (self.mom.shortname, i) for i in range(2)]
-        self.server.manager(MGR_CMD_SET, NODE, n, id=vn[0])
-        self.server.manager(MGR_CMD_SET, NODE, n, id=vn[1])
+        self.server.manager(MGR_CMD_SET, NODE, n, id=vn)
 
         jids1 = []
         job_attrs = {'Resource_List.select': '1:ncpus=1', 'queue': 'wq1'}
@@ -1308,7 +1307,7 @@ class TestMultipleSchedulers(TestFunctional):
         j = Job(TEST_USER, attrs=a)
         j2id = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=j2id)
-        nodes = [vn[3], vn[4]]
+        nodes = vn[3:5]
         self.check_vnodes(j, nodes, j2id)
         a = {'Resource_List.select': '3:ncpus=2'}
         j = Job(TEST_USER, attrs=a)

--- a/test/tests/functional/pbs_multi_sched.py
+++ b/test/tests/functional/pbs_multi_sched.py
@@ -102,10 +102,13 @@ class TestMultipleSchedulers(TestFunctional):
         p3 = {'partition': 'P3'}
         self.server.manager(MGR_CMD_SET, QUEUE, p3, id='wq3')
         a = {'resources_available.ncpus': 2}
-        self.server.create_vnodes('vnode', a, 4, self.mom)
-        self.server.manager(MGR_CMD_SET, NODE, p1, id='vnode[0]')
-        self.server.manager(MGR_CMD_SET, NODE, p2, id='vnode[1]')
-        self.server.manager(MGR_CMD_SET, NODE, p3, id='vnode[2]')
+        self.mom.create_vnodes(a, 4)
+        vnode0 = self.mom.shortname + '[0]'
+        vnode1 = self.mom.shortname + '[1]'
+        vnode2 = self.mom.shortname + '[2]'
+        self.server.manager(MGR_CMD_SET, NODE, p1, id=vnode0)
+        self.server.manager(MGR_CMD_SET, NODE, p2, id=vnode1)
+        self.server.manager(MGR_CMD_SET, NODE, p3, id=vnode2)
 
     def common_setup(self):
         self.setup_sc1()
@@ -305,7 +308,8 @@ class TestMultipleSchedulers(TestFunctional):
                             {'Scheduling': 'True'}, id="sc5")
         self.server.expect(SCHED, {'state': 'idle'}, id='sc5', max_attempts=10)
         a = {'resources_available.ncpus': 100}
-        self.server.manager(MGR_CMD_SET, NODE, a, id='vnode[2]')
+        vn = self.mom.shortname
+        self.server.manager(MGR_CMD_SET, NODE, a, id=vn + '[2]')
         self.server.manager(MGR_CMD_SET, SCHED,
                             {'scheduling': 'False'}, id="sc5")
         for _ in range(500):
@@ -372,11 +376,12 @@ class TestMultipleSchedulers(TestFunctional):
         into a node associated with that partition.
         """
         self.common_setup()
+        vn = self.mom.shortname
         j = Job(TEST_USER1, attrs={ATTR_queue: 'wq1',
                                    'Resource_List.select': '1:ncpus=2'})
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
-        self.check_vnodes(j, ['vnode[0]'], jid)
+        self.check_vnodes(j, [vn + '[0]'], jid)
         self.scheds['sc1'].log_match(
             jid + ';Job run', max_attempts=10,
             starttime=self.server.ctime)
@@ -384,7 +389,7 @@ class TestMultipleSchedulers(TestFunctional):
                                    'Resource_List.select': '1:ncpus=2'})
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
-        self.check_vnodes(j, ['vnode[1]'], jid)
+        self.check_vnodes(j, [vn + '[1]'], jid)
         self.scheds['sc2'].log_match(
             jid + ';Job run', max_attempts=10,
             starttime=self.server.ctime)
@@ -392,7 +397,7 @@ class TestMultipleSchedulers(TestFunctional):
                                    'Resource_List.select': '1:ncpus=2'})
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
-        self.check_vnodes(j, ['vnode[2]'], jid)
+        self.check_vnodes(j, [vn + '[2]'], jid)
         self.scheds['sc3'].log_match(
             jid + ';Job run', max_attempts=10,
             starttime=self.server.ctime)
@@ -405,11 +410,12 @@ class TestMultipleSchedulers(TestFunctional):
         """
         self.setup_sc1()
         self.setup_queues_nodes()
+        vn = self.mom.shortname
         j = Job(TEST_USER1, attrs={ATTR_queue: 'wq1',
                                    'Resource_List.select': '1:ncpus=1'})
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
-        self.check_vnodes(j, ['vnode[0]'], jid)
+        self.check_vnodes(j, [vn + '[0]'], jid)
         self.scheds['sc1'].log_match(
             jid + ';Job run', max_attempts=10,
             starttime=self.server.ctime)
@@ -419,7 +425,7 @@ class TestMultipleSchedulers(TestFunctional):
                                    'Resource_List.select': '1:ncpus=1'})
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
-        self.check_vnodes(j, ['vnode[0]'], jid)
+        self.check_vnodes(j, [vn + '[0]'], jid)
         self.scheds['sc1'].log_match(
             jid + ';Job run', max_attempts=10,
             starttime=self.server.ctime)
@@ -468,8 +474,9 @@ class TestMultipleSchedulers(TestFunctional):
         self.server.manager(MGR_CMD_CREATE, QUEUE, q, id='highp_P2')
 
         n = {'resources_available.ncpus': 20}
-        self.server.manager(MGR_CMD_SET, NODE, n, id='vnode[0]')
-        self.server.manager(MGR_CMD_SET, NODE, n, id='vnode[1]')
+        vn = self.mom.shortname
+        self.server.manager(MGR_CMD_SET, NODE, n, id=vn + '[0]')
+        self.server.manager(MGR_CMD_SET, NODE, n, id=vn + '[1]')
 
         jids1 = []
         job_attrs = {'Resource_List.select': '1:ncpus=1', 'queue': 'wq1'}
@@ -1231,8 +1238,9 @@ class TestMultipleSchedulers(TestFunctional):
         a.update(p3)
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='wq1')
         a = {'resources_available.ncpus': 2}
-        self.server.create_vnodes('vnode', a, 2, self.mom)
-        self.server.manager(MGR_CMD_SET, NODE, p3, id='vnode[0]')
+        self.mom.create_vnodes(a, 2)
+        vn = self.mom.shortname
+        self.server.manager(MGR_CMD_SET, NODE, p3, id=vn + '[0]')
         # Set job_sort_formula on the server
         self.server.manager(MGR_CMD_SET, SERVER, {'job_sort_formula': 'ncpus'})
         # Set job_sort_formula_threshold on the multisched
@@ -1271,8 +1279,8 @@ class TestMultipleSchedulers(TestFunctional):
     def setup_placement_set(self):
         self.server.add_resource('switch', 'string_array', 'h')
         a = {'resources_available.ncpus': 2}
-        self.server.create_vnodes(
-            'vnode', a, 12, self.mom, attrfunc=self.cust_attr)
+        self.mom.create_vnodes(
+            a, 12, attrfunc=self.cust_attr)
         self.server.manager(MGR_CMD_SET, SERVER, {'node_group_key': 'switch'})
         self.server.manager(MGR_CMD_SET, SERVER, {'node_group_enable': 't'})
 
@@ -1293,19 +1301,20 @@ class TestMultipleSchedulers(TestFunctional):
         j = Job(TEST_USER, attrs=a)
         j1id = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=j1id)
-        nodes = ['vnode[5]']
+        vn_pref = self.mom.shortname
+        nodes = [vn_pref + '[5]']
         self.check_vnodes(j, nodes, j1id)
         a = {'Resource_List.select': '2:ncpus=2'}
         j = Job(TEST_USER, attrs=a)
         j2id = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=j2id)
-        nodes = ['vnode[3]', 'vnode[4]']
+        nodes = [vn_pref + '[3]', vn_pref + '[4]']
         self.check_vnodes(j, nodes, j2id)
         a = {'Resource_List.select': '3:ncpus=2'}
         j = Job(TEST_USER, attrs=a)
         j3id = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=j3id)
-        nodes = ['vnode[0]', 'vnode[1]', 'vnode[2]']
+        nodes = [vn_pref + '[0]', vn_pref + '[1]', vn_pref + '[2]']
         self.check_vnodes(j, nodes, j3id)
         self.server.manager(MGR_CMD_SET, SCHED,
                             {'only_explicit_psets': 't'}, id='sc2')
@@ -1313,13 +1322,13 @@ class TestMultipleSchedulers(TestFunctional):
         j = Job(TEST_USER, attrs=a)
         j4id = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=j4id)
-        nodes = ['vnode[9]']
+        nodes = [vn_pref + '[9]']
         self.check_vnodes(j, nodes, j4id)
         a = {'Resource_List.select': '2:ncpus=2', ATTR_queue: 'wq2'}
         j = Job(TEST_USER, attrs=a)
         j5id = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=j5id)
-        nodes = ['vnode[6]', 'vnode[7]']
+        nodes = [vn_pref + '[6]', vn_pref + '[7]']
         self.check_vnodes(j, nodes, j5id)
         a = {'Resource_List.select': '3:ncpus=2', ATTR_queue: 'wq2'}
         j = Job(TEST_USER, attrs=a)
@@ -1708,7 +1717,8 @@ class TestMultipleSchedulers(TestFunctional):
         # queue associated to it. Expectation is in this case scheduler won't
         # crash
         a = {ATTR_queue: 'wq1'}
-        self.server.manager(MGR_CMD_SET, NODE, a, id='vnode[0]')
+        vn = self.mom.shortname
+        self.server.manager(MGR_CMD_SET, NODE, a, id=vn + '[0]')
 
         self.scheds['sc1'].terminate()
 
@@ -1752,17 +1762,18 @@ class TestMultipleSchedulers(TestFunctional):
         self.setup_sc1()
         self.setup_queues_nodes()
         a = {'partition': 'P1'}
+        vn = self.mom.shortname
         self.server.manager(MGR_CMD_SET, NODE, a, id='@default')
         a = {'node_sort_key': '"ncpus HIGH " ALL'}
         self.scheds['sc1'].set_sched_config(a)
         a = {'resources_available.ncpus': 1}
-        self.server.manager(MGR_CMD_SET, NODE, a, id='vnode[0]')
+        self.server.manager(MGR_CMD_SET, NODE, a, id=vn + '[0]')
         a = {'resources_available.ncpus': 2}
-        self.server.manager(MGR_CMD_SET, NODE, a, id='vnode[1]')
+        self.server.manager(MGR_CMD_SET, NODE, a, id=vn + '[1]')
         a = {'resources_available.ncpus': 3}
-        self.server.manager(MGR_CMD_SET, NODE, a, id='vnode[2]')
+        self.server.manager(MGR_CMD_SET, NODE, a, id=vn + '[2]')
         a = {'resources_available.ncpus': 4}
-        self.server.manager(MGR_CMD_SET, NODE, a, id='vnode[3]')
+        self.server.manager(MGR_CMD_SET, NODE, a, id=vn + '[3]')
 
         a = {'Resource_List.select': '1:ncpus=1',
              'Resource_List.place': 'excl',
@@ -1770,19 +1781,19 @@ class TestMultipleSchedulers(TestFunctional):
         j = Job(TEST_USER1, a)
         jid1 = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
-        self.check_vnodes(j, ['vnode[3]'], jid1)
+        self.check_vnodes(j, [vn + '[3]'], jid1)
         j = Job(TEST_USER1, a)
         jid2 = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
-        self.check_vnodes(j, ['vnode[2]'], jid2)
+        self.check_vnodes(j, [vn + '[2]'], jid2)
         j = Job(TEST_USER1, a)
         jid3 = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid3)
-        self.check_vnodes(j, ['vnode[1]'], jid3)
+        self.check_vnodes(j, [vn + '[1]'], jid3)
         j = Job(TEST_USER1, a)
         jid4 = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid4)
-        self.check_vnodes(j, ['vnode[0]'], jid4)
+        self.check_vnodes(j, [vn + '[0]'], jid4)
 
     @skipOnCpuSet
     def test_multi_sched_priority_sockets(self):
@@ -1852,7 +1863,8 @@ class TestMultipleSchedulers(TestFunctional):
         rid = self.server.submit(r)
         a = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
         self.server.expect(RESV, a, rid)
-        rnodes = {'resv_nodes': '(vnode[1]:ncpus=2)'}
+        vn = self.mom.shortname
+        rnodes = {'resv_nodes': '(' + vn + '[1]:ncpus=2)'}
         self.server.expect(RESV, rnodes, id=rid)
 
         # Wait for reservation to run and then submit a job to the
@@ -1862,7 +1874,7 @@ class TestMultipleSchedulers(TestFunctional):
         a = {ATTR_q: rid.split('.')[0]}
         j4 = Job(TEST_USER, attrs=a)
         jid4 = self.server.submit(j4)
-        result = {'job_state': 'R', 'exec_vnode': '(vnode[1]:ncpus=1)'}
+        result = {'job_state': 'R', 'exec_vnode': '(' + vn + '[1]:ncpus=1)'}
         self.server.expect(JOB, result, id=jid4)
 
     @skipOnCpuSet
@@ -1921,7 +1933,8 @@ class TestMultipleSchedulers(TestFunctional):
         rid = self.server.submit(r)
         exp_attrs = {'reserve_state': (MATCH_RE, 'RESV_RUNNING|5')}
         self.server.expect(RESV, exp_attrs, id=rid)
-        result = {'job_state': 'R', 'exec_vnode': '(vnode[2]:ncpus=2)'}
+        exec_vn = '(' + self.mom.shortname + '[2]:ncpus=2)'
+        result = {'job_state': 'R', 'exec_vnode': exec_vn}
         self.server.expect(JOB, result, id=jid)
 
     def test_standing_resv_reject(self):
@@ -2055,7 +2068,8 @@ e.accept()
         attr = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2'),
                 'partition': 'P1'}
         self.server.expect(RESV, attr, modify_resv)
-        rnodes = {'resv_nodes': '(vnode[0]:ncpus=2)'}
+        vn = self.mom.shortname
+        rnodes = {'resv_nodes': '(' + vn + '[0]:ncpus=2)'}
         self.server.expect(RESV, rnodes, id=modify_resv)
         msg = modify_resv + ";Reservation Confirmed"
         self.scheds['sc1'].log_match(msg, starttime=time_now)
@@ -2072,7 +2086,8 @@ e.accept()
         self.assertIn("Default partition name is not allowed",
                       e.exception.msg[0])
         with self.assertRaises(PbsManagerError) as e:
-            self.server.manager(MGR_CMD_SET, NODE, a, id='vnode[3]')
+            vn = self.mom.shortname
+            self.server.manager(MGR_CMD_SET, NODE, a, id=vn + '[3]')
         self.assertIn("Default partition name is not allowed",
                       e.exception.msg[0])
         with self.assertRaises(PbsManagerError) as e:
@@ -2088,7 +2103,8 @@ e.accept()
         # schedulers serving partition P2 and P3. Make scheduler sc1 serve
         # only partition P1 (vnode[0], vnode[1]).
         p1 = {'partition': 'P1'}
-        self.server.manager(MGR_CMD_SET, NODE, p1, id="vnode[1]")
+        vn = self.mom.shortname
+        self.server.manager(MGR_CMD_SET, NODE, p1, id=vn + "[1]")
         self.server.expect(SCHED, p1, id="sc1")
 
         a = {'reserve_retry_time': 5}
@@ -2132,10 +2148,10 @@ e.accept()
 
         self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': 'True'},
                             id="sc1")
-
-        other_node = "vnode[1]"
-        if resv_node == "vnode[1]":
-            other_node = "vnode[0]"
+        vn = self.mom.shortname
+        other_node = vn + "[1]"
+        if resv_node == vn + "[1]":
+            other_node = vn + "[0]"
 
         if run:
             a = {'reserve_substate': 5}

--- a/test/tests/functional/pbs_node_buckets.py
+++ b/test/tests/functional/pbs_node_buckets.py
@@ -887,9 +887,8 @@ class TestNodeBuckets(TestFunctional):
         """
         Test that buckets work with nodes associated to a queue
         """
-        vn = self.mom.shortname
-        v1 = vn + '[1431]'
-        v2 = vn + '[1435]'
+        v1 = self.mom.shortname + '[1431]'
+        v2 = self.mom.shortname + '[1435]'
         a = {'queue_type': 'execution', 'started': 'True', 'enabled': 'True'}
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='q2')
 

--- a/test/tests/functional/pbs_node_rampdown_keep_select.py
+++ b/test/tests/functional/pbs_node_rampdown_keep_select.py
@@ -194,8 +194,8 @@ class TestPbsNodeRampDownKeepSelect(TestFunctional):
             if mom.has_vnode_defs():
                 mom.delete_vnode_defs()
             start_time = time.time()
-            self.server.create_vnodes(mom.shortname, conf.a, conf.vnode_ct,
-                                      mom, delall=False,
+            mom.create_vnodes(conf.a, conf.vnode_ct,
+                                      delall=False,
                                       usenatvnode=conf.usenatvnode)
             self.vnode_dict[mom.shortname] = {'mom': mom,
                                               'res': conf}

--- a/test/tests/functional/pbs_node_rampdown_keep_select.py
+++ b/test/tests/functional/pbs_node_rampdown_keep_select.py
@@ -195,8 +195,8 @@ class TestPbsNodeRampDownKeepSelect(TestFunctional):
                 mom.delete_vnode_defs()
             start_time = time.time()
             mom.create_vnodes(conf.a, conf.vnode_ct,
-                                      delall=False,
-                                      usenatvnode=conf.usenatvnode)
+                              delall=False,
+                              usenatvnode=conf.usenatvnode)
             self.vnode_dict[mom.shortname] = {'mom': mom,
                                               'res': conf}
             vn_ct = conf.vnode_ct

--- a/test/tests/functional/pbs_nodes_queues.py
+++ b/test/tests/functional/pbs_nodes_queues.py
@@ -50,19 +50,12 @@ class TestNodesQueues(TestFunctional):
         a = {'resources_available.ncpus': 4}
         self.mom.create_vnodes(
             a, 8, attrfunc=self.cust_attr)
-        self.vn = [self.mom.shortname + '[' + str(i) + ']' for i in range(4)]
+        self.vn = ['%s[%d]' % (self.mom.shortname, i) for i in range(4)]
         a = {'queue_type': 'execution', 'started': 't', 'enabled': 't'}
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='workq2')
 
         self.server.manager(MGR_CMD_SET, NODE, {
-                            'queue': 'workq2'}, id=self.vn[0])
-        self.server.manager(MGR_CMD_SET, NODE, {
-                            'queue': 'workq2'}, id=self.vn[1])
-        self.server.manager(MGR_CMD_SET, NODE, {
-                            'queue': 'workq2'}, id=self.vn[2])
-        self.server.manager(MGR_CMD_SET, NODE, {
-                            'queue': 'workq2'}, id=self.vn[3])
-
+                            'queue': 'workq2'}, id=self.vn)
         self.server.manager(MGR_CMD_SET, SERVER, {'node_group_key': 'foo'})
         self.server.manager(MGR_CMD_SET, SERVER, {'node_group_enable': 't'})
 

--- a/test/tests/functional/pbs_nodes_queues.py
+++ b/test/tests/functional/pbs_nodes_queues.py
@@ -50,18 +50,18 @@ class TestNodesQueues(TestFunctional):
         a = {'resources_available.ncpus': 4}
         self.mom.create_vnodes(
             a, 8, attrfunc=self.cust_attr)
-        vn = self.mom.shortname
+        vn = [self.mom.shortname + '[' + str(i) + ']' for i in range(4)]
         a = {'queue_type': 'execution', 'started': 't', 'enabled': 't'}
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='workq2')
 
         self.server.manager(MGR_CMD_SET, NODE, {
-                            'queue': 'workq2'}, id=vn + '[0]')
+                            'queue': 'workq2'}, id=self.vn[0])
         self.server.manager(MGR_CMD_SET, NODE, {
-                            'queue': 'workq2'}, id=vn + '[1]')
+                            'queue': 'workq2'}, id=self.vn[1])
         self.server.manager(MGR_CMD_SET, NODE, {
-                            'queue': 'workq2'}, id=vn + '[2]')
+                            'queue': 'workq2'}, id=self.vn[2])
         self.server.manager(MGR_CMD_SET, NODE, {
-                            'queue': 'workq2'}, id=vn + '[3]')
+                            'queue': 'workq2'}, id=self.vn[3])
 
         self.server.manager(MGR_CMD_SET, SERVER, {'node_group_key': 'foo'})
         self.server.manager(MGR_CMD_SET, SERVER, {'node_group_enable': 't'})
@@ -85,10 +85,9 @@ class TestNodesQueues(TestFunctional):
              'Resource_List.place': 'vscatter', 'queue': 'workq2'}
         j = Job(TEST_USER, attrs=a)
         jid = self.server.submit(j)
-        vn = self.mom.shortname
         self.server.expect(JOB, 'exec_vnode', id=jid, op=SET)
         nodes = j.get_vnodes(j.exec_vnode)
-        self.assertTrue((nodes[0] == vn + '[0]' and
-                         nodes[1] == vn + '[2]') or
-                        (nodes[0] == vn + '[1]' and
-                         nodes[1] == vn + '[3]'))
+        self.assertTrue((nodes[0] == self.vn[0] and
+                         nodes[1] == self.vn[2]) or
+                        (nodes[0] == self.vn[1] and
+                         nodes[1] == self.vn[3]))

--- a/test/tests/functional/pbs_nodes_queues.py
+++ b/test/tests/functional/pbs_nodes_queues.py
@@ -50,7 +50,7 @@ class TestNodesQueues(TestFunctional):
         a = {'resources_available.ncpus': 4}
         self.mom.create_vnodes(
             a, 8, attrfunc=self.cust_attr)
-        vn = [self.mom.shortname + '[' + str(i) + ']' for i in range(4)]
+        self.vn = [self.mom.shortname + '[' + str(i) + ']' for i in range(4)]
         a = {'queue_type': 'execution', 'started': 't', 'enabled': 't'}
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='workq2')
 

--- a/test/tests/functional/pbs_nodes_queues.py
+++ b/test/tests/functional/pbs_nodes_queues.py
@@ -48,20 +48,20 @@ class TestNodesQueues(TestFunctional):
         self.server.add_resource('foo', 'string', 'h')
 
         a = {'resources_available.ncpus': 4}
-        self.server.create_vnodes(
-            'vnode', a, 8, self.mom, attrfunc=self.cust_attr)
-
+        self.mom.create_vnodes(
+            a, 8, attrfunc=self.cust_attr)
+        vn = self.mom.shortname
         a = {'queue_type': 'execution', 'started': 't', 'enabled': 't'}
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='workq2')
 
         self.server.manager(MGR_CMD_SET, NODE, {
-                            'queue': 'workq2'}, id='vnode[0]')
+                            'queue': 'workq2'}, id=vn + '[0]')
         self.server.manager(MGR_CMD_SET, NODE, {
-                            'queue': 'workq2'}, id='vnode[1]')
+                            'queue': 'workq2'}, id=vn + '[1]')
         self.server.manager(MGR_CMD_SET, NODE, {
-                            'queue': 'workq2'}, id='vnode[2]')
+                            'queue': 'workq2'}, id=vn + '[2]')
         self.server.manager(MGR_CMD_SET, NODE, {
-                            'queue': 'workq2'}, id='vnode[3]')
+                            'queue': 'workq2'}, id=vn + '[3]')
 
         self.server.manager(MGR_CMD_SET, SERVER, {'node_group_key': 'foo'})
         self.server.manager(MGR_CMD_SET, SERVER, {'node_group_enable': 't'})
@@ -85,7 +85,10 @@ class TestNodesQueues(TestFunctional):
              'Resource_List.place': 'vscatter', 'queue': 'workq2'}
         j = Job(TEST_USER, attrs=a)
         jid = self.server.submit(j)
+        vn = self.mom.shortname
         self.server.expect(JOB, 'exec_vnode', id=jid, op=SET)
         nodes = j.get_vnodes(j.exec_vnode)
-        self.assertTrue((nodes[0] == 'vnode[0]' and nodes[1] == 'vnode[2]') or
-                        (nodes[0] == 'vnode[1]' and nodes[1] == 'vnode[3]'))
+        self.assertTrue((nodes[0] == vn + '[0]' and
+                         nodes[1] == vn + '[2]') or
+                        (nodes[0] == vn + '[1]' and
+                         nodes[1] == vn + '[3]'))

--- a/test/tests/functional/pbs_pbsnodes_output_trimmed.py
+++ b/test/tests/functional/pbs_pbsnodes_output_trimmed.py
@@ -60,7 +60,7 @@ class TestPbsnodesOutputTrimmed(TestFunctional):
                                 "bin", "pbsnodes")
         hname = "long123456789012345678901234567890.pbs.com"
         a = {'resources_available.ncpus': 4}
-        rc = self.server.create_vnodes(hname, a, 1, self.mom)
+        rc = self.mom.create_vnodes(a, 1, vname=hname)
         command = pbsnodes + " -s " + self.server.hostname + \
             ' -v ' + hname + "[0]"
         rc = self.du.run_cmd(cmd=command, sudo=True)

--- a/test/tests/functional/pbs_preemption.py
+++ b/test/tests/functional/pbs_preemption.py
@@ -426,7 +426,7 @@ exit 3
         Test to make sure that preemption happens when the resource in
         contention is vnode.
         """
-        vn = self.mom.shortname
+        vn4 = self.mom.shortname + '[4]'
         a = {'resources_available.ncpus': 2}
         self.mom.create_vnodes(attrib=a, num=11, usenatvnode=False)
 
@@ -438,16 +438,16 @@ exit 3
 
         # Randomly select a vnode with running jobs on it. Request this
         # vnode in the high priority job later.
-        self.server.expect(NODE, {'state': 'job-busy'}, id=vn + '[4]')
+        self.server.expect(NODE, {'state': 'job-busy'}, id=vn4)
 
-        a = {ATTR_q: 'expressq', 'Resource_List.vnode': vn + '[4]'}
+        a = {ATTR_q: 'expressq', 'Resource_List.vnode': vn4}
         hj = Job(TEST_USER, attrs=a)
         hjid = self.server.submit(hj)
         self.server.expect(JOB, {'job_state': 'R'}, id=hjid)
 
         # Since high priority job consumed only one ncpu, vnode[4]'s
         # node state should be free now
-        self.server.expect(NODE, {'state': 'free'}, id=vn + '[4]')
+        self.server.expect(NODE, {'state': 'free'}, id=vn4)
 
     @requirements(num_moms=2)
     @skipOnCpuSet
@@ -732,7 +732,6 @@ exit 3
         to see whether the nodes they occupy are useful.
         """
         attr = {'type': 'string_array', 'flag': 'h'}
-        vn = self.mom.shortname
         self.server.manager(MGR_CMD_CREATE, RSC, attr, id='app')
         self.scheduler.add_resource('app')
 
@@ -762,7 +761,7 @@ exit 3
 
         # submit job 1
         a = {'Resource_List.select': '1:ncpus=1:vnode=' +
-             vn + '[0]', ATTR_q: 'lopri'}
+             self.mom.shortname + '[0]', ATTR_q: 'lopri'}
         j1 = Job(TEST_USER, attrs=a)
         jid1 = self.server.submit(j1)
 

--- a/test/tests/functional/pbs_preemption.py
+++ b/test/tests/functional/pbs_preemption.py
@@ -212,8 +212,7 @@ exit 1
         # set node share attribute to force_exclhost
         a = {'resources_available.ncpus': '1',
              'sharing': 'force_exclhost'}
-        self.server.create_vnodes(name=self.mom.shortname, attrib=a, num=0,
-                                  mom=self.mom)
+        self.mom.create_vnodes(attrib=a, num=0)
         start_time = time.time()
         self.submit_and_preempt_jobs(preempt_order='R')
         self.scheduler.log_match(
@@ -427,10 +426,9 @@ exit 3
         Test to make sure that preemption happens when the resource in
         contention is vnode.
         """
-
+        vn = self.mom.shortname
         a = {'resources_available.ncpus': 2}
-        self.server.create_vnodes(name='vnode', attrib=a, num=11,
-                                  mom=self.mom, usenatvnode=False)
+        self.mom.create_vnodes(attrib=a, num=11, usenatvnode=False)
 
         a = {'Resource_List.select': '1:ncpus=2+1:ncpus=2'}
         for _ in range(5):
@@ -440,16 +438,16 @@ exit 3
 
         # Randomly select a vnode with running jobs on it. Request this
         # vnode in the high priority job later.
-        self.server.expect(NODE, {'state': 'job-busy'}, id='vnode[4]')
+        self.server.expect(NODE, {'state': 'job-busy'}, id=vn + '[4]')
 
-        a = {ATTR_q: 'expressq', 'Resource_List.vnode': 'vnode[4]'}
+        a = {ATTR_q: 'expressq', 'Resource_List.vnode': vn + '[4]'}
         hj = Job(TEST_USER, attrs=a)
         hjid = self.server.submit(hj)
         self.server.expect(JOB, {'job_state': 'R'}, id=hjid)
 
         # Since high priority job consumed only one ncpu, vnode[4]'s
         # node state should be free now
-        self.server.expect(NODE, {'state': 'free'}, id='vnode[4]')
+        self.server.expect(NODE, {'state': 'free'}, id=vn + '[4]')
 
     @requirements(num_moms=2)
     @skipOnCpuSet
@@ -734,16 +732,16 @@ exit 3
         to see whether the nodes they occupy are useful.
         """
         attr = {'type': 'string_array', 'flag': 'h'}
-
+        vn = self.mom.shortname
         self.server.manager(MGR_CMD_CREATE, RSC, attr, id='app')
         self.scheduler.add_resource('app')
 
         a = {'resources_available.ncpus': 1, 'resources_available.app': 'appA'}
-        self.server.create_vnodes('vna', a, num=1, mom=self.mom,
-                                  usenatvnode=False)
+        self.mom.create_vnodes(a, num=1,
+                               usenatvnode=False)
         b = {'resources_available.ncpus': 1, 'resources_available.app': 'appB'}
-        self.server.create_vnodes('vnb', b, num=1, mom=self.mom,
-                                  usenatvnode=False, additive=True)
+        self.mom.create_vnodes(b, num=1,
+                               usenatvnode=False, additive=True)
 
         # set the preempt_order to kill/requeue only -- try old and new syntax
         self.server.manager(MGR_CMD_SET, SCHED, {'preempt_order': 'R'})
@@ -763,7 +761,8 @@ exit 3
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, "lopri")
 
         # submit job 1
-        a = {'Resource_List.select': '1:ncpus=1:vnode=vna[0]', ATTR_q: 'lopri'}
+        a = {'Resource_List.select': '1:ncpus=1:vnode=' +
+             vn + '[0]', ATTR_q: 'lopri'}
         j1 = Job(TEST_USER, attrs=a)
         jid1 = self.server.submit(j1)
 

--- a/test/tests/functional/pbs_provisioning_enhancement.py
+++ b/test/tests/functional/pbs_provisioning_enhancement.py
@@ -458,7 +458,6 @@ e.reject()
         If set to 1 and job requests a 4 node provision, the provision should
         occur 1 node at a time
         """
-        vnode = self.momA.shortname
         # Setup provisioning hook with smaller alarm.
         a = {'event': 'provision', 'enabled': 'True', 'alarm': '5'}
         rv = self.server.create_import_hook(
@@ -478,8 +477,8 @@ e.reject()
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R',
                                  'substate': 71}, attrop=PTL_AND, id=jid)
-        exp_msg = "Provisioning vnode " + vnode + \
-            "\[[0-3]\] with AOE osimage1 started"
+        exp_msg = "Provisioning vnode " + self.momA.shortname
+        exp_msg += "\[[0-3]\] with AOE osimage1 started"
         logs = self.server.log_match(msg=exp_msg, regexp=True, allmatch=True)
 
         # since max_concurrent_provision is 1, there should be only one

--- a/test/tests/functional/pbs_provisioning_enhancement.py
+++ b/test/tests/functional/pbs_provisioning_enhancement.py
@@ -458,7 +458,7 @@ e.reject()
         If set to 1 and job requests a 4 node provision, the provision should
         occur 1 node at a time
         """
-
+        vnode = self.momA.shortname
         # Setup provisioning hook with smaller alarm.
         a = {'event': 'provision', 'enabled': 'True', 'alarm': '5'}
         rv = self.server.create_import_hook(
@@ -470,15 +470,16 @@ e.reject()
              'current_aoe': 'App1',
              'provision_enable': 'True',
              'resources_available.ncpus': 1}
-        rv = self.server.create_vnodes('vnode', a, 4, self.momA,
-                                       sharednode=False)
+        rv = self.momA.create_vnodes(a, 4,
+                                     sharednode=False)
         self.assertTrue(rv)
         j = Job(TEST_USER,
                 attrs={'Resource_List.select': '4:ncpus=1:aoe=osimage1'})
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R',
-                           'substate': 71}, attrop=PTL_AND, id=jid)
-        exp_msg = "Provisioning vnode vnode\[[0-3]\] with AOE osimage1 started"
+                                 'substate': 71}, attrop=PTL_AND, id=jid)
+        exp_msg = "Provisioning vnode " + vnode + \
+            "\[[0-3]\] with AOE osimage1 started"
         logs = self.server.log_match(msg=exp_msg, regexp=True, allmatch=True)
 
         # since max_concurrent_provision is 1, there should be only one

--- a/test/tests/functional/pbs_qmgr.py
+++ b/test/tests/functional/pbs_qmgr.py
@@ -121,7 +121,7 @@ class TestQmgr(TestFunctional):
             long_string += blah
             # Create a new vnode
             attrs = {ATTR_rescavail + ".ncpus": 2}
-            self.server.create_vnodes(node_prefix, attrs, 1, self.mom)
+            self.mom.create_vnodes(attrs, 1, vname=node_prefix)
             # Set 'comment' attribute to the long string we created above
             attrs = {ATTR_comment: long_string}
             self.server.manager(MGR_CMD_SET, VNODE, attrs, nodename)

--- a/test/tests/functional/pbs_ralter.py
+++ b/test/tests/functional/pbs_ralter.py
@@ -73,8 +73,8 @@ class TestPbsResvAlter(TestFunctional):
             self.tzone = 'Asia/Kolkata'
 
         a = {'resources_available.ncpus': 4, 'resources_available.mem': '1gb'}
-        self.server.create_vnodes('vnode', a, num=2, mom=self.mom,
-                                  usenatvnode=True)
+        self.mom.create_vnodes(a, num=2,
+                               usenatvnode=True)
 
         self.server.manager(MGR_CMD_SET, SERVER, {'log_events': 4095})
 
@@ -1245,8 +1245,8 @@ class TestPbsResvAlter(TestFunctional):
         offset = 10
 
         a = {'resources_available.ncpus': 4}
-        self.server.create_vnodes('vnode', a, num=256, mom=self.mom,
-                                  usenatvnode=True)
+        self.mom.create_vnodes(a, num=256,
+                               usenatvnode=True)
 
         rid, start, end = self.submit_and_confirm_reservation(
             offset, duration, select="256:ncpus=4")
@@ -1361,10 +1361,10 @@ class TestPbsResvAlter(TestFunctional):
                                  sequence=seq)
         self.alter_a_reservation(rid1, start1, end1, shift, alter_s=True,
                                  alter_e=True, whichMessage=mtype,
-                                 interactive=2, sequence=seq+1)
+                                 interactive=2, sequence=seq + 1)
         self.alter_a_reservation(rid2, start2, end2, shift, alter_s=True,
                                  alter_e=True, whichMessage=mtype,
-                                 interactive=2, sequence=seq+1)
+                                 interactive=2, sequence=seq + 1)
 
     @skipOnCpuSet
     def test_alter_resv_name(self):
@@ -1545,13 +1545,14 @@ class TestPbsResvAlter(TestFunctional):
         self.server.manager(MGR_CMD_CREATE, RSC, a, id='color')
 
         a = {'resources_available.ncpus': 4, 'resources_available.mem': '4gb'}
-        self.server.create_vnodes('vn', a, 3, self.mom)
+        self.mom.create_vnodes(a, 3)
 
         a = {'resources_available.color': 'red'}
-        self.server.manager(MGR_CMD_SET, NODE, a, id='vn[0]')
-        self.server.manager(MGR_CMD_SET, NODE, a, id='vn[1]')
+        vn = self.mom.shortname
+        self.server.manager(MGR_CMD_SET, NODE, a, id=vn + '[0]')
+        self.server.manager(MGR_CMD_SET, NODE, a, id=vn + '[1]')
         a = {'resources_available.color': 'green'}
-        self.server.manager(MGR_CMD_SET, NODE, a, id='vn[2]')
+        self.server.manager(MGR_CMD_SET, NODE, a, id=vn + '[2]')
 
         a = {'node_group_key': 'color', 'node_group_enable': True}
         self.server.manager(MGR_CMD_SET, SERVER, a)
@@ -2251,7 +2252,7 @@ class TestPbsResvAlter(TestFunctional):
 
         a = {'resources_available.ncpus': 1,
              'resources_available.mem': '8gb'}
-        self.server.create_vnodes('vnode', a, num=8, mom=self.mom)
+        self.mom.create_vnodes(a, num=8)
 
         rid, start, end = self.submit_and_confirm_reservation(offset, dur,
                                                               select=select)
@@ -2319,10 +2320,10 @@ class TestPbsResvAlter(TestFunctional):
         st = self.server.status(RESV)
         self.assertEquals(len(st[0]['resv_nodes'].split('+')), 4)
         t = int(time.mktime(time.strptime(st[0]['reserve_start'], '%c')))
-        self.assertEquals(t, start+shift)
+        self.assertEquals(t, start + shift)
 
         t = int(time.mktime(time.strptime(st[0]['reserve_end'], '%c')))
-        self.assertEquals(t, end+shift)
+        self.assertEquals(t, end + shift)
 
     def test_alter_select_with_running_jobs(self):
         """
@@ -2336,8 +2337,8 @@ class TestPbsResvAlter(TestFunctional):
         select3 = '1:ncpus=4'
 
         a = {'resources_available.ncpus': 4, 'resources_available.mem': '1gb'}
-        self.server.create_vnodes('vnode', a, num=3, mom=self.mom,
-                                  usenatvnode=True)
+        self.mom.create_vnodes(a, num=3,
+                               usenatvnode=True)
 
         rid, start, end = self.submit_and_confirm_reservation(offset, duration,
                                                               select=select)
@@ -2385,8 +2386,8 @@ class TestPbsResvAlter(TestFunctional):
         select2 = '1:ncpus=4'
 
         a = {'resources_available.ncpus': 4, 'resources_available.mem': '1gb'}
-        self.server.create_vnodes('vnode', a, num=3, mom=self.mom,
-                                  usenatvnode=True)
+        self.mom.create_vnodes(a, num=3,
+                               usenatvnode=True)
 
         rid, start, end = self.submit_and_confirm_reservation(offset, duration,
                                                               select=select)
@@ -2448,7 +2449,7 @@ class TestPbsResvAlter(TestFunctional):
         st = self.server.status(RESV)
         self.assertEquals(len(st[0]['resv_nodes'].split('+')), 4)
         t = int(time.mktime(time.strptime(st[0]['reserve_start'], '%c')))
-        self.assertEquals(t, start+shift)
+        self.assertEquals(t, start + shift)
 
         t = int(time.mktime(time.strptime(st[0]['reserve_end'], '%c')))
         self.assertEquals(t, end + shift)

--- a/test/tests/functional/pbs_release_limited_res_suspend.py
+++ b/test/tests/functional/pbs_release_limited_res_suspend.py
@@ -224,13 +224,13 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
 
         vn_attrs = {ATTR_rescavail + '.ncpus': 8,
                     ATTR_rescavail + '.mem': '1024mb'}
-        self.server.create_vnodes("vnode1", vn_attrs, 1,
-                                  self.mom, fname="vnodedef1")
+        self.mom.create_vnodes(vn_attrs, 1,
+                               fname="vnodedef1", vname="vnode1")
         # Append a vnode
         vn_attrs = {ATTR_rescavail + '.ncpus': 6,
                     ATTR_rescavail + '.mem': '1024mb'}
-        self.server.create_vnodes("vnode2", vn_attrs, 1,
-                                  self.mom, additive=True, fname="vnodedef2")
+        self.mom.create_vnodes(vn_attrs, 1, additive=True,
+                               fname="vnodedef2", vname="vnode2")
 
         # Submit a low priority job
         j1 = Job(TEST_USER)
@@ -374,13 +374,13 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
 
         vn_attrs = {ATTR_rescavail + '.ncpus': 8,
                     ATTR_rescavail + '.mem': '1024mb'}
-        self.server.create_vnodes("vnode1", vn_attrs, 1,
-                                  self.mom, fname="vnodedef1")
+        self.mom.create_vnodes(vn_attrs, 1,
+                               fname="vnodedef1", vname="vnode1")
         # Append a vnode
         vn_attrs = {ATTR_rescavail + '.ncpus': 6,
                     ATTR_rescavail + '.mem': '1024mb'}
-        self.server.create_vnodes("vnode2", vn_attrs, 1,
-                                  self.mom, additive=True, fname="vnodedef2")
+        self.mom.create_vnodes(vn_attrs, 1, additive=True,
+                               fname="vnodedef2", vname="vnode2")
 
         # Submit a low priority job
         j1 = Job(TEST_USER)
@@ -782,13 +782,13 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
 
         vn_attrs = {ATTR_rescavail + '.ncpus': 2,
                     ATTR_rescavail + '.mem': '1024mb'}
-        self.server.create_vnodes("vnode1", vn_attrs, 1,
-                                  self.mom, fname="vnodedef1")
+        self.mom.create_vnodes(vn_attrs, 1, fname="vnodedef1",
+                               vname="vnode1")
         # Append a vnode
         vn_attrs = {ATTR_rescavail + '.ncpus': 6,
                     ATTR_rescavail + '.mem': '1024mb'}
-        self.server.create_vnodes("vnode2", vn_attrs, 1,
-                                  self.mom, additive=True, fname="vnodedef2")
+        self.mom.create_vnodes(vn_attrs, 1, additive=True,
+                               fname="vnodedef2", vname="vnode2")
         j1 = Job(TEST_USER)
         j1.set_attributes({ATTR_l + '.select':
                            '1:ncpus=2+1:ncpus=6',

--- a/test/tests/functional/pbs_reservations.py
+++ b/test/tests/functional/pbs_reservations.py
@@ -115,8 +115,8 @@ class TestReservations(TestFunctional):
         self.scheduler.add_resource('color')
 
         a = {'resources_available.ncpus': 1}
-        self.server.create_vnodes('vn', a, num=5, mom=self.mom,
-                                  attrfunc=self.cust_attr)
+        self.mom.create_vnodes(a, num=5,
+                               attrfunc=self.cust_attr)
 
         now = int(time.time())
 
@@ -180,7 +180,7 @@ class TestReservations(TestFunctional):
         self.server.manager(MGR_CMD_SET, SERVER, a)
 
         a = {'resources_available.ncpus': 1}
-        self.server.create_vnodes('vn', a, num=2, mom=self.mom)
+        self.mom.create_vnodes(a, num=2)
 
         now = time.time()
 
@@ -340,7 +340,7 @@ class TestReservations(TestFunctional):
         """
         retry = 15
         a = {'resources_available.ncpus': 1}
-        self.server.create_vnodes('vn', a, num=6, mom=self.mom)
+        self.mom.create_vnodes(a, num=6)
         self.server.manager(MGR_CMD_SET, SERVER, {'reserve_retry_time': retry})
 
         now = int(time.time())
@@ -386,7 +386,7 @@ class TestReservations(TestFunctional):
         self.server.manager(MGR_CMD_SET, SERVER, {'reserve_retry_time': 5})
 
         a = {'resources_available.ncpus': 1}
-        self.server.create_vnodes('vn', a, 5, self.mom)
+        self.mom.create_vnodes(a, 5)
 
         # Submit two jobs to take up nodes 0 and 1. This forces the reservation
         # onto nodes 3 and 4. The idea is to delete the two jobs and see
@@ -446,7 +446,7 @@ class TestReservations(TestFunctional):
         self.server.manager(MGR_CMD_SET, SERVER, a)
 
         a = {'resources_available.ncpus': 1}
-        self.server.create_vnodes('vn', a, num=2, mom=self.mom)
+        self.mom.create_vnodes(a, num=2)
 
         start_time = time.time()
         now = int(start_time)
@@ -506,7 +506,7 @@ class TestReservations(TestFunctional):
         self.server.manager(MGR_CMD_SET, SERVER, a)
 
         a = {'resources_available.ncpus': 1}
-        self.server.create_vnodes('vn', a, num=2, mom=self.mom)
+        self.mom.create_vnodes(a, num=2)
 
         now = int(time.time())
         start = now + 25
@@ -549,7 +549,7 @@ class TestReservations(TestFunctional):
         """
 
         a = {'resources_available.ncpus': 4}
-        self.server.create_vnodes('vn', a, 1, self.mom, usenatvnode=True)
+        self.mom.create_vnodes(a, 1, usenatvnode=True)
 
         now = int(time.time())
         start1 = now + 15
@@ -1207,7 +1207,7 @@ class TestReservations(TestFunctional):
         with current reservations on a multi-vnoded host
         """
         a = {'resources_available.ncpus': 4}
-        self.server.create_vnodes('vn', a, num=3, mom=self.mom)
+        self.mom.create_vnodes(a, num=3)
 
         # Submit a long term standing reservation with
         # exclusive nodes.
@@ -1255,7 +1255,7 @@ class TestReservations(TestFunctional):
         reservations on a multi-vnoded host
         """
         a = {'resources_available.ncpus': 4}
-        self.server.create_vnodes('vn', a, num=3, mom=self.mom)
+        self.mom.create_vnodes(a, num=3)
 
         # Submit 3 exclusive jobs, so all the nodes are busy
         # j1 requesting 4 cpus, j2 requesting 4 cpus and j3
@@ -2053,8 +2053,8 @@ class TestReservations(TestFunctional):
         "test_standing_resv_with_multivnode_job_array"
         """
         vn_attrs = {ATTR_rescavail + '.ncpus': 4}
-        self.server.create_vnodes("vnode1", vn_attrs, 2,
-                                  self.mom, fname="vnodedef1")
+        self.mom.create_vnodes(vn_attrs, 2,
+                               fname="vnodedef1")
         self.server.manager(MGR_CMD_SET, SERVER,
                             {'job_history_enable': 'True'})
 
@@ -2230,7 +2230,7 @@ class TestReservations(TestFunctional):
         """
 
         a = {'resources_available.ncpus': 1}
-        self.server.create_vnodes('vn', a, num=2, mom=self.mom)
+        self.mom.create_vnodes(a, num=2)
         now = int(time.time())
         rid = self.submit_reservation(user=TEST_USER, select='1:ncpus=1',
                                       start=now + 5, end=now + 300)
@@ -2281,7 +2281,7 @@ class TestReservations(TestFunctional):
         a = {'reserve_retry_time': 5}
         self.server.manager(MGR_CMD_SET, SERVER, a)
         a = {'resources_available.ncpus': 2}
-        self.server.create_vnodes('vn', a, num=3, mom=self.mom)
+        self.mom.create_vnodes(a, num=3)
         vn_list = ['vn[0]', 'vn[1]', 'vn[2]']
 
         now = int(time.time())

--- a/test/tests/functional/pbs_sched_runjobwait.py
+++ b/test/tests/functional/pbs_sched_runjobwait.py
@@ -76,7 +76,7 @@ class TestSchedJobRunWait(TestFunctional):
             prefix = 'vnode' + str(i)
             nname = prefix + "[0]"
             self.mom.create_vnodes(prefix, a, 1, delall=False,
-                                   additive=True, vname=name)
+                                   additive=True, vname=nname)
         return sc_quenames
 
     def test_throughput_mode_deprecated(self):

--- a/test/tests/functional/pbs_sched_runjobwait.py
+++ b/test/tests/functional/pbs_sched_runjobwait.py
@@ -75,8 +75,8 @@ class TestSchedJobRunWait(TestFunctional):
             a = {'resources_available.ncpus': 1, 'partition': pname}
             prefix = 'vnode' + str(i)
             nname = prefix + "[0]"
-            self.server.create_vnodes(prefix, a, 1, self.mom,
-                                      delall=False, additive=True)
+            self.mom.create_vnodes(prefix, a, 1, delall=False,
+                                   additive=True, vname=name)
         return sc_quenames
 
     def test_throughput_mode_deprecated(self):

--- a/test/tests/functional/pbs_schedule_indirect_resources.py
+++ b/test/tests/functional/pbs_schedule_indirect_resources.py
@@ -87,27 +87,27 @@ class TestIndirectResources(TestFunctional):
         # Create 6 vnodes
         attr = {'resources_available.ncpus': 1}
         self.mom.create_vnodes(attr, 6)
-        vn = self.mom.shortname
+        vn = ['%s[%d]' % (self.mom.shortname, i) for i in range(6)]
         # Configure a system with 6 vnodes and 'foostr' as node_group_key
         self.config_complex_for_grouping('foostr')
 
         # Set 'foostr' to 'A', 'B' and 'C' respectively for the first
         # three vnodes
         attr = {'resources_available.foostr': 'A'}
-        self.server.manager(MGR_CMD_SET, NODE, attr, vn + '[0]')
+        self.server.manager(MGR_CMD_SET, NODE, attr, vn[0])
         attr = {'resources_available.foostr': 'B'}
-        self.server.manager(MGR_CMD_SET, NODE, attr, vn + '[1]')
+        self.server.manager(MGR_CMD_SET, NODE, attr, vn[1])
         attr = {'resources_available.foostr': 'C'}
-        self.server.manager(MGR_CMD_SET, NODE, attr, vn + '[2]')
+        self.server.manager(MGR_CMD_SET, NODE, attr, vn[2])
 
         # Set 'foostr' for last three vnodes as indirect resource to
         # the first three vnodes correcpondingly
-        attr = {'resources_available.foostr': '@' + vn + '[0]'}
-        self.server.manager(MGR_CMD_SET, NODE, attr, vn + '[3]')
-        attr = {'resources_available.foostr': '@' + vn + '[1]'}
-        self.server.manager(MGR_CMD_SET, NODE, attr, vn + '[4]')
-        attr = {'resources_available.foostr': '@' + vn + '[2]'}
-        self.server.manager(MGR_CMD_SET, NODE, attr, vn + '[5]')
+        attr = {'resources_available.foostr': '@' + vn[0]}
+        self.server.manager(MGR_CMD_SET, NODE, attr, vn[3])
+        attr = {'resources_available.foostr': '@' + vn[1]}
+        self.server.manager(MGR_CMD_SET, NODE, attr, vn[4])
+        attr = {'resources_available.foostr': '@' + vn[2]}
+        self.server.manager(MGR_CMD_SET, NODE, attr, vn[5])
 
         # Submit 3 jobs requesting 2 vnodes and check they ran on the nodes
         # within same group

--- a/test/tests/functional/pbs_schedule_indirect_resources.py
+++ b/test/tests/functional/pbs_schedule_indirect_resources.py
@@ -86,28 +86,28 @@ class TestIndirectResources(TestFunctional):
 
         # Create 6 vnodes
         attr = {'resources_available.ncpus': 1}
-        self.server.create_vnodes('vnode', attr, 6, mom=self.mom)
-
+        self.mom.create_vnodes(attr, 6)
+        vn = self.mom.shortname
         # Configure a system with 6 vnodes and 'foostr' as node_group_key
         self.config_complex_for_grouping('foostr')
 
         # Set 'foostr' to 'A', 'B' and 'C' respectively for the first
         # three vnodes
         attr = {'resources_available.foostr': 'A'}
-        self.server.manager(MGR_CMD_SET, NODE, attr, 'vnode[0]')
+        self.server.manager(MGR_CMD_SET, NODE, attr, vn + '[0]')
         attr = {'resources_available.foostr': 'B'}
-        self.server.manager(MGR_CMD_SET, NODE, attr, 'vnode[1]')
+        self.server.manager(MGR_CMD_SET, NODE, attr, vn + '[1]')
         attr = {'resources_available.foostr': 'C'}
-        self.server.manager(MGR_CMD_SET, NODE, attr, 'vnode[2]')
+        self.server.manager(MGR_CMD_SET, NODE, attr, vn + '[2]')
 
         # Set 'foostr' for last three vnodes as indirect resource to
         # the first three vnodes correcpondingly
-        attr = {'resources_available.foostr': '@vnode[0]'}
-        self.server.manager(MGR_CMD_SET, NODE, attr, 'vnode[3]')
-        attr = {'resources_available.foostr': '@vnode[1]'}
-        self.server.manager(MGR_CMD_SET, NODE, attr, 'vnode[4]')
-        attr = {'resources_available.foostr': '@vnode[2]'}
-        self.server.manager(MGR_CMD_SET, NODE, attr, 'vnode[5]')
+        attr = {'resources_available.foostr': '@' + vn + '[0]'}
+        self.server.manager(MGR_CMD_SET, NODE, attr, vn + '[3]')
+        attr = {'resources_available.foostr': '@' + vn + '[1]'}
+        self.server.manager(MGR_CMD_SET, NODE, attr, vn + '[4]')
+        attr = {'resources_available.foostr': '@' + vn + '[2]'}
+        self.server.manager(MGR_CMD_SET, NODE, attr, vn + '[5]')
 
         # Submit 3 jobs requesting 2 vnodes and check they ran on the nodes
         # within same group
@@ -121,4 +121,4 @@ class TestIndirectResources(TestFunctional):
             self.server.expect(JOB, {'job_state': 'R'}, id=jid)
             self.server.status(JOB, 'exec_vnode', jid)
             vn = j.get_vnodes()
-            self.assertEqual(int(vn[0][6])+3, int(vn[1][6]))
+            self.assertEqual(int(vn[0][-2]) + 3, int(vn[1][-2]))

--- a/test/tests/functional/pbs_snapshot_unittest.py
+++ b/test/tests/functional/pbs_snapshot_unittest.py
@@ -131,8 +131,7 @@ class TestPBSSnapshot(TestFunctional):
                "started": "True",
                "enabled": "True"}
         a_n = {"resources_available.ncpus": 2}
-        self.server.create_vnodes("vnode", a_n, (num_partitions + 1),
-                                  self.mom)
+        self.mom.create_vnodes(a_n, (num_partitions + 1))
         for i in range(num_partitions):
             partition_id = "P" + str(i + 1)
 

--- a/test/tests/functional/pbs_strict_ordering.py
+++ b/test/tests/functional/pbs_strict_ordering.py
@@ -55,7 +55,7 @@ class TestStrictOrderingAndBackfilling(TestFunctional):
     def test_t1(self):
 
         a = {'resources_available.ncpus': 4}
-        self.server.create_vnodes('vn', a, 1, self.mom, usenatvnode=True)
+        self.mom.create_vnodes(a, 1, usenatvnode=True)
 
         rv = self.scheduler.set_sched_config(
             {'round_robin': 'false all', 'by_queue': 'false all',
@@ -167,7 +167,7 @@ class TestStrictOrderingAndBackfilling(TestFunctional):
         and backfill_depth is set to 0 on the queue
         """
         a = {'resources_available.ncpus': 2}
-        self.server.create_vnodes('vn', a, 1, self.mom, usenatvnode=True)
+        self.mom.create_vnodes(a, 1, usenatvnode=True)
 
         rv = self.scheduler.set_sched_config(
             {'round_robin': 'false all', 'by_queue': 'false all',
@@ -247,7 +247,7 @@ class TestStrictOrderingAndBackfilling(TestFunctional):
         enabled on another queue.
         """
         a = {'resources_available.ncpus': 1}
-        self.server.create_vnodes('vn', a, 1, self.mom, usenatvnode=True)
+        self.mom.create_vnodes(a, 1, usenatvnode=True)
 
         rv = self.scheduler.set_sched_config(
             {'round_robin': 'false all', 'by_queue': 'false all',

--- a/test/tests/functional/pbs_suspend_resume_accounting.py
+++ b/test/tests/functional/pbs_suspend_resume_accounting.py
@@ -250,13 +250,13 @@ class TestSuspendResumeAccounting(TestFunctional):
 
         vn_attrs = {ATTR_rescavail + '.ncpus': 8,
                     ATTR_rescavail + '.mem': '1024mb'}
-        self.server.create_vnodes("vnode1", vn_attrs, 1,
-                                  self.mom, fname="vnodedef1")
+        self.mom.create_vnodes(vn_attrs, 1,
+                                  fname="vnodedef1", vname="vnode1")
         # Append a vnode
         vn_attrs = {ATTR_rescavail + '.ncpus': 6,
                     ATTR_rescavail + '.mem': '1024mb'}
-        self.server.create_vnodes("vnode2", vn_attrs, 1,
-                                  self.mom, additive=True, fname="vnodedef2")
+        self.mom.create_vnodes(vn_attrs, 1, additive=True,
+                                  fname="vnodedef2", vname="vnode2")
 
         # Submit a low priority job
         j1 = Job()

--- a/test/tests/functional/pbs_suspend_resume_accounting.py
+++ b/test/tests/functional/pbs_suspend_resume_accounting.py
@@ -251,12 +251,12 @@ class TestSuspendResumeAccounting(TestFunctional):
         vn_attrs = {ATTR_rescavail + '.ncpus': 8,
                     ATTR_rescavail + '.mem': '1024mb'}
         self.mom.create_vnodes(vn_attrs, 1,
-                                  fname="vnodedef1", vname="vnode1")
+                               fname="vnodedef1", vname="vnode1")
         # Append a vnode
         vn_attrs = {ATTR_rescavail + '.ncpus': 6,
                     ATTR_rescavail + '.mem': '1024mb'}
         self.mom.create_vnodes(vn_attrs, 1, additive=True,
-                                  fname="vnodedef2", vname="vnode2")
+                               fname="vnodedef2", vname="vnode2")
 
         # Submit a low priority job
         j1 = Job()

--- a/test/tests/functional/pbs_test_tpp.py
+++ b/test/tests/functional/pbs_test_tpp.py
@@ -358,8 +358,7 @@ class TestTPP(TestFunctional):
         if not self.mom.is_cpuset_mom():
             a = {'resources_available.ncpus': 1}
             self.mom.create_vnodes(a, 2)
-            vnode_val = "vnode=" + vn + \
-                "[0]:ncpus=1+vnode=" + vn + "[1]:ncpus=1"
+            vnode_val = "vnode=%s[0]:ncpus=1+vnode=%s[1]:ncpus=1" % (vn, vn)
         else:
             vnode_val = "vnode=%s:ncpus=1" % self.server.status(NODE)[1]['id']
             vnode_val += "+vnode=%s:ncpus=1" % self.server.status(NODE)[
@@ -373,8 +372,8 @@ class TestTPP(TestFunctional):
                           resv_set_attr=resv_set_attr)
         self.comm.stop('-KILL')
         if self.mom.is_cpuset_mom():
-            vnode_list = [self.server.status(NODE)[1]['id'],
-                          self.server.status(NODE)[2]['id']]
+            ret = self.server.status(NODE)
+            vnode_list = [ret[i]['id'] for i in range(1, 3)]
         else:
             vnode_list = [vn + "[0]", vn + "[1]"]
         a = {'state': (MATCH_RE, "down")}

--- a/test/tests/functional/pbs_test_tpp.py
+++ b/test/tests/functional/pbs_test_tpp.py
@@ -354,10 +354,12 @@ class TestTPP(TestFunctional):
         """
         Test for verifying vnode insertion when using TPP
         """
+        vn = self.mom.shortname
         if not self.mom.is_cpuset_mom():
             a = {'resources_available.ncpus': 1}
-            self.server.create_vnodes('vn', a, 2, self.mom)
-            vnode_val = "vnode=vn[0]:ncpus=1+vnode=vn[1]:ncpus=1"
+            self.mom.create_vnodes(a, 2)
+            vnode_val = "vnode=" + vn + \
+                "[0]:ncpus=1+vnode=" + vn + "[1]:ncpus=1"
         else:
             vnode_val = "vnode=%s:ncpus=1" % self.server.status(NODE)[1]['id']
             vnode_val += "+vnode=%s:ncpus=1" % self.server.status(NODE)[
@@ -374,7 +376,7 @@ class TestTPP(TestFunctional):
             vnode_list = [self.server.status(NODE)[1]['id'],
                           self.server.status(NODE)[2]['id']]
         else:
-            vnode_list = ["vn[0]", "vn[1]"]
+            vnode_list = [vn + "[0]", vn + "[1]"]
         a = {'state': (MATCH_RE, "down")}
         for vnode in vnode_list:
             self.server.expect(VNODE, a, id=vnode)

--- a/test/tests/functional/pbs_test_tpp.py
+++ b/test/tests/functional/pbs_test_tpp.py
@@ -373,7 +373,7 @@ class TestTPP(TestFunctional):
         self.comm.stop('-KILL')
         if self.mom.is_cpuset_mom():
             ret = self.server.status(NODE)
-            vnode_list = [ret[i]['id'] for i in range(1, 3)]
+            vnode_list = [ret[1]['id'], ret[2]['id']]
         else:
             vnode_list = [vn + "[0]", vn + "[1]"]
         a = {'state': (MATCH_RE, "down")}

--- a/test/tests/performance/pbs_equiv_classes_perf.py
+++ b/test/tests/performance/pbs_equiv_classes_perf.py
@@ -55,8 +55,8 @@ class TestJobEquivClassPerf(TestPerformance):
 
         # Create vnodes
         a = {'resources_available.ncpus': 1, 'resources_available.mem': '8gb'}
-        self.server.create_vnodes('vnode', a, 10000, self.mom, expect=False,
-                                  sharednode=False)
+        self.mom.create_vnodes(a, 10000, expect=False,
+                               sharednode=False)
         self.server.expect(NODE, {'state=free': 10001})
 
     def run_n_get_cycle_time(self):

--- a/test/tests/performance/pbs_preemptperformance.py
+++ b/test/tests/performance/pbs_preemptperformance.py
@@ -140,7 +140,7 @@ class TestPreemptPerformance(TestPerformance):
         """
         a = {'resources_available.ncpus': 4800,
              'resources_available.mem': '2800mb'}
-        self.server.create_vnodes('vn', a, 1, self.mom, usenatvnode=True)
+        self.mom.create_vnodes(a, 1, usenatvnode=True)
         p = '"express_queue, normal_jobs, server_softlimits, queue_softlimits"'
         a = {'preempt_prio': p}
         self.server.manager(MGR_CMD_SET, SCHED, a, runas=ROOT_USER)
@@ -157,7 +157,7 @@ class TestPreemptPerformance(TestPerformance):
         """
         a = {'resources_available.ncpus': 4800,
              'resources_available.mem': '1500mb'}
-        self.server.create_vnodes('vn', a, 1, self.mom, usenatvnode=True)
+        self.mom.create_vnodes(a, 1, usenatvnode=True)
         p = '"express_queue, normal_jobs, server_softlimits, queue_softlimits"'
         a = {'preempt_prio': p}
         self.server.manager(MGR_CMD_SET, SCHED, a, runas=ROOT_USER)
@@ -179,13 +179,13 @@ class TestPreemptPerformance(TestPerformance):
 
         a = {ATTR_rescavail + ".qlist": "list1",
              ATTR_rescavail + ".ncpus": "8"}
-        self.server.create_vnodes(
-            "vn1", a, 400, self.mom, additive=True, fname="vnodedef1")
+        self.mom.create_vnodes(
+            a, 400, self.mom, additive=True, fname="vnodedef1")
 
         a = {ATTR_rescavail + ".qlist": "list2",
              ATTR_rescavail + ".ncpus": "1"}
-        self.server.create_vnodes(
-            "vn2", a, 1, self.mom, additive=True, fname="vnodedef2")
+        self.mom.create_vnodes(
+            a, 1, self.mom, additive=True, fname="vnodedef2")
 
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
 
@@ -261,18 +261,18 @@ class TestPreemptPerformance(TestPerformance):
 
         a = {ATTR_rescavail + ".qlist": "list1",
              ATTR_rescavail + ".ncpus": "8"}
-        self.server.create_vnodes(
-            "vn1", a, 400, self.mom, additive=True, fname="vnodedef1")
+        self.mom.create_vnodes(
+            a, 400, additive=True, fname="vnodedef1")
 
         a = {ATTR_rescavail + ".qlist": "list2",
              ATTR_rescavail + ".ncpus": "1"}
-        self.server.create_vnodes(
-            "vn2", a, 1, self.mom, additive=True, fname="vnodedef2")
+        self.mom.create_vnodes(
+            a, 1, additive=True, fname="vnodedef2")
 
         a = {ATTR_rescavail + ".qlist": "list3",
              ATTR_rescavail + ".ncpus": "1"}
-        self.server.create_vnodes(
-            "vn3", a, 1, self.mom, additive=True, fname="vnodedef3")
+        self.mom.create_vnodes(
+            a, 1, additive=True, fname="vnodedef3")
 
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
 
@@ -353,8 +353,8 @@ class TestPreemptPerformance(TestPerformance):
         self.server.manager(MGR_CMD_CREATE, RSC, a, id='foo')
 
         a = {ATTR_rescavail + ".ncpus": "8"}
-        self.server.create_vnodes(
-            "vn1", a, 401, self.mom, additive=True, fname="vnodedef1")
+        self.mom.create_vnodes(
+            a, 401, additive=True, fname="vnodedef1")
 
         # Make resource foo available on server
         a = {ATTR_rescavail + ".foo": 50, 'scheduling': 'False'}
@@ -422,8 +422,8 @@ class TestPreemptPerformance(TestPerformance):
         """
 
         a = {ATTR_rescavail + ".ncpus": "8"}
-        self.server.create_vnodes(
-            "vn1", a, 400, self.mom, additive=True, fname="vnodedef1")
+        self.mom.create_vnodes(
+            a, 400, additive=True, fname="vnodedef1")
 
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
 
@@ -487,8 +487,8 @@ class TestPreemptPerformance(TestPerformance):
         """
         a = {'resources_available.ncpus': 4,
              'resources_available.mem': '6400mb'}
-        self.server.create_vnodes('vn', a, 500, self.mom, usenatvnode=False,
-                                  sharednode=False)
+        self.mom.create_vnodes(a, 500, usenatvnode=False,
+                               sharednode=False)
         p = "express_queue, normal_jobs, server_softlimits, queue_softlimits"
         a = {'preempt_prio': p}
         self.server.manager(MGR_CMD_SET, SCHED, a)
@@ -565,13 +565,13 @@ class TestPreemptPerformance(TestPerformance):
         """
         a = {'resources_available.ncpus': 4,
              'resources_available.mem': '6400mb'}
-        self.server.create_vnodes('vn', a, 500, self.mom, usenatvnode=False,
-                                  sharednode=False)
+        self.mom.create_vnodes(a, 500, usenatvnode=False,
+                               sharednode=False)
         p = "express_queue, normal_jobs, server_softlimits, queue_softlimits"
         a = {'preempt_prio': p}
         self.server.manager(MGR_CMD_SET, SCHED, a)
 
-        a = {'max_run_res_soft.ncpus': "[u:" + str(TEST_USER)+"=1]"}
+        a = {'max_run_res_soft.ncpus': "[u:" + str(TEST_USER) + "=1]"}
         self.server.manager(MGR_CMD_SET, QUEUE, a, 'workq')
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
 

--- a/test/tests/performance/pbs_runjobwait_perf.py
+++ b/test/tests/performance/pbs_runjobwait_perf.py
@@ -51,8 +51,8 @@ class TestRunjobWaitPerf(TestPerformance):
         """
         # Create 100 vnodes with 100 ncpus each, capable of running 10k jobs
         a = {"resources_available.ncpus": 100}
-        self.server.create_vnodes(
-            'vnode', a, 100, self.mom, sharednode=False, expect=False)
+        self.mom.create_vnodes(
+            a, 100, sharednode=False, expect=False)
         self.server.expect(NODE, {'state=free': (GE, 100)})
 
         # Start pbs_mom in mock run mode

--- a/test/tests/performance/pbs_sched_perf.py
+++ b/test/tests/performance/pbs_sched_perf.py
@@ -56,9 +56,9 @@ class TestSchedPerf(TestPerformance):
         a = {'resources_available.ncpus': 1, 'resources_available.mem': '8gb'}
         # 10010 nodes since it divides into 7 evenly.
         # Each node bucket will have 1430 nodes in it
-        self.server.create_vnodes('vnode', a, 10010, self.mom,
-                                  sharednode=False,
-                                  attrfunc=self.cust_attr_func, expect=False)
+        self.mom.create_vnodes(a, 10010,
+                               sharednode=False,
+                               attrfunc=self.cust_attr_func, expect=False)
         self.server.expect(NODE, {'state=free': (GE, 10010)})
         self.scheduler.add_resource('color')
 
@@ -326,7 +326,7 @@ class TestSchedPerf(TestPerformance):
         """
         # Create 1 node with 1 cpu
         a = {"resources_available.ncpus": 1}
-        self.server.create_vnodes('vnode', a, 1, self.mom, sharednode=False)
+        self.mom.create_vnodes(a, 1, sharednode=False)
 
         a = {"attr_update_period": 10000, "scheduling": "False"}
         self.server.manager(MGR_CMD_SET, SCHED, a, id="default")
@@ -412,7 +412,7 @@ class TestSchedPerf(TestPerformance):
         single scheduler and workload divided among 5 schedulers.
         """
         a = {'resources_available.ncpus': 1000}
-        self.server.create_vnodes(self.mom.shortname, a, 5, self.mom)
+        self.mom.create_vnodes(a, 5)
         a = {'scheduling': 'False'}
         self.server.manager(MGR_CMD_SET, SERVER, a)
         self.submit_njobs(5000)

--- a/test/tests/performance/pbs_standing_resv_quasihang.py
+++ b/test/tests/performance/pbs_standing_resv_quasihang.py
@@ -62,8 +62,7 @@ class StandingResvQuasihang(TestPerformance):
             self.tzone = 'Asia/Kolkata'
 
         a = {'resources_available.ncpus': 2}
-        self.server.create_vnodes('vnode', a, num=2000, mom=self.mom,
-                                  usenatvnode=True)
+        self.mom.create_vnodes(a, num=2000, usenatvnode=True)
 
     @timeout(6000)
     def test_time_for_stat_after_mom_hup(self):

--- a/test/tests/resilience/pbs_hook_alarm_large_multinode_job.py
+++ b/test/tests/resilience/pbs_hook_alarm_large_multinode_job.py
@@ -59,8 +59,7 @@ class TestPbsHookAlarmLargeMultinodeJob(TestResilience):
         if not self.mom.is_cpuset_mom():
             a = {'resources_available.mem': '1gb',
                  'resources_available.ncpus': '1'}
-            self.server.create_vnodes(self.mom.shortname, a, 5000, self.mom,
-                                      expect=False)
+            self.mom.create_vnodes(a, 5000, expect=False)
             # Make sure all the nodes are in state free.  We can't let
             # create_vnodes() do this because it does
             # a pbsnodes -v on each vnode.

--- a/test/tests/selftest/pbs_cycles_test.py
+++ b/test/tests/selftest/pbs_cycles_test.py
@@ -60,11 +60,11 @@ class PBSTestCycle(TestSelf):
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='wq')
 
         a = {'resources_available.ncpus': 2}
-        self.server.create_vnodes('vnode', a, 1, self.mom)
-
+        self.mom.create_vnodes(a, 1)
+        vn = self.mom.shortname
         p1 = {'partition': 'P1'}
         self.server.manager(MGR_CMD_SET, QUEUE, p1, id='wq')
-        self.server.manager(MGR_CMD_SET, NODE, p1, id='vnode[0]')
+        self.server.manager(MGR_CMD_SET, NODE, p1, id=vn + '[0]')
 
         a = {'partition': 'P1',
              'sched_host': self.server.hostname,

--- a/test/tests/selftest/pbs_job_cleanup.py
+++ b/test/tests/selftest/pbs_job_cleanup.py
@@ -86,8 +86,8 @@ class TestJobCleanup(TestSelf):
         num_jobs = 1000
         a = {'resources_available.ncpus': 1,
              'resources_available.mem': '2gb'}
-        self.server.create_vnodes('vnode', a, num_jobs, self.mom,
-                                  sharednode=False, expect=False)
+        self.mom.create_vnodes(a, num_jobs,
+                               sharednode=False, expect=False)
         self.server.expect(NODE, {'state=free': (GE, num_jobs)})
 
         self.server.manager(MGR_CMD_SET, MGR_OBJ_SERVER,
@@ -111,8 +111,8 @@ class TestJobCleanup(TestSelf):
         num_jobs = 1000
         a = {'resources_available.ncpus': 1,
              'resources_available.mem': '2gb'}
-        self.server.create_vnodes('vnode', a, num_jobs, self.mom,
-                                  sharednode=False, expect=False)
+        self.mom.create_vnodes(a, num_jobs,
+                               sharednode=False, expect=False)
         self.server.expect(NODE, {'state=free': (GE, num_jobs)})
 
         self.server.manager(MGR_CMD_SET, MGR_OBJ_SERVER,

--- a/test/tests/selftest/pbs_test_create_vnodes.py
+++ b/test/tests/selftest/pbs_test_create_vnodes.py
@@ -52,21 +52,18 @@ class Test_create_vnodes(TestSelf):
         if len(self.moms) != 2:
             self.skipTest("test requires atleast two MoMs as input, "
                           "use -p moms=<mom1:mom2>")
-        mom1 = self.moms.values()[0]
-        mom2 = self.moms.values()[1]
         a = {'resources_available.ncpus': 4}
-        self.server.create_vnodes(mom1.shortname, a, 4, mom1)
-        self.server.create_vnodes(mom2.shortname, a, 5, mom2,
-                                  usenatvnode=True, delall=False)
+        self.moms.values()[0].create_vnodes(a, 4)
+        self.moms.values()[1].create_vnodes(a, 5,
+                                            usenatvnode=True, delall=False)
         stat = self.server.status(NODE)
         self.assertEqual(len(stat), 10)
 
     def test_delall(self):
         a = {'resources_available.ncpus': 4}
-        self.server.create_vnodes('first', a, 4, self.mom)
-        self.server.create_vnodes('second', a, 5, self.mom,
-                                  usenatvnode=True, delall=False)
-        self.server.create_vnodes('third', a, 5, self.mom,
-                                  delall=False)
+        self.mom.create_vnodes(a, 4, vname='first')
+        self.mom.create_vnodes(a, 5, usenatvnode=True,
+                               delall=False, vname='second')
+        self.mom.create_vnodes(a, 5, delall=False, vname='third')
         stat = self.server.status(NODE)
         self.assertEqual(len(stat), 14)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Move PTL create_vnodes method from class Server to Mom


#### Describe Your Change
1.Moved PTL create_vnodes method from class Server to Mom
2. Removed the mom object and the vnode_prefix name sent to create_vnodes function and added back an optional vnode_prefix which can be given under necessary conditions.
3.Make mom hostname as the default vnode_prefix and removed the vnode_prefix from tests if not absolutely necessary.
4. Modified TestOfflineVnode test suite to verify vnodes from both the moms.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
https://openpbs.atlassian.net/wiki/spaces/PD/pages/2083028993/Move+create+vnodes+from+Class+Server+to+Mom+in+PTL

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Mainline :
Description: Tests from given sources on platforms UBUNTU1804, SUSE15, CENTOS8, CENTOS7
Platforms: UBUNTU1804,SUSE15,CENTOS8,CENTOS7
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|3759|968|3|2|1|1|961|

create_vnodes branch:
Description: Tests from given sources on platforms UBUNTU1804, SUSE15, CENTOS8, CENTOS7
Platforms: UBUNTU1804,SUSE15,CENTOS8,CENTOS7
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|3758|968|3|1|1|1|962|


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
