### PR TITLE
PP-1333: Subjobs are sometimes aborted on server restart

### DIFF
--- a/src/include/pbs_db.h
+++ b/src/include/pbs_db.h
@@ -180,7 +180,7 @@ struct pbs_db_job_info {
 	BIGINT   ji_fromaddr;	/* host job coming from   */
 	char     ji_jid[8];	/* extended job save data */
 	INTEGER  ji_credtype;	/* credential type */
-	INTEGER  ji_qrank;	/* sort key for db query */
+	BIGINT   ji_qrank;	/* sort key for db query */
 	pbs_db_attr_list_t db_attr_list; /* list of attributes for database */
 };
 typedef struct pbs_db_job_info pbs_db_job_info_t;

--- a/src/lib/Libdb/pgsql/db_job.c
+++ b/src/lib/Libdb/pgsql/db_job.c
@@ -327,7 +327,7 @@ load_job(const  PGresult *res, pbs_db_job_info_t *pj, int row)
 	GET_PARAM_BIGINT(res, row, pj->ji_fromaddr, ji_fromaddr_fnum);
 	GET_PARAM_STR(res, row, pj->ji_jid, ji_jid_fnum);
 	GET_PARAM_INTEGER(res, row, pj->ji_credtype, ji_credtype_fnum);
-	GET_PARAM_INTEGER(res, row, pj->ji_qrank, ji_qrank_fnum);
+	GET_PARAM_BIGINT(res, row, pj->ji_qrank, ji_qrank_fnum);
 	GET_PARAM_BIN(res, row, raw_array, attributes_fnum);
 
 	/* convert attributes from postgres raw array format */
@@ -374,7 +374,7 @@ pbs_db_save_job(void *conn, pbs_db_obj_info_t *obj, int savetype)
 		SET_PARAM_BIGINT(conn_data, pjob->ji_fromaddr, 12);
 		SET_PARAM_STR(conn_data, pjob->ji_jid, 13);
 		SET_PARAM_INTEGER(conn_data, pjob->ji_credtype, 14);
-		SET_PARAM_INTEGER(conn_data, pjob->ji_qrank, 15);
+		SET_PARAM_BIGINT(conn_data, pjob->ji_qrank, 15);
 
 		stmt = STMT_UPDATE_JOB_QUICK;
 		params = 16;

--- a/src/lib/Libdb/pgsql/pbs_db_schema.sql
+++ b/src/lib/Libdb/pgsql/pbs_db_schema.sql
@@ -175,7 +175,7 @@ CREATE TABLE pbs.job (
     ji_fromaddr     BIGINT,
     ji_jid          TEXT,
     ji_credtype     INTEGER,
-    ji_qrank        INTEGER     NOT NULL,
+    ji_qrank        BIGINT      NOT NULL,
     ji_savetm       TIMESTAMP   NOT NULL,
     ji_creattm      TIMESTAMP   NOT NULL,
     attributes      hstore      NOT NULL default '',

--- a/src/lib/Libdb/pgsql/pbs_schema_upgrade
+++ b/src/lib/Libdb/pgsql/pbs_schema_upgrade
@@ -257,6 +257,7 @@ upgrade_pbs_schema_from_v1_4_0() {
 		ALTER TABLE pbs.job DROP COLUMN ji_momaddr;
 		ALTER TABLE pbs.job DROP COLUMN ji_momport;
 		ALTER TABLE pbs.job RENAME COLUMN ji_4jid to ji_jid;
+		ALTER TABLE pbs.job ALTER COLUMN ji_qrank TYPE BIGINT;
 		ALTER TABLE pbs.job DROP COLUMN ji_4ash;
 		ALTER TABLE pbs.resv DROP COLUMN ri_type;
 		ALTER TABLE pbs.resv DROP COLUMN ri_numattr;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Subjobs are sometimes aborted on a server restart.
This is because the ji_qrank attribute is defined as a INTEGER in the postgres database.  But JOB_ATR_qrank job attribute is a long type.
Storing this attribute to the database results in misleading qrank. Once the server is restarted, the order of recovered jobs is sorted by the qrank. The inconsistency in data type may lead to reading subjob before parentjob, which leads to aborting the subjob because no parent job is read yet.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Changed the ji_qrank in the database from an INTEGER to a BIGINT.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Testing was done manually by changing the system time and starting subjobs at different times so they would get different qrank values.
[subjobs_before.txt](https://github.com/openpbs/openpbs/files/5242304/subjobs_before.txt)
[subjobs_after.txt](https://github.com/openpbs/openpbs/files/5242305/subjobs_after.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
