### PR TITLE
Comment out code in test_reservation due to a PBS bug

### DIFF
--- a/test/tests/functional/pbs_accumulate_resc_used.py
+++ b/test/tests/functional/pbs_accumulate_resc_used.py
@@ -753,6 +753,9 @@ else:
     def test_reservation(self):
         """
         Test that job inside reservations works same
+        NOTE: Due to the reservation duration and the job duration
+        both being equal, this test found 2 race conditions.
+        KEEP the durations equal to each other.
         """
         # Create non-host level resources from qmgr
         attr = {}
@@ -827,10 +830,14 @@ j.resources_used["stra2"] = '"glad"'
         self.server.expect(JOB, a, extend='x', attrop=PTL_AND,
                            offset=30, interval=1, id=jid)
 
-        # Restart server and verifies that the values are still the same
-        self.server.restart()
+        # Below is commented out due to a problem with history jobs
+        # disapearing after a server restart when the reservation is
+        # in state BD during restart. 
+        # Once that bug is fixed, this test code should be uncommented
+        # and run.
 
-        # Below is commented due to a known PBS issue
+        # Restart server and verifies that the values are still the same
+        # self.server.restart()
         # self.server.expect(JOB, a, extend='x', id=jid)
 
     def test_server_restart(self):

--- a/test/tests/functional/pbs_accumulate_resc_used.py
+++ b/test/tests/functional/pbs_accumulate_resc_used.py
@@ -832,7 +832,7 @@ j.resources_used["stra2"] = '"glad"'
 
         # Below is commented out due to a problem with history jobs
         # disapearing after a server restart when the reservation is
-        # in state BD during restart. 
+        # in state BD during restart.
         # Once that bug is fixed, this test code should be uncommented
         # and run.
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
There was a dangling server restart at the end of a test.  The check that would have happened after the restart was commented out for a "known issue".  But we didn't know what the issue was.  And we should have also commented out the server restart.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
I added details about what the issue is that is causing the code to be commented out.
I also commented out the server restart.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

Showing that the test still passes.
[after.txt](https://github.com/openpbs/openpbs/files/5248668/after.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
