### PR TITLE
Make resume_multinode function platform independent

### DIFF
--- a/src/resmom/start_exec.c
+++ b/src/resmom/start_exec.c
@@ -5925,51 +5925,6 @@ job_nodes(struct job *pjob)
 	return job_nodes_inner(pjob, NULL);
 }
 
-/**
- * @brief
- * 	Resume multinode job after one or more sisters has been restarted
- *
- * @param[in] pjob - job pointer
- *
- * @return	Void
- *
- */
-
-void resume_multinode(job *pjob)
-{
-	if (pjob->ji_hosts == NULL)
-		return;
-
-	int com = IM_JOIN_RECOV_JOB;
-	hnodent *np = NULL;
-	eventent *ep = NULL;
-	int i;
-	for(i = 1; i < pjob->ji_numnodes; i++) {
-		np = &pjob->ji_hosts[i];
-
-		if( i == 1 )
-			ep = event_alloc(pjob, com, -1, np, TM_NULL_EVENT, TM_NULL_TASK);
-		else
-			ep = event_dup(ep, pjob, np);
-
-		if (ep == NULL) {
-			exec_bail(pjob, JOB_EXEC_FAIL1, NULL);
-			return;
-		}
-
-		int stream = np->hn_stream;
-		im_compose(stream, pjob->ji_qs.ji_jobid,
-			get_jattr_str(pjob, JOB_ATR_Cookie),
-			com, ep->ee_event, TM_NULL_TASK,  IM_OLD_PROTOCOL_VER);
-		(void)diswsi(stream, pjob->ji_numnodes);
-		(void)diswsi(stream, pjob->ji_ports[0]);
-		(void)diswsi(stream, pjob->ji_ports[1]);
-		dis_flush(stream);
-#if defined(PBS_SECURITY) && (PBS_SECURITY == KRB5)
-		send_cred_sisters(pjob);
-#endif
-	}
-}
 
 /**
  * @brief


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Currently resume_multinode() compiles only for few platforms.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Made it platform independent.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

Description: Rerun All Tests From #3840
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|3841|3547|14|0|1|6|3526|

Description: Rerun Only Failed Tests From #3841
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|3850|15|10|1|0|0|4|

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
