### PR TITLE
TestPreemption.test_preempt_wrong_cull was failing on all platforms

### DIFF
--- a/test/tests/functional/pbs_preemption.py
+++ b/test/tests/functional/pbs_preemption.py
@@ -767,11 +767,11 @@ exit 3
         j1 = Job(TEST_USER, attrs=a)
         jid1 = self.server.submit(j1)
 
-        self.server.expect(JOB, {'state': 'R'}, id=jid1)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
 
         # submit job 2
         a = {'Resource_List.select': '1:ncpus=1:app=appA', ATTR_q: 'hipri'}
         j2 = Job(TEST_USER, attrs=a)
         jid2 = self.server.submit(j2)
 
-        self.server.expect(JOB, {'state': 'R'}, id=jid2)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid2)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
TestPreemption.test_preempt_wrong_cull failing on all platforms.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Modified the attribute we are querying to server for job from 'state' to 'job_state'.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

Description: Tests from given sources on platforms UBUNTU1804, SUSE15, CENTOS8, CENTOS7
Platforms: UBUNTU1804,SUSE15,CENTOS8,CENTOS7
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|3875|1834|1|1|0|1|1831|

Description: Rerun Only Failed Tests From #3875
Platforms: UBUNTU1804,SUSE15,CENTOS8,CENTOS7
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|3885|2|0|0|0|0|2|

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
