### PR TITLE
fix rescdef not sent when live node is recreated

### DIFF
--- a/src/resmom/requests.c
+++ b/src/resmom/requests.c
@@ -5051,6 +5051,9 @@ req_del_hookfile(struct batch_request *preq) /* ptr to the decoded request   */
 			req_reject(PBSE_INTERNAL, 0, preq);
 			mark_hook_file_bad(namebuf);
 		}
+	} else {
+		if (!strcmp(preq->rq_ind.rq_hookfile.rq_filename, PBS_RESCDEF))
+			hooks_rescdef_checksum = 0LU;
 	}
 
 	reply_ack(preq);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug
<!--- Describe the problem, ideally from the customer's viewpoint  -->
custom resources are not synced if a node is deleted/added back without restart of node
```
Problem is reproduced as follows:

# create a mom hook

nadal:/home/bayucan/PBSPro_2020.1.1 # qmgr -c "c h begin event=execjob_begin"

# create a resource

nadal:/home/bayucan/PBSPro_2020.1.1 # qmgr -c "c r foo type=string,flag=h"

# this results in server adding 'foo' to server_priv/hook/resourcedef file, which then get sent to mom:
nadal:/var/spool/pbs/mom_priv/hooks # ls
 begin.HK      resourcedef tmp
nadal:/var/spool/pbs/mom_priv/hooks # cat resourcedef
foo type=string flag=h

# Now delete all the nodes

nadal:/var/spool/pbs/mom_priv/hooks # qmgr -c "d n @default"
# Now all the mom hooks disappear from the node
nadal:/var/spool/pbs/mom_priv/hooks # ls
tmp

# now re-create the node
nadal:/var/spool/pbs/mom_priv/hooks # qmgr -c "c n nadal"

# check status

nadal:/var/spool/pbs/mom_priv/hooks # pbsnodes -av
nadal
     Mom = nadal.pbspro.com
     Port = 15002
     pbs_version = 2020.1.1
     ntype = PBS
     state = free
     pcpus = 1
     resources_available.arch = linux
     resources_available.host = nadal
     resources_available.mem = 757388kb
     resources_available.ncpus = 1
     resources_available.vnode = nadal
     resources_assigned.accelerator_memory = 0kb
     resources_assigned.hbmem = 0kb
     resources_assigned.mem = 0kb
     resources_assigned.naccelerators = 0
     resources_assigned.ncpus = 0
     resources_assigned.vmem = 0kb
     resv_enable = True
     sharing = default_shared
     last_state_change_time = Fri Sep 18 19:52:36 2020



# With the hook sync code fix, resourcedef is not copied

nadal:/var/spool/pbs/mom_priv/hooks # ls
 begin.HK    tmp

 

Snapshot of server_logs showed:

The message about "sent rescdef file' goes missing:

09/18/2020 20:22:25;0080;Server@corretja;Req;Server@corretja;successfully sent hook file /var/spool/pbs/server_priv/hooks/begin.HK to corretja.pbspro.com:15002
```
Thanks to @bayucan for providing these steps

This bug surfaced after merge of https://github.com/openpbs/openpbs/pull/1992

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Fixed by resetting the global `hooks_rescdef_checksum` of moms when it deletes the `rescdef` file as per server's request when the node was deleted

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[rescdef_sync_logs.zip](https://github.com/openpbs/openpbs/files/5269169/rescdef_sync_logs.zip)
[Fixed_output.txt](https://github.com/openpbs/openpbs/files/5269170/Fixed_output.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
