### PR TITLE
Fix compilation failure

### DIFF
--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -3449,7 +3449,6 @@ set_checkpoint_path(char *value)
 {
 	int		rc = 0;
 	char		newpath[_POSIX_PATH_MAX] = "\0";
-	int	perm;
 
 	/*
 	 * If value and path_checkpoint both contain the same address,
@@ -3496,6 +3495,7 @@ set_checkpoint_path(char *value)
 		strcat(newpath, "/");
 	}
 #if !defined(DEBUG) && !defined(NO_SECURITY_CHECK)
+	int	perm;
 	perm = get_permission("write");
 	rc = chk_file_sec(newpath, 1, 0, perm, 0);
 #else
@@ -4194,7 +4194,6 @@ read_config(char *file)
 	struct	config		*ap;
 	int			i, j;
 	int			addconfig_ret;
-	int perm;
 
 	/*	initialize variable that can be set by config entries in case	*/
 	/*	they are removed and we are HUPped				*/
@@ -4285,6 +4284,7 @@ read_config(char *file)
 			return 0;	/* ok for "config" not to be there  */
 	}
 #if !defined(DEBUG) && !defined(NO_SECURITY_CHECK)
+	int perm;
 	perm = get_permission("write");
 	if (chk_file_sec(file, 0, 0, perm, FULLPATH)) {
 		sprintf(log_buffer,


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Compilation fails because of unused variable in some platform.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Fix the variable declaration at right place.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

Before fix:
[91m/tmp/builddir/1/2/3/pbs/src/resmom/mom_main.c: In function ‘set_checkpoint_path’:
[0m[91m/tmp/builddir/1/2/3/pbs/src/resmom/mom_main.c:3452:6: error: unused variable ‘perm’ [-Werror=unused-variable]
  int perm;
      ^
[0m[91m/tmp/builddir/1/2/3/pbs/src/resmom/mom_main.c: In function ‘read_config’:
[0m[91m/tmp/builddir/1/2/3/pbs/src/resmom/mom_main.c:4197:6: error: unused variable ‘perm’ [-Werror=unused-variable]
  int perm;
      ^


Regression job id: 3543

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
