### PR TITLE
add PTL TestMomHookSync.test_rescdef_mom_recreate to test #efa7bfa

### DIFF
--- a/test/tests/functional/pbs_mom_hook_sync.py
+++ b/test/tests/functional/pbs_mom_hook_sync.py
@@ -402,8 +402,8 @@ class TestMomHookSync(TestFunctional):
         self.compare_rescourcedef()
 
         # delete node
-        self.server.manager(MGR_CMD_DELETE, NODE, id=self.momB.hostname)
-        self.server.expect(NODE, 'state', id=self.momB.hostname, op=UNSET)
+        self.server.manager(MGR_CMD_DELETE, NODE, id=self.momB.shortname)
+        self.server.expect(NODE, 'state', id=self.momB.shortname, op=UNSET)
 
         # check if rescdef is deleted
         file = os.path.join(self.momB.pbs_conf['PBS_HOME'], 'mom_priv',
@@ -413,10 +413,10 @@ class TestMomHookSync(TestFunctional):
             "resourcedef not deleted at mom")
 
         # recreate node
-        self.server.manager(MGR_CMD_CREATE, NODE, id=self.momB.hostname)
+        self.server.manager(MGR_CMD_CREATE, NODE, id=self.momB.shortname)
 
         # check for status of the node
-        self.server.expect(NODE, {'state': 'free'}, id=self.momB.hostname)
+        self.server.expect(NODE, {'state': 'free'}, id=self.momB.shortname)
 
         # compare rescdef files between mom and server
         self.compare_rescourcedef()

--- a/test/tests/functional/pbs_mom_hook_sync.py
+++ b/test/tests/functional/pbs_mom_hook_sync.py
@@ -361,3 +361,62 @@ class TestMomHookSync(TestFunctional):
             'successfully sent hook file .*cpufreq.PY ' +
             'to %s.*' % self.momB.hostname, existence=False,
             starttime=now, max_attempts=10, regexp=True)
+
+    def compare_rescourcedef(self):
+        srvret = None
+
+        for _ in range(5):
+            time.sleep(1)
+            if srvret is None:
+                file = os.path.join(self.server.pbs_conf['PBS_HOME'],
+                                    'server_priv', 'hooks', 'resourcedef')
+                srvret = self.du.cat(self.server.hostname, file, logerr=False,
+                                     sudo=True)
+                if srvret['rc'] != 0 or len(srvret['out']) == 0:
+                    srvret = None
+                    continue
+
+            file = os.path.join(self.momB.pbs_conf['PBS_HOME'], 'mom_priv',
+                                'hooks', 'resourcedef')
+            momret = self.momB.du.cat(self.momB.hostname, file, logerr=False,
+                                      sudo=True)
+            if momret['rc'] != 0 or len(momret['out']) == 0:
+                continue
+
+            if momret['out'] == srvret['out']:
+                return
+            else:
+                srvret = None
+        raise self.failureException("resourcedef file is not in sync")
+
+    def test_rescdef_mom_recreate(self):
+        """
+        test if rescdef file is recreated when a mom is deleted and added back
+        """
+
+        # create a custom resource
+        self.server.manager(MGR_CMD_CREATE, RSC,
+                            {'type': 'string', 'flag': 'h'}, id='foo')
+
+        # compare rescdef files between mom and server
+        self.compare_rescourcedef()
+
+        # delete node
+        self.server.manager(MGR_CMD_DELETE, NODE, id=self.momB.hostname)
+        self.server.expect(NODE, 'state', id=self.momB.hostname, op=UNSET)
+
+        # check if rescdef is deleted
+        file = os.path.join(self.momB.pbs_conf['PBS_HOME'], 'mom_priv',
+                            'resourcedef')
+        self.assertFalse(
+            self.momB.du.isfile(self.momB.hostname, file, sudo=True),
+            "resourcedef not deleted at mom")
+
+        # recreate node
+        self.server.manager(MGR_CMD_CREATE, NODE, id=self.momB.hostname)
+
+        # check for status of the node
+        self.server.expect(NODE, {'state': 'free'}, id=self.momB.hostname)
+
+        # compare rescdef files between mom and server
+        self.compare_rescourcedef()


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
The fix in https://github.com/openpbs/openpbs/commit/efa7bfac8fa41815f3c5e7681b5fa1fc57a754b8 can be tested using automation

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Added automated PTL test case `TestMomHookSync.test_rescdef_mom_recreate` for testing the fix https://github.com/openpbs/openpbs/commit/efa7bfac8fa41815f3c5e7681b5fa1fc57a754b8



#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[ptl_out_bug.txt](https://github.com/openpbs/openpbs/files/5280922/ptl_out_bug.txt)
[ptl_out_fixed.txt](https://github.com/openpbs/openpbs/files/5280923/ptl_out_fixed.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
