### PR TITLE
Enable passwordless ssh login for non root users

### DIFF
--- a/ci/etc/install-system-packages
+++ b/ci/etc/install-system-packages
@@ -222,14 +222,13 @@ chmod 0600 ~/.ssh/id_rsa
 chmod 0644 ~/.ssh/id_rsa.pub
 cp ~/.ssh/id_rsa.pub ~/.ssh/authorized_keys
 chmod 0600 ~/.ssh/authorized_keys
-echo 'Host *' >>/etc/ssh/ssh_config
-echo '  StrictHostKeyChecking no' >>/etc/ssh/ssh_config
-echo 'PermitRootLogin yes' >>/etc/ssh/sshd_config
 echo 'root:pbs' | chpasswd
 cat /etc/profile.d/0container-env-setup.sh >>/root/.profile
 cat /etc/profile.d/0container-env-setup.sh >>/root/.bash_profile
 cat /etc/profile.d/0container-env-setup.sh >>/root/.bashrc
 for user in $(awk -F: '/^(pbs|tst)/ {print $1}' /etc/passwd); do
+  rm -rf /home/${user}/.ssh
+  cp -rfp ~/.ssh /home/${user}/
   chown -R ${user}: /home/${user}/.ssh
   echo "${user}:pbs" | chpasswd
   cat /etc/profile.d/0container-env-setup.sh >>/home/${user}/.profile
@@ -237,6 +236,16 @@ for user in $(awk -F: '/^(pbs|tst)/ {print $1}' /etc/passwd); do
   cat /etc/profile.d/0container-env-setup.sh >>/home/${user}/.bashrc
   chown ${user}: /home/${user}/.bashrc /home/${user}/.profile /home/${user}/.bash_profile
 done
+echo 'Host *' >>/etc/ssh/ssh_config
+echo '  StrictHostKeyChecking no' >>/etc/ssh/ssh_config
+echo '  ConnectionAttempts 3' >>/etc/ssh/ssh_config
+echo '  IdentityFile ~/.ssh/id_rsa' >>/etc/ssh/ssh_config
+echo '  PreferredAuthentications publickey,password' >>/etc/ssh/ssh_config
+echo 'PermitRootLogin yes' >>/etc/ssh/sshd_config
+echo 'UseDNS no' >>/etc/ssh/sshd_config
+sed -i 's/AcceptEnv/# AcceptEnv/g' /etc/ssh/sshd_config
+ssh-keygen -A
+rm -f /var/run/*.pid /run/nologin
 
 rm -rf ~/.cache ~/.cpanm /var/{log,cache} /tmp /var/tmp /run/*.pid /var/run/*.pid
 mkdir -p --mode=0755 /var/{log,cache}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
PTL was failing runnning as pbsroot as ssh was prompting for password

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Enabled passwordless ssh login for non root users

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[logfile-2020-09-25-113950.txt](https://github.com/openpbs/openpbs/files/5282526/logfile-2020-09-25-113950.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
