### PR TITLE
fixing a minor bug in pbs_logutils

### DIFF
--- a/test/fw/ptl/utils/pbs_logutils.py
+++ b/test/fw/ptl/utils/pbs_logutils.py
@@ -927,7 +927,7 @@ class PBSServerLog(PBSLogAnalyzer):
     server_run_tag = re.compile(tm_re + ".*" + job_re + ".*;Job Run at.*")
     server_nodeup_tag = re.compile(tm_re + ".*Node;.*;node up.*")
     server_enquejob_tag = re.compile(tm_re + ".*" + job_re +
-                                     ".*enqueuing into.*state R .*")
+                                     ".*enqueuing into.*state Q .*")
     server_endjob_tag = re.compile(tm_re + ".*" + job_re +
                                    ".*;Exit_status.*")
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
With https://github.com/openpbs/openpbs/pull/2016 server now prints letter job states instead of numerics. But I changed pbs_logutils to add the wrong job state letter for a particular log message. This just corrects that.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Changed state letter from R to Q in a server log message matching inside pbs_logutils.py

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Existing tests passing should be good enough for this.


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
