### PR TITLE
Fix JSON errors

### DIFF
--- a/src/lib/Libcmds/pbs_json.c
+++ b/src/lib/Libcmds/pbs_json.c
@@ -275,7 +275,7 @@ free_json_node_list()
  *
  */
 static int
-whitespace_only(char *str) {
+whitespace_only(const char *str) {
 
 	if (str == NULL)
 		return (0);

--- a/src/lib/Libcmds/pbs_json.c
+++ b/src/lib/Libcmds/pbs_json.c
@@ -184,21 +184,12 @@ strdup_escape(JsonEscapeType esc_type, const char *str)
 				if (esc_type == JSON_ESCAPE) {
 					bufstr = str + 1;
 					if (*bufstr && ((*bufstr == '\'') || (*bufstr == ','))) {
-						int slash_ct = 0;
-						bufstr--;
-						while ((bufstr >= orig_str) && (*bufstr == '\\')) {
-							slash_ct++;
-							bufstr--;
-						}
-						/* detected balanced escaping (even # slashes) */
-						if ((slash_ct % 2) == 0) {
-							buf[i++] = *str++;
-						} else {
-							str++;
-						}
-
+						str++;
+						buf[i++] = *str++;
 					} else {
 						buf[i++] = *str++;
+						if (*bufstr)
+							buf[i++] = *str++;
 					}
 					break;
 				} /* else JSON_FULLESCAPE */

--- a/test/tests/functional/pbs_nodes_json.py
+++ b/test/tests/functional/pbs_nodes_json.py
@@ -138,31 +138,8 @@ class TestPbsnodes_json(TestFunctional):
                            'bin', 'pbsnodes') + ' -av -Fjson'
         ret = self.du.run_cmd(self.server.hostname, cmd=cmd)
         n_out = "\n".join(ret['out'])
-        self.logger.info(n_out)
         try:
             json.loads(n_out)
         except ValueError:
-            self.assertFalse(True, "Json failed to load")
-
-    def test_empty_job_pset_json(self):
-        """
-        Test an empty pset resource value under json.
-        """
-        # create a custom resource
-        self.server.manager(MGR_CMD_CREATE, RSC,
-                            {'type': 'string', 'flag': 'h'}, id='iru')
-        attr = {'node_group_enable': 'True', 'node_group_key': 'iru'}
-        self.server.manager(MGR_CMD_SET, SERVER, attr)
-
-        j = Job(TEST_USER)
-        jid = self.server.submit(j)
-        # when job runs, pset will be set to iru="""
-        qstat_cmd_json = os.path.join(self.server.pbs_conf['PBS_EXEC'], 'bin',
-                                      'qstat') + ' -f -F json ' + str(jid)
-        ret = self.du.run_cmd(self.server.hostname, cmd=qstat_cmd_json)
-        qstat_out = "\n".join(ret['out'])
-        self.logger.info(qstat_out)
-        try:
-            json.loads(qstat_out)
-        except ValueError:
+            self.logger.info(n_out)
             self.assertFalse(True, "Json failed to load")

--- a/test/tests/functional/pbs_nodes_json.py
+++ b/test/tests/functional/pbs_nodes_json.py
@@ -126,3 +126,43 @@ class TestPbsnodes_json(TestFunctional):
             json.loads("\n".join(n_out))
         except ValueError:
             self.assertFalse(True, "Json failed to load")
+
+    def test_empty_comment_json(self):
+        """
+        Test an empty node comment (only a space) under json.
+        """
+
+        self.server.manager(MGR_CMD_SET, NODE,
+                            {'comment': ' '}, id=self.mom.shortname)
+        cmd = os.path.join(self.server.pbs_conf['PBS_EXEC'],
+                           'bin', 'pbsnodes') + ' -av -Fjson'
+        ret = self.du.run_cmd(self.server.hostname, cmd=cmd)
+        n_out = "\n".join(ret['out'])
+        self.logger.info(n_out)
+        try:
+            json.loads(n_out)
+        except ValueError:
+            self.assertFalse(True, "Json failed to load")
+
+    def test_empty_job_pset_json(self):
+        """
+        Test an empty pset resource value under json.
+        """
+        # create a custom resource
+        self.server.manager(MGR_CMD_CREATE, RSC,
+                            {'type': 'string', 'flag': 'h'}, id='iru')
+        attr = {'node_group_enable': 'True', 'node_group_key': 'iru'}
+        self.server.manager(MGR_CMD_SET, SERVER, attr)
+
+        j = Job(TEST_USER)
+        jid = self.server.submit(j)
+        # when job runs, pset will be set to iru="""
+        qstat_cmd_json = os.path.join(self.server.pbs_conf['PBS_EXEC'], 'bin',
+                                      'qstat') + ' -f -F json ' + str(jid)
+        ret = self.du.run_cmd(self.server.hostname, cmd=qstat_cmd_json)
+        qstat_out = "\n".join(ret['out'])
+        self.logger.info(qstat_out)
+        try:
+            json.loads(qstat_out)
+        except ValueError:
+            self.assertFalse(True, "Json failed to load")

--- a/test/tests/functional/pbs_qstat_formats.py
+++ b/test/tests/functional/pbs_qstat_formats.py
@@ -580,6 +580,20 @@ class TestQstatFormats(TestFunctional):
         """
         os.environ["DOUBLEQUOTES"] = 'hi"ha'
         os.environ["REVERSESOLIDUS"] = r'hi\ha'
+        os.environ["MYVAR"] = """\'\"asads\"\'"""
+        os.environ["MYVAR2"] = """/home/pbstest01/Mo\\'"""
+        os.environ["FOO"] = """005"""
+        os.environ["MYVAR1"] = """\'"""
+        os.environ["MYVAR2"] = """\\'"""
+        os.environ["MYVAR3"] = """\\\\'"""
+        os.environ["MYVAR4"] = """\\\\\\'"""
+        os.environ["MYVAR5"] = """\\\\\\\\\\'"""
+        os.environ["MYVAR6"] = """\,"""
+        os.environ["MYVAR7"] = """\\,"""
+        os.environ["MYVAR8"] = """\\\\,"""
+        os.environ["MYVAR9"] = """\\\\\\,"""
+        os.environ["MYVAR10"] = """\\\\\\\\\\,"""
+        os.environ["MYVAR11"] = """apple\,delight"""
 
         self.server.manager(MGR_CMD_SET, SERVER,
                             {'default_qsub_arguments': '-V'})
@@ -593,6 +607,7 @@ class TestQstatFormats(TestFunctional):
             ' -f -F json ' + str(jid)
         ret = self.du.run_cmd(self.server.hostname, cmd=qstat_cmd_json)
         qstat_out = "\n".join(ret['out'])
+        self.logger.info(qstat_out)
         try:
             json.loads(qstat_out)
         except ValueError:

--- a/test/tests/functional/pbs_qstat_formats.py
+++ b/test/tests/functional/pbs_qstat_formats.py
@@ -581,19 +581,21 @@ class TestQstatFormats(TestFunctional):
         os.environ["DOUBLEQUOTES"] = 'hi"ha'
         os.environ["REVERSESOLIDUS"] = r'hi\ha'
         os.environ["MYVAR"] = """\'\"asads\"\'"""
-        os.environ["MYVAR2"] = """/home/pbstest01/Mo\\'"""
+        os.environ["MYHOME"] = """/home/pbstest01/Mo\\'"""
         os.environ["FOO"] = """005"""
-        os.environ["MYVAR1"] = """\'"""
-        os.environ["MYVAR2"] = """\\'"""
+        os.environ["MYVAR0"] = """\'"""
+        os.environ["MYVAR1"] = """\\'"""
+        os.environ["MYVAR2"] = """\\\'"""
         os.environ["MYVAR3"] = """\\\\'"""
         os.environ["MYVAR4"] = """\\\\\\'"""
         os.environ["MYVAR5"] = """\\\\\\\\\\'"""
         os.environ["MYVAR6"] = """\,"""
         os.environ["MYVAR7"] = """\\,"""
-        os.environ["MYVAR8"] = """\\\\,"""
-        os.environ["MYVAR9"] = """\\\\\\,"""
-        os.environ["MYVAR10"] = """\\\\\\\\\\,"""
-        os.environ["MYVAR11"] = """apple\,delight"""
+        os.environ["MYVAR8"] = """\\\,"""
+        os.environ["MYVAR9"] = """\\\\,"""
+        os.environ["MYVAR10"] = """\\\\\\,"""
+        os.environ["MYVAR11"] = """\\\\\\\\\\,"""
+        os.environ["MYVAR12"] = """apple\,delight"""
 
         self.server.manager(MGR_CMD_SET, SERVER,
                             {'default_qsub_arguments': '-V'})
@@ -607,10 +609,10 @@ class TestQstatFormats(TestFunctional):
             ' -f -F json ' + str(jid)
         ret = self.du.run_cmd(self.server.hostname, cmd=qstat_cmd_json)
         qstat_out = "\n".join(ret['out'])
-        self.logger.info(qstat_out)
         try:
             json.loads(qstat_out)
         except ValueError:
+            self.logger.info(qstat_out)
             self.assertTrue(False)
 
     def test_qstat_json_valid_job_longint_env(self):
@@ -734,3 +736,27 @@ class TestQstatFormats(TestFunctional):
         self.assertNotIn(jid, qstat_out)
         self.assertNotIn(jname, qstat_out)
         self.assertNotIn(qname, qstat_out)
+
+    def test_qstat_json_empty_job_pset(self):
+        """
+        Test an empty pset resource value under json.
+        """
+        # create a custom resource
+        self.server.manager(MGR_CMD_CREATE, RSC,
+                            {'type': 'string', 'flag': 'h'}, id='iru')
+        attr = {'node_group_enable': 'True', 'node_group_key': 'iru'}
+        self.server.manager(MGR_CMD_SET, SERVER, attr)
+
+        j = Job(TEST_USER)
+        jid = self.server.submit(j)
+        time.sleep(6)
+        # when job runs, pset will be set to iru="""
+        qstat_cmd_json = os.path.join(self.server.pbs_conf['PBS_EXEC'], 'bin',
+                                      'qstat') + ' -f -F json ' + str(jid)
+        ret = self.du.run_cmd(self.server.hostname, cmd=qstat_cmd_json)
+        qstat_out = "\n".join(ret['out'])
+        try:
+            json.loads(qstat_out)
+        except ValueError:
+            self.logger.info(qstat_out)
+            self.assertFalse(True, "Json failed to load")


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
The -Fjson feature in qstat and pbsnodes are reporting JSON errors when some conflicting substrings are read from PBS.
* If the following environment is passed to PBS, the resulting json output is an error:
```
export MYVAR=\'\"asads\"\'
qsub -V -- /bin/sleep 30
qstat -f shows:
MYVAR=\'\"asads\"\'
qstat -f -Fjson outputs:
"MYVAR":"\'\"asads\"\'"
but the \' is an error in JSON when fed to json.loads(). Fix is to drop the unnecessary \ (backslash):
"MYVAR":"'\"asads\"'"
```
* Similarly, if that \ is escaped, as in:
```
export MYVAR2=/home/pbstest01/Mo\\\'
echo $MYVAR2
/home/pbstest01/Mo\'
qsub -V -- /bin/sleep 30
qstat -f shows:
MYVAR2=/home/pbstest01/Mo\\\'
but qstat -f -Fjson would output:
"MYVAR2":"/home/pbstest01/Mo\\\'",
When fed to json.loads(), JSON error is returned for that \'. Fix is to drop that un-escaped \ (backslash).
"MYVAR2":"/home/pbsetst01/Mo\\'"
```
* If there's a comma in the environment variable value, PBS stores it with a backslash since comma has a special meaning in PBS. Comma is the delimiter  when PBS stores environment variables.
```
export MYVAR2="ab,c"
qsub -V -- /bin/sleep 30
qstat -f would show:
MYVAR="ab\,c"
qstat -f -Fjson would output:
"MYVAR"="ab\,c"
which would produce an error by json.loads() because of \, . Fix is to drop the unescaped \ (backslash).
"MYVAR":"ab,c"
```
* If a job is submitted with an environment variable value with leading 0s that is not all 000 or is part of a decimal number (i.e. 0.1020), the resulting int from json  would produce an error. This is because Python3 would not recognize such a value as int.
```
qsub -v foo=005 --/bin/sleep 30
qstat -f shows:
foo=005
qstat -f -Fjson outputs:
"foo":005
```
Feeding the above data to json.loads() produces JSON error as 005 is not recognized as an int in Python3. Fix is to detect the situation and output as a string value:
```
"foo":"005"
```
* The following sequence of steps would produce an attribute value of pset="" and would produce a bad json output:
```
Create a string array resource: qmgr -c 'c r iru type=string_array, flag=h'
Set a node group key: qmgr -c 's s node_group_key = iru'
Enable node grouping: qmgr -c 's s node_group_enable=True'
Submit a job which runs on a node where iru is not set.
Look at the qstat -f output:
qstat -f| grep pset:
pset = iru=""
Look at the qstat -f -F json output:
"pset":"iru="""
When fed to json.loads(), this results in an error due to the unescaped double quote ("). Fix is to escape
the embedded double quotes:
"pset":"\"\""
```
* If a node is given a comment with only whitespace characters, this produces a bad json output:
```
qmgr -c "set node nodeA comment='   '"
pbsndnodes -av
comment =   
pbsnodes -av -Fjson produces:
"comment": 
which is an error when fed to json.loads(). Fix is to show the whitespace values:
"comment":"   "
```
#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->


[ptl.qstat_formats_special_env.FAIL.txt](https://github.com/openpbs/openpbs/files/5295314/ptl.qstat_formats_special_env.FAIL.txt)

[ptl.qstat_formats_special_env.PASS.txt](https://github.com/openpbs/openpbs/files/5295315/ptl.qstat_formats_special_env.PASS.txt)
[ptl.json_nodes.FAIL.txt](https://github.com/openpbs/openpbs/files/5295318/ptl.json_nodes.FAIL.txt)
[ptl.json_nodes.PASS.txt](https://github.com/openpbs/openpbs/files/5295320/ptl.json_nodes.PASS.txt)
[ptl.qstat_formats.full2.txt](https://github.com/openpbs/openpbs/files/5313957/ptl.qstat_formats.full2.txt)
 [ptl.nodes_json.full2.txt](https://github.com/openpbs/openpbs/files/5313958/ptl.nodes_json.full2.txt)
 [ptl.pbs_nodes_json2.PASS.txt](https://github.com/openpbs/openpbs/files/5313959/ptl.pbs_nodes_json2.PASS.txt)
 [ptl.qstat_formats2.PASS.txt](https://github.com/openpbs/openpbs/files/5313960/ptl.qstat_formats2.PASS.txt)

The following testsuite have some json-related test cases:
[ptl.json_nodes_full.txt](https://github.com/openpbs/openpbs/files/5295324/ptl.json_nodes_full.txt)
[ptl.qstat_formats_full.txt](https://github.com/openpbs/openpbs/files/5295325/ptl.qstat_formats_full.txt)
[ptl.nonprint_chars_full.txt](https://github.com/openpbs/openpbs/files/5295327/ptl.nonprint_chars_full.txt)
(NOTE: The two test failures in nonprint_chars* are known test issues and is not related to this bug fix.)
[ptl.snapshot_json_full.txt](https://github.com/openpbs/openpbs/files/5295331/ptl.snapshot_json_full.txt)
[ptl.json_report.txt](https://github.com/openpbs/openpbs/files/5295332/ptl.json_report.txt)

Valgrind output of qstat, pbsnodes:
[valgrind.qstat_formats.txt](https://github.com/openpbs/openpbs/files/5295336/valgrind.qstat_formats.txt)
[valgrind.json_nodes.txt](https://github.com/openpbs/openpbs/files/5295337/valgrind.json_nodes.txt)





<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
