### PR TITLE
Hiding set_attr_* calls behind job object calls

### DIFF
--- a/src/include/job.h
+++ b/src/include/job.h
@@ -1048,6 +1048,7 @@ void set_job_substate(job *pjob, long val);
 int set_jattr_str_slim(job *pjob, int attr_idx, char *val, char *rscn);
 int set_jattr_l_slim(job *pjob, int attr_idx, long val, enum batch_op op);
 int set_jattr_b_slim(job *pjob, int attr_idx, long val, enum batch_op op);
+int set_jattr_c_slim(job *pjob, int attr_idx, char val, enum batch_op op);
 int set_jattr_generic(job *pjob, int attr_idx, char *val, char *rscn, enum batch_op op);
 int is_jattr_set(const job *pjob, int attr_idx);
 void free_jattr(job *pjob, int attr_idx);

--- a/src/include/svrfunc.h
+++ b/src/include/svrfunc.h
@@ -218,7 +218,7 @@ extern int set_entity_ct_sum_queued(job *, pbs_queue *, enum batch_op);
 extern int set_entity_resc_sum_max(job *, pbs_queue *, attribute *, enum batch_op);
 extern int set_entity_resc_sum_queued(job *, pbs_queue *, attribute *, enum batch_op);
 extern int account_entity_limit_usages(job *, pbs_queue *, attribute *, enum batch_op, int);
-extern void eval_chkpnt(attribute *, attribute *);
+extern void eval_chkpnt(job *pjob, attribute *queckp);
 #endif /* _QUEUE_H */
 
 #ifdef _BATCH_REQUEST_H

--- a/src/server/array_func.c
+++ b/src/server/array_func.c
@@ -393,13 +393,13 @@ update_array_indices_remaining_attr(job *parent)
 	struct ajtrkhd	*ptbl = parent->ji_ajtrk;
 
 	if (ptbl->tkm_flags & TKMFLG_REVAL_IND_REMAINING) {
-		attribute *premain = &parent->ji_wattr[JOB_ATR_array_indices_remaining];
 		char *pnewstr = range_to_str(parent->ji_ajtrk->trk_rlist);
 
 		if ((pnewstr == NULL) || (*pnewstr == '\0'))
 			pnewstr = "-";
-		job_attr_def[JOB_ATR_array_indices_remaining].at_free(premain);
-		set_attr_generic(premain, &job_attr_def[JOB_ATR_array_indices_remaining], pnewstr, 0, INTERNAL);
+
+		free_jattr(parent, JOB_ATR_array_indices_remaining);
+		set_jattr_generic(parent, JOB_ATR_array_indices_remaining, pnewstr, NULL, INTERNAL);
 		/* also update value of attribute "array_state_count" */
 		update_subjob_state_ct(parent);
 		ptbl->tkm_flags &= ~TKMFLG_REVAL_IND_REMAINING;
@@ -907,12 +907,8 @@ create_subjob(job *parent, char *newjid, int *rc)
 		}
 	}
 
-	psub = &subj->ji_wattr[(int)JOB_ATR_array_id];
-	set_attr_generic(psub, &job_attr_def[JOB_ATR_array_id],
-		parent->ji_qs.ji_jobid, NULL, INTERNAL);
-
-	psub = &subj->ji_wattr[(int)JOB_ATR_array_index];
-	set_attr_generic(psub, &job_attr_def[JOB_ATR_array_index], index, NULL, INTERNAL);
+	set_jattr_generic(subj, JOB_ATR_array_id, parent->ji_qs.ji_jobid, NULL, INTERNAL);
+	set_jattr_generic(subj, JOB_ATR_array_index, index, NULL, INTERNAL);
 
 	/* Lastly, set or clear a few flags and link in the structure */
 
@@ -944,15 +940,11 @@ create_subjob(job *parent, char *newjid, int *rc)
 		return NULL;
 	}
 
-	psub = &subj->ji_wattr[JOB_ATR_outpath];
 	snprintf(tmp_path, MAXPATHLEN + 1, "%s", psub->at_val.at_str);
-	set_attr_generic(psub, &job_attr_def[JOB_ATR_outpath],
-		subst_array_index(subj, tmp_path), NULL, INTERNAL);
+	set_jattr_generic(subj, JOB_ATR_outpath, subst_array_index(subj, tmp_path), NULL, INTERNAL);
 
-	psub = &subj->ji_wattr[JOB_ATR_errpath];
 	snprintf(tmp_path, MAXPATHLEN + 1, "%s", psub->at_val.at_str);
-	set_attr_generic(psub, &job_attr_def[JOB_ATR_errpath],
-		subst_array_index(subj, tmp_path), NULL, INTERNAL);
+	set_jattr_generic(subj, JOB_ATR_errpath, subst_array_index(subj, tmp_path), NULL, INTERNAL);
 
 	*rc = PBSE_NONE;
 	return subj;

--- a/src/server/jattr_get_set.c
+++ b/src/server/jattr_get_set.c
@@ -357,6 +357,30 @@ set_jattr_b_slim(job *pjob, int attr_idx, long val, enum batch_op op)
 }
 
 /**
+ * @brief	"fast" job attribute setter for char values
+ *
+ * @param[in]	pjob - pointer to job
+ * @param[in]	attr_idx - attribute index to set
+ * @param[in]	val - new val to set
+ * @param[in]	op - batch_op operation, SET, INCR, DECR etc.
+ *
+ * @return	int
+ * @retval	0 for success
+ * @retval	1 for failure
+ */
+int
+set_jattr_c_slim(job *pjob, int attr_idx, char val, enum batch_op op)
+{
+	if (pjob == NULL)
+		return 1;
+
+	set_attr_c(&pjob->ji_wattr[attr_idx], val, op);
+
+	return 0;
+}
+
+
+/**
  * @brief	Check if a job attribute is set
  *
  * @param[in]	pjob - pointer to job

--- a/src/server/pbsd_init.c
+++ b/src/server/pbsd_init.c
@@ -1300,7 +1300,7 @@ pbsd_init_job(job *pjob, int type)
 	/* update at_server attribute in case name changed */
 
 	free_jattr(pjob, JOB_ATR_at_server);
-	set_attr_generic(&pjob->ji_wattr[JOB_ATR_at_server], &job_attr_def[JOB_ATR_at_server], server_name, NULL, SET);
+	set_jattr_generic(pjob, JOB_ATR_at_server, server_name, NULL, SET);
 
 	/* now based on the initialization type */
 

--- a/src/server/req_preemptjob.c
+++ b/src/server/req_preemptjob.c
@@ -239,17 +239,12 @@ static int issue_preempt_request(int preempt_method, job *pjob, struct batch_req
  */
 static void clear_preempt_hold(job *pjob)
 {
-	attribute temphold;
 	long old_hold;
 	int newsub;
 	char newstate;
 
-	clear_attr(&temphold, &job_attr_def[(int)JOB_ATR_hold]);
-	set_attr_generic(&temphold, &job_attr_def[JOB_ATR_hold], "s", NULL, INTERNAL);
-
 	old_hold = get_jattr_long(pjob, JOB_ATR_hold);
-	set_attr_with_attr(&job_attr_def[(int)JOB_ATR_hold], &pjob->ji_wattr[(int)JOB_ATR_hold],
-					       &temphold, DECR);
+	set_jattr_generic(pjob, JOB_ATR_hold, "s", NULL, DECR);
 
 	if (old_hold != get_jattr_long(pjob, JOB_ATR_hold)) {
 		svr_evaljobstate(pjob, &newstate, &newsub, 0);

--- a/src/server/req_quejob.c
+++ b/src/server/req_quejob.c
@@ -266,7 +266,6 @@ req_quejob(struct batch_request *preq)
 #ifndef PBS_MOM
 	int set_project = 0;
 	int i;
-	attribute tempattr;
 	char jidbuf[PBS_MAXSVRJOBID+1];
 	pbs_queue *pque;
 	char *qname;
@@ -836,21 +835,15 @@ req_quejob(struct batch_request *preq)
 		set_jattr_l_slim(pj, JOB_ATR_hopcount, 1, SET);
 
 		/* need to set certain environmental variables per POSIX */
-
-		clear_attr(&tempattr, &job_attr_def[(int)JOB_ATR_variables]);
-		(void)strcpy(buf, pbs_o_que);
-		(void)strcat(buf, pque->qu_qs.qu_name);
+		strcpy(buf, pbs_o_que);
+		strcat(buf, pque->qu_qs.qu_name);
 		if (get_variable(pj, pbs_o_host) == NULL) {
-			(void)strcat(buf, ",");
-			(void)strcat(buf, pbs_o_host);
-			(void)strcat(buf, "=");
-			(void)strcat(buf, conn->cn_physhost);
+			strcat(buf, ",");
+			strcat(buf, pbs_o_host);
+			strcat(buf, "=");
+			strcat(buf, conn->cn_physhost);
 		}
-		set_attr_generic(&tempattr, &job_attr_def[JOB_ATR_variables], buf, NULL, INTERNAL);
-		set_attr_with_attr(&job_attr_def[(int)JOB_ATR_variables], 
-			&pj->ji_wattr[(int)JOB_ATR_variables],
-			&tempattr, INCR);
-		job_attr_def[(int)JOB_ATR_variables].at_free(&tempattr);
+		set_jattr_generic(pj, JOB_ATR_variables, buf, NULL, INCR);
 
 		/* if JOB_ATR_outpath/JOB_ATR_errpath not set, set default */
 

--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -789,8 +789,8 @@ post_stagein(struct work_task *pwt)
 				paltjob = pjob;
 			}
 			pwait = &paltjob->ji_wattr[(int)JOB_ATR_exectime];
-			if (!is_attr_set(pwait)) {
-				set_attr_l(pwait, time_now + PBS_STAGEFAIL_WAIT, SET);
+			if (!is_jattr_set(paltjob, JOB_ATR_exectime)) {
+				set_jattr_l_slim(paltjob, JOB_ATR_exectime, time_now + PBS_STAGEFAIL_WAIT, SET);
 				job_set_wait(pwait, paltjob, 0);
 			}
 			svr_setjobstate(paltjob, JOB_STATE_LTR_WAITING, JOB_SUBSTATE_STAGEFAIL);

--- a/src/server/svr_func.c
+++ b/src/server/svr_func.c
@@ -462,7 +462,7 @@ ck_chkpnt(attribute *pattr, void *pobject, int mode)
 	if (mode == ATR_ACTION_ALTER) {
 		pque = ((job *)pobject)->ji_qhdr;
 
-		eval_chkpnt(pattr, &pque->qu_attr[(int)QE_ATR_ChkptMin]);
+		eval_chkpnt((job *)pobject, &pque->qu_attr[(int)QE_ATR_ChkptMin]);
 	}
 	return (0);
 }

--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -210,8 +210,6 @@ tickle_for_reply(void)
 int
 svr_enquejob(job *pjob)
 {
-	attribute *pattrjb;
-	attribute_def *pdef;
 	job *pjcur;
 	pbs_queue *pque;
 	int rc;
@@ -335,11 +333,7 @@ svr_enquejob(job *pjob)
 	}
 
 	/* update the current location and type attribute */
-
-	pdef    = &job_attr_def[(int)JOB_ATR_in_queue];
-	pattrjb = &pjob->ji_wattr[(int)JOB_ATR_in_queue];
-	pdef->at_free(pattrjb);
-	set_attr_generic(pattrjb, pdef, pque->qu_qs.qu_name, NULL, SET);
+	set_jattr_generic(pjob, JOB_ATR_in_queue, pque->qu_qs.qu_name, NULL, SET);
 
 	if (pque->qu_attr[(int)QA_ATR_QType].at_val.at_str == NULL) {
 		sprintf(log_buffer, "queue type must be set for queue `%s`",
@@ -348,7 +342,7 @@ svr_enquejob(job *pjob)
 			pjob->ji_qs.ji_jobid, log_buffer);
 		return PBSE_NEEDQUET;
 	}
-	set_attr_c(&pjob->ji_wattr[JOB_ATR_queuetype], *pque->qu_attr[(int)QA_ATR_QType].at_val.at_str, SET);
+	set_jattr_c_slim(pjob, JOB_ATR_queuetype, *pque->qu_attr[QA_ATR_QType].at_val.at_str, SET);
 
 	if (!is_jattr_set(pjob, JOB_ATR_qtime))
 		set_jattr_l_slim(pjob, JOB_ATR_qtime, time_now, SET);
@@ -393,8 +387,7 @@ svr_enquejob(job *pjob)
 
 		/* check the job checkpoint against the queue's  min */
 
-		eval_chkpnt(&pjob->ji_wattr[(int)JOB_ATR_chkpnt],
-			&pque->qu_attr[(int)QE_ATR_ChkptMin]);
+		eval_chkpnt(pjob, &pque->qu_attr[QE_ATR_ChkptMin]);
 
 		/*
 		 * do anything needed doing regarding job dependencies,
@@ -575,8 +568,6 @@ svr_setjobstate(job *pjob, char newstate, int newsubstate)
 
 				if ((pque->qu_qs.qu_type == QTYPE_Execution) &&
 					(newstate == JOB_STATE_LTR_QUEUED)) {
-					attribute *etime = &pjob->ji_wattr[(int)JOB_ATR_etime];
-
 					if (find_assoc_sched_jid(pjob->ji_qs.ji_jobid, &psched))
 						set_scheduler_flag(SCH_SCHEDULE_NEW, psched);
 					else {
@@ -584,8 +575,8 @@ svr_setjobstate(job *pjob, char newstate, int newsubstate)
 						log_err(-1, __func__, log_buffer);
 					}
 
-					if (!is_attr_set(etime))
-						set_attr_l(etime, time_now, SET);
+					if (!is_jattr_set(pjob, JOB_ATR_etime))
+						set_jattr_l_slim(pjob, JOB_ATR_etime, time_now, SET);
 
 					/* clear start time (stime) */
 					free_jattr(pjob, JOB_ATR_stime);
@@ -2264,15 +2255,13 @@ set_resc_deflt(void *pobj, int objtype, pbs_queue *pque)
  */
 
 void
-eval_chkpnt(attribute *jobckp, attribute *queckp)
+eval_chkpnt(job *pjob, attribute *queckp)
 {
-	char *pv;
+	char *pv = get_jattr_str(pjob, JOB_ATR_chkpnt);
 
-	if (((is_attr_set(jobckp)) == 0)  ||
-		((queckp->at_flags & ATR_VFLAG_SET) == 0))
+	if (!is_jattr_set(pjob, JOB_ATR_chkpnt) || !is_attr_set(queckp))
 		return;		/* need do nothing */
 
-	pv = jobckp->at_val.at_str;
 	if ((*pv == 'c') || (*pv == 'w')) {
 		int jobs;
 		char queues[30];
@@ -2283,9 +2272,8 @@ eval_chkpnt(attribute *jobckp, attribute *queckp)
 			pv++;
 		jobs = atoi(pv);
 		if (jobs < queckp->at_val.at_long) {
-			(void)sprintf(queues, "%c=%ld", ckt, queckp->at_val.at_long);
-			free_str(jobckp);
-			set_attr_generic(jobckp, &job_attr_def[JOB_ATR_chkpnt], queues, NULL, INTERNAL);
+			sprintf(queues, "%c=%ld", ckt, queckp->at_val.at_long);
+			set_jattr_generic(pjob, JOB_ATR_chkpnt, queues, NULL, INTERNAL);
 		}
 	}
 }

--- a/src/server/svr_movejob.c
+++ b/src/server/svr_movejob.c
@@ -205,7 +205,6 @@ local_move(job *jobp, struct batch_request *req)
 	pbs_queue *qp;
 	char	  *destination = jobp->ji_qs.ji_destin;
 	int	   mtype;
-	attribute *pattr;
 	long	newtype = -1;
 	long	time_msec;
 	struct timeval	tval;
@@ -253,12 +252,11 @@ local_move(job *jobp, struct batch_request *req)
 
 	set_jattr_l_slim(jobp, JOB_ATR_qrank, time_msec, SET);
 
-	pattr = &jobp->ji_wattr[(int)JOB_ATR_reserve_ID];
 	if (qp->qu_resvp) {
-		set_attr_generic(pattr, &job_attr_def[JOB_ATR_reserve_ID], qp->qu_resvp->ri_qs.ri_resvID, NULL, INTERNAL);
+		set_jattr_generic(jobp, JOB_ATR_reserve_ID, qp->qu_resvp->ri_qs.ri_resvID, NULL, INTERNAL);
 		jobp->ji_myResv = qp->qu_resvp;
 	} else
-		set_attr_generic(pattr, &job_attr_def[JOB_ATR_reserve_ID], NULL, NULL, INTERNAL);
+		set_jattr_generic(jobp, JOB_ATR_reserve_ID, NULL, NULL, INTERNAL);
 
 	if (server.sv_attr[(int)SVR_ATR_EligibleTimeEnable].at_val.at_long == 1) {
 		newtype = determine_accruetype(jobp);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
This is just refactoring. The attribute level functions should be hidden behind job level functions if working on a job object's attribute. So, here I'm just converting calls to set_attr_* with set_jattr_* calls. 

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Since there's no functional change, existing tests passing should be good enough


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
