### PR TITLE
Fix test_nonprint_character_job_array of TestNonprintingCharacters timeout issue

### DIFF
--- a/test/tests/functional/pbs_nonprint_characters.py
+++ b/test/tests/functional/pbs_nonprint_characters.py
@@ -687,6 +687,7 @@ sleep 5
         if qstat_out.find(match) != -1:
             self.logger.info('Found %s in qstat -f -F dsv output' % match)
 
+    @timeout(1200)
     def test_nonprint_character_job_array(self):
         """
         Using each of the non-printable ASCII characters, except NULL


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
test_nonprint_character_job_array of TestNonprintingCharacters is getting timed out on slower machines.


#### Describe Your Change
After increasing the timeout of that test case to 1200, test case has passed.

#### Attach Test and Valgrind Logs/Output
[testnonprint_after_fix.txt](https://github.com/openpbs/openpbs/files/5298516/testnonprint_after_fix.txt)
[testnonprint_before_fix.txt](https://github.com/openpbs/openpbs/files/5298517/testnonprint_before_fix.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
