### PR TITLE
Increase job run time so slower machines catch the running state

### DIFF
--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -354,7 +354,7 @@ if sleeptime2 > 0 and (end_time2 - start_time2) < sleeptime2 :
             '#PBS -joe\n' \
             '#PBS -S /bin/bash\n' \
             'sync\n' \
-            'sleep 4\n' \
+            'sleep 10\n' \
             'python_path=`which python 2>/dev/null`\n' \
             'python3_path=`which python3 2>/dev/null`\n' \
             'python2_path=`which python2 2>/dev/null`\n' \

--- a/test/tests/functional/pbs_hook_execjob_end.py
+++ b/test/tests/functional/pbs_hook_execjob_end.py
@@ -494,7 +494,7 @@ class TestPbsExecjobEnd(TestFunctional):
         attr = {'event': 'execjob_end', 'enabled': 'True', 'alarm': '40'}
         self.server.create_import_hook(hook_name, attr, hook_body)
         j = Job(TEST_USER)
-        j.set_sleep_time(5)
+        j.set_sleep_time(10)
         jid = self.server.submit(j)
         self.job_list.append(jid)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)

--- a/test/tests/functional/pbs_runjob_hook.py
+++ b/test/tests/functional/pbs_runjob_hook.py
@@ -117,7 +117,7 @@ else:
         lower = 1
         upper = 3
         j1 = Job(TEST_USER)
-        j1.set_sleep_time(3)
+        j1.set_sleep_time(10)
         j1.set_attributes({ATTR_J: '%d-%d' % (lower, upper)})
         jid = self.server.submit(j1)
         self.server.expect(JOB, {ATTR_state: 'B'}, id=jid)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
On some very slow machines, or if the machine has a pause while running the expect(), a test might fail due not finding the job in the expected state.  
For example:
ptl.lib.pbs_testlib.PtlExpectError: rc=1, rv=False, msg=expected on server xarm-05-c8p1: no data for job_state = R && substate = 42 job 12.xarm-05-c8p1 attempt: 180

The longest pause I saw was for 6 seconds.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
I made the job run for 10 seconds in hopes that it is a long enough time to see the job in the expected state, but without adding too much time to running the test.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[after.txt](https://github.com/openpbs/openpbs/files/5308872/after.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
