### PR TITLE
fix pbs_rsub segfault while parsing hosts

### DIFF
--- a/src/cmds/pbs_rsub.c
+++ b/src/cmds/pbs_rsub.c
@@ -301,7 +301,7 @@ process_opts(int argc, char **argv, struct attrl **attrp, char *dest)
 				return (++errflg);
 			}
 
-			maintenance_hosts[num_hosts] = NULL;
+			maintenance_hosts[0] = NULL;
 
 			for (i = 0; optind < argc; optind++, i++) {
 				hostp = maintenance_hosts;
@@ -313,12 +313,11 @@ process_opts(int argc, char **argv, struct attrl **attrp, char *dest)
 				}
 
 				if (strlen(argv[optind]) == 0) {
-					num_hosts--;
 					i--;
-					maintenance_hosts[num_hosts] = NULL;
 					continue;
 				}
 
+				maintenance_hosts[i + 1] = NULL;
 				maintenance_hosts[i] = strdup(argv[optind]);
 				if (maintenance_hosts[i] == NULL) {
 					fprintf(stderr, "pbs_rsub: Out of memory\n");

--- a/test/tests/functional/pbs_maintenance_reservations.py
+++ b/test/tests/functional/pbs_maintenance_reservations.py
@@ -694,3 +694,25 @@ class TestMaintenanceReservations(TestFunctional):
         a = {'comment': 'Can Never Run: Reservation is in an invalid state',
              'job_state': 'Q'}
         self.server.expect(JOB, a, id=jid)
+
+    def test_maintenance_parse_numerous_hosts(self):
+        """
+        Test if the parsing of numerous hosts succeed.
+        """
+        now = int(time.time())
+
+        a = {'reserve_start': now + 3600,
+             'reserve_end': now + 7200}
+        chars = 'abcdefghijklmnopqrstuvwxyz'
+        h = [''.join(random.choices(chars, k=8)) for i in range(200)]
+        r = Reservation(TEST_USER, attrs=a, hosts=h)
+
+        msg = ""
+
+        try:
+            self.server.submit(r)
+        except PbsSubmitError as err:
+            msg = err.msg[0].strip()
+
+        regex = "^pbs_rsub: Host with resources not found: .*"
+        self.assertTrue(re.search(regex, msg))

--- a/test/tests/functional/pbs_maintenance_reservations.py
+++ b/test/tests/functional/pbs_maintenance_reservations.py
@@ -62,12 +62,10 @@ class TestMaintenanceReservations(TestFunctional):
         h = [self.mom.shortname]
         r = Reservation(TEST_USER, attrs=a, hosts=h)
 
-        msg = ""
-
-        try:
+        with self.assertRaises(PbsSubmitError) as err:
             self.server.submit(r)
-        except PbsSubmitError as err:
-            msg = err.msg[0].strip()
+
+        msg = err.exception.msg[0].strip()
 
         self.assertEqual("pbs_rsub: Unauthorized Request", msg)
 
@@ -86,12 +84,10 @@ class TestMaintenanceReservations(TestFunctional):
         h = [self.mom.shortname]
         r = Reservation(TEST_USER, attrs=a, hosts=h)
 
-        msg = ""
-
-        try:
+        with self.assertRaises(PbsSubmitError) as err:
             self.server.submit(r)
-        except PbsSubmitError as err:
-            msg = err.msg[0].strip()
+
+        msg = err.exception.msg[0].strip()
 
         self.assertEqual("pbs_rsub: can't use -l with --hosts", msg)
 
@@ -101,12 +97,10 @@ class TestMaintenanceReservations(TestFunctional):
         h = [self.mom.shortname]
         r = Reservation(TEST_USER, attrs=a, hosts=h)
 
-        msg = ""
-
-        try:
+        with self.assertRaises(PbsSubmitError) as err:
             self.server.submit(r)
-        except PbsSubmitError as err:
-            msg = err.msg[0].strip()
+
+        msg = err.exception.msg[0].strip()
 
         self.assertEqual("pbs_rsub: can't use -l with --hosts", msg)
 
@@ -116,12 +110,10 @@ class TestMaintenanceReservations(TestFunctional):
         h = [self.mom.shortname]
         r = Reservation(TEST_USER, attrs=a, hosts=h)
 
-        msg = ""
-
-        try:
+        with self.assertRaises(PbsSubmitError) as err:
             self.server.submit(r)
-        except PbsSubmitError as err:
-            msg = err.msg[0].strip()
+
+        msg = err.exception.msg[0].strip()
 
         self.assertEqual("pbs_rsub: can't use -I with --hosts", msg)
 
@@ -155,12 +147,10 @@ class TestMaintenanceReservations(TestFunctional):
         h = [self.mom.shortname, "foo"]
         r = Reservation(TEST_USER, attrs=a, hosts=h)
 
-        msg = ""
-
-        try:
+        with self.assertRaises(PbsSubmitError) as err:
             self.server.submit(r)
-        except PbsSubmitError as err:
-            msg = err.msg[0].strip()
+
+        msg = err.exception.msg[0].strip()
 
         self.assertEqual("pbs_rsub: Host with resources not found: foo", msg)
 
@@ -169,12 +159,10 @@ class TestMaintenanceReservations(TestFunctional):
         h = [""]
         r = Reservation(TEST_USER, attrs=a, hosts=h)
 
-        msg = ""
-
-        try:
+        with self.assertRaises(PbsSubmitError) as err:
             self.server.submit(r)
-        except PbsSubmitError as err:
-            msg = err.msg[0].strip()
+
+        msg = err.exception.msg[0].strip()
 
         self.assertEqual("pbs_rsub: missing host(s)", msg)
 
@@ -192,12 +180,10 @@ class TestMaintenanceReservations(TestFunctional):
         h = ["foo", "foo"]
         r = Reservation(TEST_USER, attrs=a, hosts=h)
 
-        msg = ""
-
-        try:
+        with self.assertRaises(PbsSubmitError) as err:
             self.server.submit(r)
-        except PbsSubmitError as err:
-            msg = err.msg[0].strip()
+
+        msg = err.exception.msg[0].strip()
 
         self.assertEqual("pbs_rsub: Duplicate host: foo", msg)
 
@@ -262,12 +248,10 @@ class TestMaintenanceReservations(TestFunctional):
         self.server.manager(MGR_CMD_SET, SERVER,
                             {'managers': (DECR, '%s@*' % TEST_USER)})
 
-        msg = ""
-
-        try:
+        with self.assertRaises(PbsDeleteError) as err:
             self.server.delete(rid, runas=TEST_USER)
-        except PbsDeleteError as err:
-            msg = err.msg[0].strip()
+
+        msg = err.exception.msg[0].strip()
 
         self.assertEqual("pbs_rdel: Unauthorized Request  " + rid, msg)
 
@@ -707,12 +691,10 @@ class TestMaintenanceReservations(TestFunctional):
         h = [''.join(random.choices(chars, k=8)) for i in range(200)]
         r = Reservation(TEST_USER, attrs=a, hosts=h)
 
-        msg = ""
-
-        try:
+        with self.assertRaises(PbsSubmitError) as err:
             self.server.submit(r)
-        except PbsSubmitError as err:
-            msg = err.msg[0].strip()
+
+        msg = err.exception.msg[0].strip()
 
         regex = "^pbs_rsub: Host with resources not found: .*"
         self.assertTrue(re.search(regex, msg))


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Submitting maintenance, pbs_rsub can segfault. The reason is the array **hostp initializes only the last item (to NULL) and it is supposed the array will be full in the end. The problem is the array is checked for duplicate items while an item is not NULL before. An inaccessible part of memory can occur within the array like this: 

```
311					for (; *hostp; hostp++) {
(gdb) 
312						if (strcmp(*hostp, argv[optind]) == 0) {
(gdb) print *hostp
$16 = 0x10271c25 <error: Cannot access memory at address 0x10271c25>
(gdb) n

Program received signal SIGSEGV, Segmentation fault.
__strcmp_avx2 () at ../sysdeps/x86_64/multiarch/strcmp-avx2.S:101
101	../sysdeps/x86_64/multiarch/strcmp-avx2.S: No such file or directory.
```

#### Describe Your Change
Initialize the first item in the array **hostp to NULL, and once a valid item is added to the array the subsequent item is always initialized to NULL. This way the array always ends with NULL.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
This bug can not be reliable reproduced because the inaccessible part of memory is not always present in the array. The bigger the array is, the bigger chance to reproduce. So, numerous random hostnames are conveyed to pbs_rsub in the PTL test.
[ptl_maintenance.log](https://github.com/openpbs/openpbs/files/5316307/ptl_maintenance.log)

<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
