### PR TITLE
Altering standing reservations do not affect future occurrences

### DIFF
--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -765,6 +765,7 @@ struct resv_info
 	node_info **resv_nodes;		/* node universe for reservation */
 	char *partition;		/* name of the partition in which the reservation was confirmed */
 	selspec *select_orig;		/* original schedselect pre-alter */
+	selspec *select_standing;	/* original schedselect for standing reservations */
 	nspec **orig_nspec_arr;		/* original non-shrunk exec_vnode with exec_vnode chunk mapped to select chunk */
 };
 

--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -535,7 +535,7 @@ query_reservations(int pbs_sd, server_info *sinfo, struct batch_status *resvs)
 					 */
 					release_nodes(resresv_ocr);
 
-					if (resresv_ocr->resv->select_standing) {
+					if (resresv_ocr->resv->select_standing != NULL) {
 						free_selspec(resresv_ocr->select);
 						resresv_ocr->select = dup_selspec(resresv_ocr->resv->select_standing);
 					}
@@ -1166,7 +1166,7 @@ check_new_reservations(status *policy, int pbs_sd, resource_resv **resvs, server
 							nresv_copy = dup_resource_resv(nresv_copy, sinfo, NULL, err);
 							if (nresv_copy == NULL)
 								break;
-							if (nresv_copy->resv->select_standing) {
+							if (nresv_copy->resv->select_standing != NULL) {
 								free_selspec(nresv_copy->select);
 								nresv_copy->select = dup_selspec(nresv_copy->resv->select_standing);
 							}

--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -1164,6 +1164,9 @@ check_new_reservations(status *policy, int pbs_sd, resource_resv **resvs, server
 							nresv_copy = dup_resource_resv(nresv_copy, sinfo, NULL, err);
 							if (nresv_copy == NULL)
 								break;
+
+							free_selspec(nresv_copy->select);
+							nresv_copy->select = dup_selspec(nresv_copy->resv->select_standing);
 						}
 						/* Duplication deep-copies node info array. This array gets
 						 * overwritten and needs to be freed. This is an alternative
@@ -1172,8 +1175,6 @@ check_new_reservations(status *policy, int pbs_sd, resource_resv **resvs, server
 						 */
 						release_nodes(nresv_copy);
 
-						free_selspec(nresv_copy->select);
-						nresv_copy->select = dup_selspec(nresv_copy->resv->select_standing);
 						nresv_copy->resv->orig_nspec_arr = parse_execvnode(occr_execvnodes_arr[j], sinfo, nresv_copy->select);
 						nresv_copy->ninfo_arr = create_node_array_from_nspec(nresv_copy->nspec_arr);
 						nresv_copy->nspec_arr = combine_nspec_array(nresv_copy->resv->orig_nspec_arr);

--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -535,8 +535,10 @@ query_reservations(int pbs_sd, server_info *sinfo, struct batch_status *resvs)
 					 */
 					release_nodes(resresv_ocr);
 
-					free_selspec(resresv_ocr->select);
-					resresv_ocr->select = dup_selspec(resresv_ocr->resv->select_standing);
+					if (resresv_ocr->resv->select_standing) {
+						free_selspec(resresv_ocr->select);
+						resresv_ocr->select = dup_selspec(resresv_ocr->resv->select_standing);
+					}
 
 					resresv_ocr->resv->orig_nspec_arr = parse_execvnode(
 						execvnode_ptr[degraded_idx - 1], sinfo, resresv_ocr->select);
@@ -1164,9 +1166,10 @@ check_new_reservations(status *policy, int pbs_sd, resource_resv **resvs, server
 							nresv_copy = dup_resource_resv(nresv_copy, sinfo, NULL, err);
 							if (nresv_copy == NULL)
 								break;
-
-							free_selspec(nresv_copy->select);
-							nresv_copy->select = dup_selspec(nresv_copy->resv->select_standing);
+							if (nresv_copy->resv->select_standing) {
+								free_selspec(nresv_copy->select);
+								nresv_copy->select = dup_selspec(nresv_copy->resv->select_standing);
+							}
 						}
 						/* Duplication deep-copies node info array. This array gets
 						 * overwritten and needs to be freed. This is an alternative

--- a/test/tests/functional/pbs_ralter.py
+++ b/test/tests/functional/pbs_ralter.py
@@ -2850,8 +2850,8 @@ class TestPbsResvAlter(TestFunctional):
         then reconfirmed, the reservation will use the original
         select
         """
-        duration = 20
-        offset = 20
+        duration = 60
+        offset = 60
 
         self.server.manager(MGR_CMD_SET, SERVER, {'reserve_retry_time': 2})
 

--- a/test/tests/functional/pbs_ralter.py
+++ b/test/tests/functional/pbs_ralter.py
@@ -2853,7 +2853,7 @@ class TestPbsResvAlter(TestFunctional):
         duration = 60
         offset = 60
 
-        self.server.manager(MGR_CMD_SET, SERVER, {'reserve_retry_time': 2})
+        self.server.manager(MGR_CMD_SET, SERVER, {'reserve_retry_time': 5})
 
         rid, start, end = self.submit_and_confirm_reservation(
             offset, duration, standing=True, select="2:ncpus=2")
@@ -2867,6 +2867,7 @@ class TestPbsResvAlter(TestFunctional):
         self.server.status(RESV, id=rid)
         resv_node = self.server.reservations[rid].get_vnodes()[0]
 
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': False})
         offline = {'state': 'offline'}
         self.server.manager(MGR_CMD_SET, NODE, offline, id=resv_node)
         degraded = {'reserve_state': (MATCH_RE, 'RESV_DEGRADED|10')}
@@ -2876,6 +2877,7 @@ class TestPbsResvAlter(TestFunctional):
 
         stat = self.server.status(RESV, id=rid)[0]
         resvnodes = stat['resv_nodes']
+        self.assertNotEquals(resv_node, resvnodes)
         self.assertEquals(1, len(resvnodes.split('+')))
 
         self.check_occr_finish(rid, end - time.time())


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
If a standing reservation has its select altered, and then goes degraded, the scheduler will attempt to reconfirm the current and future occurrences with the existing altered select.  This will cause the future occurrences to be short nodes.

#### Describe Your Change
For future occurrences of standing reservations, use the saved standing reservation's select.

This also fixes a potential crash in the scheduler

#### Attach Test and Valgrind Logs/Output
[after-fix-all.txt](https://github.com/openpbs/openpbs/files/5329448/after-fix-all.txt)

[after-fix.txt](https://github.com/openpbs/openpbs/files/5320817/after-fix.txt)
[before_fix.txt](https://github.com/openpbs/openpbs/files/5320818/before_fix.txt)
[crash.txt](https://github.com/openpbs/openpbs/files/5320819/crash.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
