### PR TITLE
Fixing a printjob bug caused by recent refactoring for job state

### DIFF
--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -670,7 +670,7 @@ def job_is_running(jobid):
     Returns True if job shows a running state and substate
     """
     jobinfo = printjob_info(jobid)
-    if 'state' in jobinfo and jobinfo['state'] != 4:
+    if 'state' in jobinfo and jobinfo['state'] != 'R':
         return False
     if 'substate' in jobinfo:
         return jobinfo['substate'] == 42
@@ -2447,7 +2447,7 @@ class NodeUtils(object):
         for vnode_name in vnode_comments:
             if vnode_comments[vnode_name] != self.offline_msg:
                 pbs.logmsg(pbs.EVENT_DEBUG, ('%s: Comment for vnode %s '
-                           + 'was not set by this hook')
+                                             + 'was not set by this hook')
                            % (caller_name(), vnode_name))
                 continue
             vnode = pbs.event().vnode_list[vnode_name]
@@ -2817,7 +2817,7 @@ class CgroupUtils(object):
                 config_dict['enabled'] = False
             if (config_dict['enabled'] and
                     any([fnmatch.fnmatch(vntype, p)
-                        for p in config_dict['exclude_vntypes']])):
+                         for p in config_dict['exclude_vntypes']])):
                 config_dict['enabled'] = False
                 if subsection is None:
                     subname = 'all subsystems'
@@ -2845,7 +2845,7 @@ class CgroupUtils(object):
                 config_dict['enabled'] = False
             if (config_dict['enabled'] and
                 any([fnmatch.fnmatch(self.hostname, p)
-                    for p in config_dict['exclude_hosts']])):
+                     for p in config_dict['exclude_hosts']])):
                 config_dict['enabled'] = False
                 if subsection is None:
                     subname = 'all subsystems'
@@ -2872,7 +2872,7 @@ class CgroupUtils(object):
                     or not isinstance(config_dict['enabled'], bool)):
                 config_dict['enabled'] = \
                     (any([fnmatch.fnmatch(self.hostname, p)
-                         for p in config_dict['include_hosts']]))
+                          for p in config_dict['include_hosts']]))
             else:
                 config_dict['enabled'] = \
                     (config_dict['enabled']
@@ -2898,7 +2898,7 @@ class CgroupUtils(object):
             config_dict['enabled'] = \
                 (config_dict['enabled']
                  and any([fnmatch.fnmatch(self.hostname, p)
-                         for p in config_dict['run_only_on_hosts']]))
+                          for p in config_dict['run_only_on_hosts']]))
             pbs.logmsg(pbs.EVENT_DEBUG4,
                        "%s: Config file parsing,"
                        " set %s to %s based on run_only_on_hosts"
@@ -4247,7 +4247,8 @@ class CgroupUtils(object):
                                                  ['cpu']
                                                  ['zero_cpus_shares_fraction'])
                     # Note that the minimum in the kernel is 2
-                    self.write_value(path, int(max(2, weightless_shares*1000)))
+                    self.write_value(
+                        path, int(max(2, weightless_shares * 1000)))
                     value = (self.cfg['cgroup']
                                      ['cpu']
                                      ['zero_cpus_quota_fraction'])
@@ -5119,7 +5120,7 @@ class CgroupUtils(object):
         # default for _cgroup_path for parent is empty string
         try:
             with open(self._cgroup_path('cpu', 'cfs_quota_us',
-                      jobid), 'r') as fd:
+                                        jobid), 'r') as fd:
                 return int(fd.readline().strip())
         except Exception:
             return None

--- a/src/tools/printjob.c
+++ b/src/tools/printjob.c
@@ -99,15 +99,14 @@ print_usage()
  *
  * @param[in]	pjob	-	pointer to the job struct.
  */
-void
-prt_job_struct(job *pjob)
+static void
+prt_job_struct(job *pjob, char *state, char *substate)
 {
 	printf("---------------------------------------------------\n");
 	printf("jobid:\t%s\n", pjob->ji_qs.ji_jobid);
 	printf("---------------------------------------------------\n");
-	printf("state:\t\t0x%c\n", pjob->ji_wattr[JOB_ATR_state].at_val.at_char);
-	printf("substate:\t0x%ld (%ld)\n", pjob->ji_wattr[JOB_ATR_substate].at_val.at_long,
-		pjob->ji_wattr[JOB_ATR_substate].at_val.at_long);
+	printf("state:\t\t%s\n", state);
+	printf("substate:\t0x%s (%s)\n", substate, substate);
 	printf("svrflgs:\t0x%x (%d)\n", pjob->ji_qs.ji_svrflags,
 		pjob->ji_qs.ji_svrflags);
 	printf("stime:\t\t%ld\n", (long)pjob->ji_qs.ji_stime);
@@ -188,6 +187,26 @@ prt_task_struct(pbs_task *ptask)
 }
 
 #define ENDATTRIBUTES -711
+
+/**
+ * @brief	Print an attribute
+ *
+ * @param[in]	pal  - pointer to attribute
+ *
+ * @return	void
+ */
+static void
+print_attr(svrattrl *pal)
+{
+	printf("%s", pal->al_name);
+	if (pal->al_resc)
+		printf(".%s", pal->al_resc);
+	printf(" = ");
+	if (pal->al_value)
+		printf("%s", show_nonprint_chars(pal->al_value));
+	printf("\n");
+}
+
 /**
  * @brief
  * 		read attributes from file descriptor.
@@ -198,21 +217,21 @@ prt_task_struct(pbs_task *ptask)
  * @return	1	: success
  * @return	0	: failure
  */
-int
+static svrattrl *
 read_attr(int fd)
 {
-	int	  amt;
-	int       i;
+	int amt;
+	int i;
 	svrattrl *pal;
-	svrattrl  tempal;
+	svrattrl tempal;
 
 	i = read(fd, (char *)&tempal, sizeof(tempal));
 	if (i != sizeof(tempal)) {
 		fprintf(stderr, "bad read of attribute\n");
-		return 0;
+		return NULL;
 	}
 	if (tempal.al_tsize == ENDATTRIBUTES)
-		return 0;
+		return NULL;
 
 	pal = (svrattrl *)malloc(tempal.al_tsize);
 	if (pal == NULL) {
@@ -239,17 +258,48 @@ read_attr(int fd)
 	else
 		pal->al_value = NULL;
 
-	printf("%s", pal->al_name);
-	if (pal->al_resc)
-		printf(".%s", pal->al_resc);
-	printf(" = ");
-	if (pal->al_value)
-		printf("%s", show_nonprint_chars(pal->al_value));
-	printf("\n");
-
-	free(pal);
-	return 1;
+	return pal;
 }
+
+/**
+ * @brief	Read all job attribute values
+ *
+ * @param[in]	fd - fd of job file
+ * @param[out]	state - return pointer to state value
+ * @param[out]	substate - return pointer for substate value
+ *
+ * @return	void
+ */
+static svrattrl *
+read_all_attrs(int fd, char **state, char **substate)
+{
+	svrattrl *pal = NULL;
+	svrattrl *pali = NULL;
+
+	while ((pali = read_attr(fd)) != NULL) {
+		if (pal == NULL) {
+			pal = pali;
+			(&pal->al_link)->ll_struct = (void *)(&pal->al_link);
+			(&pal->al_link)->ll_next = NULL;
+			(&pal->al_link)->ll_prior = NULL;
+		} else {
+			pbs_list_link *head = &pal->al_link;
+			pbs_list_link *newp = &pali->al_link;
+			newp->ll_prior = NULL;
+			newp->ll_next  = head;
+			newp->ll_struct = pali;
+			pal = pali;
+		}
+		/* Check if the attribute read is state/substate and store it separately */
+		if (strcmp(pali->al_name, ATTR_state) == 0)
+			*state = pali->al_value;
+		else if (strcmp(pali->al_name, ATTR_substate) == 0)
+			*substate = pali->al_value;
+	}
+
+	return pal;
+}
+
 /**
  * @brief
  * 		save the db info into job structure
@@ -361,6 +411,8 @@ print_db_job(char *id, int no_attributes)
 	 * retrieve the job info from database.
 	 */
 	else {
+		char state[2];
+		char substate[4];
 		obj.pbs_db_obj_type = PBS_DB_JOB;
 		obj.pbs_db_un.pbs_db_job = &dbjob;
 		strcpy(dbjob.ji_jobid, id);
@@ -374,7 +426,9 @@ print_db_job(char *id, int no_attributes)
 			return (1);
 		}
 		db_2_job(&xjob, &dbjob);
-		prt_job_struct(&xjob);
+		snprintf(state, sizeof(state), "%c", xjob.ji_wattr[JOB_ATR_state].at_val.at_char);
+		snprintf(substate, sizeof(substate), "%ld", xjob.ji_wattr[JOB_ATR_substate].at_val.at_long);
+		prt_job_struct(&xjob, state, substate);
 
 		if (no_attributes == 0) {
 			svrattrl *pal;
@@ -553,13 +607,15 @@ char *argv[];
 
 		/* If not asked for displaying of script, execute below code */
 		if (!display_script) {
+			svrattrl *pal, *pali;
+			char *state = "";
+			char *substate = "";
+
 			amt = read(fp, &xjob.ji_qs, sizeof(xjob.ji_qs));
 			if (amt != sizeof(xjob.ji_qs)) {
 				fprintf(stderr, "Short read of %d bytes, file %s\n",
 					amt, jobfile);
 			}
-			/* print out job structure */
-			prt_job_struct(&xjob);
 
 			/* if present, skip over extended area */
 			if (xjob.ji_qs.ji_jsversion > 500) {
@@ -585,10 +641,23 @@ char *argv[];
 				}
 			}
 
+			pal = read_all_attrs(fp, &state, &substate);
+
+			/* Print the summary first */
+			prt_job_struct(&xjob, state, substate);
+
 			/* now do attributes, one at a time */
 			if (no_attributes == 0) {
+				/* Now print all attributes */
 				printf("--attributes--\n");
-				while (read_attr(fp)) ;
+
+				pali = GET_NEXT(pal->al_link);
+				while (pali != NULL) {
+					print_attr(pali);
+					if (pali->al_link.ll_next == NULL)
+						break;
+					pali = GET_NEXT(pali->al_link);
+				}
 			}
 
 			(void)close(fp);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
After the refactoring change for job attributes, the server now logs job states in state characters instead of numerics, and we removed state and substate from job object's quick save area. This caused printjob to print the wrong output as it reads the job file as it is, tries to print the job's quick save area, which earlier had the state and substate, before reading the attribute list and then prints the attribute list. Since we removed state and substate, the summary prints bogus (null) values for state and substate. This causes cgroups hook to fail as well as it reads the output of printjob.

Fix:
This calls for a refactoring of printjob. I had to read the attribute list completely before printing the job summary because i needed the state and substate from the attr list.

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

**Printjob header, Before fix:**
```
---------------------------------------------------
jobid:      26.stblr3
---------------------------------------------------
state:                     0x
substate:             0x0 (0)
```

**After fix:**
```
---------------------------------------------------
jobid:	1003.pbs2
---------------------------------------------------
state:		R
substate:	0x42 (42)
```

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
