### PR TITLE
Fix invalid write in ds_queue_is_empty and mem leak while updating subjob counts

### DIFF
--- a/src/scheduler/queue.c
+++ b/src/scheduler/queue.c
@@ -86,8 +86,10 @@ new_ds_queue(void)
 void
 free_ds_queue(ds_queue *queue)
 {
-	free(queue->content_arr);
-	free(queue);
+	if (queue != NULL) {
+		free(queue->content_arr);
+		free(queue);
+	}
 }
 
 
@@ -176,12 +178,13 @@ ds_dequeue(ds_queue *queue)
 int
 ds_queue_is_empty(ds_queue *queue)
 {
-	if (queue == NULL || queue->front == queue->rear) {
+	if (queue == NULL)
+		return 1;
+	if (queue->front == queue->rear) {
 		/* Make sure front and rear pointers are set to 0 */
 		queue->front = 0;
 		queue->rear = 0;
 		return 1;
-	}
-	else
+	} else
 		return 0;
 }

--- a/src/server/array_func.c
+++ b/src/server/array_func.c
@@ -369,7 +369,7 @@ set_subjob_tblstate(job *parent, int offset, char newstate)
 		ptbl->tkm_subjsct[ostatenum]--;
 	if (nstatenum != -1)
 		ptbl->tkm_subjsct[nstatenum]++;
-	
+
 	if (oldstate == JOB_STATE_LTR_QUEUED)
 		range_remove_value(&ptbl->trk_rlist , SJ_TBLIDX_2_IDX(parent, offset));
 	else if (newstate == JOB_STATE_LTR_QUEUED)
@@ -569,23 +569,20 @@ get_subjob_state(job *parent, int iindx)
 void
 update_subjob_state_ct(job *pjob)
 {
-	char *buf;
+	char buf[BUF_SIZE];
 	static char *statename[] = {
 		"Transit", "Queued", "Held", "Waiting", "Running",
-		"Exiting", "Expired", "Beginning", "Moved", "Finished" };
+		"Exiting", "Expired", "Beginning", "Moved", "Finished"};
 
-
-	buf = malloc(150);
-	if (buf == NULL)
-		return;
 	buf[0] = '\0';
-	sprintf(buf+strlen(buf), "%s:%d ", statename[JOB_STATE_QUEUED],
-		pjob->ji_ajtrk->tkm_subjsct[JOB_STATE_QUEUED]);
-	sprintf(buf+strlen(buf), "%s:%d ", statename[JOB_STATE_RUNNING],
-		pjob->ji_ajtrk->tkm_subjsct[JOB_STATE_RUNNING]);
-	sprintf(buf+strlen(buf), "%s:%d ", statename[JOB_STATE_EXITING],
-		pjob->ji_ajtrk->tkm_subjsct[JOB_STATE_EXITING]);
-	sprintf(buf+strlen(buf), "%s:%d ", statename[JOB_STATE_EXPIRED],
+	sprintf(buf, "%s:%d %s:%d %s:%d %s:%d",
+		statename[JOB_STATE_QUEUED],
+		pjob->ji_ajtrk->tkm_subjsct[JOB_STATE_QUEUED],
+		statename[JOB_STATE_RUNNING],
+		pjob->ji_ajtrk->tkm_subjsct[JOB_STATE_RUNNING],
+		statename[JOB_STATE_EXITING],
+		pjob->ji_ajtrk->tkm_subjsct[JOB_STATE_EXITING],
+		statename[JOB_STATE_EXPIRED],
 		pjob->ji_ajtrk->tkm_subjsct[JOB_STATE_EXPIRED]);
 
 	set_jattr_str_slim(pjob, JOB_ATR_array_state_count, buf, NULL);
@@ -725,10 +722,10 @@ setup_arrayjob_attrs(attribute *pattr, void *pobj, int mode)
 		if ((pjob->ji_ajtrk = mk_subjob_index_tbl(get_jattr_str(pjob, JOB_ATR_array_indices_submitted),
 			                                      JOB_STATE_LTR_QUEUED, &pbs_error, mode)) == NULL)
 			return pbs_error;
-			
+
 		if ((pjob->ji_ajtrk->trk_rlist = range_parse(pjob->ji_wattr[(int)JOB_ATR_array_indices_submitted].at_val.at_str)) == NULL)
 			return pbs_error;
-		
+
 	}
 
 	if (mode == ATR_ACTION_RECOV) {
@@ -1132,4 +1129,3 @@ cvt_range(job *pjob, char state)
 
 	return buf;
 }
-

--- a/src/server/array_func.c
+++ b/src/server/array_func.c
@@ -575,7 +575,7 @@ update_subjob_state_ct(job *pjob)
 		"Exiting", "Expired", "Beginning", "Moved", "Finished"};
 
 	buf[0] = '\0';
-	snprintf(buf, sizeof(buf) - 1, "%s:%d %s:%d %s:%d %s:%d",
+	snprintf(buf, sizeof(buf), "%s:%d %s:%d %s:%d %s:%d",
 		statename[JOB_STATE_QUEUED],
 		pjob->ji_ajtrk->tkm_subjsct[JOB_STATE_QUEUED],
 		statename[JOB_STATE_RUNNING],

--- a/src/server/array_func.c
+++ b/src/server/array_func.c
@@ -570,12 +570,12 @@ void
 update_subjob_state_ct(job *pjob)
 {
 	char buf[BUF_SIZE];
-	static char *statename[] = {
+	const char *statename[] = {
 		"Transit", "Queued", "Held", "Waiting", "Running",
 		"Exiting", "Expired", "Beginning", "Moved", "Finished"};
 
 	buf[0] = '\0';
-	sprintf(buf, "%s:%d %s:%d %s:%d %s:%d",
+	snprintf(buf, sizeof(buf) - 1, "%s:%d %s:%d %s:%d %s:%d",
 		statename[JOB_STATE_QUEUED],
 		pjob->ji_ajtrk->tkm_subjsct[JOB_STATE_QUEUED],
 		statename[JOB_STATE_RUNNING],

--- a/src/server/req_jobobit.c
+++ b/src/server/req_jobobit.c
@@ -396,7 +396,7 @@ on_job_exit(struct work_task *ptask)
 			end_job(pjob, 1);
 			return;
 		} else if (rc > 0 && !hs)
-			svr_setjobstate(pjob, JOB_STATE_EXITING, JOB_SUBSTATE_EXITED);
+			svr_setjobstate(pjob, JOB_STATE_LTR_EXITING, JOB_SUBSTATE_EXITED);
 	}
 
 	if (is_jattr_set(pjob, JOB_ATR_relnodes_on_stageout) &&


### PR DESCRIPTION


<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* Valgrind shows below leak and invalid write:
```
Invalid write of size 8
   at 0x47A2A4: ds_queue_is_empty (queue.c:181)
   by 0x4477FB: close_servers (pbs_sched.c:548)
   by 0x446CAD: die (pbs_sched.c:204)
   by 0x4486F7: main (pbs_sched.c:1044)
Address 0x8 is not stack'd, malloc'd or (recently) free'd

150 bytes in 1 blocks are possibly lost in loss record 1,008 of 1,446
   at 0x4C29133: malloc (vg_replace_malloc.c:299)
   by 0x465A4D: update_subjob_state_ct (array_func.c:578)
   by 0x4655C2: update_array_indices_remaining_attr (array_func.c:404)
   by 0x4657B9: chk_array_doneness (array_func.c:469)
   by 0x465985: update_subjob_state (array_func.c:520)
   by 0x4E8DA1: svr_setjobstate (svr_jobfunc.c:601)
   by 0x4CB316: post_sendmom (req_runjob.c:1613)
   by 0x54C6AF: dispatch_task (work_task.c:144)
   by 0x47C7CC: process_DreplyTPP (issue_request.c:875)
   by 0x49108F: is_request (node_manager.c:4280)
   by 0x49E09D: do_tpp (pbsd_main.c:395)
   by 0x49E139: tpp_request (pbsd_main.c:439)
```

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* Added NULL check for given parameter in ds_queue_is_empty
* Modified update_subjob_state_ct() to use local buffer instead malloc-ed area
* Fixed typo in job state in on_job_exit

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
* None

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[valgrind_after.txt](https://github.com/openpbs/openpbs/files/5340143/valgrind_after.txt)
[valgrind_before.txt](https://github.com/openpbs/openpbs/files/5340144/valgrind_before.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
