### PR TITLE
fixed race condition in 'TestProvisioningJob_Enh.test_provisioning_with_placement'

### DIFF
--- a/test/tests/functional/pbs_provisioning_enhancement.py
+++ b/test/tests/functional/pbs_provisioning_enhancement.py
@@ -317,7 +317,6 @@ e.reject()
         j.set_attributes({'Resource_List.select':
                           '1:ncpus=1:aoe=App1+1:ncpus=12',
                           'Resource_List.place': 'pack'})
-        j.set_sleep_time(5)
         jid = self.server.submit(j)
         self.server.expect(JOB, {ATTR_state: 'Q',
                                  ATTR_comment:
@@ -331,7 +330,6 @@ e.reject()
         j.set_attributes({'Resource_List.select':
                           '1:ncpus=1:aoe=App1+1:ncpus=1',
                           'Resource_List.place': 'pack'})
-        j.set_sleep_time(20)
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
         self.server.expect(JOB, ATTR_execvnode, id=jid, op=SET)
@@ -353,7 +351,6 @@ e.reject()
         j.set_attributes({'Resource_List.select':
                           '1:ncpus=1:aoe=App1+1:ncpus=1',
                           'Resource_List.place': 'scatter'})
-        j.set_sleep_time(20)
         jid = self.server.submit(j)
         self.server.expect(JOB, ATTR_execvnode, id=jid, op=SET)
         nodes = j.get_vnodes(j.exec_vnode)

--- a/test/tests/functional/pbs_provisioning_enhancement.py
+++ b/test/tests/functional/pbs_provisioning_enhancement.py
@@ -331,7 +331,7 @@ e.reject()
         j.set_attributes({'Resource_List.select':
                           '1:ncpus=1:aoe=App1+1:ncpus=1',
                           'Resource_List.place': 'pack'})
-        j.set_sleep_time(5)
+        j.set_sleep_time(20)
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
         self.server.expect(JOB, ATTR_execvnode, id=jid, op=SET)
@@ -353,7 +353,7 @@ e.reject()
         j.set_attributes({'Resource_List.select':
                           '1:ncpus=1:aoe=App1+1:ncpus=1',
                           'Resource_List.place': 'scatter'})
-        j.set_sleep_time(5)
+        j.set_sleep_time(20)
         jid = self.server.submit(j)
         self.server.expect(JOB, ATTR_execvnode, id=jid, op=SET)
         nodes = j.get_vnodes(j.exec_vnode)


### PR DESCRIPTION
#### Describe Bug or Feature
tests from 'TestProvisioningJob_Enh.test_provisioning_with_placement' is failing due to race condition.

* TestProvisioningJob_Enh.test_provisioning_with_placement
race condition such that in test we are submitting 5 sec. sleep job and expecting job is in 'R' state. sometime when PTL try to check job state in 'R' till that point job completed and PTL didn't get expected job state due to test got failed.

On some very slow machines, or if the machine has a pause while running the expect(), a test might fail due not finding the job in the expected state.
For example:
 raise PtlExpectError(rc=1, rv=False, msg=_msg)
ptl.lib.pbs_testlib.PtlExpectError: rc=1, rv=False, msg=expected on server xyz:  no data for job_state = R && substate = 42 job 8.xyz attempt: 180

The longest delay observed was for 6 seconds.


#### Describe Your Change
Increased job sleep time from 5 sec, to 20 sec, for the job expecting in R state 
Anyways we are not waiting for to finish job so increasing sleep time won't increase execution time testing wise.



#### Attach Test and Valgrind Logs/Output
fail case log:-
[test_provisioning_with_placement_before_change_7.txt](https://github.com/openpbs/openpbs/files/5345834/test_provisioning_with_placement_before_change_7.txt)

after fix :

[test_provisioning_with_placement_after_change_30.txt](https://github.com/openpbs/openpbs/files/5345139/test_provisioning_with_placement_after_change_30.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
