### PR TITLE
Fix invalid read of a deleted job data

### DIFF
--- a/src/include/job.h
+++ b/src/include/job.h
@@ -471,6 +471,7 @@ struct job {
 	int ji_updated;				    /* set to 1 if job's node assignment was updated */
 	time_t ji_walltime_stamp;		    /* time stamp for accumulating walltime */
 	struct work_task *ji_bg_hook_task;
+	struct work_task *ji_report_task;
 #ifdef WIN32
 	HANDLE		ji_momsubt;	/* process HANDLE to mom subtask */
 #else	/* not WIN32 */

--- a/src/resmom/start_exec.c
+++ b/src/resmom/start_exec.c
@@ -2537,6 +2537,9 @@ report_failed_node_hosts_task(struct work_task *ptask)
 		log_err(-1, __func__, "task structure contains reference to NULL job");
 		return;
 	}
+	if (pjob->ji_report_task)
+		pjob->ji_report_task = NULL;
+
 	if (!check_job_state(pjob, JOB_STATE_LTR_RUNNING) ||
 	    !check_job_substate(pjob, JOB_SUBSTATE_PRERUN))
 		return;	/* job not longer waiting for healthy moms */
@@ -2626,7 +2629,7 @@ receive_pipe_request(int sd)
 			 * out on job_launch_delay.
 			 */
  			delay_value = 0.95 * job_launch_delay;
-			(void)set_task(WORK_Timed, time_now + delay_value, report_failed_node_hosts_task, pjob);
+			pjob->ji_report_task = set_task(WORK_Timed, time_now + delay_value, report_failed_node_hosts_task, pjob);
 		}
 	} else {
 		snprintf(msg, sizeof(msg), "ignoring unknown cmd %d", cmd);

--- a/src/server/job_func.c
+++ b/src/server/job_func.c
@@ -339,6 +339,7 @@ job_alloc(void)
 	pj->ji_updated = 0;
 	pj->ji_hook_running_bg_on = BG_NONE;
 	pj->ji_bg_hook_task = NULL;
+	pj->ji_report_task = NULL;
 	pj->ji_env.v_envp = NULL;
 #ifdef WIN32
 	pj->ji_hJob = NULL;
@@ -573,6 +574,9 @@ job_free(job *pj)
 		}
 		delete_task(pj->ji_bg_hook_task);
 	}
+
+	if (pj->ji_report_task)
+		delete_task(pj->ji_report_task);
 
 	/*
 	 ** This gets rid of any dependent job structure(s) from ji_setup.


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* With valgrind enabled running TestPbsReliableJobStartup testsuite, in particular 2 test cases (TestPbsReliableJobStartup.test_t18,TestPbsReliableJobStartup.test_t7 together), the following message is emitted:
```
==19445== Invalid read of size 1
==19445==    at 0x492150: get_attr_c (attr_fn_c.c:276)
==19445==    by 0x44862E: check_job_state (jattr_get_set.c:70)
==19445==    by 0x4880D7: report_failed_node_hosts_task (start_exec.c:2540)
==19445==    by 0x4C9668: dispatch_task (work_task.c:144)
==19445==    by 0x4C98E4: default_next_task (work_task.c:301)
==19445==    by 0x445A58: main (mom_main.c:8613)
==19445==  Address 0x7be33e8 is 1,608 bytes inside a block of size 6,584 free'd
==19445==    at 0x4C2AF6C: free (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==19445==    by 0x449916: job_purge (job_func.c:1228)
==19445==    by 0x45AC48: mom_deljob (catch_child.c:1420)
==19445==    by 0x47B88C: is_request (mom_server.c:1023)
==19445==    by 0x4751F8: do_tpp (mom_main.c:5366)
==19445==    by 0x47524B: tpp_request (mom_main.c:5403)
==19445==    by 0x499C95: process_socket (net_server.c:511)
==19445==    by 0x499E61: wait_request (net_server.c:627)
==19445==    by 0x46EA88: finish_loop (mom_func.c:146)
==19445==    by 0x4463F4: main (mom_main.c:8581)
==19445==
```
Culprit is that a report_failed_node_hosts_task() function was called as part of a serviced task, and that function was accessing an attribute of a job that had already been deleted. This usually happens when a job is prematurely killed, like these tests are doing qrerun of the job.
#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* Fix is that when a job is deleted, any tasks that will access that job's data should also be deleted.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
* [valgrind.mom.with_invalid_read.txt](https://github.com/openpbs/openpbs/files/5351637/valgrind.mom.with_invalid_read.txt)
* [valgrind.mom.without_invalid_read.txt](https://github.com/openpbs/openpbs/files/5351640/valgrind.mom.without_invalid_read.txt)
* TH3 run of TestPbsReliableJobStartup valgrind log results:
Before fix:
```
################################################################################
# Occurred In: 
#   Suites: TestPbsReliableJobStartup
#   Platforms: SLES12
################################################################################
Invalid read of size 1
   at 0x4AFD08: get_attr_c (attr_fn_c.c:276)
   by 0x445509: get_job_state (jattr_get_set.c:111)
   by 0x44548F: check_job_state (jattr_get_set.c:70)
   by 0x4A2D6D: report_failed_node_hosts_task (start_exec.c:2540)
   by 0x4F9D50: dispatch_task (work_task.c:144)
   by 0x4FA0BF: default_next_task (work_task.c:301)
   by 0x488AB8: main (mom_main.c:8363)
Address 0x94aa5b8 is 1,608 bytes inside a block of size 6,584 free'd
   at 0x4C2A37C: free (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
   by 0x44627E: job_free (job_func.c:598)
   by 0x4472C6: job_purge (job_func.c:1134)
   by 0x45FE09: job_purge_mom (catch_child.c:1622)
   by 0x45FB7E: mom_deljob_wait (catch_child.c:1480)
   by 0x45FBD1: mom_deljob_wait2 (catch_child.c:1523)
   by 0x494ACD: req_deletejob (requests.c:652)
   by 0x449493: dispatch_request (process_request.c:849)
   by 0x48F4EB: process_IS_CMD (mom_server.c:452)
   by 0x4906F8: is_request (mom_server.c:1048)
   by 0x482BC2: do_tpp (mom_main.c:5118)
   by 0x482C23: tpp_request (mom_main.c:5155)
```
* TH3 run of TestPbsReliableJobStartup valgrind log results:
After fix:
Valgrind log empty:
```
(-rw-r--r--)	0B	valgrind.log
```

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
