### PR TITLE
Fixed race condition issues in 'TestPbsResvAlter'

### DIFF
--- a/test/tests/functional/pbs_ralter.py
+++ b/test/tests/functional/pbs_ralter.py
@@ -631,9 +631,9 @@ class TestPbsResvAlter(TestFunctional):
         The above operation is expected to be successful.
         """
         duration = 20
-        shift = 10
+        shift = 30
         offset = 10
-        sleep = 25
+        sleep = 45
         rid, start, end = self.submit_and_confirm_reservation(offset, duration)
 
         # Submit a job to the reservation.
@@ -1372,19 +1372,19 @@ class TestPbsResvAlter(TestFunctional):
         This test checks the alter of reservation name.
         """
         duration = 30
-        offset = 5
+        offset = 10
 
         rid1 = self.submit_and_confirm_reservation(
             offset, duration)
-        rid2 = self.submit_and_confirm_reservation(
-            offset, duration, standing=True)
         attr1 = {ATTR_N: "Adv_Resv"}
         self.server.alterresv(rid1[0], attr1)
+        attr1 = {'Reserve_Name': "Adv_Resv"}
+        self.server.expect(RESV, attr1, id=rid1[0])
+        rid2 = self.submit_and_confirm_reservation(
+            offset, duration, standing=True)
         attr2 = {ATTR_N: "Std_Resv"}
         self.server.alterresv(rid2[0], attr2)
-        attr1 = {'Reserve_Name': "Adv_Resv"}
         attr2 = {'Reserve_Name': "Std_Resv"}
-        self.server.expect(RESV, attr1, id=rid1[0])
         self.server.expect(RESV, attr2, id=rid2[0])
 
     @skipOnCpuSet


### PR DESCRIPTION
#### Describe Bug or Feature
Below test from TestPbsResvAlter failed due to race condition 
1. test_alter_advance_resv_end_time_after_run
2. test_alter_resv_name

* TestPbsResvAlter.test_alter_advance_resv_end_time_after_run
On some very slow machines, or if the machine has a pause while running the expect(), a test might fail due not finding the job/reservation in the expected state.
For example:-
ptl.lib.pbs_testlib.PtlExpectError: rc=1, rv=False, msg=expected on server x-05-c1:  no data for job_state = R && substate = 42 job 16.x-05-c1 attempt: 180
The longest pause observed was for 6 seconds.

Race condition in such way in test submitting job of 25sec and reservation with 20 sec and then altering reservation end  time to 30sec and after that checking job is running in expect()
In slow machine which observed pause while running the expect() of approx 6sec , so by the time expect() check for job state , job is already finished .

* TestPbsResvAlter.test_alter_resv_name
Some time test failed with
ptl.lib.pbs_testlib.PbsResvAlterError: rc=236, rv=False, msg=['pbs_ralter: Unknown Reservation Id']

Race in condition in such way in test we are submitting one advance reservation (rid1)and one standing reservation (rid2) request 2 instance which start in 5sec with  duration of 30sec and altering reservation name of both reservations.
In fail case on slow machine which observed pause while running the expect() of approx 6sec

the pbs_rstat -f command run for S33.x-05-c1  took 5 sec which caused slowness for running first attempt for expect() and state of reservation S33.x-05-c1 changed to RESV_RUNNING while submit_confirm_reservation() is looking for RESV_CONFIRMED since max_attempt is now 180 its keep trying and  got state RESV_CONFIRMED for instance 2 of S33.x05-c1 ,meanwhile advance reservation R32..x-05-c1 is got finished , so the expect() looking for resv_name for rid1 is failed.

Also some time test failed while doing expect () for reseravtion_state as RESV_CONFIRMED in submit_confirm_reservation() itself since offset is 5 sec only , so if pause of 5-6sec hit there test fail there.

Note :- More detail is given in internal ticket with detail logs

#### Describe Your Change
For test_alter_advance_resv_end_time_after_run
Increase job sleep time from 25sec to 45sec and shift from 10sec to 30sec.

For test_alter_resv_name
Increase offset to 10 sec
and Alter advance reservation name and verify before submitting standing reservation 

#### Attach Test and Valgrind Logs/Output
fail case log:
[test_alter_advance_resv_end_time_after_run_fail_log.txt](https://github.com/openpbs/openpbs/files/5353477/test_alter_advance_resv_end_time_after_run_fail_log.txt)
[test_alter_resv_name_fail_log.txt](https://github.com/openpbs/openpbs/files/5353480/test_alter_resv_name_fail_log.txt)
[TestPbsResvAlter_2test_reproduce_4.txt](https://github.com/openpbs/openpbs/files/5353484/TestPbsResvAlter_2test_reproduce_4.txt)
[TestPbsResvAlter_2test_reproduce_20.txt](https://github.com/openpbs/openpbs/files/5353486/TestPbsResvAlter_2test_reproduce_20.txt)


 after fix : 
[TestPbsResvAlter_2test_after_fix2_30.txt](https://github.com/openpbs/openpbs/files/5353489/TestPbsResvAlter_2test_after_fix2_30.txt)




 
