### PR TITLE
Fixed race condition in test_advance_reservation_with_job_array

### DIFF
--- a/test/tests/functional/pbs_reservations.py
+++ b/test/tests/functional/pbs_reservations.py
@@ -1368,7 +1368,7 @@ class TestReservations(TestFunctional):
 
         a = {ATTR_q: rid_q, ATTR_J: '1-4'}
         j2 = Job(TEST_USER, attrs=a)
-        j2.set_sleep_time(10)
+        j2.set_sleep_time(20)
         jid2 = self.server.submit(j2)
         subjid = []
         for i in range(1, 5):
@@ -1425,7 +1425,7 @@ class TestReservations(TestFunctional):
         # Submit another job-array with small sleep time than job j2
         a = {ATTR_q: rid_q, ATTR_J: '1-4'}
         j3 = Job(TEST_USER, attrs=a)
-        j3.set_sleep_time(10)
+        j3.set_sleep_time(20)
         jid3 = self.server.submit(j3)
         subjid2 = []
         for i in range(1, 5):


### PR DESCRIPTION

#### Describe Bug or Feature
On some very slow machines, or if the machine has a pause while running the expect(), a test might fail due not finding the job in the expected state.
For example:
ptl.lib.pbs_testlib.PtlExpectError: rc=1, rv=False, msg=expected on server x-05-c1: no data for job_state=Q = 3 job 2[].xarm-05-c8p1 attempt: 180
or 
ptl.lib.pbs_testlib.PtlExpectError: rc=1, rv=False, msg=expected on server x-05-c1:  no data for job_state = B job 5[].x-05-c1 attempt: 180

The longest pause observed was for 6 seconds.

#### Describe Your Change
Increase job sleep time to 20sec 

#### Attach Test and Valgrind Logs/Output
Fail log:
[test_advance_reservation_with_job_array_fail_log.txt](https://github.com/openpbs/openpbs/files/5353747/test_advance_reservation_with_job_array_fail_log.txt)


after fix:
[TestReservations.test_advance_reservation_with_job_array_after_fix_20.txt](https://github.com/openpbs/openpbs/files/5353793/TestReservations.test_advance_reservation_with_job_array_after_fix_20.txt)

