### PR TITLE
Fix sched-crash parsing node_sort_key

### DIFF
--- a/src/scheduler/parse.c
+++ b/src/scheduler/parse.c
@@ -522,19 +522,21 @@ parse_config(char *fname)
 						else
 							error = 1;
 
-						tok = strtok(NULL, DELIM);
-						if (tok == NULL)
-							sort_type = RF_AVAIL;
-						else {
-							if (!strcmp(tok, "total"))
+						if (!error) {
+							tok = strtok(NULL, DELIM);
+							if (tok == NULL)
 								sort_type = RF_AVAIL;
-							else if (!strcmp(tok, "assigned"))
-								sort_type = RF_ASSN;
-							else if (!strcmp(tok, "unused"))
-								sort_type = RF_UNUSED;
 							else {
-								free(sort_res_name);
-								error = 1;
+								if (!strcmp(tok, "total"))
+									sort_type = RF_AVAIL;
+								else if (!strcmp(tok, "assigned"))
+									sort_type = RF_ASSN;
+								else if (!strcmp(tok, "unused"))
+									sort_type = RF_UNUSED;
+								else {
+									free(sort_res_name);
+									error = 1;
+								}
 							}
 						}
 


### PR DESCRIPTION
#### Describe Bug or Feature
If node_sort_key's values in sched config were out of order, the scheduler could crash.


#### Describe Your Change
Add error guards to node_sort_key's parsing.


#### Attach Test and Valgrind Logs/Output
No automated test is required, there's no value.
Here are the logs:
```
[vstumpf@shecil test-scripts]$ tail -n 5 /var/spool/pbs/sched_logs/20201009 
10/09/2020 13:43:36.633352;0002;pbs_sched;Svr;pbs_sched;ipv6 interface lo: localhost6.localdomain6 
10/09/2020 13:43:36.633377;0002;pbs_sched;Svr;pbs_sched;ipv6 interface ens33: shecil 
10/09/2020 13:43:36.633383;0002;pbs_sched;Svr;restart;restart on signal 1
10/09/2020 13:43:36.633402;0040;pbs_sched;Sched;reconfigure;Scheduler is reconfiguring
10/09/2020 13:43:36.633707;0040;pbs_sched;Fil;sched_config;Error reading line 195: 
[vstumpf@shecil test-scripts]$ sudo cat /var/spool/pbs/sched_priv/sched_config | grep node_sort_key
node_sort_key: "HIGH cpus"      ALL
```


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
