### PR TITLE
Job with released nodes should rerun from a downed mom using original request

### DIFF
--- a/src/server/req_rerun.c
+++ b/src/server/req_rerun.c
@@ -182,6 +182,7 @@ force_reque(job *pjob)
 	free_jattr(pjob, JOB_ATR_pset);
 	/* job dir has no meaning for re-queued jobs, so unset it */
 	free_jattr(pjob, JOB_ATR_jobdir);
+	unset_extra_attributes(pjob);
 	svr_evaljobstate(pjob, &newstate, &newsubstate, 1);
 	svr_setjobstate(pjob, newstate, newsubstate);
 }


### PR DESCRIPTION


<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
For instance, say a job has been submitted requesting 3 nodes:
```
bayucan@corretja:~/ptl/tests/functional> qsub -l select=3:ncpus=1 -l place=scatter -- /bin/sleep 60
20768.corretja
bayucan@corretja:~/ptl/tests/functional> qstat -f | egrep "state|Resource_List|exec"
    job_state = R
    exec_host = corretja/0+federer/0+lendl/0
    exec_vnode = (corretja:ncpus=1)+(federer:ncpus=1)+(lendl:ncpus=1)
    Resource_List.ncpus = 3
    Resource_List.nodect = 3
    Resource_List.place = scatter
    Resource_List.select = 3:ncpus=1
```
Then release one of the nodes from the job:
```
bayucan@corretja:~/ptl/tests/functional> pbs_release_nodes -j 20768 lendl
bayucan@corretja:~/ptl/tests/functional> qstat -f | egrep "state|Resource_List|exec"
    job_state = R
    exec_host = corretja/0+federer/0
    exec_vnode = (corretja:ncpus=1)+(federer:ncpus=1)
    Resource_List.ncpus = 2
    Resource_List.nodect = 2
    Resource_List.place = scatter
    Resource_List.select = 1:ncpus=1+1:ncpus=1
```
Now kill -9 the primary mom and restart it, and watch job goes into exiting state:
```
corretja:/opt/pbs/sbin # ps -eaf | grep pbs_mom
root     32028     1  0 16:23 ?        00:00:00 /opt/pbs/sbin/pbs_mom
root     32763  9258  0 16:27 pts/7    00:00:00 grep --color=auto pbs_mom
corretja:/opt/pbs/sbin # kill -9 32028
ccorretja:/opt/pbs/sbin # /opt/pbs/sbin/pbs_mom
cbayucan@corretja:~/ptl/tests/functional> qstat -f | egrep "state|Resource_List|exec"
    job_state = E
    exec_host = corretja/0+federer/0
    exec_vnode = (corretja:ncpus=1)+(federer:ncpus=1)
    Resource_List.ncpus = 2
    Resource_List.nodect = 2
    Resource_List.place = scatter
    Resource_List.select = 1:ncpus=1+1:ncpus=1
 ```
Eventually, job goes back into Running state (it was requeued/rerun by the server due to the downed primary mom), and see that it's no longer using the original resource request of 3 nodes but 2, which is a bug:
```
bayucan@corretja:~/ptl/tests/functional> qstat -f | egrep "state|Resource_List|exec"
    job_state = R
    exec_host = corretja/0+federer/0
    exec_vnode = (corretja:ncpus=1)+(federer:ncpus=1)
    Resource_List.ncpus = 2
    Resource_List.nodect = 2
    Resource_List.place = scatter
    Resource_List.select = 1:ncpus=1+1:ncpus=1
```
Per node rampdown design, any requeue/rerun of the job should go back to the original request:
```
bayucan@corretja:~/ptl/tests/functional> qstat -f | egrep "state|Resource_List|exec"
    job_state = R
    exec_host = corretja/0+federer/0+lendl/0
    exec_vnode = (corretja:ncpus=1)+(federer:ncpus=1)+(lendl:ncpus=1)
    Resource_List.ncpus = 3
    Resource_List.nodect = 3
    Resource_List.place = scatter
    Resource_List.select = 3:ncpus=1
```

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* The force_reque() function in req_rerun.c is missing the unset_extra_attributes() call for restoring job's original request.
* Updated the pbs_node_rampdown.py testsuite, so that the body of test_release_nodes_rerun() is put into a separate function. This separate function is called in test_release_nodes_rerun() and the new function test_release_nodes_rerun_downed_mom(). The former which will do the normal qrerun call, while the latter will kill -9 primary mom and restart to force server to requeue/rerun the job.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Valgrind log is empty after running the 2 test cases test_release_nodes_rerun, test_release_nodes_rerun_downed_mom:

  (-rw-r--r--)     0B  valgrind.log

Regression test result (note: 1 failed test is a known test problem):
![Screenshot_2020-10-14 PBS Pareeksha](https://user-images.githubusercontent.com/8485051/96045590-06786900-0e27-11eb-9b6a-cbeab78eb19b.png)

Test logs:
* [ptl.release_nodes_rerun.FAIL.txt](https://github.com/openpbs/openpbs/files/5380884/ptl.release_nodes_rerun.FAIL.txt)
* [ptl.release_nodes_rerun.PASS.txt](https://github.com/openpbs/openpbs/files/5380885/ptl.release_nodes_rerun.PASS.txt)
* [ptl.noderampdown.txt](https://github.com/openpbs/openpbs/files/5380886/ptl.noderampdown.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
