### PR TITLE
Fix leak in resv_info

### DIFF
--- a/src/scheduler/resv_info.cpp
+++ b/src/scheduler/resv_info.cpp
@@ -916,6 +916,9 @@ free_resv_info(resv_info *rinfo)
 	if (rinfo->select_orig != NULL)
 		free_selspec(rinfo->select_orig);
 
+	if (rinfo->select_standing != NULL)
+		free_selspec(rinfo->select_standing);
+
 	if (rinfo->orig_nspec_arr != NULL)
 		free_nspecs(rinfo->orig_nspec_arr);
 


### PR DESCRIPTION
#### Describe Bug or Feature
3c13fa5a7650af8aaf5bfeaae3d9341c2fe4b7c2 introduced a leak in resv_infos, the newly added `selspec *select_standing` was not being freed when the resv_info was.


#### Describe Your Change
Free select_standing.


#### Attach Test and Valgrind Logs/Output
Description: Tests from given sources on platforms UBUNTU1804, SUSE15, CENTOS8, CENTOS7
Platforms: UBUNTU1804,SUSE15,CENTOS8,CENTOS7
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|4246|1|0|0|0|0|1|

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
