### PR TITLE
Make export hook config command to run on remote hosts

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -9891,7 +9891,10 @@ class Server(PBSService):
             hook_t = "pbshook"
         cmd = ["export", hook_t, hook_name]
         cmd += ["application/x-config", "default"]
-        cmd = " ".join(cmd)
+        if not self._is_local:
+            cmd = '\'' + " ".join(cmd) + '\''
+        else:
+            cmd = " ".join(cmd)
         pcmd = [os.path.join(self.pbs_conf['PBS_EXEC'], 'bin', 'qmgr'),
                 '-c', cmd]
         ret = self.du.run_cmd(self.hostname, pcmd, sudo=True)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
export_hook_config method was not supported to run export command from non-server host. 

#### Describe Your Change
Added a quotes around the command to run on remote hosts.

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
