### PR TITLE
Fixed race condition in test_qmove_job_into_standing_reservation

### DIFF
--- a/test/tests/functional/pbs_reservations.py
+++ b/test/tests/functional/pbs_reservations.py
@@ -2374,7 +2374,7 @@ class TestReservations(TestFunctional):
             self.server.expect(JOB, {'job_state': 'R'}, id=jid1[0])
             self.logger.info('Job %s is in R as expected' % jid1[0])
         jid2 = self.submit_job(job_running=True)
-        self.server.delete([rid, jid2[0]])
+        self.server.delete([rid, jid2[0]], wait=True)
 
     def test_qmove_job_into_standing_reservation(self):
         """


### PR DESCRIPTION
#### Describe Bug or Feature
In slow machine test "test_qmove_job_into_standing_reservation" is failing because of race condition, by the time test do submission of second reservation say S15.xyz , first reservation  say S12.xyz is not yet  deleted so the request for S15 reservation is got denied and cause the failure in expect() while verify sate 

ptl.lib.pbs_testlib.PtlExpectError: rc=1, rv=False, msg=expected on server xyz:  no data for reserve_state = RESV_RUNNING && reserve_substate = 5 reservation S15.xyz attempt: 180
 

#### Describe Your Change
Added wait=True in  
self.server.delete([rid, jid2[0]])
to be sure the reservation and job from first step of test delete before submitting of other one.

#### Attach Test and Valgrind Logs/Output
[Test_log_after_fix.txt](https://github.com/openpbs/openpbs/files/5401614/Test_log_after_fix.txt)
[Test_log_before_fix.txt](https://github.com/openpbs/openpbs/files/5401615/Test_log_before_fix.txt)
