### PR TITLE
TestPBSSnapshot.test_multisched_support failed due to wrong vnode name

### DIFF
--- a/test/tests/functional/pbs_snapshot_unittest.py
+++ b/test/tests/functional/pbs_snapshot_unittest.py
@@ -130,7 +130,7 @@ class TestPBSSnapshot(TestFunctional):
                "started": "True",
                "enabled": "True"}
         a_n = {"resources_available.ncpus": 2}
-        self.mom.create_vnodes(a_n, (num_partitions + 1))
+        self.mom.create_vnodes(a_n, (num_partitions + 1), vname='vnode')
         for i in range(num_partitions):
             partition_id = "P" + str(i + 1)
 


### PR DESCRIPTION
#### Describe Bug or Feature
Test failed due to wrong vnode name used while setting node attribute.
This issue was introduced in PR https://github.com/openpbs/openpbs/pull/2033.
we need to pass vnode name in create_vnodes()

#### Describe Your Change
pass vnode name in create_vnodes() function.

#### Attach Test and Valgrind Logs/Output
Before fix:
[test_multisched_support_before_fix.txt](https://github.com/openpbs/openpbs/files/5410604/test_multisched_support_before_fix.txt)

After fix:
[test_multisched_support_u18.txt](https://github.com/openpbs/openpbs/files/5410605/test_multisched_support_u18.txt)
[test_multisched_support_after_fix.txt](https://github.com/openpbs/openpbs/files/5410606/test_multisched_support_after_fix.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
