### PR TITLE
fixed timedout issue for few tests in TestMomHookSync

### DIFF
--- a/test/tests/functional/pbs_mom_hook_sync.py
+++ b/test/tests/functional/pbs_mom_hook_sync.py
@@ -267,7 +267,7 @@ class TestMomHookSync(TestFunctional):
 
         now = time.time()
         self.momB.signal('-KILL')
-        self.momB.restart()
+        self.momB.pi.restart()
 
         # Killing and restarting mom would cause server to sync
         # up its version of the mom hook file resulting in an
@@ -337,7 +337,7 @@ class TestMomHookSync(TestFunctional):
         # mom hook sends are done.
         now = time.time()
         self.momB.signal('-KILL')
-        self.momB.restart()
+        self.momB.pi.restart()
 
         # Put another sleep delay so log_match() can see all the matches
         self.logger.info("Waiting 3 secs for new hook updates to complete")


### PR DESCRIPTION
#### Describe Bug or Feature
fixed timedout issue for few tests in TestMomHookSync
following tests are failing:

- test_momhook_to_serverhook_with_restart
- test_momhook_to_momhook_with_restart

The issue such that, in test we are killing pbs_mom process and restart it. to restart pbs_mom we use self.mom.restart() function which is internally calling is_Up() to check process id of pbs_mom getting from mom.lock is running or not.
we already killed pbs_mom process due to PTL didn't get expected result and continuously tried to check pbs_mom is running or not. 
sometime while checking pbs_mom is running or not test got timedout and failed. 

#### Describe Your Change
use restart function in 'PBSInitServices' which didn't call is_Up() and restart pbs_mom.

#### Attach Test and Valgrind Logs/Output
Before fix:
[test_momhook_to_momhook_with_restart_before_fix.txt](https://github.com/openpbs/openpbs/files/5422163/test_momhook_to_momhook_with_restart_before_fix.txt)
[test_momhook_to_serverhook_with_restart_before_fix.txt](https://github.com/openpbs/openpbs/files/5422164/test_momhook_to_serverhook_with_restart_before_fix.txt)

After fix:
[res_after_fix.txt](https://github.com/openpbs/openpbs/files/5422167/res_after_fix.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
