### PR TITLE
Fix log match error in test_max_hooks of TestPythonRestartSettings

### DIFF
--- a/test/tests/functional/pbs_python_restart_settings.py
+++ b/test/tests/functional/pbs_python_restart_settings.py
@@ -307,7 +307,7 @@ pbs.event().accept()
         # every 3s
         logs = self.server.log_match(
             "Restarting Python interpreter to reduce mem usage",
-            allmatch=True, starttime=stime, max_attempts=8)
+            allmatch=True, starttime=stime, max_attempts=8, n='ALL')
         self.assertTrue(len(logs) > 1)
         log1 = logs[0][1]
         log2 = logs[1][1]


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
test_max_hooks of TestPythonRestartSettings is failing with assertion error. Test is because we are setting python_restart_min_interval to '3' seconds and checking if Python has restarted after every 3 seconds by counting  number of logs appeared in server logs. When log match is searching with all existences of logs in server logs, it is getting only the last log match. This is because, in framework we are searching logs by tailing server logs output with last 100 lines.


#### Describe Your Change
We need to pass n='ALL' while calling log_match function in test case.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->

#### Attach Test and Valgrind Logs/Output
[TestPythonRestartSettings_after_fix.txt](https://github.com/openpbs/openpbs/files/5428400/TestPythonRestartSettings_after_fix.txt)
[TestPythonRestartSettings_before_fix.txt](https://github.com/openpbs/openpbs/files/5428401/TestPythonRestartSettings_before_fix.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
