### PR TITLE
Fix timeout issue of TestHookDebugNoCrash testsuite

### DIFF
--- a/test/tests/functional/pbs_hook_debug_nocrash.py
+++ b/test/tests/functional/pbs_hook_debug_nocrash.py
@@ -85,7 +85,7 @@ class TestHookDebugNoCrash(TestFunctional):
             self.skipTest(msg)
         TestFunctional.setUp(self)
 
-    @timeout(1000)
+    @timeout(2400)
     def test_hook_debug_no_crash(self):
 
         hook_body = """


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
TestHookDebugNoCrash  is timed out on machines with valgrind with qdel taking time to delete large number of jobs.


#### Describe Your Change
Increase the time out of test case to 2400.

#### Attach Test and Valgrind Logs/Output
[TestHookDebugNoCrash_with_fix.txt](https://github.com/openpbs/openpbs/files/5463288/TestHookDebugNoCrash_with_fix.txt)

[TestHookDebugNoCrash_without_fix.txt](https://github.com/openpbs/openpbs/files/5459302/TestHookDebugNoCrash_without_fix.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
