### PR TITLE
Automate test from reservations and dedicated time test suite

### DIFF
--- a/test/tests/functional/pbs_reservations.py
+++ b/test/tests/functional/pbs_reservations.py
@@ -2464,9 +2464,11 @@ class TestReservations(TestFunctional):
         next_day_start = PBSLogUtils.convert_date_time(
             next_day_start.strftime("%m/%d/%Y %H:%M:%S"))
         next_day_end = next_day_start + 86400
-        self.scheduler.set_sched_config({'resv_confirm_ignore': 'dedicated_time'})
+        self.scheduler.set_sched_config({'resv_confirm_ignore':
+                                         'dedicated_time'})
 
-        self.scheduler.add_dedicated_time(start=next_day_start, end=next_day_end)
+        self.scheduler.add_dedicated_time(start=next_day_start,
+                                          end=next_day_end)
         now = time.time()
         rid = self.submit_reservation(user=TEST_USER, select='1:ncpus=1',
                                       start=now + 5, end=now + 3600)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Automated test from reservations and dedicated time test suite.
Intention of test is to set sched attribute resv_confirm_ignore to dedicated_time and check reservation submission which conflicts with dedicated time


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
[test_reservation_logs.txt](https://github.com/openpbs/openpbs/files/5464043/test_reservation_logs.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
