### PR TITLE
Fix for sched fails to register on server when non-resvport auth is used

### DIFF
--- a/src/server/process_request.c
+++ b/src/server/process_request.c
@@ -472,11 +472,6 @@ process_request(int sfds)
 	}
 
 #ifndef PBS_MOM
-	if (request->rq_type == PBS_BATCH_RegisterSched) {
-		req_register_sched(conn, request);
-		return;
-	}
-
 	if (request->rq_type != PBS_BATCH_Connect) {
 		if (transport_chan_get_ctx_status(sfds, FOR_AUTH) != AUTH_STATUS_CTX_READY &&
 			(conn->cn_authen & PBS_NET_CONN_AUTHENTICATED) == 0) {
@@ -531,6 +526,11 @@ process_request(int sfds)
 		}
 
 		conn->cn_authen |= PBS_NET_CONN_AUTHENTICATED;
+	}
+
+	if (request->rq_type == PBS_BATCH_RegisterSched) {
+		req_register_sched(conn, request);
+		return;
 	}
 
 	access_by_krb = 0;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Sched fails to register with below error when authentication method is set to non-resvport like munge:
```
10/30/2020 07:41:55;0040;pbs_sched;Fil;fairshare usage;Creating usage database for fairshare
10/30/2020 07:41:55;0080;pbs_sched;Req;;Launching 6 worker threads
10/30/2020 07:42:02;0001;pbs_sched;Svr;pbs_sched;Unauthorized Request  (15007) in connect_svrpool, Couldn't register the scheduler default with the configured servers
```
Reason: Once sched does pbs_connect() connection is authenticated successfully but conn is not marked as authenticated in process_request() before we process register request, so fix is simply as we have to move handling of sched register request after we mark conn as authenticated (when non-resvport) block (aka `if (request->rq_type != PBS_BATCH_Connect) {` block)

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* Changed position of handling PBS_BATCH_register request after connection auth is completed when non-resvport

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
None

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
After fix:
```
10/30/2020 08:44:16;0040;pbs_sched;Fil;fairshare usage;Creating usage database for fairshare
10/30/2020 08:44:16;0080;pbs_sched;Req;;Launching 6 worker threads
10/30/2020 08:44:22;0004;pbs_sched;Sched;pbs_sched;Connected to all the configured servers
10/30/2020 08:44:22;0040;pbs_sched;Sched;reconfigure;Scheduler is reconfiguring
10/30/2020 08:44:22;0040;pbs_sched;Fil;fairshare usage;Creating usage database for fairshare
10/30/2020 08:44:22;0080;pbs_sched;Req;;Updating scheduler attributes
10/30/2020 08:44:22;0040;pbs_sched;Sched;reconfigure;Scheduler is reconfiguring
10/30/2020 08:44:22;0040;pbs_sched;Fil;fairshare usage;Creating usage database for fairshare
10/30/2020 08:44:22;0080;pbs_sched;Req;;Updating scheduler attributes
10/30/2020 08:44:22;0080;pbs_sched;Req;;Updating scheduler attributes
10/30/2020 08:44:22;0080;pbs_sched;Req;;Starting Scheduling Cycle
10/30/2020 08:44:22;0080;pbs_sched;Req;;Leaving Scheduling Cycle
10/30/2020 08:44:50;0080;pbs_sched;Req;;Starting Scheduling Cycle
10/30/2020 08:44:50;0080;pbs_sched;Job;0.node1;Considering job to run
10/30/2020 08:44:50;0040;pbs_sched;Job;0.node1;Job run
10/30/2020 08:44:50;0080;pbs_sched;Req;;Leaving Scheduling Cycle
10/30/2020 08:45:01;0080;pbs_sched;Req;;Starting Scheduling Cycle
10/30/2020 08:45:01;0080;pbs_sched;Req;;Leaving Scheduling Cycle
```


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
