### PR TITLE
test_preempt_wrong_cull test fix

### DIFF
--- a/test/tests/functional/pbs_preemption.py
+++ b/test/tests/functional/pbs_preemption.py
@@ -711,10 +711,10 @@ exit 3
 
         a = {'resources_available.ncpus': 1, 'resources_available.app': 'appA'}
         self.mom.create_vnodes(a, num=1,
-                               usenatvnode=False)
+                               usenatvnode=False, vname='vna')
         b = {'resources_available.ncpus': 1, 'resources_available.app': 'appB'}
         self.mom.create_vnodes(b, num=1,
-                               usenatvnode=False, additive=True)
+                               usenatvnode=False, additive=True, vname='vnb')
 
         # set the preempt_order to kill/requeue only -- try old and new syntax
         self.server.manager(MGR_CMD_SET, SCHED, {'preempt_order': 'R'})
@@ -734,8 +734,7 @@ exit 3
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, "lopri")
 
         # submit job 1
-        a = {'Resource_List.select': '1:ncpus=1:vnode=' +
-             self.mom.shortname + '[0]', ATTR_q: 'lopri'}
+        a = {'Resource_List.select': '1:ncpus=1:vnode=vna[0]', ATTR_q: 'lopri'}
         j1 = Job(TEST_USER, attrs=a)
         jid1 = self.server.submit(j1)
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature

test_preempt_wrong_cull test bug introduced while removing vnode name for create_vnodes change

#### Describe Your Change
Reverted back the vnode names as prior to change

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Description: Tests from given sources on platforms UBUNTU1804, SUSE15, CENTOS8, CENTOS7
Platforms: UBUNTU1804,SUSE15,CENTOS8,CENTOS7
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|4598|1|0|0|0|0|1|


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
