### PR TITLE
ubuntu20.04 compilation issues

### DIFF
--- a/src/cmds/qsub.c
+++ b/src/cmds/qsub.c
@@ -1833,7 +1833,7 @@ read_job_script(char *script)
 	int errflg; /* error code from get_script() */
 	struct stat statbuf;
 	char *bnp;
-	char basename[PBS_MAXJOBNAME + 1]; /* base name of script for job name*/
+	char basename[MAXPATHLEN + 1]; /* base name of script for job name*/
 	FILE *f; /* FILE pointer to the script */
 
 	/* if script is empty, get standard input */

--- a/src/cmds/qsub.c
+++ b/src/cmds/qsub.c
@@ -1833,7 +1833,7 @@ read_job_script(char *script)
 	int errflg; /* error code from get_script() */
 	struct stat statbuf;
 	char *bnp;
-	char basename[MAXPATHLEN + 1]; /* base name of script for job name*/
+	char basename[PBS_MAXJOBNAME + 1]; /* base name of script for job name*/
 	FILE *f; /* FILE pointer to the script */
 
 	/* if script is empty, get standard input */

--- a/src/include/pbs_ifl.h
+++ b/src/include/pbs_ifl.h
@@ -466,7 +466,7 @@ enum mgr_obj {
 #define PBS_MAXPWLEN		256		/* max password length */
 #define PBS_MAXGRPN		256		/* max group name length */
 #define PBS_MAXQUEUENAME	15		/* max queue name length */
-#define PBS_MAXJOBNAME  	MAXPATHLEN + 1	/* max job name length */
+#define PBS_MAXJOBNAME  	230		/* max job name length */
 #define PBS_MAXSERVERNAME	PBS_MAXHOSTNAME	/* max server name length */
 #define PBS_MAXSEQNUM		12		/* max sequence number length */
 #define PBS_DFLT_MAX_JOB_SEQUENCE_ID 9999999	/* default value of max_job_sequence_id server attribute */

--- a/src/include/pbs_ifl.h
+++ b/src/include/pbs_ifl.h
@@ -466,7 +466,7 @@ enum mgr_obj {
 #define PBS_MAXPWLEN		256		/* max password length */
 #define PBS_MAXGRPN		256		/* max group name length */
 #define PBS_MAXQUEUENAME	15		/* max queue name length */
-#define PBS_MAXJOBNAME  	230		/* max job name length */
+#define PBS_MAXJOBNAME  	MAXPATHLEN + 1	/* max job name length */
 #define PBS_MAXSERVERNAME	PBS_MAXHOSTNAME	/* max server name length */
 #define PBS_MAXSEQNUM		12		/* max sequence number length */
 #define PBS_DFLT_MAX_JOB_SEQUENCE_ID 9999999	/* default value of max_job_sequence_id server attribute */

--- a/src/lib/Libtpp/tpp_util.c
+++ b/src/lib/Libtpp/tpp_util.c
@@ -2081,18 +2081,19 @@ tpp_get_addresses(char *names, int *count)
 tpp_addr_t *
 tpp_get_local_host(int sock)
 {
-	struct sockaddr addr;
+	struct sockaddr_storage addrs;
+	struct sockaddr *addr = (struct sockaddr *)&addrs;
 	struct sockaddr_in *inp = NULL;
 	struct sockaddr_in6 *inp6 = NULL;
 	tpp_addr_t *taddr = NULL;
-	socklen_t len = sizeof(addr);
+	socklen_t len = sizeof(struct sockaddr);
 
-	if (getsockname(sock, &addr, &len) == -1) {
+	if (getsockname(sock, addr, &len) == -1) {
 		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Could not get name of peer for sock %d, errno=%d", sock, errno);
 		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
 		return NULL;
 	}
-	if (addr.sa_family != AF_INET && addr.sa_family != AF_INET6) {
+	if (addr->sa_family != AF_INET && addr->sa_family != AF_INET6) {
 		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Bad address family for sock %d", sock);
 		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
 		return NULL;
@@ -2104,13 +2105,13 @@ tpp_get_local_host(int sock)
 		return NULL;
 	}
 
-	if (addr.sa_family == AF_INET) {
-		inp = (struct sockaddr_in *) &addr;
+	if (addr->sa_family == AF_INET) {
+		inp = (struct sockaddr_in *) addr;
 		memcpy(&taddr->ip, &inp->sin_addr, sizeof(inp->sin_addr));
 		taddr->port = inp->sin_port; /* keep in network order */
 		taddr->family = TPP_ADDR_FAMILY_IPV4;
-	} else if (addr.sa_family == AF_INET6){
-		inp6 = (struct sockaddr_in6 *) &addr;
+	} else if (addr->sa_family == AF_INET6){
+		inp6 = (struct sockaddr_in6 *) addr;
 		memcpy(&taddr->ip, &inp6->sin6_addr, sizeof(inp6->sin6_addr));
 		taddr->port = inp6->sin6_port; /* keep in network order */
 		taddr->family = TPP_ADDR_FAMILY_IPV6;
@@ -2133,13 +2134,14 @@ tpp_get_local_host(int sock)
 tpp_addr_t *
 tpp_get_connected_host(int sock)
 {
-	struct sockaddr addr;
+	struct sockaddr_storage addrs;
+	struct sockaddr *addr = (struct sockaddr *)&addrs;
 	struct sockaddr_in *inp = NULL;
 	struct sockaddr_in6 *inp6 = NULL;
 	tpp_addr_t *taddr = NULL;
-	socklen_t len = sizeof(addr);
+	socklen_t len = sizeof(struct sockaddr);
 
-	if (getpeername(sock, &addr, &len) == -1) {
+	if (getpeername(sock, addr, &len) == -1) {
 		if (errno == ENOTCONN)
 			snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Peer disconnected sock %d", sock);
 		else
@@ -2148,7 +2150,7 @@ tpp_get_connected_host(int sock)
 		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
 		return NULL;
 	}
-	if (addr.sa_family != AF_INET && addr.sa_family != AF_INET6) {
+	if (addr->sa_family != AF_INET && addr->sa_family != AF_INET6) {
 		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Bad address family for sock %d", sock);
 		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
 		return NULL;
@@ -2160,13 +2162,13 @@ tpp_get_connected_host(int sock)
 		return NULL;
 	}
 
-	if (addr.sa_family == AF_INET) {
-		inp = (struct sockaddr_in *) &addr;
+	if (addr->sa_family == AF_INET) {
+		inp = (struct sockaddr_in *) addr;
 		memcpy(&taddr->ip, &inp->sin_addr, sizeof(inp->sin_addr));
 		taddr->port = inp->sin_port; /* keep in network order */
 		taddr->family = TPP_ADDR_FAMILY_IPV4;
-	} else if (addr.sa_family == AF_INET6){
-		inp6 = (struct sockaddr_in6 *) &addr;
+	} else if (addr->sa_family == AF_INET6){
+		inp6 = (struct sockaddr_in6 *) addr;
 		memcpy(&taddr->ip, &inp6->sin6_addr, sizeof(inp6->sin6_addr));
 		taddr->port = inp6->sin6_port; /* keep in network order */
 		taddr->family = TPP_ADDR_FAMILY_IPV6;

--- a/src/resmom/mom_hook_func.c
+++ b/src/resmom/mom_hook_func.c
@@ -750,7 +750,7 @@ run_hook(hook *phook, unsigned int event_type, mom_hook_input_t *hook_input,
 	pid_t myseq; /* just some unique sequence number */
 	char logmask[BUFSIZ];
 	char path_hooks_rescdef[MAXPATHLEN + 1];
-	char cmdline[3 * BUFSIZ + 1];
+	char cmdline[2 * BUFSIZ + 16]; /* Additional bytes for command options */
 	struct passwd *pwdp = NULL;
 #ifdef WIN32
 	FILE *fp2 = NULL;

--- a/src/resmom/mom_hook_func.c
+++ b/src/resmom/mom_hook_func.c
@@ -750,7 +750,7 @@ run_hook(hook *phook, unsigned int event_type, mom_hook_input_t *hook_input,
 	pid_t myseq; /* just some unique sequence number */
 	char logmask[BUFSIZ];
 	char path_hooks_rescdef[MAXPATHLEN + 1];
-	char cmdline[2 * BUFSIZ + 1];
+	char cmdline[3 * BUFSIZ + 1];
 	struct passwd *pwdp = NULL;
 #ifdef WIN32
 	FILE *fp2 = NULL;

--- a/src/tools/pbs_idled.c
+++ b/src/tools/pbs_idled.c
@@ -117,7 +117,7 @@ main(int argc, char *argv[], char *envp[])
 	char *username;
 	struct xy cur_xy, prev_xy;
 	struct stat st;
-	char errbuf[1037];
+	char errbuf[BUFSIZ]; /* BUFSIZ is sufficient to hold buffer msg */
 	int fd;
 	int c;
 

--- a/src/tools/pbs_idled.c
+++ b/src/tools/pbs_idled.c
@@ -117,7 +117,7 @@ main(int argc, char *argv[], char *envp[])
 	char *username;
 	struct xy cur_xy, prev_xy;
 	struct stat st;
-	char errbuf[256];
+	char errbuf[1037];
 	int fd;
 	int c;
 

--- a/src/tools/pbs_python.c
+++ b/src/tools/pbs_python.c
@@ -1648,7 +1648,7 @@ main(int argc, char *argv[], char *envp[])
 		int	print_env = 0;
 		char	*tmp_str = NULL;
 		char	perf_label[MAXBUF];
-		char	perf_action[MAXBUFLEN + 13];
+		char	perf_action[MAXBUFLEN + 13]; /* Additional 13 byte for description string*/
 		char	*sp;
 
 		the_input[0] = '\0';

--- a/src/tools/pbs_python.c
+++ b/src/tools/pbs_python.c
@@ -1648,7 +1648,7 @@ main(int argc, char *argv[], char *envp[])
 		int	print_env = 0;
 		char	*tmp_str = NULL;
 		char	perf_label[MAXBUF];
-		char	perf_action[MAXBUFLEN];
+		char	perf_action[MAXBUFLEN + 13];
 		char	*sp;
 
 		the_input[0] = '\0';

--- a/src/tools/printjob.c
+++ b/src/tools/printjob.c
@@ -731,9 +731,11 @@ char *argv[];
 				print_usage();
 				exit(1);
 			}
-			printf("----------------------------------------------------------------\n");
-			printf("jobscript for %s\n", job_id);
-			printf("----------------------------------------------------------------\n");
+			if (job_id) {
+				printf("--------------------------------------------------\n");
+				printf("jobscript for %s\n", job_id);
+				printf("--------------------------------------------------\n");
+			}
 			while ((fgets(job_script, BUF_SIZE-1, fp_script)) != NULL) {
 				if (fputs(job_script, stdout) < 0) {
 					fprintf(stderr, "Error reading job-script file\n");


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Getting warnings while compiling on ubuntu20 that is using higher gcc version 9.3. Read and write size doesn't match in snprintf(), structure sockaddr doesn't give correct size of ipv6. reading data from null string.
[ubuntu_issue.txt](https://github.com/openpbs/openpbs/files/5481183/ubuntu_issue.txt)


#### Describe Your Change
Uses structure sockaddr_storage to store ipv6. Provides required size to the writing destination. Uses if condition to check null string,


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

[ubuntu_build.txt](https://github.com/openpbs/openpbs/files/5483651/ubuntu_build.txt)


Description: Tests from given build on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, SLES12, SLES15
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,SLES12,SLES15
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|4663|3845|14|0|0|0|3831|

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
