### PR TITLE
systemd missing daemons only start

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -363,6 +363,7 @@ AC_CONFIG_FILES([
 	src/cmds/scripts/modulefile
 	src/cmds/scripts/pbs_habitat
 	src/cmds/scripts/pbs_init.d
+	src/cmds/scripts/pbs_wrap
 	src/cmds/scripts/pbs_poerun
 	src/cmds/scripts/pbs_postinstall
 	src/cmds/scripts/pbs.service

--- a/openpbs.spec.in
+++ b/openpbs.spec.in
@@ -474,8 +474,10 @@ ${RPM_INSTALL_PREFIX:=%{pbs_prefix}}/libexec/pbs_posttrans \
 %exclude %{_sysconfdir}/profile.d/ptl.sh
 %if %{defined have_systemd}
 %attr(644, root, root) %{_unitdir}/pbs.service
+%attr(644, root, root) %{pbs_prefix}/libexec/pbs_wrap
 %else
 %exclude %{_unitdir}/pbs.service
+%exclude %{pbs_prefix}/libexec/pbs_wrap
 %endif
 %exclude %{pbs_prefix}/unsupported/*.pyc
 %exclude %{pbs_prefix}/unsupported/*.pyo

--- a/src/cmds/scripts/Makefile.am
+++ b/src/cmds/scripts/Makefile.am
@@ -82,7 +82,8 @@ dist_libexec_SCRIPTS = \
 	pbs_init.d \
 	pbs_postinstall \
 	pbs_preuninstall \
-	pbs_posttrans
+	pbs_posttrans \
+	pbs_wrap
 
 dist_bin_SCRIPTS = \
 	pbs_topologyinfo \

--- a/src/cmds/scripts/pbs_wrap.in
+++ b/src/cmds/scripts/pbs_wrap.in
@@ -1,3 +1,5 @@
+#!/bin/sh
+#
 # Copyright (C) 1994-2020 Altair Engineering, Inc.
 # For more information, contact Altair at www.altair.com.
 #
@@ -35,39 +37,9 @@
 # "OpenPBS®", "PBS Professional®", and "PBS Pro™" and Altair's logos is
 # subject to Altair's trademark licensing policies.
 
-
-
-
-# It's not recommended to modify this file in-place, because it will be
-# overwritten during package upgrades.  If you want to customize, the
-# best way is to create a file "/etc/systemd/system/pbs.service",
-# containing
-#       .include /lib/systemd/system/pbs.service
-#       ...make your changes here...
-# For more info about custom unit files, see -
-# http://fedoraproject.org/wiki/Systemd#How_do_I_customize_a_unit_file.2F_add_a_custom_unit_file.3F
-
-
-[Unit]
-Documentation=man:pbs(8)
-SourcePath=@prefix@/libexec/pbs_init.d
-Description=Portable Batch System
-After=network-online.target remote-fs.target nss-lookup.target
-Wants=network-online.target
-DefaultDependencies=true
-
-[Service]
-Type=forking
-Restart=no
-TimeoutStartSec=0
-TimeoutStopSec=5min
-Delegate=yes
-IgnoreSIGPIPE=no
-GuessMainPID=no
-ExecStart=@prefix@/libexec/pbs_init.d start
-ExecStop=@prefix@/libexec/pbs_init.d stop
-ExecReload=@prefix@/libexec/pbs_wrap @prefix@/libexec/pbs_init.d start
-TasksMax=infinity
-
-[Install]
-WantedBy=multi-user.target
+check_cgroup=$$
+cgpath=/sys/fs/cgroup/systemd/system.slice/pbs.service
+if [ -e $cgpath/cgroup.procs ]; then
+    echo $check_cgroup > $cgpath/cgroup.procs
+fi
+exec "$@"

--- a/test/tests/functional/pbs_systemd.py
+++ b/test/tests/functional/pbs_systemd.py
@@ -90,9 +90,11 @@ class Test_systemd(TestFunctional):
         if ('1' == self.server.pbs_conf['PBS_START_SCHED'] and
                 self.scheduler.isUp(max_attempts=10)):
             return False
-        if '1' == self.server.pbs_conf['PBS_START_COMM'] and self.comm.isUp(max_attempts=10):
+        if ('1' == self.server.pbs_conf['PBS_START_COMM'] and
+                self.comm.isUp(max_attempts=10)):
             return False
-        if '1' == self.server.pbs_conf['PBS_START_MOM'] and self.mom.isUp(max_attempts=10):
+        if ('1' == self.server.pbs_conf['PBS_START_MOM'] and
+                self.mom.isUp(max_attempts=10)):
             return False
         return True
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
If PBS is started using systemd and if some how any daemon get killed, systemctl status still shows pbs service running without the daemon in process list that got killed. We were not able to start that missing daemon until we restart the service all together.


#### Describe Your Change
Added a directive in the pbs.service unit file that will be used to reload pbs service by doing the reload only the missing daemon/ daemons will be started again and will be seen in the process list when we do systemctl status pbs.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[res_systemd.txt](https://github.com/openpbs/openpbs/files/5483196/res_systemd.txt)

|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|4637|3845|5|0|0|0|3840|


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
