### PR TITLE
Scheduler server_dyn_res leaves trail of zombies depleting host PID space

### DIFF
--- a/src/scheduler/server_info.cpp
+++ b/src/scheduler/server_info.cpp
@@ -749,6 +749,8 @@ query_server_dyn_res(server_info *sinfo)
 				} else if (ret == 0) {
 					log_eventf(PBSEVENT_DEBUG, PBS_EVENTCLASS_SERVER, LOG_DEBUG, "server_dyn_res",
 					"Program %s timed out", conf.dynamic_res[i].command_line);
+				}
+				if (ret == -1 || ret == 0) {
 					/* we know pid is initialized here, otherwise pipe_err would have been set */
 					kill(-pid, SIGTERM);
 					if (waitpid(pid, NULL, WNOHANG) == 0) {

--- a/src/scheduler/server_info.cpp
+++ b/src/scheduler/server_info.cpp
@@ -751,7 +751,7 @@ query_server_dyn_res(server_info *sinfo)
 					log_eventf(PBSEVENT_DEBUG, PBS_EVENTCLASS_SERVER, LOG_DEBUG, "server_dyn_res",
 					"Program %s timed out", conf.dynamic_res[i].command_line);
 				}
-				if ( pid > 0 && ret > 0 ) {
+				if (pid > 0 && ret > 0) {
 					/* Parent; only open if child created and select showed sth to read,
 					 * but assume fdopen can't fail
 					 */

--- a/src/scheduler/server_info.cpp
+++ b/src/scheduler/server_info.cpp
@@ -749,14 +749,13 @@ query_server_dyn_res(server_info *sinfo)
 				} else if (ret == 0) {
 					log_eventf(PBSEVENT_DEBUG, PBS_EVENTCLASS_SERVER, LOG_DEBUG, "server_dyn_res",
 					"Program %s timed out", conf.dynamic_res[i].command_line);
+					/* we know pid is initialized here, otherwise pipe_err would have been set */
 					kill(-pid, SIGTERM);
-					if (pid != 0) {
-					    if (waitpid(pid, NULL, WNOHANG) == 0) {
-							usleep(250000);
-							if (waitpid(pid, NULL, WNOHANG) == 0) {
-								kill(-pid, SIGKILL);
-								waitpid(pid, NULL, 0);
-							}
+					if (waitpid(pid, NULL, WNOHANG) == 0) {
+						usleep(250000);
+						if (waitpid(pid, NULL, WNOHANG) == 0) {
+							kill(-pid, SIGKILL);
+							waitpid(pid, NULL, 0);
 						}
 					}
 				}
@@ -801,7 +800,9 @@ query_server_dyn_res(server_info *sinfo)
 			else
 				log_eventf(PBSEVENT_DEBUG2, PBS_EVENTCLASS_SERVER, LOG_DEBUG, "server_dyn_res",
 					"%s = %s (\"%s\")", conf.dynamic_res[i].command_line, res_to_str(res, RF_AVAIL), buf);
+
 			if (pid != 0) {
+				kill(-pid, SIGTERM);
 				if (waitpid(pid, NULL, WNOHANG) == 0) {
 					usleep(250000);
 					if (waitpid(pid, NULL, WNOHANG) == 0) {


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
We've just discovered a PID leak in 2020 in the scheduler: the method to spawn a child was changed from using popen() to fork() to allow for setting up an alarm and killing a child that would hang the scheduler, but code is missing to use waitpid() to clean up the zombies after reading the result of the server_dyn_res child.

The result is a PID leak (a zombie process left in the process table for every server_dyn_res resource every cycle):

[root@tc72linux2 sched_priv]# grep wobbly sched_config
    server_dyn_res: "wobbly !/bin/echo 10"
[root@tc72linux2 sched_priv]# qmgr
Max open servers: 49
Qmgr: s s scheduling=true
Qmgr: s s scheduling=true
Qmgr: s s scheduling=true
Qmgr: s s scheduling=true
Qmgr: s s scheduling=true
Qmgr: s s scheduling=true
Qmgr: s s scheduling=true
Qmgr: s s scheduling=true
Qmgr: s s scheduling=true
Qmgr: s s scheduling=true

[root@tc72linux2 sched_priv]# ps -ef | grep pbs_sched
root     11206     1  0 17:24 ?        00:00:00 /opt/pbs/sbin/pbs_sched
root     11649  2013  0 17:29 pts/0    00:00:00 grep --color=auto pbs_sched
[root@tc72linux2 sched_priv]# pstree -c 11206
pbs_sched─┬─echo
          ├─echo
          ├─echo
          ├─echo
          ├─echo
          ├─echo
          ├─echo
          ├─echo
          ├─echo
          ├─echo
          └─{pbs_sched}

To work around this, sites will have to periodically restart the scheduler manually, or they'll risk depleting the PID space on their hosts.


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Insert the same loop that uses waitpid() to clean up children that is already there when there is an error in the case that everything actually works. Initialize pid to zero in the loop and add a guard to avoid risking calling waitpid() on an uninitialized PID.
#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
N/A -- bug fix

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

See above for test showing the bug. When fixed, pstree shows a pbs_sched that has no "echo" zombie children.

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
