### PR TITLE
fix few tests from 'TestNodePartition' and 'TestPartition' when mom is on remotehost.

### DIFF
--- a/test/tests/interfaces/pbs_partition.py
+++ b/test/tests/interfaces/pbs_partition.py
@@ -99,7 +99,7 @@ class TestPartition(TestInterfaces):
                 self.assertTrue(False, msg)
         elif obj_name is "NODE":
             if name is "Q1":
-                name = self.server.shortname
+                name = self.mom.shortname
             attr = {'partition': partition}
             if mgr_cmd == MGR_CMD_SET:
                 self.server.manager(MGR_CMD_SET, NODE, attr,
@@ -251,7 +251,7 @@ class TestPartition(TestInterfaces):
             partition="P2")
         self.partition_attr(mgr_cmd=MGR_CMD_UNSET, obj_name="NODE")
         self.server.manager(MGR_CMD_SET, NODE, {
-                            'queue': "Q2"}, id=self.server.shortname)
+                            'queue': "Q2"}, id=self.mom.shortname)
         self.partition_attr(obj_name="NODE", partition="P2")
 
     def test_mismatch_of_partition_on_node_and_queue(self):
@@ -273,7 +273,7 @@ class TestPartition(TestInterfaces):
         try:
             self.server.manager(MGR_CMD_SET,
                                 NODE, {'queue': "Q1"},
-                                id=self.server.shortname)
+                                id=self.mom.shortname)
         except PbsManagerError as e:
             # self.assertEqual(e.rc, 15220)
             # The above code has to be uncommented when the PTL framework


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
few tests from 'TestNodePartition' and 'TestPartition' when mom is on remotehost.
Current code uses server hostname(server.hostname) or current machine(socket.gethostname().split('.')[0]) name while setting node attribute, due to PTL didn't get required mom and tests got failed.

following tests failed:

- **TestNodePartition**
1. test_mismatch_of_partition_on_node_and_queue
2. test_partition_association_with_node_and_queue
3. test_set_partition_node_attr_user_permissions
4. test_set_unset_partition_node_attr

- **TestPartition** 
1. test_mismatch_of_partition_on_node_and_queue
2. test_partition_association_with_node_and_queue
3. test_partition_node_attr
4. test_set_partition_node_attr_user_permissions

#### Describe Your Change
Use mom hostname(mom.shortname) to set Node attribute in tests.

#### Attach Test and Valgrind Logs/Output
Before Fix:
Description: Tests from given sources on platforms CENTOS8
Platforms: CENTOS8
Profile: Custom
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|4680|8|0|8|0|0|0|

[res_TestNodePartition_before_fix.txt](https://github.com/openpbs/openpbs/files/5493214/res_TestNodePartition_before_fix.txt)
[res_TestPartition_before_fix.txt](https://github.com/openpbs/openpbs/files/5493216/res_TestPartition_before_fix.txt)

After Fix:

- no mom on remote host:

Description: Tests from given sources on platforms CENTOS7, CENTOS8, SUSE15, UBUNTU1804
Platforms: CENTOS7,CENTOS8,SUSE15,UBUNTU1804
Profile: Custom
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|4684|32|0|0|0|0|32|

- mom on same host:

Description: Tests from given sources on platforms CENTOS7, CENTOS8, SUSE15, UBUNTU1804
Platforms: CENTOS7,CENTOS8,SUSE15,UBUNTU1804
Profile: Custom
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|4688|32|0|0|0|0|32|


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
