### PR TITLE
Fixes to printjob

### DIFF
--- a/src/tools/printjob.c
+++ b/src/tools/printjob.c
@@ -102,11 +102,18 @@ print_usage()
 static void
 prt_job_struct(job *pjob, char *state, char *substate)
 {
+	unsigned int ss_num;
+	unsigned int s_num;
+	char *endp = NULL;
+
+	ss_num = strtol(substate, &endp, 10);
+	s_num = state_char2int(state[0]);
+
 	printf("---------------------------------------------------\n");
 	printf("jobid:\t%s\n", pjob->ji_qs.ji_jobid);
 	printf("---------------------------------------------------\n");
-	printf("state:\t\t%s\n", state);
-	printf("substate:\t0x%s (%s)\n", substate, substate);
+	printf("state:\t\t0x%x\n", s_num);
+	printf("substate:\t0x%x (%d)\n", ss_num, ss_num);
 	printf("svrflgs:\t0x%x (%d)\n", pjob->ji_qs.ji_svrflags,
 		pjob->ji_qs.ji_svrflags);
 	printf("stime:\t\t%ld\n", (long)pjob->ji_qs.ji_stime);

--- a/test/tests/functional/pbs_printjob.py
+++ b/test/tests/functional/pbs_printjob.py
@@ -1,0 +1,71 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2020 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of both the OpenPBS software ("OpenPBS")
+# and the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# OpenPBS is free software. You can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# OpenPBS is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# PBS Pro is commercially licensed software that shares a common core with
+# the OpenPBS software.  For a copy of the commercial license terms and
+# conditions, go to: (http://www.pbspro.com/agreement.html) or contact the
+# Altair Legal Department.
+#
+# Altair's dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of OpenPBS and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair's trademarks, including but not limited to "PBS™",
+# "OpenPBS®", "PBS Professional®", and "PBS Pro™" and Altair's logos is
+# subject to Altair's trademark licensing policies.
+
+
+from tests.functional import *
+
+
+class TestPrintjob(TestFunctional):
+    def test_state_substate(self):
+        """
+        Verify that printjob prints the state and substate in expected format
+        """
+        j = Job(TEST_USER)
+        jid = self.server.submit(j)
+        a = {'job_state': 'R', 'substate': 42}
+        self.server.expect(JOB, a, id=jid)
+        ret = self.mom.printjob(jid)
+        self.assertEqual(ret['rc'], 0)
+        sfound = False
+        ssfound = False
+        for line in ret['out']:
+            if line.startswith("state:"):
+                val = line.split("state:", 1)[1]
+                val = val.strip()
+                numval = int(val, 16)
+                self.assertEqual(numval, 4)  # R state = numeric 4
+                sfound = True
+            elif line.startswith("substate:"):
+                val = line.split("substate:", 1)[1]
+                val = val.split()[0]
+                val = val.strip()
+                numval = int(val, 16)
+                self.assertEqual(numval, 42)
+                ssfound = True
+        self.assertTrue(sfound and ssfound)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Couple of fixes:
- Reverting the state field value back to being a numeric instead of a letter
- Fixing substate field value, it was printing the decimal value instead of hex


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
**Before:**
state:                    R
substate:             0x42 (42)

**After:**
state:		0x4
substate:	0x2a (42)

**PTL test logs:**
[test.log](https://github.com/openpbs/openpbs/files/5502732/test.log)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
