### PR TITLE
Use mom object shortname instead of fqdn name

### DIFF
--- a/test/fw/ptl/lib/ptl_server.py
+++ b/test/fw/ptl/lib/ptl_server.py
@@ -2236,7 +2236,7 @@ class Server(PBSService):
                     momobj.check_mem_request(attrib)
                     if len(attrib) == 0:
                         return True
-                    vnodes = self.status(HOST, id=cmom)
+                    vnodes = self.status(HOST, id=momobj.shortname)
                     del vnodes[0]  # don't set anything on a naturalnode
                     for vn in vnodes:
                         momobj.check_ncpus_request(attrib, vn)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
mom fqdn is causing test errors on some machines


#### Describe Your Change
Removed the mom fullname and used mom object's shortname


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

Machine | OS | Build_Status | Artifacts link | PTL_REPORT | Total_Tests | Passed | Skipped | Failed | Error | Timedout | Build_Start_Time[PDT] | Test_Time | Total_Build_Time
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
pbi-23-r7p1-altix | linux310_x86_64 | Success | Artifacts | Results_Link | 1306 | 1210 | 89 | 7 | 0 | 0 | 03:07:42 | 3:38:41 | 04:22:10




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
