### PR TITLE
Test reservation no mom server

### DIFF
--- a/test/tests/functional/pbs_reservations.py
+++ b/test/tests/functional/pbs_reservations.py
@@ -144,7 +144,8 @@ class TestReservations(TestFunctional):
 
         rid = self.submit_reservation(user=TEST_USER,
                                       select='2:ncpus=1:color=red',
-                                      rrule=rrule, start=start, end=end)
+                                      rrule=rrule, start=now + start,
+                                      end=now + end)
 
         a = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
         self.server.expect(RESV, a, id=rid)
@@ -207,7 +208,8 @@ class TestReservations(TestFunctional):
         now = time.time()
 
         rid = self.submit_reservation(user=TEST_USER, select='1:ncpus=1',
-                                      rrule=rrule, start=start, end=end)
+                                      rrule=rrule, start=now + start,
+                                      end=now + end)
 
         a = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
         self.server.expect(RESV, a, id=rid)
@@ -280,8 +282,7 @@ class TestReservations(TestFunctional):
         Verify that degraded standing reservations are reconfirmed
         on other nodes
         """
-        t = int(time.time())
-        self.degraded_resv_reconfirm(start=t + 25, end=t + 625,
+        self.degraded_resv_reconfirm(start=25, end=625,
                                      rrule='freq=HOURLY;count=5')
 
     def test_degraded_advance_reservations(self):
@@ -289,16 +290,14 @@ class TestReservations(TestFunctional):
         Verify that degraded advance reservations are reconfirmed
         on other nodes
         """
-        t = int(time.time())
-        self.degraded_resv_reconfirm(start=t + 25, end=t + 625)
+        self.degraded_resv_reconfirm(start=25, end=625)
 
     def test_degraded_standing_running_reservations(self):
         """
         Verify that degraded standing reservations are reconfirmed
         on other nodes
         """
-        t = int(time.time())
-        self.degraded_resv_reconfirm(start=t + 25, end=t + 625,
+        self.degraded_resv_reconfirm(start=25, end=625,
                                      rrule='freq=HOURLY;count=5', run=True)
 
     def test_degraded_advance_running_reservations(self):
@@ -306,17 +305,15 @@ class TestReservations(TestFunctional):
         Verify that degraded advance reservations are not reconfirmed
         on other nodes if no space is available
         """
-        t = int(time.time())
         self.degraded_resv_reconfirm(
-            start=t + 25, end=t + 625, run=True)
+            start=25, end=625, run=True)
 
     def test_degraded_standing_reservations_fail(self):
         """
         Verify that degraded standing reservations are not
         reconfirmed on other nodes if there is no space available
         """
-        t = int(time.time())
-        self.degraded_resv_failed_reconfirm(start=t + 120, end=t + 720,
+        self.degraded_resv_failed_reconfirm(start=120, end=720,
                                             rrule='freq=HOURLY;count=5')
 
     def test_degraded_advance_reservations_fail(self):
@@ -324,16 +321,14 @@ class TestReservations(TestFunctional):
         Verify that advance reservations are not reconfirmed if there
         is no space available
         """
-        t = int(time.time())
-        self.degraded_resv_failed_reconfirm(start=t + 120, end=t + 720)
+        self.degraded_resv_failed_reconfirm(start=120, end=720)
 
     def test_degraded_standing_running_reservations_fail(self):
         """
         Verify that degraded running standing reservations are not
         reconfirmed on other nodes if there is no space available
         """
-        t = int(time.time())
-        self.degraded_resv_failed_reconfirm(start=t + 25, end=t + 55,
+        self.degraded_resv_failed_reconfirm(start=25, end=55,
                                             rrule='freq=HOURLY;count=5',
                                             run=True)
 
@@ -342,9 +337,8 @@ class TestReservations(TestFunctional):
         Verify that advance running reservations are not reconfirmed if there
         is no space available
         """
-        t = int(time.time())
         self.degraded_resv_failed_reconfirm(
-            start=t + 25, end=t + 625, run=True)
+            start=25, end=625, run=True)
 
     def test_degraded_advanced_reservation_superchunk(self):
         """


### PR DESCRIPTION
#### Describe Bug or Feature
Few test from "TestReservations" throwing error when mom is on remote host.
ptl.lib.ptl_error.PbsSubmitError: rc=238, rv=None, msg=['pbs_rsub: Bad time specification(s)']
With current code test is failing at time reservation submission due to race condition.
In tests we are taking current time as t+25 as start time and passing it to degraded_resv_reconfirm ()
t = int(time.time())
self.degraded_resv_reconfirm(start=t + 25, end=t + 625)
and by the time degraded_resv_reconfirm () is submitting reservation using start = t + 25 , start time is already crossed  so the reservation submission is failed with error
pbs_rsub: Bad time specification(s)' 



#### Describe Your Change
Removed  t = int(time.time()) from tests and updated start and end value in degraded_resv_reconfirm() and degraded_resv_failed_reconfirm()

#### Attach Test and Valgrind Logs/Output
Befor fix
Description: Tests from given build on platforms CENTOS8, RHEL8, SLES12, SLES15, SUSE15, UBUNTU1604, UBUNTU1804
Platforms: CENTOS8,RHEL8,SLES12,SLES15,SUSE15,UBUNTU1604,UBUNTU1804
Profile: Custom
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|4762|56|0|30|0|0|26|


After fix : 

1. When mom on remote host 

Id: 4742
Description: Tests from given sources on platforms CENTOS7, CENTOS8, SUSE15, UBUNTU1804
Platforms: CENTOS7,CENTOS8,SUSE15,UBUNTU1804
Profile: Custom

Test Summary: total: 32, fail: 0, error: 0, timedout: 0, skip: 0, pass: 32

2. When mom on server 

Id: 4743
Description: Tests from given sources on platforms CENTOS7, CENTOS8, SUSE15, UBUNTU1804
Platforms: CENTOS7,CENTOS8,SUSE15,UBUNTU1804
Profile: Custom

Test Summary: total: 32, fail: 0, error: 0, timedout: 0, skip: 0, pass: 32





