### PR TITLE
Fix Tests which are failing as cpuset mom has multiple vnodes

### DIFF
--- a/test/tests/functional/pbs_pbsnodes.py
+++ b/test/tests/functional/pbs_pbsnodes.py
@@ -236,6 +236,8 @@ class TestPbsnodes(TestFunctional):
             attr = attr_list[i].split('=')[0].strip()
             val = attr_list[i].split('=')[1].strip()
             attr_dict[attr] = val
+        if self.mom.is_cpuset_mom():
+            del expected_attrs['resources_available.vnode']
 
         # comparing the pbsnodes -a output with expected result
         for attr in expected_attrs:

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -381,7 +381,10 @@ class SmokeTest(PBSTestSuite):
         self.scheduler.set_sched_config({'strict_ordering': 'True'})
         a = {'resources_available.ncpus': '1'}
         self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
-        a = {'state=free': 1}
+        if self.mom.is_cpuset_mom():
+            a = {'state=free': (GE, 1)}
+        else:
+            a = {'state=free': 1}
         self.server.expect(VNODE, a, attrop=PTL_AND)
         a = {'scheduling': 'False'}
         self.server.manager(MGR_CMD_SET, SERVER, a)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Tests failing as cpuset mom has multiple vnodes

#### Describe Your Change
Cpuset mom has more than 1 node so expect more than 1 node in test_job_scheduling_order test.
resources_available.vnode has various in test_pbsnodes_as_root , So don't check vnode name in test_pbsnodes_as_root test.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[joborder.txt](https://github.com/openpbs/openpbs/files/5524926/joborder.txt)
[pbsnodes.txt](https://github.com/openpbs/openpbs/files/5524931/pbsnodes.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
