### PR TITLE
fix eatcpu script failure if mom is on remote host

### DIFF
--- a/test/fw/ptl/lib/ptl_resourceresv.py
+++ b/test/fw/ptl/lib/ptl_resourceresv.py
@@ -503,12 +503,6 @@ while True:
         script_path = self.du.create_temp_file(hostname=hostname,
                                                body=script_body,
                                                suffix='.py')
-        if not self.du.is_localhost(hostname):
-            d = pwd.getpwnam(self.username).pw_dir
-            ret = self.du.run_copy(hosts=hostname, src=script_path, dest=d)
-            if ret is None or ret['rc'] != 0:
-                raise AssertionError("Failed to copy file %s to %s"
-                                     % (script_path, hostname))
         pbs_conf = self.du.parse_pbs_config(hostname)
         shell_path = os.path.join(pbs_conf['PBS_EXEC'],
                                   'bin', 'pbs_python')

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -339,11 +339,10 @@ class SmokeTest(PBSTestSuite):
         self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
         a = {'job_history_enable': 'True'}
         self.server.manager(MGR_CMD_SET, SERVER, a)
-        a = {'Resource_List.ncpus': 2}
+        a = {'Resource_List.ncpus': 2, ATTR_k: 'oe'}
         j = Job(TEST_USER, a)
         j.set_sleep_time(15)
-        mom = self.moms.values()[0].shortname
-        j.create_eatcpu_job(15, mom)
+        j.create_eatcpu_job(15, self.mom.shortname)
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'F'}, extend='x', offset=15,
                            interval=1, id=jid)

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -339,7 +339,7 @@ class SmokeTest(PBSTestSuite):
         self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
         a = {'job_history_enable': 'True'}
         self.server.manager(MGR_CMD_SET, SERVER, a)
-        a = {'Resource_List.ncpus': 2, ATTR_k: 'oe'}
+        a = {'Resource_List.ncpus': 2}
         j = Job(TEST_USER, a)
         j.set_sleep_time(15)
         j.create_eatcpu_job(15, self.mom.shortname)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
fix eatcpu script failure if mom is on remote host. 
Current code create temp_eatcpu_script on mom, but when we have remote mom PTL try to copy temp_eatcpu_script file from current host to remote mom user home directory, but we created temp_eatcpu_script on mom only due to PTL didn't get expected file for copy and failed.

#### Describe Your Change
As we are creating temp_eatcpu_script on mom, no need of copy created temp_eatcpu_script to remote mom users home directory. removed code for file copy. 

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
**Before fix:**
[res_before_fix.txt](https://github.com/openpbs/openpbs/files/5530046/res_before_fix.txt)

**After Fix:**
MoM on same host:
Description: PBSMoM on same host
Platforms: CENTOS7,CENTOS8,SUSE15,UBUNTU1804
Profile: Custom
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|4824|4|0|0|0|0|4|

[res_test_finished_jobs_mom_on_same_host.txt](https://github.com/openpbs/openpbs/files/5530066/res_test_finished_jobs_mom_on_same_host.txt)

MoM on remote host:
Description: Tests from given sources on platforms CENTOS7, CENTOS8, SUSE15, UBUNTU1804
Platforms: CENTOS7,CENTOS8,SUSE15,UBUNTU1804
Profile: Custom
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|4823|4|0|0|0|0|4|

[res_test_finished_jobs_mom_on_different_host.txt](https://github.com/openpbs/openpbs/files/5530069/res_test_finished_jobs_mom_on_different_host.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
