### PR TITLE
Adding mock run to scheduler

### DIFF
--- a/src/scheduler/Makefile.am
+++ b/src/scheduler/Makefile.am
@@ -87,6 +87,8 @@ libpbs_sched_a_SOURCES = \
 	limits.cpp \
 	misc.cpp \
 	misc.h \
+	mock_run.cpp \
+	mock_run.h \
 	multi_threading.cpp \
 	multi_threading.h \
 	node_info.cpp \

--- a/src/scheduler/buckets.h
+++ b/src/scheduler/buckets.h
@@ -44,6 +44,8 @@ extern "C" {
 #ifndef _BUCKETS_H
 #define _BUCKETS_H
 
+#include "data_types.h"
+
 /* bucket_bitpool constructor, copy constructor, destructor */
 bucket_bitpool *new_bucket_bitpool();
 void free_bucket_bitpool(bucket_bitpool *bp);

--- a/src/scheduler/fifo.h
+++ b/src/scheduler/fifo.h
@@ -37,15 +37,15 @@
  * subject to Altair's trademark licensing policies.
  */
 
-#ifndef	_FIFO_H
-#define	_FIFO_H
-#ifdef	__cplusplus
+#ifndef _FIFO_H
+#define _FIFO_H
+#ifdef __cplusplus
 extern "C" {
 #endif
 
-#include  <limits.h>
 #include "data_types.h"
 #include "sched_cmds.h"
+#include <limits.h>
 
 /**
  * @brief Gets the Scheduler Command sent by the Server
@@ -171,8 +171,7 @@ int sim_run_update_resresv(status *policy, resource_resv *resresv, nspec **ns_ar
  */
 int
 run_update_resresv(status *policy, int pbs_sd, server_info *sinfo, queue_info *qinfo,
-	resource_resv *rresv, nspec **ns_arr, unsigned int flags, schd_error *err);
-
+		   resource_resv *rresv, nspec **ns_arr, unsigned int flags, schd_error *err);
 
 /*
  *	update_job_can_not_run - do post job 'can't run' processing
@@ -205,6 +204,7 @@ int add_job_to_calendar(int pbs_sd, status *policy, server_info *sinfo, resource
  */
 int run_job(int pbs_sd, resource_resv *rjob, char *execvnode, int had_runjob_hook, schd_error *err);
 
+int send_run_job(int pbs_sd, int has_runjob_hook, char *jobid, char *execvnode);
 /*
  *	should_backfill_with_job - should we call add_job_to_calendar() with job
  *	returns 1: we should backfill 0: we should not
@@ -224,7 +224,6 @@ int should_backfill_with_job(status *policy, server_info *sinfo, resource_resv *
  *
  */
 void update_cycle_status(struct status *policy, time_t current_time);
-
 
 /*
  *
@@ -258,7 +257,7 @@ int validate_running_user(char *exename);
 
 void clear_last_running();
 
-#ifdef	__cplusplus
+#ifdef __cplusplus
 }
 #endif
-#endif	/* _FIFO_H */
+#endif /* _FIFO_H */

--- a/src/scheduler/globals.cpp
+++ b/src/scheduler/globals.cpp
@@ -193,3 +193,6 @@ int clust_primary_sock = -1;
 
 /* secondary socket descriptor to the server pool */
 int clust_secondary_sock = -1;
+
+/* Scheduler runs in "mock" run mode? */
+int mock_run = 0;

--- a/src/scheduler/globals.h
+++ b/src/scheduler/globals.h
@@ -121,6 +121,8 @@ extern int clust_primary_sock;
 
 extern int clust_secondary_sock;
 
+extern int mock_run;
+
 /**
  * @brief
  * It is used as a placeholder to store aoe name. This aoe name will be

--- a/src/scheduler/mock_run.cpp
+++ b/src/scheduler/mock_run.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 1994-2020 Altair Engineering, Inc.
+ * For more information, contact Altair at www.altair.com.
+ *
+ * This file is part of both the OpenPBS software ("OpenPBS")
+ * and the PBS Professional ("PBS Pro") software.
+ *
+ * Open Source License Information:
+ *
+ * OpenPBS is free software. You can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * OpenPBS is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Commercial License Information:
+ *
+ * PBS Pro is commercially licensed software that shares a common core with
+ * the OpenPBS software.  For a copy of the commercial license terms and
+ * conditions, go to: (http://www.pbspro.com/agreement.html) or contact the
+ * Altair Legal Department.
+ *
+ * Altair's dual-license business model allows companies, individuals, and
+ * organizations to create proprietary derivative works of OpenPBS and
+ * distribute them - whether embedded or bundled with other software -
+ * under a commercial license agreement.
+ *
+ * Use of Altair's trademarks, including but not limited to "PBS™",
+ * "OpenPBS®", "PBS Professional®", and "PBS Pro™" and Altair's logos is
+ * subject to Altair's trademark licensing policies.
+ */
+#include <stdio.h>
+
+#include "check.h"
+#include "constant.h"
+#include "data_types.h"
+#include "fifo.h"
+#include "log.h"
+#include "mock_run.h"
+#include "resource.h"
+#include "server_info.h"
+
+/**
+ * @brief	Perform scheduling in "mock run" mode
+ *
+ * @param[in]	policy	-	policy info
+ * @param[in]	sd	-	primary socket descriptor to the server pool
+ * @param[in]	sinfo	-	pbs universe we're going to loop over
+ * @param[out]	rerr	-	error bits from the last job considered
+ *
+ *	@return return code of last job scheduled
+ *	@retval -1	: on error
+ */
+int
+mock_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rerr)
+{
+	node_info **nodes = sinfo->nodes;
+	resource_resv **jobs = sinfo->jobs;
+	int ij;
+	int in = 0;
+
+	/* Algorithm:
+     * - Loop over all jobs, assume that they need just 1 ncpu to run, and
+     *  choose the next free node for it
+     */
+	for (ij = 0; jobs[ij] != NULL; ij++) {
+		char execvnode[PBS_MAXHOSTNAME + 1];
+		execvnode[0] = '\0';
+
+		/* Find the first free node and fill it */
+		for (; nodes[in] != NULL; in++) {
+			node_info *node = nodes[in];
+			schd_resource *ncpures = NULL;
+
+			if (node->is_busy || node->is_job_busy)
+				continue;
+
+			ncpures = find_resource(node->res, getallres(RES_NCPUS));
+			if (ncpures == NULL)
+				continue;
+
+			/* Assign a cpu on this node */
+			ncpures->assigned += 1;
+			if (dynamic_avail(ncpures) == 0) {
+				node->is_busy = 1;
+				node->is_job_busy;
+				node->is_free = 0;
+			}
+
+			/* Create the exec_node for the job */
+			snprintf(execvnode, sizeof(execvnode), "(%s:ncpus=1)", node->name);
+
+			/* Send the run request */
+			send_run_job(sd, 0, jobs[ij]->name, execvnode);
+
+			break;
+		}
+		if (execvnode[0] == '\0') {
+			log_event(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_NOTICE, "",
+				  "No free nodes available, won't consider any more jobs");
+			break;
+		}
+	}
+	return SUCCESS;
+}

--- a/src/scheduler/mock_run.h
+++ b/src/scheduler/mock_run.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 1994-2020 Altair Engineering, Inc.
+ * For more information, contact Altair at www.altair.com.
+ *
+ * This file is part of both the OpenPBS software ("OpenPBS")
+ * and the PBS Professional ("PBS Pro") software.
+ *
+ * Open Source License Information:
+ *
+ * OpenPBS is free software. You can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * OpenPBS is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Commercial License Information:
+ *
+ * PBS Pro is commercially licensed software that shares a common core with
+ * the OpenPBS software.  For a copy of the commercial license terms and
+ * conditions, go to: (http://www.pbspro.com/agreement.html) or contact the
+ * Altair Legal Department.
+ *
+ * Altair's dual-license business model allows companies, individuals, and
+ * organizations to create proprietary derivative works of OpenPBS and
+ * distribute them - whether embedded or bundled with other software -
+ * under a commercial license agreement.
+ *
+ * Use of Altair's trademarks, including but not limited to "PBS™",
+ * "OpenPBS®", "PBS Professional®", and "PBS Pro™" and Altair's logos is
+ * subject to Altair's trademark licensing policies.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#ifndef _MOCK_RUN_H
+#define _MOCK_RUN_H
+
+int mock_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rerr);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* _MOCK_RUN_H */

--- a/src/scheduler/pbs_sched.cpp
+++ b/src/scheduler/pbs_sched.cpp
@@ -839,7 +839,7 @@ main(int argc, char *argv[])
 	segv_start_time = segv_last_time = time(NULL);
 
 	opterr = 0;
-	while ((c = getopt(argc, argv, "lL:NI:d:p:c:nt:")) != EOF) {
+	while ((c = getopt(argc, argv, "lL:NmI:d:p:c:nt:")) != EOF) {
 		switch (c) {
 			case 'l':
 #ifdef _POSIX_MEMLOCK
@@ -853,6 +853,9 @@ main(int argc, char *argv[])
 				break;
 			case 'N':
 				stalone = 1;
+				break;
+			case 'm':
+				mock_run = 1;
 				break;
 			case 'I':
 				sc_name = optarg;
@@ -1118,6 +1121,11 @@ main(int argc, char *argv[])
 
 	sched_svr_init();
 	connect_svrpool();
+
+	if (mock_run) {
+		log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_SERVER, LOG_DEBUG, "",
+			  "Scheduler running in mock run mode");
+	}
 
 	for (go=1; go;) {
 		int i;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Often, we have a need to isolate performance bottlenecks in PBS, and it’s not always straight-forward. Is it the server? scheduler? mom? is it IO? To rule out scheduler as the bottleneck and focus on testing performance of the server(s), it is desirable to add an option to scheduler which will make it very lean so that it does the bare minimum needed to schedule jobs.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Adding new option to pbs_sched called -m to make it run in "mock run" mode. See design doc for more info.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
https://openpbs.atlassian.net/wiki/spaces/PD/pages/2257944577/Mock+Run+option+for+Scheduler

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
**Setup**
50k vnodes, 10 ncpus each, 50k jobs, each requesting 1 ncpu, pbs_mom running in mock run mode.

**Regular Scheduling**
Time taken to schedule 50k jobs = **88 seconds**

**Mock run scheduling**
Time taken to schedule 50k jobs = **3.5 seconds (out of which ~3 seconds was time taken to query the universe)**


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
