### PR TITLE
Fix pbs_benchpress so timeout on command line overrides test timeout

### DIFF
--- a/test/fw/bin/pbs_benchpress
+++ b/test/fw/bin/pbs_benchpress
@@ -54,6 +54,7 @@ from nose.plugins.base import Plugin
 from ptl.lib.pbs_testlib import PtlConfig
 from distutils.version import LooseVersion
 from ptl.utils.pbs_cliutils import CliUtils
+from ptl.utils.pbs_dshutils import TimeOut
 from ptl.utils.plugins.ptl_test_loader import PTLTestLoader
 from ptl.utils.plugins.ptl_test_runner import PTLTestRunner
 from ptl.utils.plugins.ptl_test_db import PTLTestDb
@@ -77,6 +78,10 @@ sys.excepthook = trap_exceptions
 def sighandler(signum, frames):
     signal.alarm(0)
     raise KeyboardInterrupt('Signal %d received' % (signum))
+
+
+def timeout_handler(signum, frames):
+    raise TimeOut('pbs_benchpress timed out by signal %d' % (signum))
 
 
 # join process group of caller makes it possible to programmatically interrupt
@@ -432,7 +437,8 @@ if __name__ == '__main__':
         os.mkdir(os.path.dirname(outfile))
 
     if timeout is not None:
-        signal.signal(signal.SIGALRM, sighandler)
+        PTLTestRunner.timeout = timeout
+        signal.signal(signal.SIGALRM, timeout_handler)
         signal.alarm(timeout)
 
     if list_test:

--- a/test/fw/ptl/utils/plugins/ptl_test_runner.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_runner.py
@@ -520,6 +520,7 @@ class PTLTestRunner(Plugin):
     name = 'PTLTestRunner'
     score = sys.maxsize - 4
     logger = logging.getLogger(__name__)
+    timeout = None
 
     def __init__(self):
         Plugin.__init__(self)
@@ -970,10 +971,11 @@ class PTLTestRunner(Plugin):
 
         def timeout_handler(signum, frame):
             raise TimeOut('Timed out after %s second' % timeout)
-        timeout = self.__get_timeout(test)
-        old_handler = signal.signal(signal.SIGALRM, timeout_handler)
-        setattr(test, 'old_sigalrm_handler', old_handler)
-        signal.alarm(timeout)
+        if PTLTestRunner.timeout is None:
+            timeout = self.__get_timeout(test)
+            old_handler = signal.signal(signal.SIGALRM, timeout_handler)
+            setattr(test, 'old_sigalrm_handler', old_handler)
+            signal.alarm(timeout)
 
     def stopTest(self, test):
         """


### PR DESCRIPTION

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
timeout alarm set by pbs_benchpress is taken over by timeout decorator or default test timeout alarm. But timeout set by pbs_benchpress should have high priority than timeout decorator and default test timeout.


#### Describe Your Change
If timeout alarm is set by pbs_benchpress then timeout decorator or default test timeout does not reset timeout alarm.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[benchpress_timeout.txt](https://github.com/openpbs/openpbs/files/5551444/benchpress_timeout.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
