### PR TITLE
Fix few tests from 'TestResourceUsageLog' when mom is on remote host

### DIFF
--- a/test/tests/functional/pbs_resource_usage_log.py
+++ b/test/tests/functional/pbs_resource_usage_log.py
@@ -62,11 +62,11 @@ class TestResourceUsageLog(TestFunctional):
         """
         a = {'Resource_List.select': '1:ncpus=1:mem=200gb'}
         j1 = Job(TEST_USER, a)
-        j1.create_eatcpu_job(40)
+        j1.create_eatcpu_job(40, self.mom.shortname)
         jid1 = self.server.submit(j1)
 
         j2 = Job(TEST_USER, a)
-        j2.create_eatcpu_job(30)
+        j2.create_eatcpu_job(30, self.mom.shortname)
         jid2 = self.server.submit(j2)
 
         self.server.expect(JOB, {'job_state': 'R'}, jid1)
@@ -77,7 +77,7 @@ class TestResourceUsageLog(TestFunctional):
                            offset=40, extend='x', id=jid1)
 
         j3 = Job(TEST_USER, a)
-        j3.create_eatcpu_job()
+        j3.create_eatcpu_job(hostname=self.mom.shortname)
         jid3 = self.server.submit(j3)
         self.server.expect(JOB, {'job_state': 'R'}, jid3)
         self.server.delete(jid3, wait=True)
@@ -289,7 +289,7 @@ class TestResourceUsageLog(TestFunctional):
         """
         a = {'Resource_List.select': '1:ncpus=1:mem=200gb'}
         j1 = Job(TEST_USER, a)
-        j1.create_eatcpu_job()
+        j1.create_eatcpu_job(hostname=self.mom.shortname)
         jid1 = self.server.submit(j1)
         self.server.expect(JOB, {'job_state': 'R'}, jid1)
 
@@ -346,13 +346,13 @@ class TestResourceUsageLog(TestFunctional):
 
         a = {'Resource_List.select': '1:ncpus=1:mem=200gb'}
         j1 = Job(TEST_USER, a)
-        j1.create_eatcpu_job(30)
+        j1.create_eatcpu_job(30, self.mom.shortname)
         jid1 = self.server.submit(j1)
         self.server.expect(JOB, {'job_state': 'R'}, jid1)
 
         a = {'Resource_List.select': '1:ncpus=1:mem=200gb', 'queue': 'highp'}
         j2 = Job(TEST_USER, a)
-        j2.create_eatcpu_job(60)
+        j2.create_eatcpu_job(60, self.mom.shortname)
         jid2 = self.server.submit(j2)
         self.server.expect(JOB, {ATTR_state: 'R'}, jid2)
         self.server.expect(JOB, {ATTR_state: 'Q'}, jid1)

--- a/test/tests/functional/pbs_resource_usage_log.py
+++ b/test/tests/functional/pbs_resource_usage_log.py
@@ -121,7 +121,7 @@ class TestResourceUsageLog(TestFunctional):
         # Submit a job
         a = {'Resource_List.select': '1:ncpus=1:mem=20gb'}
         j = Job(TEST_USER, a)
-        j.create_eatcpu_job()
+        j.create_eatcpu_job(hostname=self.mom.shortname)
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, jid)
 
@@ -130,7 +130,7 @@ class TestResourceUsageLog(TestFunctional):
             ATTR_J: '1-2',
             'Resource_List.select': 'ncpus=1:mem=20gb'}
         )
-        ja.create_eatcpu_job()
+        ja.create_eatcpu_job(hostname=self.mom.shortname)
         jid_a = self.server.submit(ja)
 
         subjid1 = j.create_subjob_id(jid_a, 1)
@@ -206,7 +206,7 @@ class TestResourceUsageLog(TestFunctional):
         # Submit job
         a = {'Resource_List.select': '1:ncpus=1:mem=20gb'}
         j = Job(TEST_USER, a)
-        j.create_eatcpu_job()
+        j.create_eatcpu_job(hostname=self.mom.shortname)
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, jid)
 
@@ -215,7 +215,7 @@ class TestResourceUsageLog(TestFunctional):
             ATTR_J: '1-2',
             'Resource_List.select': 'ncpus=1:mem=20gb'}
         )
-        ja.create_eatcpu_job()
+        ja.create_eatcpu_job(hostname=self.mom.shortname)
         jid_a = self.server.submit(ja)
         subjid1 = j.create_subjob_id(jid_a, 1)
         subjid2 = j.create_subjob_id(jid_a, 2)
@@ -316,7 +316,7 @@ class TestResourceUsageLog(TestFunctional):
         """
         a = {'Resource_List.select': '1:ncpus=1:mem=200gb'}
         j1 = Job(TEST_USER, a)
-        j1.create_eatcpu_job(60)
+        j1.create_eatcpu_job(60, self.mom.shortname)
         jid1 = self.server.submit(j1)
         self.server.expect(JOB, {'job_state': 'R'}, jid1)
 


### PR DESCRIPTION
#### Describe Bug or Feature
All these three test cases
./TestResourceUsageLog/test_acclog_force_requeue
./TestResourceUsageLog/test_acclog_for_job_states
./TestResourceUsageLog/test_acclog_preempt_order
failed  with PTL expect error
ptl.lib.ptl_error.PtlExpectError: rc=1, rv=False, msg=expected on server xyz-r8:  no data for job_state = R && substate = 42 job 8.xyz-r8 attempt: 180

create_eatcpu_job() is not working  when mom is onn remote host , due to this job is getting submitted in test is just getting submitted and terminated with resource_used_walltime=0 
resources_used.walltime = 00:00:00
sub state = 41
so test failed to get job_state=R and sub state=42 and failed with expect error.

 
#### Describe Your Change
Pass self.mom.shortname in create_eatcpu_job() to work test on setup where mom is on remote host 

Note : -
[#2121](https://github.com/openpbs/openpbs/pull/2121) is already raised to handle eatcpu script to work  on remote host as well.
taken 'ptl_resourceresv.py' changes in my branch , and done changes for TestResourceUsageLog
As part of this ticket  I have taken 'ptl_resourceresv.py' changes in my branch , and done changes in test of TestResourceUsageLog to work on remote host .


#### Attach Test and Valgrind Logs/Output
Before fix 
[before_fix_TestResourceUsageLog.txt](https://github.com/openpbs/openpbs/files/5552193/before_fix_TestResourceUsageLog.txt)

After fix
[after_fix_TestResourceUsageLog.txt](https://github.com/openpbs/openpbs/files/5552195/after_fix_TestResourceUsageLog.txt)
[after_fix_TestResourceUsageLog_non_mom_on_server.txt](https://github.com/openpbs/openpbs/files/5552197/after_fix_TestResourceUsageLog_non_mom_on_server.txt)


