### PR TITLE
Update TestJobTask such that it works on remote mom host

### DIFF
--- a/test/tests/functional/pbs_job_task.py
+++ b/test/tests/functional/pbs_job_task.py
@@ -56,7 +56,7 @@ class TestJobTask(TestFunctional):
         """
         This function validates job's output file
         """
-        ret = self.du.cat(hostname=self.mom.shortname,
+        ret = self.du.cat(hostname=self.server.shortname,
                           filename=out_file,
                           runas=TEST_USER)
         _msg = "cat command failed with error:%s" % ret['err']


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature

- Tests of TestJobTask were failing while verifying the contents of job's output file

#### Describe Your Change

- In the test, we are matching the job's output file on mom host but once the job is completed , job's output and error files are copied back to server host. Hence updated the code to check the job's output file on server host but not on mom host.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
Before Fix:

4896 | zulekam | regression | TestJobTask_Without_Fix | openpbs/openpbs@master | 17th Nov 2020 05:22:44.610 PM +05:30 | 00:03:53.406 | 2 | 0 | 0 | 2 | 0 | 0 | 0 | 0
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --



After Fix:

4897 | regression | TestJobTask_After_fix | Mahalty/pbspro@no_mom | 17th Nov 2020 05:25:11.415 PM +05:30 | 00:06:59.096 | 8 | 0 | 0 | 0 | 0 | 0 | 0 | 8
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --






<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
