### PR TITLE
mom should be ready before importing pbs_cgroups hook

### DIFF
--- a/test/fw/ptl/lib/ptl_mom.py
+++ b/test/fw/ptl/lib/ptl_mom.py
@@ -1390,6 +1390,8 @@ class MoM(PBSService):
             a = {'content-type': 'application/x-config',
                  'content-encoding': 'default',
                  'input-file': path}
+            # check that mom is ready before importing hook
+            self.server.expect(NODE, {'state': 'free'}, id=self.hostname)
             self.server.manager(MGR_CMD_IMPORT, HOOK, a,
                                 'pbs_cgroups')
             os.remove(path)

--- a/test/fw/ptl/lib/ptl_mom.py
+++ b/test/fw/ptl/lib/ptl_mom.py
@@ -1391,7 +1391,7 @@ class MoM(PBSService):
                  'content-encoding': 'default',
                  'input-file': path}
             # check that mom is ready before importing hook
-            self.server.expect(NODE, {'state': 'free'}, id=self.hostname)
+            self.server.expect(NODE, {'state': 'free'}, id=self.shortname)
             self.server.manager(MGR_CMD_IMPORT, HOOK, a,
                                 'pbs_cgroups')
             os.remove(path)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Oftentimes on the UV300 the import of the pbs_cgroups hook does not register on the mom and the mom does not log the message "pbs_cgroups.CF;copy hook-related file request received".


#### Describe Your Change
Before importing the pbs_cgroups hook check first that the mom is ready in state = free.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
[TestHookSmokeTest_before.txt](https://github.com/openpbs/openpbs/files/5562862/TestHookSmokeTest_before.txt)
[TestHookSmokeTest_uv02_after.txt](https://github.com/openpbs/openpbs/files/5562863/TestHookSmokeTest_uv02_after.txt)
[TestHookSmokeTest_uv300_after.txt](https://github.com/openpbs/openpbs/files/5562864/TestHookSmokeTest_uv300_after.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
