### PR TITLE
Few tests from "TestResourceUsageLog" expect 2 "R" records in the accounting log for the same rerun

### DIFF
--- a/test/tests/functional/pbs_resource_usage_log.py
+++ b/test/tests/functional/pbs_resource_usage_log.py
@@ -172,28 +172,25 @@ class TestResourceUsageLog(TestFunctional):
         self.server.delete(jid, wait=True)
         self.server.delete(jid_a, wait=True)
 
-        # job1 has 2 R records and a E record
-        matches = self.server.accounting_match(
+        # job1 has R and E record
+        self.server.accounting_match(
             msg='R;' + jid + '.*Exit_status=0.*resources_used.*run_count=1',
             id=jid, regexp=True, allmatch=True)
-        self.assertEqual(len(matches), 2, " 2 R records expected")
         self.server.accounting_match(
             msg='E;' + jid +
             '.*Exit_status=271.*resources_used.*run_count=2',
             id=jid, regexp=True)
 
-        # job array's subjobs have 2 R records and
+        # job array's subjobs have a R record and
         # the jobarray has E record with run_count=0
-        matches = self.server.accounting_match(
+        self.server.accounting_match(
             msg='R;' + re.escape(subjid1) +
             '.*Exit_status=0.*resources_used.*run_count=1',
             id=subjid1, regexp=True, allmatch=True)
-        self.assertEqual(len(matches), 2, " 2 R records expected")
-        matches = self.server.accounting_match(
+        self.server.accounting_match(
             msg='R;' + re.escape(subjid2) +
             '.*Exit_status=0.*resources_used.*run_count=1',
             id=subjid2, regexp=True, allmatch=True)
-        self.assertEqual(len(matches), 2, " 2 R records expected")
         self.server.accounting_match(
             msg='E;' + re.escape(jid_a) +
             '.*Exit_status=1.*run_count=0', id=jid_a, regexp=True)
@@ -273,16 +270,14 @@ class TestResourceUsageLog(TestFunctional):
             '.*Exit_status=271.*resources_used.*run_count=3', id=jid,
             regexp=True)
 
-        matches = self.server.accounting_match(
+        self.server.accounting_match(
             msg='R;' + re.escape(subjid1) +
             '.*Exit_status=-11.*resources_used.*run_count=1',
             id=subjid1, regexp=True, allmatch=True)
-        self.assertEqual(len(matches), 2, "Expected 2 R records")
-        matches = self.server.accounting_match(
+        self.server.accounting_match(
             msg='R;' + re.escape(subjid1) +
             '.*Exit_status=-11.*resources_used.*run_count=1',
             id=subjid2, regexp=True, allmatch=True)
-        self.assertEqual(len(matches), 2, "Expected 2 R records")
         self.server.accounting_match(
             msg='E;' + re.escape(jid_a) +
             '.*Exit_status=1.*run_count=0',


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Test "test_acclog_mom_down" and "test_acclog_job_multiple_qrerun" expect 2 "R" records in the accounting log for same job for same rerun.
But accounting log holds only 1 "R" record


#### Describe Your Change
Modified tests to expect only 1 "R" record in accounting log for same job for same rerun


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
[after_changes_r_record_on_rerun.txt](https://github.com/openpbs/openpbs/files/5581412/after_changes_r_record_on_rerun.txt)
[r_record_on_qrerun.txt](https://github.com/openpbs/openpbs/files/5581415/r_record_on_qrerun.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
