### PR TITLE
Exceeded resources notification

### DIFF
--- a/src/include/job.h
+++ b/src/include/job.h
@@ -981,6 +981,14 @@ task_find	(job		*pjob,
 					* This is neither a success nor a failure exit code,
 					* so we are using a positive value
 					*/
+#define JOB_EXEC_KILL_NCPUS_BURST -24 /* job exec failed due to exceeding ncpus (burst) */
+#define JOB_EXEC_KILL_NCPUS_SUM -25 /* job exec failed due to exceeding ncpus (sum) */
+#define JOB_EXEC_KILL_VMEM -26 /* job exec failed due to exceeding vmem */
+#define JOB_EXEC_KILL_MEM -27 /* job exec failed due to exceeding mem */
+#define JOB_EXEC_KILL_CPUT -28 /* job exec failed due to exceeding cput */
+#define JOB_EXEC_KILL_WALLTIME -29 /* job exec failed due to exceeding walltime */
+#define JOB_EXEC_KILL_MPPE -30 /* job exec failed due to exceeding mppe */
+#define JOB_EXEC_KILL_MPPSSP -40 /* job exec failed due to exceeding mppssp */
 
 /*
  * Fake "random" number added onto the end of the staging

--- a/src/include/job.h
+++ b/src/include/job.h
@@ -987,8 +987,6 @@ task_find	(job		*pjob,
 #define JOB_EXEC_KILL_MEM -27 /* job exec failed due to exceeding mem */
 #define JOB_EXEC_KILL_CPUT -28 /* job exec failed due to exceeding cput */
 #define JOB_EXEC_KILL_WALLTIME -29 /* job exec failed due to exceeding walltime */
-#define JOB_EXEC_KILL_MPPE -30 /* job exec failed due to exceeding mppe */
-#define JOB_EXEC_KILL_MPPSSP -40 /* job exec failed due to exceeding mppssp */
 
 /*
  * Fake "random" number added onto the end of the staging

--- a/src/lib/Liblog/pbs_messages.c
+++ b/src/lib/Liblog/pbs_messages.c
@@ -165,6 +165,18 @@ char *msg_new_inventory_mom = "Setting inventory_mom for vnode_pool %d to %s";
 char *msg_auth_request = "Type %d request is authenticated. The credential id is %s@%s, host %s, sock=%d";
 
 /*
+ * This set of messages is used in e-mail to inform the user that the job exceeded resources.
+ */
+char *msg_momkillncpusburst = "Job exceeded resource ncpus (burst)\nSee job standard error file";
+char *msg_momkillncpussum = "Job exceeded resource ncpus (sum)\nSee job standard error file";
+char *msg_momkillvmem = "Job exceeded resource vmem\nSee job standard error file";
+char *msg_momkillmem = "Job exceeded resource mem\nSee job standard error file";
+char *msg_momkillcput = "Job exceeded resource cput\nSee job standard error file";
+char *msg_momkillwalltime = "Job exceeded resource walltime\nSee job standard error file";
+char *msg_momkillmppe = "Job exceeded resource mppe\nSee job standard error file";
+char *msg_momkillmppssp = "Job exceeded resource mppssp\nSee job standard error file";
+
+/*
  * This next set of messages are returned to the client on an error.
  * They may also be logged.
  */

--- a/src/lib/Liblog/pbs_messages.c
+++ b/src/lib/Liblog/pbs_messages.c
@@ -173,8 +173,6 @@ char *msg_momkillvmem = "Job exceeded resource vmem\nSee job standard error file
 char *msg_momkillmem = "Job exceeded resource mem\nSee job standard error file";
 char *msg_momkillcput = "Job exceeded resource cput\nSee job standard error file";
 char *msg_momkillwalltime = "Job exceeded resource walltime\nSee job standard error file";
-char *msg_momkillmppe = "Job exceeded resource mppe\nSee job standard error file";
-char *msg_momkillmppssp = "Job exceeded resource mppssp\nSee job standard error file";
 
 /*
  * This next set of messages are returned to the client on an error.

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -5898,6 +5898,7 @@ mom_over_limit(job *pjob)
 					"ncpus %.1f exceeded limit %lu (burst)",
 					(float)num/100.0, value);
 				if (cpuburst) {	/* abort job */
+					pjob->ji_qs.ji_un.ji_momt.ji_exitstat = JOB_EXEC_KILL_NCPUS_BURST;
 					return (TRUE);
 				} else if ((pjob->ji_qs.ji_svrflags & JOB_SVFLG_cpuperc) == 0) {
 					/* just log it */
@@ -5927,6 +5928,7 @@ mom_over_limit(job *pjob)
 								(double)cput_sum/(double)walltime_sum,
 								value);
 							if (cpuaverage) { /* abort job */
+								pjob->ji_qs.ji_un.ji_momt.ji_exitstat = JOB_EXEC_KILL_NCPUS_SUM;
 								return (TRUE);
 							} else if ((pjob->ji_qs.ji_svrflags & JOB_SVFLG_cpuperc) == 0) {
 								/* just log it */
@@ -5952,6 +5954,7 @@ mom_over_limit(job *pjob)
 		if (retval == PBSE_NONE) {
 			if (llnum > llvalue) {
 				sprintf(log_buffer, "vmem %lukb exceeded limit %lukb", llnum/1024, llvalue/1024);
+				pjob->ji_qs.ji_un.ji_momt.ji_exitstat = JOB_EXEC_KILL_VMEM;
 				return (TRUE);
 			}
 		}
@@ -5966,6 +5969,7 @@ mom_over_limit(job *pjob)
 		if (retval == PBSE_NONE) {
 			if ((llnum > llvalue) && enforce_mem) {
 				sprintf(log_buffer, "mem %lukb exceeded limit %lukb", llnum/1024, llvalue/1024);
+				pjob->ji_qs.ji_un.ji_momt.ji_exitstat = JOB_EXEC_KILL_MEM;
 				return (TRUE);
 			}
 		}
@@ -5998,6 +6002,7 @@ mom_over_limit(job *pjob)
 					sprintf(log_buffer,
 						"cput %lu exceeded limit %lu",
 						num, value);
+					pjob->ji_qs.ji_un.ji_momt.ji_exitstat = JOB_EXEC_KILL_CPUT;
 					return (TRUE);
 				}
 			} else if (strcmp(pname, "walltime") == 0) {
@@ -6014,6 +6019,7 @@ mom_over_limit(job *pjob)
 					sprintf(log_buffer,
 						"walltime %lu exceeded limit %lu",
 						num, value);
+					pjob->ji_qs.ji_un.ji_momt.ji_exitstat = JOB_EXEC_KILL_WALLTIME;
 					return (TRUE);
 				}
 			}
@@ -6030,6 +6036,7 @@ mom_over_limit(job *pjob)
 				sprintf(log_buffer,
 					"mppe %lu exceeded limit %lu",
 					num, value);
+				pjob->ji_qs.ji_un.ji_momt.ji_exitstat = JOB_EXEC_KILL_MPPE;
 				return (TRUE);
 			}
 		} else if (strcmp(pname, "mppssp") == 0) {
@@ -6043,6 +6050,7 @@ mom_over_limit(job *pjob)
 				sprintf(log_buffer,
 					"mppssp %lu exceeded limit %lu",
 					num, value);
+				pjob->ji_qs.ji_un.ji_momt.ji_exitstat = JOB_EXEC_KILL_MPPSSP;
 				return (TRUE);
 			}
 		}

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -6036,7 +6036,6 @@ mom_over_limit(job *pjob)
 				sprintf(log_buffer,
 					"mppe %lu exceeded limit %lu",
 					num, value);
-				pjob->ji_qs.ji_un.ji_momt.ji_exitstat = JOB_EXEC_KILL_MPPE;
 				return (TRUE);
 			}
 		} else if (strcmp(pname, "mppssp") == 0) {
@@ -6050,7 +6049,6 @@ mom_over_limit(job *pjob)
 				sprintf(log_buffer,
 					"mppssp %lu exceeded limit %lu",
 					num, value);
-				pjob->ji_qs.ji_un.ji_momt.ji_exitstat = JOB_EXEC_KILL_MPPSSP;
 				return (TRUE);
 			}
 		}

--- a/src/server/req_jobobit.c
+++ b/src/server/req_jobobit.c
@@ -102,8 +102,6 @@ extern char *msg_momkillvmem;
 extern char *msg_momkillmem;
 extern char *msg_momkillcput;
 extern char *msg_momkillwalltime;
-extern char *msg_momkillmppe;
-extern char *msg_momkillmppssp;
 extern time_t time_now;
 
 /* External Functions called */
@@ -1744,18 +1742,6 @@ RetryJob:
 				/* MOM killed job due to exceeding walltime, abort job */
 				DBPRT(("%s: MOM killed job %s due to exceeding walltime.\n", __func__, pruu->ru_pjobid))
 				svr_mailowner(pjob, MAIL_ABORT, MAIL_FORCE, msg_momkillwalltime);
-				alreadymailed = 1;
-				break;
-			case JOB_EXEC_KILL_MPPE:
-				/* MOM killed job due to exceeding mppe, abort job */
-				DBPRT(("%s: MOM killed job %s due to exceeding mppe.\n", __func__, pruu->ru_pjobid))
-				svr_mailowner(pjob, MAIL_ABORT, MAIL_FORCE, msg_momkillmppe);
-				alreadymailed = 1;
-				break;
-			case JOB_EXEC_KILL_MPPSSP:
-				/* MOM killed job due to exceeding mppssp, abort job */
-				DBPRT(("%s: MOM killed job %s due to exceeding mppssp.\n", __func__, pruu->ru_pjobid))
-				svr_mailowner(pjob, MAIL_ABORT, MAIL_FORCE, msg_momkillmppssp);
 				alreadymailed = 1;
 				break;
 			}

--- a/src/server/req_jobobit.c
+++ b/src/server/req_jobobit.c
@@ -96,6 +96,14 @@ extern char *msg_obitnodel;
 extern char *msg_bad_password;
 extern char *msg_hook_reject_deletejob;
 extern char *msg_hook_reject_rerunjob;
+extern char *msg_momkillncpusburst;
+extern char *msg_momkillncpussum;
+extern char *msg_momkillvmem;
+extern char *msg_momkillmem;
+extern char *msg_momkillcput;
+extern char *msg_momkillwalltime;
+extern char *msg_momkillmppe;
+extern char *msg_momkillmppssp;
 extern time_t time_now;
 
 /* External Functions called */
@@ -1702,6 +1710,54 @@ RetryJob:
 				free(mailbuf);
 				free(acctbuf);
 				return 0;
+			case JOB_EXEC_KILL_NCPUS_BURST:
+				/* MOM killed job due to exceeding ncpus (burst), abort job */
+				DBPRT(("%s: MOM killed job %s due to exceeding ncpus (burst).\n", __func__, pruu->ru_pjobid))
+				svr_mailowner(pjob, MAIL_ABORT, MAIL_FORCE, msg_momkillncpusburst);
+				alreadymailed = 1;
+				break;
+			case JOB_EXEC_KILL_NCPUS_SUM:
+				/* MOM killed job due to exceeding ncpus (sum), abort job */
+				DBPRT(("%s: MOM killed job %s due to exceeding ncpus (sum).\n", __func__, pruu->ru_pjobid))
+				svr_mailowner(pjob, MAIL_ABORT, MAIL_FORCE, msg_momkillncpussum);
+				alreadymailed = 1;
+				break;
+			case JOB_EXEC_KILL_VMEM:
+				/* MOM killed job due to exceeding vmem, abort job */
+				DBPRT(("%s: MOM killed job %s due to exceeding vmem.\n", __func__, pruu->ru_pjobid))
+				svr_mailowner(pjob, MAIL_ABORT, MAIL_FORCE, msg_momkillvmem);
+				alreadymailed = 1;
+				break;
+			case JOB_EXEC_KILL_MEM:
+				/* MOM killed job due to exceeding mem, abort job */
+				DBPRT(("%s: MOM killed job %s due to exceeding mem.\n", __func__, pruu->ru_pjobid))
+				svr_mailowner(pjob, MAIL_ABORT, MAIL_FORCE, msg_momkillmem);
+				alreadymailed = 1;
+				break;
+			case JOB_EXEC_KILL_CPUT:
+				/* MOM killed job due to exceeding cput, abort job */
+				DBPRT(("%s: MOM killed job %s due to exceeding cput.\n", __func__, pruu->ru_pjobid))
+				svr_mailowner(pjob, MAIL_ABORT, MAIL_FORCE, msg_momkillcput);
+				alreadymailed = 1;
+				break;
+			case JOB_EXEC_KILL_WALLTIME:
+				/* MOM killed job due to exceeding walltime, abort job */
+				DBPRT(("%s: MOM killed job %s due to exceeding walltime.\n", __func__, pruu->ru_pjobid))
+				svr_mailowner(pjob, MAIL_ABORT, MAIL_FORCE, msg_momkillwalltime);
+				alreadymailed = 1;
+				break;
+			case JOB_EXEC_KILL_MPPE:
+				/* MOM killed job due to exceeding mppe, abort job */
+				DBPRT(("%s: MOM killed job %s due to exceeding mppe.\n", __func__, pruu->ru_pjobid))
+				svr_mailowner(pjob, MAIL_ABORT, MAIL_FORCE, msg_momkillmppe);
+				alreadymailed = 1;
+				break;
+			case JOB_EXEC_KILL_MPPSSP:
+				/* MOM killed job due to exceeding mppssp, abort job */
+				DBPRT(("%s: MOM killed job %s due to exceeding mppssp.\n", __func__, pruu->ru_pjobid))
+				svr_mailowner(pjob, MAIL_ABORT, MAIL_FORCE, msg_momkillmppssp);
+				alreadymailed = 1;
+				break;
 			}
 	}
 

--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -4873,8 +4873,49 @@ update_job_finish_comment(job *pjob, int newsubstate, char *user)
 		snprintf(buffer, LOG_BUF_SIZE, "%s and finished",
 			get_jattr_str(pjob, JOB_ATR_Comment));
 	} else if (newsubstate == JOB_SUBSTATE_FAILED) {
-		snprintf(buffer, LOG_BUF_SIZE, "%s and failed",
-			get_jattr_str(pjob, JOB_ATR_Comment));
+		if (is_jattr_set(pjob, JOB_ATR_exit_status)) {
+			switch (get_jattr_long(pjob, JOB_ATR_exit_status)) {
+				case JOB_EXEC_KILL_NCPUS_BURST:
+					snprintf(buffer, LOG_BUF_SIZE, "%s and exceeded resource ncpus (burst)",
+						get_jattr_str(pjob, JOB_ATR_Comment));
+					break;
+				case JOB_EXEC_KILL_NCPUS_SUM:
+					snprintf(buffer, LOG_BUF_SIZE, "%s and exceeded resource ncpus (sum)",
+						get_jattr_str(pjob, JOB_ATR_Comment));
+					break;
+				case JOB_EXEC_KILL_VMEM:
+					snprintf(buffer, LOG_BUF_SIZE, "%s and exceeded resource vmem",
+						get_jattr_str(pjob, JOB_ATR_Comment));
+					break;
+				case JOB_EXEC_KILL_MEM:
+					snprintf(buffer, LOG_BUF_SIZE, "%s and exceeded resource mem",
+						get_jattr_str(pjob, JOB_ATR_Comment));
+					break;
+				case JOB_EXEC_KILL_CPUT:
+					snprintf(buffer, LOG_BUF_SIZE, "%s and exceeded resource cput",
+						get_jattr_str(pjob, JOB_ATR_Comment));
+					break;
+				case JOB_EXEC_KILL_WALLTIME:
+					snprintf(buffer, LOG_BUF_SIZE, "%s and exceeded resource walltime",
+						get_jattr_str(pjob, JOB_ATR_Comment));
+					break;
+				case JOB_EXEC_KILL_MPPE:
+					snprintf(buffer, LOG_BUF_SIZE, "%s and exceeded resource mppe",
+						get_jattr_str(pjob, JOB_ATR_Comment));
+					break;
+				case JOB_EXEC_KILL_MPPSSP:
+					snprintf(buffer, LOG_BUF_SIZE, "%s and exceeded resource mppssp",
+						get_jattr_str(pjob, JOB_ATR_Comment));
+					break;
+				default:
+					snprintf(buffer, LOG_BUF_SIZE, "%s and failed",
+						get_jattr_str(pjob, JOB_ATR_Comment));
+					break;
+			}
+		} else {
+			snprintf(buffer, LOG_BUF_SIZE, "%s and failed",
+				get_jattr_str(pjob, JOB_ATR_Comment));
+		}
 	} else if (newsubstate == JOB_SUBSTATE_TERMINATED) {
 		/* Don't overwrite the comment; if already set by req_deletejob2 */
 		if (strstr(get_jattr_str(pjob, JOB_ATR_Comment), "terminated") == NULL) {

--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -4899,14 +4899,6 @@ update_job_finish_comment(job *pjob, int newsubstate, char *user)
 					snprintf(buffer, LOG_BUF_SIZE, "%s and exceeded resource walltime",
 						get_jattr_str(pjob, JOB_ATR_Comment));
 					break;
-				case JOB_EXEC_KILL_MPPE:
-					snprintf(buffer, LOG_BUF_SIZE, "%s and exceeded resource mppe",
-						get_jattr_str(pjob, JOB_ATR_Comment));
-					break;
-				case JOB_EXEC_KILL_MPPSSP:
-					snprintf(buffer, LOG_BUF_SIZE, "%s and exceeded resource mppssp",
-						get_jattr_str(pjob, JOB_ATR_Comment));
-					break;
 				default:
 					snprintf(buffer, LOG_BUF_SIZE, "%s and failed",
 						get_jattr_str(pjob, JOB_ATR_Comment));

--- a/test/fw/ptl/utils/pbs_dshutils.py
+++ b/test/fw/ptl/utils/pbs_dshutils.py
@@ -1817,7 +1817,7 @@ class DshUtils(object):
                             runas=runas, logerr=logerr, level=level)
 
     def tail(self, hostname=None, filename=None, sudo=False, runas=None,
-            logerr=True, level=logging.INFOCLI2, option=None):
+             logerr=True, level=logging.INFOCLI2, option=None):
         """
         Generic function of tail with remote host support
 

--- a/test/fw/ptl/utils/pbs_dshutils.py
+++ b/test/fw/ptl/utils/pbs_dshutils.py
@@ -1816,6 +1816,34 @@ class DshUtils(object):
         return self.run_cmd(hostname, cmd=cmd, sudo=sudo,
                             runas=runas, logerr=logerr, level=level)
 
+    def tail(self, hostname=None, filename=None, sudo=False, runas=None,
+            logerr=True, level=logging.INFOCLI2, option=None):
+        """
+        Generic function of tail with remote host support
+
+        :param hostname: hostname (default current host)
+        :type hostname: str or None
+        :param filename: the path to the filename to cat
+        :type filename: str or None
+        :param sudo: whether to create directories as root or not.
+                     Defaults to False
+        :type sudo: boolean
+        :param runas: create directories as given user. Defaults
+                      to calling user
+        :type runas: str or None
+        :param logerr: whether to log error messages or not. Defaults
+                       to True.
+        :type logerr: boolean
+        :returns: output of run_cmd
+        """
+        cmd = [self.which(hostname, 'tail', level=level)]
+        if option:
+            cmd += [option, filename]
+        else:
+            cmd.append(filename)
+        return self.run_cmd(hostname, cmd=cmd, sudo=sudo,
+                            runas=runas, logerr=logerr, level=level)
+
     def cmp(self, hostname=None, fileA=None, fileB=None, sudo=False,
             runas=None, logerr=True):
         """

--- a/test/fw/ptl/utils/pbs_dshutils.py
+++ b/test/fw/ptl/utils/pbs_dshutils.py
@@ -1823,7 +1823,7 @@ class DshUtils(object):
 
         :param hostname: hostname (default current host)
         :type hostname: str or None
-        :param filename: the path to the filename to cat
+        :param filename: the path to the filename to tail
         :type filename: str or None
         :param sudo: whether to create directories as root or not.
                      Defaults to False

--- a/test/tests/functional/pbs_exceeded_resources_notification.py
+++ b/test/tests/functional/pbs_exceeded_resources_notification.py
@@ -1,0 +1,242 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2020 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of both the OpenPBS software ("OpenPBS")
+# and the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# OpenPBS is free software. You can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# OpenPBS is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# PBS Pro is commercially licensed software that shares a common core with
+# the OpenPBS software.  For a copy of the commercial license terms and
+# conditions, go to: (http://www.pbspro.com/agreement.html) or contact the
+# Altair Legal Department.
+#
+# Altair's dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of OpenPBS and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair's trademarks, including but not limited to "PBS™",
+# "OpenPBS®", "PBS Professional®", and "PBS Pro™" and Altair's logos is
+# subject to Altair's trademark licensing policies.
+
+from tests.functional import *
+
+
+class TestExceededResourcesNotification(TestFunctional):
+    """
+    This test suite tests exceeding resources notification.
+    The notification is done via email, job comment, and job exit code.
+    """
+
+    def setUp(self):
+        TestFunctional.setUp(self)
+
+        a = {'job_history_enable': 'True'}
+        rc = self.server.manager(MGR_CMD_SET, SERVER, a)
+        self.assertEqual(rc, 0)
+
+    def check_mail(self, jid, msg):
+        """
+        Check the mail file of TEST_USER for message.
+        """
+
+        mailfile = os.path.join('/var/mail', str(TEST_USER))
+
+        if not os.path.isfile(mailfile):
+            self.skip_test("Mail file '%s' does not exist or "
+                           "mail is not setup. "
+                           "Hence this step would be skipped. "
+                           "Please check manually." % mailfile)
+
+        ret = self.du.cat(filename=mailfile, sudo=True)
+        maillog = [x.strip() for x in ret['out'][-50:]]
+
+        emailpass = False
+        for i in range(0, len(maillog)-3):
+            if 'PBS Job Id: ' + jid == maillog[i] and msg == maillog[i+3]:
+                emailpass = True
+                break
+
+        return emailpass
+
+    def test_exceeding_walltime(self):
+        """
+        This test suite tests exceeding walltime.
+        """
+
+        a = {'Resource_List.walltime': 1}
+        j = Job(TEST_USER, a)
+
+        j.set_sleep_time(60)
+
+        jid = self.server.submit(j)
+        j_comment = '.* and exceeded resource walltime'
+        self.server.expect(JOB, {ATTR_state: 'F',
+                                 ATTR_comment: (MATCH_RE, j_comment),
+                                 ATTR_exit_status: -29},
+                           id=jid, extend='x')
+
+        self.logger.info('Wait 3s for saving the e-mail')
+        time.sleep(3)
+
+        msg = 'Job exceeded resource walltime'
+        emailpass = self.check_mail(jid, msg)
+        self.assertTrue(emailpass, "Message '" + msg +
+                        "' not found in mailfile for job: " + jid)
+
+    def test_exceeding_mem(self):
+        """
+        This test suite tests exceeding memory.
+        """
+
+        self.mom.add_config(
+            {'$enforce mem': ''})
+
+        self.mom.stop()
+        self.mom.start()
+
+        a = {'Resource_List.walltime': 3600,
+             'Resource_List.select': 'mem=1kb'}
+        j = Job(TEST_USER, a)
+
+        test = []
+        test += ['#!/bin/bash']
+        test += ['tail -c 100K /dev/zero']
+        j.create_script(body=test)
+
+        jid = self.server.submit(j)
+        j_comment = '.* and exceeded resource mem'
+        self.server.expect(JOB, {ATTR_state: "F",
+                                 ATTR_comment: (MATCH_RE, j_comment),
+                                 ATTR_exit_status: -27},
+                           id=jid, extend='x')
+
+        self.logger.info('Wait 3s for saving the e-mail')
+        time.sleep(3)
+
+        msg = 'Job exceeded resource mem'
+        emailpass = self.check_mail(jid, msg)
+        self.assertTrue(emailpass, "Message '" + msg +
+                        "' not found in mailfile for job: " + jid)
+
+    def test_exceeding_ncpus_sum(self):
+        """
+        This test suite tests exceeding ncpus (sum).
+        """
+
+        self.mom.add_config(
+            {'$enforce average_percent_over': '0',
+             '$enforce average_cpufactor': '0.1',
+             '$enforce average_trialperiod': '1',
+             '$enforce cpuaverage': ''})
+
+        self.mom.stop()
+        self.mom.start()
+
+        a = {'Resource_List.walltime': 3600}
+        j = Job(TEST_USER, a)
+
+        test = []
+        test += ['#!/bin/bash']
+        test += ['dd if=/dev/zero of=/dev/null']
+        j.create_script(body=test)
+
+        jid = self.server.submit(j)
+        j_comment = '.* and exceeded resource ncpus \(sum\)'
+        self.server.expect(JOB, {ATTR_state: 'F',
+                                 ATTR_comment: (MATCH_RE, j_comment),
+                                 ATTR_exit_status: -25},
+                           id=jid, extend='x')
+
+        self.logger.info('Wait 3s for saving the e-mail')
+        time.sleep(3)
+
+        msg = 'Job exceeded resource ncpus (sum)'
+        emailpass = self.check_mail(jid, msg)
+        self.assertTrue(emailpass, "Message '" + msg +
+                        "' not found in mailfile for job: " + jid)
+
+    def test_exceeding_ncpus_burst(self):
+        """
+        This test suite tests exceeding ncpus (burst).
+        """
+
+        self.mom.add_config(
+            {'$enforce delta_percent_over': '0',
+             '$enforce delta_cpufactor': '0.1',
+             '$enforce cpuburst': ''})
+
+        self.mom.stop()
+        self.mom.start()
+
+        a = {'Resource_List.walltime': 3600}
+        j = Job(TEST_USER, a)
+
+        test = []
+        test += ['#!/bin/bash']
+        test += ['dd if=/dev/zero of=/dev/null']
+        j.create_script(body=test)
+
+        jid = self.server.submit(j)
+        j_comment = '.* and exceeded resource ncpus \(burst\)'
+        self.server.expect(JOB, {ATTR_state: 'F',
+                                 ATTR_comment: (MATCH_RE, j_comment),
+                                 ATTR_exit_status: -24},
+                           id=jid, extend='x')
+
+        self.logger.info('Wait 3s for saving the e-mail')
+        time.sleep(3)
+
+        msg = 'Job exceeded resource ncpus (burst)'
+        emailpass = self.check_mail(jid, msg)
+        self.assertTrue(emailpass, "Message '" + msg +
+                        "' not found in mailfile for job: " + jid)
+
+    def test_exceeding_cput(self):
+        """
+        This test suite tests exceeding cput.
+        """
+
+        a = {'Resource_List.cput': 10}
+        j = Job(TEST_USER, a)
+
+        # we need at least two processes otherwise the kernel
+        # would kill the process first
+        test = []
+        test += ['#!/bin/bash']
+        test += ['dd if=/dev/zero of=/dev/null & \
+dd if=/dev/zero of=/dev/null']
+        j.create_script(body=test)
+
+        jid = self.server.submit(j)
+        j_comment = '.* and exceeded resource cput'
+        self.server.expect(JOB, {ATTR_state: 'F',
+                                 ATTR_comment: (MATCH_RE, j_comment),
+                                 ATTR_exit_status: -28},
+                           id=jid, extend='x')
+
+        self.logger.info('Wait 3s for saving the e-mail')
+        time.sleep(3)
+
+        msg = 'Job exceeded resource cput'
+        emailpass = self.check_mail(jid, msg)
+        self.assertTrue(emailpass, "Message '" + msg +
+                        "' not found in mailfile for job: " + jid)

--- a/test/tests/functional/pbs_exceeded_resources_notification.py
+++ b/test/tests/functional/pbs_exceeded_resources_notification.py
@@ -49,9 +49,6 @@ class TestExceededResourcesNotification(TestFunctional):
     def setUp(self):
         TestFunctional.setUp(self)
 
-        if os.getuid() != 0:
-            self.skipTest("The test needs to run as root")
-
         a = {'job_history_enable': 'True'}
         self.server.manager(MGR_CMD_SET, SERVER, a)
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->

This change introduces a negative exit code for an exceeded resource by a job. Supposing the killing for the resource is enabled, a different exit code is used for a different resource. Also, an appropriate job comment is set and an abort email is sent to the user with info on which resource was exceeded. 

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

The change is simple. Once the exceeding is detected, a new exit code is set. The exit code is used to distinguish which comment should be set and which email should be sent.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
[Design document](https://openpbs.atlassian.net/wiki/spaces/PD/pages/2245558279/Exceeded+resources+notification)
[Link to discussion](https://community.openpbs.org/t/exceeded-resources-notification/2354)


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

[ptl_test-exceeded_resources_notification.txt](https://github.com/openpbs/openpbs/files/5588376/ptl_test-exceeded_resources_notification.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
