### PR TITLE
Fix test of Test_passing_environment_variable_via_qsub to run on remote mom

### DIFF
--- a/test/tests/functional/pbs_passing_environment_variable.py
+++ b/test/tests/functional/pbs_passing_environment_variable.py
@@ -104,10 +104,10 @@ env | grep foo
 unset -f foo
 exit 0
 """
-        fn = self.du.create_temp_file(body=foo_scr)
-        self.du.chmod(path=fn, mode=0o755)
+        fn = self.du.create_temp_file(hostname=self.mom.hostname, body=foo_scr)
+        self.du.chmod(hostname=self.mom.hostname, path=fn, mode=0o755)
         foo_msg = 'Failed to run foo_scr'
-        ret = self.du.run_cmd(self.server.hostname, cmd=fn)
+        ret = self.du.run_cmd(self.mom.hostname, cmd=fn)
         self.assertEqual(ret['rc'], 0, foo_msg)
         msg = 'BASH_FUNC_'
         n = 'foo'


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Test of Test_passing_environment_variable_via_qsub was failing with below error when mom is on remote host:
Traceback (most recent call last):
  File "/opt/ptl/tests/functional/pbs_passing_environment_variable.py", line 139, in test_passing_shell_function
    msg="Environment variable foo content does "
AssertionError: 'foo=() {  if [ /bin/true ]; then\n echo hello;\n fi\n}\nhello' != 'BASH_FUNC_foo()=() {  if [ /bin/true ]; then\n echo hello;\n fi\n}\nhello'
- foo=() {  if [ /bin/true ]; then
+ BASH_FUNC_foo()=() {  if [ /bin/true ]; then
? ++++++++++   ++
   echo hello;
   fi
  }
  hello : Environment variable foo content does not match original
Reason: Test was executing a script on local host which is supposed to run on mom node.

#### Describe Your Change
Creating a script on mom node so that when Job is submitted with a script, it will make sure that that script runs on mom node.


#### Attach Test and Valgrind Logs/Output
Logs with no mom on server:
Description: Tests from given sources on platforms SUSE15, CENTOS8, CENTOS7
Platforms: SUSE15,CENTOS8,CENTOS7
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|4998|3|0|0|0|0|3|

Logs with mom on server:
Description: Rerun All Tests From #4998
Platforms: SUSE15,CENTOS8,CENTOS7
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|5019|3|0|0|0|0|3|
<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
