### PR TITLE
Temporary reducing number of travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,9 +49,6 @@ env:
   - OS_TYPE=centos:8
   - OS_TYPE=opensuse/leap:15
   - OS_TYPE=ubuntu:20.04
-  - OS_TYPE=debian:9
-  - OS_TYPE=centos:7 BUILD_MODE=sanitize
-  - OS_TYPE=centos:7 BUILD_MODE=kerberos
 before_install:
   - .github/runchecks
   - docker pull ${OS_TYPE}
@@ -62,6 +59,5 @@ before_install:
   - docker ps -a
   - export DOCKER_EXEC="docker exec -it ${DOCKER_EXTRA_ARG} -e BUILD_MODE="${BUILD_MODE}" --privileged pbsdev"
 install:
-  - '${DOCKER_EXEC} .travis/do_sanitize_mode.sh'
   - '${DOCKER_EXEC} .travis/do.sh'
 script: true


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Temporary reducing number of travis builds. 
With recent change in pricing model in travis, we have limited credits to run builds. Till we get required credits reducing number of builds.
Taking out  debian:9, centos:7_sanitize, centos:7_kerberos builds.


#### Describe Your Change
Updated travis file


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
