### PR TITLE
Fix for test_acclog_services_restart when mom is mom remote host

### DIFF
--- a/test/tests/functional/pbs_resource_usage_log.py
+++ b/test/tests/functional/pbs_resource_usage_log.py
@@ -323,7 +323,7 @@ class TestResourceUsageLog(TestFunctional):
         # Restart PBS services
         PBSInitServices().restart()
         if self.server.shortname != self.mom.shortname:
-           self.mom.restart()
+            self.mom.restart()
 
         self.assertTrue(self.server.isUp())
         self.assertTrue(self.mom.isUp())

--- a/test/tests/functional/pbs_resource_usage_log.py
+++ b/test/tests/functional/pbs_resource_usage_log.py
@@ -322,7 +322,8 @@ class TestResourceUsageLog(TestFunctional):
 
         # Restart PBS services
         PBSInitServices().restart()
-        self.mom.restart()
+        if self.server.shortname != self.mom.shortname:
+           self.mom.restart()
 
         self.assertTrue(self.server.isUp())
         self.assertTrue(self.mom.isUp())

--- a/test/tests/functional/pbs_resource_usage_log.py
+++ b/test/tests/functional/pbs_resource_usage_log.py
@@ -322,8 +322,10 @@ class TestResourceUsageLog(TestFunctional):
 
         # Restart PBS services
         PBSInitServices().restart()
+        self.mom.restart()
 
         self.assertTrue(self.server.isUp())
+        self.assertTrue(self.mom.isUp())
 
         # Sleep so accounting logs get updated
         time.sleep(40)


### PR DESCRIPTION
#### Describe Bug or Feature
test_acclog_services_restart  of TestResourceUsageLog  is failing when mom is mom remote host with below error
ptl.lib.ptl_error.PtlLogMatchError: rc=1, rv=False, msg= xyz log match: searching for "R;0.xyz.*resources_used.*run_count=1" - using regular expression  - with existence - attempt 180

In current code we are looking for accounting log after service restart
Restart PBS services
        PBSInitServices().restart()
 , but in case where mom is on remote host , mom is not getting restarted in PBSInitServices().restart() and test fail at further step

#### Describe Your Change
Explicitly restarting mom in test 

#### Attach Test and Valgrind Logs/Output
Before fix 
[before_fix_test_acclog_services_restart.txt](https://github.com/openpbs/openpbs/files/5607136/before_fix_test_acclog_services_restart.txt)

After fix 
mom is on remote host 
[after_fix_test_acclog_services_restart_no_mom_on_server.txt](https://github.com/openpbs/openpbs/files/5607140/after_fix_test_acclog_services_restart_no_mom_on_server.txt)

Description: after_fix_no_mom_on_server
Platforms: CENTOS8,SUSE15
Profile: Custom
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|5057|2|0|0|0|0|2|

mom on server host 
[after_fix_test_acclog_services_restart_mom_on_server.txt](https://github.com/openpbs/openpbs/files/5607142/after_fix_test_acclog_services_restart_mom_on_server.txt)

Description: after_fix_mom_on_server
Platforms: CENTOS8,SUSE15
Profile: Custom
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|5058|2|0|0|0|0|2|




