### PR TITLE
Fix sleep time of jobs in test_app_provisioning 

### DIFF
--- a/test/tests/functional/pbs_provisioning.py
+++ b/test/tests/functional/pbs_provisioning.py
@@ -168,7 +168,6 @@ class TestProvisioningJob(TestFunctional):
         self.server.manager(MGR_CMD_SET, NODE, a, id=self.hostA)
 
         job = Job(TEST_USER1, attrs={ATTR_l: 'aoe=App1'})
-        job.set_sleep_time(3)
         jid = self.server.submit(job)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
         self.server.log_match(

--- a/test/tests/functional/pbs_provisioning.py
+++ b/test/tests/functional/pbs_provisioning.py
@@ -168,7 +168,7 @@ class TestProvisioningJob(TestFunctional):
         self.server.manager(MGR_CMD_SET, NODE, a, id=self.hostA)
 
         job = Job(TEST_USER1, attrs={ATTR_l: 'aoe=App1'})
-        job.set_sleep_time(1)
+        job.set_sleep_time(3)
         jid = self.server.submit(job)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
         self.server.log_match(


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
test_app_provisioning fails with "no data for job" error while searching the "R" state of the job in PTL.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Since the current sleep time in the test is less (1 second), the job's state & substate doesn't update at the server and the job immediately ends. Hence not setting a sleep time and keeping it default.


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[test_app_prov_before_fix.txt](https://github.com/openpbs/openpbs/files/5622198/test_app_prov_before_fix.txt)
[test_app_prov_after_fix_updated.txt](https://github.com/openpbs/openpbs/files/5622307/test_app_prov_after_fix_updated.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
