### PR TITLE
Preemption fails when host or vnode is requested at chunk level

### DIFF
--- a/src/scheduler/check.cpp
+++ b/src/scheduler/check.cpp
@@ -1200,7 +1200,11 @@ check_avail_resources(schd_resource *reslist, resource_req *reqlist,
 							requested,
 							res_to_str_r(res, RF_AVAIL, resbuf2, sizeof(resbuf2)));
 						set_schd_error_arg(err, ARG1, buf);
-						set_schd_error_arg(err, ARG2, requested);
+						/* Set arg2 for vnode/host resource. In case of preemption, arg2 is used to cull
+						 * the list of running jobs
+						 */
+						if ((res->def == getallres(RES_HOST)) || (res->def == getallres(RES_VNODE)))
+							set_schd_error_arg(err, ARG2, requested);
 					}
 				}
 			}

--- a/src/scheduler/check.cpp
+++ b/src/scheduler/check.cpp
@@ -1192,7 +1192,7 @@ check_avail_resources(schd_resource *reslist, resource_req *reqlist,
 				if (!compare_non_consumable(res, resreq)) {
 					fail = 1;
 					if (err != NULL) {
-						char *requested;
+						const char *requested;
 						set_schd_error_codes(err, NOT_RUN, fail_code);
 						err->rdef = res->def;
 						requested = res_to_str_r(resreq, RF_REQUEST, resbuf1, sizeof(resbuf1));

--- a/src/scheduler/check.cpp
+++ b/src/scheduler/check.cpp
@@ -1192,13 +1192,15 @@ check_avail_resources(schd_resource *reslist, resource_req *reqlist,
 				if (!compare_non_consumable(res, resreq)) {
 					fail = 1;
 					if (err != NULL) {
+						char *requested;
 						set_schd_error_codes(err, NOT_RUN, fail_code);
 						err->rdef = res->def;
-
+						requested = res_to_str_r(resreq, RF_REQUEST, resbuf1, sizeof(resbuf1));
 						snprintf(buf, sizeof(buf), "(%s != %s)",
-							res_to_str_r(resreq, RF_REQUEST, resbuf1, sizeof(resbuf1)),
+							requested,
 							res_to_str_r(res, RF_AVAIL, resbuf2, sizeof(resbuf2)));
 						set_schd_error_arg(err, ARG1, buf);
+						set_schd_error_arg(err, ARG2, requested);
 					}
 				}
 			}

--- a/src/scheduler/job_info.cpp
+++ b/src/scheduler/job_info.cpp
@@ -5324,19 +5324,10 @@ static int cull_preemptible_jobs(resource_resv *job, void *arg)
 			 * compare the resource name with the chunk name
 			 */
 			if (inp->err->rdef == getallres(RES_VNODE)) {
-				resource_req *hreq = find_resource_req(inp->job->resreq, inp->err->rdef);
-				if (hreq == NULL)
-					return 0;
-				for (index = 0; job->execselect->chunks[index] != NULL; index++)
-				{
-					resource_req *lreq = find_resource_req(job->execselect->chunks[index]->req, inp->err->rdef);
-					if (lreq != NULL)
-						if (strcmp(hreq->res_str, lreq->res_str) == 0)
-							return 1;
-				}
+				if (inp->err->arg2 != NULL && find_node_info(job->ninfo_arr, inp->err->arg2) != NULL)
+					return 1;
 			} else if (inp->err->rdef == getallres(RES_HOST)) {
-				resource_req *hreq = find_resource_req(inp->job->resreq, inp->err->rdef);
-				if (find_node_by_host(job->ninfo_arr, hreq->res_str) != NULL)
+				if (inp->err->arg2 != NULL && find_node_by_host(job->ninfo_arr, inp->err->arg2) != NULL)
 					return 1;
 			} else {
 				if (inp->err->rdef->type.is_non_consumable) {

--- a/test/tests/functional/pbs_preemption.py
+++ b/test/tests/functional/pbs_preemption.py
@@ -746,3 +746,77 @@ exit 3
         jid2 = self.server.submit(j2)
 
         self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
+
+    @requirements(num_moms=2)
+    def test_chunk_level_host_resource_contention(self):
+        """
+        Test to make sure that preemption happens when the resource in
+        contention is host requested inside a chunk.
+        """
+        # Skip test if number of mom provided is not equal to two
+        if len(self.moms) != 2:
+            self.skipTest("test requires two MoMs as input, " +
+                          "use -p moms=<mom1>:<mom2>")
+        else:
+            self.server.manager(MGR_CMD_CREATE, NODE, id=self.mom2)
+
+        a = {'resources_available.ncpus': 2}
+        self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom1)
+        a = {'resources_available.ncpus': 3}
+        self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom2)
+
+        a = {'Resource_List.select': '1:ncpus=2'}
+        j1 = Job(TEST_USER, attrs=a)
+        jid1 = self.server.submit(j1)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
+
+        # Stat job to check which job is running on mom1
+        pjid = jid1
+        job_stat = self.server.status(JOB, id=jid1)
+        ehost = job_stat[0]['exec_host'].partition('/')[0]
+
+        # Submit a express queue job requesting the host
+        a = {ATTR_q: 'expressq',
+             'Resource_List.select': '1:ncpus=2:host=' + ehost}
+        hj = Job(TEST_USER, attrs=a)
+        hjid = self.server.submit(hj)
+        self.server.expect(JOB, {'job_state': 'R'}, id=hjid)
+        self.server.expect(JOB, {'job_state': 'S'}, id=pjid)
+
+        # Submit another express queue job requesting the host,
+        # this job will stay queued
+        a = {ATTR_q: 'expressq', 'Resource_List.host': self.mom1,
+             'Resource_List.ncpus': 2}
+        hj2 = Job(TEST_USER, attrs=a)
+        hjid2 = self.server.submit(hj2)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=hjid2)
+        comment = "Not Running: Insufficient amount of resource: host"
+        self.server.expect(JOB, {'comment': comment}, id=hjid2)
+
+    def test_chunk_level_vnode_resource_contention(self):
+        """
+        Test to make sure that preemption happens when the resource in
+        contention is vnode requested inside a chunk.
+        """
+
+        a = {'resources_available.ncpus': 2}
+        self.mom.create_vnodes(attrib=a, num=11, usenatvnode=False)
+
+        a = {'Resource_List.select': '1:ncpus=2+1:ncpus=2'}
+        for _ in range(5):
+            j = Job(TEST_USER, attrs=a)
+            jid = self.server.submit(j)
+            self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+
+        # Select a vnode with running jobs on it. Request this
+        # vnode in the high priority job later.
+        vn4 = self.mom.shortname + '[4]'
+        self.server.expect(NODE, {'state': 'job-busy'}, id=vn4)
+
+        a = {ATTR_q: 'expressq',
+             'Resource_List.select': '1:ncpus=1:vnode=' + vn4}
+        hj = Job(TEST_USER, attrs=a)
+        hjid = self.server.submit(hj)
+        self.server.expect(JOB, {'job_state': 'R'}, id=hjid)
+        self.server.expect(JOB, {'job_state=R': 5})
+        self.server.expect(JOB, {'job_state=S': 1})


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
PBS scheduler while trying to preempt a job tries to limit the number of preemption candidates by checking the reason why a high priority job could not run and then cull the preemptible jobs to only those jobs who can help in running the high priority job.
While doing so, it takes special care about non-consumable resource vnode and host. The issue while checking these resources was that it was assumed these two are job wide resources and thus they are requested for the whole job. But this assumption is incorrect, one can request a multinode job to have one chunk running on a specific vnode or host.
Scheduler was crashing because of this wrong assumption.

#### Describe Your Change
In this change, we try to retain the value of vnode/host because of which the job could not run in the error structure. We store it in arg2 of error structure. Then in cull_preemptible_jobs, instead of searching though all the chunks and finding out which chunk requested the resource that caused the job to not run, we now use the arg2 member of error structure that stores the name of the vnode/host because of which the job could not run.

#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
[test_preemption_before.txt](https://github.com/openpbs/openpbs/files/5633185/test_preemption_before.txt)
[test_preemption.txt](https://github.com/openpbs/openpbs/files/5633188/test_preemption.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
