### PR TITLE
correction in ptl json report for average measurements

### DIFF
--- a/test/fw/ptl/utils/plugins/ptl_report_json.py
+++ b/test/fw/ptl/utils/plugins/ptl_report_json.py
@@ -206,8 +206,8 @@ class PTLJsonData(object):
             m_avg['testsuites'][tsname] = {
                 'testcases': {}
             }
-            test_status = "PASS"
             for tcname in data_json['testsuites'][tsname]['testcases']:
+                test_status = "PASS"
                 m_avg['testsuites'][tsname]['testcases'][tcname] = []
                 t_sum = []
                 count = 0


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Json report doesn't provide average measurements of all tests which run after a fail test in a testsuite because "test_status=PASS" is passed at the starting of the testsuite, If a test is not passed then test_status value is FAIL and remaining all test gets FAIL status.

#### Describe Your Change
Initialized test status for every test


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
[avg_json_after_change.txt](https://github.com/openpbs/openpbs/files/5635439/avg_json_after_change.txt)
[avg_json_before_changes.txt](https://github.com/openpbs/openpbs/files/5635441/avg_json_before_changes.txt)
[multiple_times_avg_measurements.txt](https://github.com/openpbs/openpbs/files/5636139/multiple_times_avg_measurements.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
