### PR TITLE
WIP: fix for memory error in qdel

### DIFF
--- a/src/server/process_request.c
+++ b/src/server/process_request.c
@@ -1517,7 +1517,7 @@ free_br(struct batch_request *preq)
 			break;
 		case PBS_BATCH_DeleteJobList:
 			if (preq->rq_ind.rq_deletejoblist.rq_jobslist)
-				free(preq->rq_ind.rq_deletejoblist.rq_jobslist);
+				free_string_array(preq->rq_ind.rq_deletejoblist.rq_jobslist);
 			break;
 		case PBS_BATCH_CopyFiles:
 		case PBS_BATCH_DelFiles:


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Memory leaks and invalid read/write errors.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Instead of freeing an array of strings, free() was used earlier. That would be potential a cause for memory leaks and errors. 
So, changed the code to a free array of strings.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
