### PR TITLE
Restore cgroup hook backward compatibility with 13.X-2020.x

### DIFF
--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -880,6 +880,9 @@ class HookUtils(object):
             self.hook_events = hook_events
         else:
             # Defined in the order they appear in module_pbs_v1.c
+            # if adding new events that may not exist in all PBS versions,
+            # use hasattr() to prevent exceptions when the hook is used
+            # on older PBS versions - see e.g. EXECJOB_ABORT
             self.hook_events = {}
             self.hook_events[pbs.QUEUEJOB] = {
                 'name': 'queuejob',

--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -3482,7 +3482,7 @@ class CgroupUtils(object):
                            ' PID %s to jobid %s'
                            % (caller_name(), pidarg, jobid))
             if (sid > 1):
-                pids = self._get_pids_in_sid(os.getsid(pidarg))
+                pids = self._get_pids_in_sid(sid)
         elif isinstance(pidarg, list):
             for pid in pidarg:
                 if not isinstance(pid, int):

--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -901,14 +901,16 @@ class HookUtils(object):
                 'name': 'runjob',
                 'handler': None
             }
-            self.hook_events[pbs.MANAGEMENT] = {
-                'name': 'management',
-                'handler': None
-            }
-            self.hook_events[pbs.MODIFYVNODE] = {
-                'name': 'modifyvnode',
-                'handler': None
-            }
+            if hasattr(pbs, "MANAGEMENT"):
+                self.hook_events[pbs.MANAGEMENT] = {
+                    'name': 'management',
+                    'handler': None
+                }
+            if hasattr(pbs, "MODIFYVNODE"):
+                self.hook_events[pbs.MODIFYVNODE] = {
+                    'name': 'modifyvnode',
+                    'handler': None
+                }
             self.hook_events[pbs.PROVISION] = {
                 'name': 'provision',
                 'handler': None
@@ -3458,7 +3460,7 @@ class CgroupUtils(object):
                             pids.append(int(entries[0]))
             except (OSError, IOError):
                 # PIDs may come and go as we read /proc so the glob data can
-                # become stale. Tollerate failures in this case.
+                # become stale. Tolerate failures in this case.
                 pass
         return pids
 
@@ -3468,8 +3470,19 @@ class CgroupUtils(object):
         """
         pbs.logmsg(pbs.EVENT_DEBUG4, '%s: Method called' % caller_name())
         # make pids a list
+        pids = []
         if isinstance(pidarg, int):
-            pids = self._get_pids_in_sid(os.getsid(pidarg))
+            sid = 0
+            try:
+                sid = os.getsid(pidarg)
+            except OSError as exc:
+                sid = -1
+                pbs.logmsg(pbs.EVENT_DEBUG2,
+                           '%s: Request to attach session of non-existing'
+                           ' PID %s to jobid %s'
+                           % (caller_name(), pidarg, jobid))
+            if (sid > 1):
+                pids = self._get_pids_in_sid(os.getsid(pidarg))
         elif isinstance(pidarg, list):
             for pid in pidarg:
                 if not isinstance(pid, int):


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Recent changes for cgroup hooks break backwards compatibility with 13.x-2020.x for no good reason at all. Part of :

https://github.com/openpbs/openpbs/pull/2105

Since many sites use different versions but want to use the same cgroup hook, developers should, in my opinion, refrain to do so unless it's really needed, to avoid to fork the hook, which would require new developments to be merged into umpteen versions of the hook.

Moreover, there is NO useful functionality in the original change anyway: it doesn't achieve anything except documenting the existence of new hook events to ignore. But the cgroup hook already ignores events that are not explicitly defined without any issue, so not adding code would have been just as good as far as funcionality is concerned (although I do agree that documenting in code that indeed these events are recognized to not require any action is not bad in se).

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
If using pbs.MANAGEMENT or pbs.MODIFYVNODE, guard the section of code with an if hasattr. In fact, there _was_ already code that did that, which would have been hard to miss if the events had been added at the _end_ of the list.

Also rolled in code in add_pids that adds another guard against crashing the hook with an uncaught exception if someone uses pbs_attach on a node using a PID that does not exist (or no longer exists). os.getsid() will return an OSError, and there is no try: construct around that call in the existing hook. 

Triggering the exception was recently demonstrated by a site using PBSPro 2020.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
N/A

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
N/A on master, since this is mainly about compatibility of the source with other releases, to avoid having to needlessly fork the hook code.


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
