### PR TITLE
Fix for pbs_tmrsh invoked from sister moms failure

### DIFF
--- a/src/resmom/catch_child.c
+++ b/src/resmom/catch_child.c
@@ -91,29 +91,29 @@ void			(*free_job_CPUs)(job *) = NULL;
 
 /* External Globals */
 
-extern  char            mom_host[];
-extern char		*path_epilog;
-extern char		*path_jobs;
-extern unsigned int	default_server_port;
-extern pbs_list_head	svr_alljobs;
-extern int		exiting_tasks;
-extern char		*msg_daemonname;
-extern char		*mom_home;
-#ifndef	WIN32
-extern int		termin_child;
+extern char mom_host[];
+extern char *path_epilog;
+extern char *path_jobs;
+extern unsigned int default_server_port;
+extern pbs_list_head svr_alljobs;
+extern int exiting_tasks;
+extern char *msg_daemonname;
+extern char *mom_home;
+#ifndef WIN32
+extern int termin_child;
 #endif
-extern int		server_stream;
-extern time_t		time_now;
-extern pbs_list_head	mom_polljobs;
-extern unsigned int	pbs_mom_port;
+extern int server_stream;
+extern time_t time_now;
+extern pbs_list_head mom_polljobs;
+extern unsigned int pbs_mom_port;
+extern int gen_nodefile_on_sister_mom;
 #if MOM_ALPS
-extern useconds_t	alps_release_wait_time;
-extern int		alps_release_timeout;
-extern useconds_t	alps_release_jitter;
+extern useconds_t alps_release_wait_time;
+extern int alps_release_timeout;
+extern useconds_t alps_release_jitter;
 #endif
 
-extern char		*path_hooks_workdir;
-
+extern char *path_hooks_workdir;
 
 #ifndef WIN32
 /**
@@ -1365,9 +1365,10 @@ del_job_resc(job *pjob)
 			exit(99);	/* simulate crash */
 	}
 
-	/* remove PBS_NODEFILE - Mother Superior only has one */
+	/* remove PBS_NODEFILE - Mother Superior shall have one and the sister
+	moms too if the mom config gen_nodefile_on_sister_mom is set to 1 */
 
-	if (pjob->ji_qs.ji_svrflags & JOB_SVFLG_HERE) {
+	if (pjob->ji_qs.ji_svrflags & JOB_SVFLG_HERE || gen_nodefile_on_sister_mom) {
 		char	file[MAXPATHLEN+1];
 #ifdef WIN32
 		(void)sprintf(file, "%s/auxiliary/%s",

--- a/src/resmom/mom_comm.c
+++ b/src/resmom/mom_comm.c
@@ -98,28 +98,28 @@
 
 /* Global Data Items */
 
-extern	int		exiting_tasks;
-extern	char		mom_host[];
-extern	char		*path_jobs;
-extern	int		pbs_errno;
-extern	pbs_list_head	mom_deadjobs;	/* for deferred purging of job */
-extern	pbs_list_head	mom_polljobs;	/* must have resource limits polled */
-extern	pbs_list_head	svr_alljobs;	/* all jobs under MOM's control */
-extern	time_t		time_now;
-extern	int		server_stream;
-extern	char		mom_short_name[];
-extern unsigned int	pbs_mom_port;
-extern unsigned int	pbs_rm_port;
+extern int exiting_tasks;
+extern char mom_host[];
+extern char *path_jobs;
+extern int pbs_errno;
+extern pbs_list_head mom_deadjobs; /* for deferred purging of job */
+extern pbs_list_head mom_polljobs; /* must have resource limits polled */
+extern pbs_list_head svr_alljobs;  /* all jobs under MOM's control */
+extern time_t time_now;
+extern int server_stream;
+extern char mom_short_name[];
+extern unsigned int pbs_mom_port;
+extern unsigned int pbs_rm_port;
+extern int gen_nodefile_on_sister_mom;
 
-extern int     mom_net_up;
-extern time_t  mom_net_up_time;
-extern int		max_poll_downtime_val;
-extern  char   *msg_err_malloc;
+extern int mom_net_up;
+extern time_t mom_net_up_time;
+extern int max_poll_downtime_val;
+extern char *msg_err_malloc;
 extern int
 write_pipe_data(int upfds, void *data, int data_size);
-char	task_fmt[] = "/%8.8X";
+char task_fmt[] = "/%8.8X";
 extern void resume_multinode(job *pjob);
-
 
 /* Function pointers
  **
@@ -3163,6 +3163,18 @@ im_request(int stream, int version)
 				SEND_ERR(errcode)
 				goto done;
 			}
+
+			pjob->ji_hosts[0].hn_stream = stream;
+
+			if (gen_nodefile_on_sister_mom) {
+				char varlist[(2 * MAXPATHLEN) + 1] = "PBS_NODEFILE=";
+				char buf[MAXPATHLEN + 1];
+				if (generate_pbs_nodefile(pjob, buf, sizeof(buf) - 1, log_buffer, LOG_BUF_SIZE - 1) == 0) {
+					strcat(varlist, buf);
+					set_jattr_generic(pjob, JOB_ATR_variables, varlist, NULL, INCR);
+				}
+			}
+
 			/*
 			 ** Check to make sure we found ourself.
 			 */

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -183,54 +183,53 @@ HANDLE	hStop = NULL;
 #endif	/* WIN32 */
 extern void	mom_vnlp_report(vnl_t *vnl, char *header);
 
-int		alien_attach = 0;		/* attach alien procs */
-int		alien_kill = 0;			/* kill alien procs */
-int		lockfds;
-float		max_load_val   = -1.0;
-int		max_poll_downtime_val = PBS_MAX_POLL_DOWNTIME;
-char	       *mom_domain;
-char           *mom_home;
-char		mom_host[PBS_MAXHOSTNAME+1];
-pid_t		mom_pid;
-int		mom_run_state = 1;
-char		mom_short_name[PBS_MAXHOSTNAME+1];
-int		next_sample_time = MAX_CHECK_POLL_TIME;
-int		max_check_poll = MAX_CHECK_POLL_TIME;
-int		min_check_poll = MIN_CHECK_POLL_TIME;
-int		inc_check_poll = 20;
-int		num_acpus = 1;
-int		num_pcpus = 1;
-int		num_oscpus = 1;
-u_Long		av_phy_mem = 0;	/* physical memory in KB */
-int		num_var_env;
-char	       *path_epilog;
-char	       *path_jobs;
-char	       *path_prolog;
-char	       *path_spool;
-char	       *path_undeliv;
-char	       *path_addconfigs;
-char		path_addconfigs_reserved_prefix[] = "PBS";
+int alien_attach = 0; /* attach alien procs */
+int alien_kill = 0;	  /* kill alien procs */
+int lockfds;
+float max_load_val = -1.0;
+int max_poll_downtime_val = PBS_MAX_POLL_DOWNTIME;
+char *mom_domain;
+char *mom_home;
+char mom_host[PBS_MAXHOSTNAME + 1];
+pid_t mom_pid;
+int mom_run_state = 1;
+char mom_short_name[PBS_MAXHOSTNAME + 1];
+int next_sample_time = MAX_CHECK_POLL_TIME;
+int max_check_poll = MAX_CHECK_POLL_TIME;
+int min_check_poll = MIN_CHECK_POLL_TIME;
+int inc_check_poll = 20;
+int num_acpus = 1;
+int num_pcpus = 1;
+int num_oscpus = 1;
+u_Long av_phy_mem = 0; /* physical memory in KB */
+int num_var_env;
+char *path_epilog;
+char *path_jobs;
+char *path_prolog;
+char *path_spool;
+char *path_undeliv;
+char *path_addconfigs;
+char path_addconfigs_reserved_prefix[] = "PBS";
 
-char	       *path_hooks;
-char	       *path_hooks_workdir;
-char		*path_rescdef;
-hook		*phook;
-char		*hook_suffix = HOOK_FILE_SUFFIX;
-int		hook_suf_len;
-char		hook_msg[HOOK_MSG_SIZE+1];
-int		baselen;
-char		*psuffix;
-struct	dirent	*pdirent;
-DIR		*dir;
-/*char		pbs_current_user[PBS_MAXUSER] = "pbs_mom";*/  /* for libpbs.a */
+char *path_hooks;
+char *path_hooks_workdir;
+char *path_rescdef;
+hook *phook;
+char *hook_suffix = HOOK_FILE_SUFFIX;
+int hook_suf_len;
+char hook_msg[HOOK_MSG_SIZE + 1];
+int baselen;
+char *psuffix;
+struct dirent *pdirent;
+DIR *dir;
+/*char		pbs_current_user[PBS_MAXUSER] = "pbs_mom";*/ /* for libpbs.a */
 /* above is TLS data now, strcpy the value "pbs_mom" into it in main */
 
-char            pbs_tmpdir[_POSIX_PATH_MAX] = TMP_DIR;
-char            pbs_jobdir_root[_POSIX_PATH_MAX]= "";
-int		pbs_jobdir_root_shared = FALSE;
-vnl_t		*vnlp = NULL;			/* vnode list */
-unsigned long	hooks_rescdef_checksum = 0;
-
+char pbs_tmpdir[_POSIX_PATH_MAX] = TMP_DIR;
+char pbs_jobdir_root[_POSIX_PATH_MAX] = "";
+int pbs_jobdir_root_shared = FALSE;
+vnl_t *vnlp = NULL; /* vnode list */
+unsigned long hooks_rescdef_checksum = 0;
 
 /* vnlp_from_hook: vnode list changes made by an exechost_startup hook, that */
 /* sent to the server initially as part of the IS_HELLO/IS_CLUSTER_ADDR/ */
@@ -238,67 +237,68 @@ unsigned long	hooks_rescdef_checksum = 0;
 /* entries matching HOOK_VNL_PERSISTENT_ATTRIBS will be merged with the */
 /* main vnlp structure,  which gets  resent when server loses contact */
 /* with mom, and server sends an IS_HELLO request */
-vnl_t		*vnlp_from_hook = NULL;
+vnl_t *vnlp_from_hook = NULL;
 
-extern char	*msg_startup1;
-extern char	*msg_init_chdir;
-extern char     *msg_corelimit;
-int		pbs_errno;
-gid_t		pbsgroup;
-unsigned int	pbs_mom_port;
-unsigned int	pbs_rm_port;
-pbs_list_head	mom_polljobs;	/* jobs that must have resource limits polled */
-pbs_list_head	mom_deadjobs;	/* jobs that need to purged, see chk_del_job */
-int		server_stream = -1;
-pbs_list_head	svr_newjobs;	/* jobs being sent to MOM */
-pbs_list_head	svr_alljobs;	/* all jobs under MOM's control */
-time_t		time_last_sample = 0;
-extern time_t		time_now;
-time_t		time_resc_updated = 0;
+extern char *msg_startup1;
+extern char *msg_init_chdir;
+extern char *msg_corelimit;
+int pbs_errno;
+gid_t pbsgroup;
+unsigned int pbs_mom_port;
+unsigned int pbs_rm_port;
+pbs_list_head mom_polljobs; /* jobs that must have resource limits polled */
+pbs_list_head mom_deadjobs; /* jobs that need to purged, see chk_del_job */
+int server_stream = -1;
+pbs_list_head svr_newjobs; /* jobs being sent to MOM */
+pbs_list_head svr_alljobs; /* all jobs under MOM's control */
+time_t time_last_sample = 0;
+extern time_t time_now;
+time_t time_resc_updated = 0;
 extern pbs_list_head svr_requests;
-struct var_table vtable;	/* see start_exec.c */
+struct var_table vtable; /* see start_exec.c */
 
 #if defined(PBS_SECURITY) && (PBS_SECURITY == KRB5)
 extern pbs_list_head svr_allcreds;
 #endif
 
-#if	MOM_ALPS
-#define	ALPS_REL_WAIT_TIME_DFLT		400000;	/* 0.4 sec */
-#define	ALPS_REL_JITTER_DFLT		120000;	/* 0.12 sec */
-#define	ALPS_REL_TIMEOUT		600;	/* 10 min */
-#define	ALPS_CONF_EMPTY_TIMEOUT		10;	/* 10 sec */
-#define	ALPS_CONF_SWITCH_TIMEOUT	35;	/* 35 sec */
-char	       *alps_client = NULL;
-useconds_t	alps_release_wait_time = ALPS_REL_WAIT_TIME_DFLT;
-useconds_t	alps_release_jitter = ALPS_REL_JITTER_DFLT;
-int		vnode_per_numa_node;
-int		alps_release_timeout;
-int		alps_confirm_empty_timeout;
-int		alps_confirm_switch_timeout;
+#if MOM_ALPS
+#define ALPS_REL_WAIT_TIME_DFLT 400000; /* 0.4 sec */
+#define ALPS_REL_JITTER_DFLT 120000;	/* 0.12 sec */
+#define ALPS_REL_TIMEOUT 600;			/* 10 min */
+#define ALPS_CONF_EMPTY_TIMEOUT 10;		/* 10 sec */
+#define ALPS_CONF_SWITCH_TIMEOUT 35;	/* 35 sec */
+char *alps_client = NULL;
+useconds_t alps_release_wait_time = ALPS_REL_WAIT_TIME_DFLT;
+useconds_t alps_release_jitter = ALPS_REL_JITTER_DFLT;
+int vnode_per_numa_node;
+int alps_release_timeout;
+int alps_confirm_empty_timeout;
+int alps_confirm_switch_timeout;
 #endif /* MOM_ALPS */
-char	       *path_checkpoint = NULL;
-static		resource_def *rdcput;
-static		resource_def *rdwall;
-int		restart_background = FALSE;
-int		reject_root_scripts = FALSE;
-int		report_hook_checksums = TRUE;
-int		restart_transmogrify = FALSE;
-int		attach_allow = TRUE;
-extern double		wallfactor;
-int		suspend_signal;
-int		resume_signal;
-int		cycle_harvester = 0;   /* MOM configured for cycle harvesting */
-int		restrict_user = 0;		/* kill non PBS user procs */
-int		restrict_user_maxsys = 999;	/* largest system user id */
-int		vnode_additive = 1;
-momvmap_t     **mommap_array = NULL;
-int		mommap_array_size = 0;
-unsigned long	QA_testing = 0;
+char *path_checkpoint = NULL;
+static resource_def *rdcput;
+static resource_def *rdwall;
+int restart_background = FALSE;
+int reject_root_scripts = FALSE;
+int report_hook_checksums = TRUE;
+int restart_transmogrify = FALSE;
+int attach_allow = TRUE;
+extern double wallfactor;
+int suspend_signal;
+int resume_signal;
+int cycle_harvester = 0;		/* MOM configured for cycle harvesting */
+int restrict_user = 0;			/* kill non PBS user procs */
+int restrict_user_maxsys = 999; /* largest system user id */
+int gen_nodefile_on_sister_mom = TRUE;
+int vnode_additive = 1;
+momvmap_t **mommap_array = NULL;
+int mommap_array_size = 0;
+unsigned long QA_testing = 0;
 
-long		joinjob_alarm_time = -1;
-long		job_launch_delay  = -1;	/* # of seconds to delay job launch due to pipe reads (pipe read timeout)  */
-int		update_joinjob_alarm_time = 0;
-int		update_job_launch_delay = 0;
+long joinjob_alarm_time = -1;
+long job_launch_delay = -1; /* # of seconds to delay job launch due to pipe reads (pipe read timeout)  */
+int update_joinjob_alarm_time = 0;
+int update_job_launch_delay = 0;
 
 #ifdef NAS /* localmod 015 */
 unsigned long	spoolsize = 0; /* default spoolsize = unlimited */
@@ -434,58 +434,59 @@ struct config_list {
 	struct	config		c;
 	struct	config_list	*c_link;
 };
-static handler_ret_t	config_versionhandler(char *, const char *, FILE *);
+static handler_ret_t config_versionhandler(char *, const char *, FILE *);
 
-static handler_ret_t	addclient(char *);
-static handler_ret_t	add_mom_action(char *);
-static handler_ret_t	config_verscheck(char *);
-static handler_ret_t	cputmult(char *);
-static handler_ret_t	parse_config(char *);
-static handler_ret_t	prologalarm(char *);
-static handler_ret_t	set_joinjob_alarm(char *);
-static handler_ret_t	set_job_launch_delay(char *);
-static handler_ret_t	restricted(char *);
-static handler_ret_t	set_alien_attach(char *);
-static handler_ret_t	set_alien_kill(char *);
-#if	MOM_ALPS
-static handler_ret_t	set_alps_client(char *);
-static handler_ret_t	set_alps_release_wait_time(char *);
-static handler_ret_t	set_alps_release_jitter(char *);
-static handler_ret_t	set_alps_release_timeout(char *);
-static handler_ret_t	set_alps_confirm_empty_timeout(char *);
-static handler_ret_t	set_vnode_per_numa_node(char *);
-static handler_ret_t	set_alps_confirm_switch_timeout(char *);
-#endif	/* MOM_ALPS */
-static handler_ret_t	set_attach_allow(char *);
-static handler_ret_t	set_checkpoint_path(char *);
-static handler_ret_t	set_enforcement(char *);
-static handler_ret_t	set_jobdir_root(char *);
-static handler_ret_t	set_kbd_idle(char *);
-static handler_ret_t	set_max_check_poll(char *);
-static handler_ret_t	set_min_check_poll(char *);
-static handler_ret_t	set_momname(char *);
-static handler_ret_t	set_momport(char *);
-#ifdef	WIN32
-static handler_ret_t	set_nrun_factor(char *);
+static handler_ret_t addclient(char *);
+static handler_ret_t add_mom_action(char *);
+static handler_ret_t config_verscheck(char *);
+static handler_ret_t cputmult(char *);
+static handler_ret_t parse_config(char *);
+static handler_ret_t prologalarm(char *);
+static handler_ret_t set_joinjob_alarm(char *);
+static handler_ret_t set_job_launch_delay(char *);
+static handler_ret_t restricted(char *);
+static handler_ret_t set_alien_attach(char *);
+static handler_ret_t set_alien_kill(char *);
+#if MOM_ALPS
+static handler_ret_t set_alps_client(char *);
+static handler_ret_t set_alps_release_wait_time(char *);
+static handler_ret_t set_alps_release_jitter(char *);
+static handler_ret_t set_alps_release_timeout(char *);
+static handler_ret_t set_alps_confirm_empty_timeout(char *);
+static handler_ret_t set_vnode_per_numa_node(char *);
+static handler_ret_t set_alps_confirm_switch_timeout(char *);
+#endif /* MOM_ALPS */
+static handler_ret_t set_attach_allow(char *);
+static handler_ret_t set_checkpoint_path(char *);
+static handler_ret_t set_enforcement(char *);
+static handler_ret_t set_jobdir_root(char *);
+static handler_ret_t set_kbd_idle(char *);
+static handler_ret_t set_max_check_poll(char *);
+static handler_ret_t set_min_check_poll(char *);
+static handler_ret_t set_momname(char *);
+static handler_ret_t set_momport(char *);
+#ifdef WIN32
+static handler_ret_t set_nrun_factor(char *);
 #endif
-static handler_ret_t	set_restart_background(char *);
-static handler_ret_t	set_restart_transmogrify(char *);
-static handler_ret_t	set_restrict_user(char *);
-static handler_ret_t	set_restrict_user_maxsys(char *);
-static handler_ret_t	set_restrict_user_exceptions(char *);
-static handler_ret_t	set_suspend_signal(char *);
-static handler_ret_t	set_tmpdir(char *);
-static handler_ret_t	set_vnode_additive(char *);
-static handler_ret_t	setidealload(char *);
-static handler_ret_t	setlogevent(char *);
-static handler_ret_t	set_reject_root_scripts(char *);
-static handler_ret_t	set_report_hook_checksums(char *);
-static handler_ret_t	setmaxload(char *);
-static handler_ret_t	set_max_poll_downtime(char *);
-static handler_ret_t	usecp(char *);
-static handler_ret_t	wallmult(char *);
+static handler_ret_t set_restart_background(char *);
+static handler_ret_t set_restart_transmogrify(char *);
+static handler_ret_t set_restrict_user(char *);
+static handler_ret_t set_restrict_user_maxsys(char *);
+static handler_ret_t set_restrict_user_exceptions(char *);
+static handler_ret_t set_gen_nodefile_on_sister_mom(char *);
+static handler_ret_t set_suspend_signal(char *);
+static handler_ret_t set_tmpdir(char *);
+static handler_ret_t set_vnode_additive(char *);
+static handler_ret_t setidealload(char *);
+static handler_ret_t setlogevent(char *);
+static handler_ret_t set_reject_root_scripts(char *);
+static handler_ret_t set_report_hook_checksums(char *);
+static handler_ret_t setmaxload(char *);
+static handler_ret_t set_max_poll_downtime(char *);
+static handler_ret_t usecp(char *);
+static handler_ret_t wallmult(char *);
 #ifdef NAS /* localmod 015 */
-static handler_ret_t	set_spoolsize(char *);
+static handler_ret_t set_spoolsize(char *);
 #endif /* localmod 015 */
 
 static struct	specials {
@@ -540,6 +541,7 @@ static struct	specials {
 	{ "restrict_user_exceptions",	set_restrict_user_exceptions },
 	{ "restrict_user_maxsysid",	set_restrict_user_maxsys },
 	{ "restricted",			restricted },
+	{ "gen_nodefile_on_sister_mom",  set_gen_nodefile_on_sister_mom},
 #ifdef NAS /* localmod 015 */
 	/*
 	 * spool size limit
@@ -3505,6 +3507,24 @@ set_restrict_user_exceptions(char *user_list)
 
 /**
  * @brief
+ *      sets value for gen_nodefile_on_sister_mom
+ *
+ * @param[in] value - value for gen_nodefile_on_sister_mom
+ *
+ * @return      handler_ret_t
+ * @retval      HANDLER_SUCCESS         success
+ * @retval      HANDLER_FAIL            Failure
+ *
+ */
+
+static handler_ret_t
+set_gen_nodefile_on_sister_mom(char *value)
+{
+	return (set_boolean(__func__, value, &gen_nodefile_on_sister_mom));
+}
+
+/**
+ * @brief
  *	Set the configuration flag that defines whether to get rid of
  *	all vnode defs when reading the config files.
  *
@@ -4003,6 +4023,7 @@ read_config(char *file)
 	strcpy(pbs_jobdir_root, "");
 	restrict_user = 0;
 	restrict_user_maxsys = 999;
+	gen_nodefile_on_sister_mom = TRUE;
 	for (j=0; j < NUM_RESTRICT_USER_EXEMPT_UIDS; j++)
 		if (restrict_user_exempt_uids[j] != 0)
 			restrict_user_exempt_uids[j] = 0;

--- a/test/tests/functional/pbs_gen_nodefile_on_sister_mom.py
+++ b/test/tests/functional/pbs_gen_nodefile_on_sister_mom.py
@@ -1,0 +1,197 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2020 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of both the OpenPBS software ("OpenPBS")
+# and the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# OpenPBS is free software. You can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# OpenPBS is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# PBS Pro is commercially licensed software that shares a common core with
+# the OpenPBS software.  For a copy of the commercial license terms and
+# conditions, go to: (http://www.pbspro.com/agreement.html) or contact the
+# Altair Legal Department.
+#
+# Altair's dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of OpenPBS and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair's trademarks, including but not limited to "PBS™",
+# "OpenPBS®", "PBS Professional®", and "PBS Pro™" and Altair's logos is
+# subject to Altair's trademark licensing policies.
+
+
+from tests.functional import *
+
+
+class TestGenNodefileOnSisterMom(TestFunctional):
+    """
+    This test suite tests the PBS_NODEFILE creation on
+    sister moms of job.
+    """
+    def test_gen_nodefile_on_sister_mom_default(self):
+        """
+        This test case verifies PBS_NODEFILE gets created on
+        sister mom by default
+        """
+        # Skip test if number of mom provided is not equal to two
+        if not len(self.moms) == 2:
+            self.skipTest("test requires two MoMs as input, " +
+                          "use -p moms=<mom1:mom2>")
+        ms = self.moms.keys()[0]
+        sister_mom = self.moms.keys()[1]
+        j = Job(TEST_USER)
+        j.set_attributes({'Resource_List.select': '2:ncpus=1',
+                          'Resource_List.place': 'scatter'})
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        nodefile = os.path.join(self.server.pbs_conf['PBS_HOME'],
+                                "aux", jid)
+
+        file_exists = self.du.isfile(hostname=sister_mom, path=nodefile,
+                                     sudo=True)
+        self.assertTrue(file_exists, "PBS_NODEFILE not created in "
+                                     "sister mom %s" % sister_mom)
+        sister_nodes = "\n".join(self.du.cat(sister_mom, nodefile,
+                                             sudo=True)['out'])
+        ms_nodes = "\n".join(self.du.cat(ms, nodefile, sudo=True)['out'])
+        self.assertEqual(ms_nodes, sister_nodes)
+        self.server.log_match(jid + ";Exit_status=0", interval=4,
+                              max_attempts=30)
+        file_exists = self.du.isfile(hostname=sister_mom, path=nodefile,
+                                     sudo=True)
+        self.assertFalse(file_exists, "PBS_NODEFILE not deleted in "
+                                      "sister mom %s" % sister_mom)
+
+    def test_gen_nodefile_on_sister_mom_config_enabled(self):
+        """
+        This test case verifies PBS_NODEFILE gets created on
+        sister mom on setting gen_nodefile_on_sister_mom mom
+        config parameter to true.
+        """
+        # Skip test if number of mom provided is not equal to two
+        if not len(self.moms) == 2:
+            self.skipTest("test requires two MoMs as input, " +
+                          "use -p moms=<mom1:mom2>")
+        ms = self.moms.keys()[0]
+        sister_mom = self.moms.keys()[1]
+        sister_mom_obj = self.moms.values()[1]
+        sister_mom_obj.add_config({'$gen_nodefile_on_sister_mom': 1})
+
+        j = Job(TEST_USER)
+        j.set_attributes({'Resource_List.select': '2:ncpus=1',
+                          'Resource_List.place': 'scatter'})
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        nodefile = os.path.join(self.server.pbs_conf['PBS_HOME'],
+                                "aux", jid)
+
+        file_exists = self.du.isfile(hostname=sister_mom, path=nodefile,
+                                     sudo=True)
+        self.assertTrue(file_exists, "PBS_NODEFILE not created in "
+                                     "sister mom %s" % sister_mom)
+        sister_nodes = "\n".join(self.du.cat(sister_mom, nodefile,
+                                             sudo=True)['out'])
+        ms_nodes = "\n".join(self.du.cat(ms, nodefile, sudo=True)['out'])
+        self.assertEqual(ms_nodes, sister_nodes)
+        self.server.log_match(jid + ";Exit_status=0", interval=4,
+                              max_attempts=30)
+        file_exists = self.du.isfile(hostname=sister_mom, path=nodefile,
+                                     sudo=True)
+        self.assertFalse(file_exists, "PBS_NODEFILE not deleted in "
+                                      "sister mom %s" % sister_mom)
+
+    def test_gen_nodefile_on_sister_mom_config_disabled(self):
+        """
+        This test case verifies PBS_NODEFILE does not get created
+        on sister mom on setting gen_nodefile_on_sister_mom mom
+        config parameter to false.
+        """
+        # Skip test if number of mom provided is not equal to two
+        if not len(self.moms) == 2:
+            self.skipTest("test requires two MoMs as input, " +
+                          "use -p moms=<mom1:mom2>")
+
+        sister_mom = self.moms.keys()[1]
+        sister_mom_obj = self.moms.values()[1]
+        sister_mom_obj.add_config({'$gen_nodefile_on_sister_mom': 0})
+        j = Job(TEST_USER)
+        j.set_attributes({'Resource_List.select': '2:ncpus=1',
+                          'Resource_List.place': 'scatter'})
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        nodefile = os.path.join(self.server.pbs_conf['PBS_HOME'],
+                                "aux", jid)
+
+        file_exists = self.du.isfile(hostname=sister_mom, path=nodefile,
+                                     sudo=True)
+        self.assertFalse(file_exists, "PBS_NODEFILE created in "
+                                      "sister mom %s" % sister_mom)
+
+    def test_gen_nodefile_on_sister_mom_hup(self):
+        """
+        This test suite verifies PBS_NODEFILE does not get created
+        on sister mom on setting gen_nodefile_on_sister_mom mom
+        config parameter to false and then HUP the mom to verify if
+        PBS_NODEFILE is created on sister.
+        """
+        # Skip test if number of mom provided is not equal to two
+        if not len(self.moms) == 2:
+            self.skipTest("test requires two MoMs as input, " +
+                          "use -p moms=<mom1:mom2>")
+        ms = self.moms.keys()[0]
+        sister_mom = self.moms.keys()[1]
+        sister_mom_obj = self.moms.values()[1]
+        sister_mom_obj.add_config({'$gen_nodefile_on_sister_mom': 0})
+        j = Job(TEST_USER)
+        j.set_attributes({'Resource_List.select': '2:ncpus=1',
+                          'Resource_List.place': 'scatter'})
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        nodefile = os.path.join(self.server.pbs_conf['PBS_HOME'], "aux", jid)
+
+        file_exists = self.du.isfile(hostname=sister_mom, path=nodefile,
+                                     sudo=True)
+        self.assertFalse(file_exists, "PBS_NODEFILE created in "
+                                      "sister mom %s" % sister_mom)
+        self.server.delete(jid)
+        config = {'$clienthost': self.server.hostname}
+        sister_mom_obj.config = config
+        sister_mom_obj.apply_config(config)
+        j = Job(TEST_USER)
+        j.set_attributes({'Resource_List.select': '2:ncpus=1',
+                          'Resource_List.place': 'scatter'})
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        nodefile = os.path.join(self.server.pbs_conf['PBS_HOME'], "aux", jid)
+        file_exists = self.du.isfile(hostname=sister_mom, path=nodefile,
+                                     sudo=True)
+        self.assertTrue(file_exists, "PBS_NODEFILE not created in "
+                                     "sister mom %s" % sister_mom)
+        sister_nodes = "\n".join(self.du.cat(sister_mom, nodefile,
+                                             sudo=True)['out'])
+        ms_nodes = "\n".join(self.du.cat(ms, nodefile, sudo=True)['out'])
+        self.assertEqual(ms_nodes, sister_nodes)
+        self.server.log_match(jid + ";Exit_status=0", interval=4,
+                              max_attempts=30)
+        file_exists = self.du.isfile(hostname=sister_mom, path=nodefile,
+                                     sudo=True)
+        self.assertFalse(file_exists, "PBS_NODEFILE not deleted in "
+                                      "sister mom %s" % sister_mom)

--- a/test/tests/functional/pbs_job_task.py
+++ b/test/tests/functional/pbs_job_task.py
@@ -103,3 +103,41 @@ class TestJobTask(TestFunctional):
         if job_status:
             job_output_file = job_status[0]['Output_Path'].split(':')[1]
         self.check_jobs_file(job_output_file)
+
+    def test_invoke_pbs_tmrsh_from_sister_mom(self):
+        """
+        This test cases verifies pbs_tmrsh invoked from sister mom
+        executes successfully
+        """
+        # Skip test if number of mom provided is not equal to three
+        if not len(self.moms) == 3:
+            self.skipTest("test requires three MoMs as input, " +
+                          "use -p moms=<mom1:mom2:mom3>")
+        mom1 = self.moms.keys()[0]
+        mom2 = self.moms.keys()[1]
+        mom3 = self.moms.keys()[2]
+        pbstmrsh_cmd = os.path.join(self.server.pbs_conf['PBS_EXEC'],
+                                    'bin', 'pbs_tmrsh')
+
+        script_mom2 = """#!/bin/bash\n%s %s hostname""" % \
+                      (pbstmrsh_cmd, mom3)
+        fn = self.du.create_temp_file(hostname=mom2, body=script_mom2)
+        self.du.chmod(hostname=mom2, path=fn, mode=0o755)
+        a = {ATTR_S: '/bin/bash'}
+        script = ['%s %s %s' % (pbstmrsh_cmd, mom2, fn)]
+        job = Job(TEST_USER, attrs=a)
+        job.set_attributes({'Resource_List.select': '3:ncpus=1',
+                            'Resource_List.place': 'scatter'})
+        job.create_script(body=script)
+        jid = self.server.submit(job)
+
+        self.server.expect(JOB, {'job_state': 'F'}, id=jid, extend='x')
+        job_status = self.server.status(JOB, id=jid, extend='x')
+        if job_status:
+            job_output_file = job_status[0]['Output_Path'].split(':')[1]
+
+        ret = self.du.cat(hostname=mom1, filename=job_output_file,
+                          runas=TEST_USER)
+        self.assertEqual(ret['out'][0], mom3, "pbs_tmrsh invoked from sister"
+                                              " mom did not execute "
+                                              "successfully")


### PR DESCRIPTION
#### Describe Bug or Feature
pbs_tmrsh invoked from sister moms fails with "cannot find PBS_NODEFILE".

#### Describe Your Change
1. PBS_NODEFILE environment variable to be set in sister mom. 
2. PBS_NODEFILE to be created in sister moms. 
3. The above change is enabled by default. For disabling it, a new boolean mom config parameter is introduced i.e. $secondary_pbs_nodefile

After making the above changes, the invocation was still failing with this error message - "start_process, no stream to MS". Explicitly initializing the mother superior's stream resolves this. 

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[TestSecondaryPBSNodefile.txt](https://github.com/openpbs/openpbs/files/5640835/TestSecondaryPBSNodefile.txt)
[TestJobTask.txt](https://github.com/openpbs/openpbs/files/5640836/TestJobTask.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
