### PR TITLE
Fix: Interactive job does not stay logged in

### DIFF
--- a/src/cmds/qsub.c
+++ b/src/cmds/qsub.c
@@ -3193,7 +3193,8 @@ regular_submit(int daemon_up)
 		else
 			rc = -1;
 	}
-	do_daemon_stuff();
+	if ((rc == 0) && !(Interact_opt != FALSE || block_opt) && (daemon_up == 0) && (no_background == 0) && !V_opt)
+		do_daemon_stuff();
 	return rc;
 }
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Interactive jobs don't stay logged in. The session ends abruptly without user intervention. This happens because the background qsub daemon exits one minute after it is created and the session exits with it.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
The do_daemon_stuff function should not be invoked when the job is interactive.


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[changelog.log](https://github.com/openpbs/openpbs/files/5641683/changelog.log)
![TH_Out](https://user-images.githubusercontent.com/40992476/101147706-bce81580-3642-11eb-86ef-04d3e8e7b4df.PNG)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
