### PR TITLE
downed node's hook files not deleted when node is deleted

### DIFF
--- a/src/server/mom_info.c
+++ b/src/server/mom_info.c
@@ -458,7 +458,7 @@ delete_svrmom_entry(mominfo_t *pmom)
 		/* we'll just send this delete request only once */
 		/* if a hook fails to delete, then that mom host when it */
 		/* come back will still have the hook. */
-		if (!(psvrmom->msr_state & INUSE_DOWN) && (mom_hooks_seen_count() > 0)) {
+		if (!(psvrmom->msr_state & INUSE_UNKNOWN) && (mom_hooks_seen_count() > 0)) {
 			uc_delete_mom_hooks(pmom);
 		}
 #endif


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
https://github.com/openpbs/openpbs/pull/1992 introduced a change that prevented deletion of hook files at mom which is in  down state when the node is deleted from the server

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
used `INUSE_UNKNOWN` instead of `INUSE_DOWN` to avoid unnecessary hook deletion operation


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[output_beforefix.txt](https://github.com/openpbs/openpbs/files/5654172/output_beforefix.txt)
[output_afterfix.txt](https://github.com/openpbs/openpbs/files/5654174/output_afterfix.txt)
[afterfix_logs.zip](https://github.com/openpbs/openpbs/files/5654177/afterfix_logs.zip)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
