### PR TITLE
Fix manager setting in maint resv test

### DIFF
--- a/test/tests/functional/pbs_maintenance_reservations.py
+++ b/test/tests/functional/pbs_maintenance_reservations.py
@@ -640,7 +640,7 @@ class TestMaintenanceReservations(TestFunctional):
         now = int(time.time())
 
         self.server.manager(MGR_CMD_SET, SERVER,
-                            {'managers': '%s@*' % TEST_USER})
+                            {'managers': (INCR, '%s@*' % TEST_USER)})
 
         a1 = {'reserve_start': now + 30,
               'reserve_end': now + 1200}


### PR DESCRIPTION
#### Describe Bug or Feature
Test was failing to change scheduling attribute with "No Permission"

#### Describe Your Change
Instead of replacing the manager list, just add to it.

#### Link to Design Doc
N/A

#### Attach Test and Valgrind Logs/Output
[logs.txt](https://github.com/openpbs/openpbs/files/5655920/logs.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
