### PR TITLE
Fix vnode check in maint resv test

### DIFF
--- a/test/tests/functional/pbs_maintenance_reservations.py
+++ b/test/tests/functional/pbs_maintenance_reservations.py
@@ -600,10 +600,10 @@ class TestMaintenanceReservations(TestFunctional):
         exp_attr = {'reserve_state': (MATCH_RE, 'RESV_DEGRADED|12'),
                     'reserve_substate': 12}
         self.server.expect(RESV, exp_attr, id=rid1)
-        resv1 = self.server.status(RESV, id=rid1)
-        vnodes = resv1.get_vnodes()
+        self.server.status(RESV, id=rid1)
+        vnodes = r1.get_vnodes()
         self.assertEqual(len(vnodes), 1)
-        vnode = self.server.status(NODE, id=vnodes[0])
+        vnode = self.server.status(NODE, id=vnodes[0])[0]
         self.assertEqual(vnode['Mom'], self.momB.hostname)
 
         self.logger.info("Wait for reservation to start (2 minutes)")

--- a/test/tests/functional/pbs_maintenance_reservations.py
+++ b/test/tests/functional/pbs_maintenance_reservations.py
@@ -578,6 +578,12 @@ class TestMaintenanceReservations(TestFunctional):
 
         self.momA = self.moms.values()[0]
         self.momB = self.moms.values()[1]
+        vnodelist = self.server.status(NODE)
+        vnodelist = [v for v in vnodelist if v['Mom'] == self.momB.hostname]
+        if len(vnodelist) > 1:
+            vnode = vnodelist[1]['id']
+        else:
+            vnode = vnodelist[0]['id']
 
         select = 'host=%s+host=%s' % (self.momA.shortname,
                                       self.momB.shortname)
@@ -597,7 +603,7 @@ class TestMaintenanceReservations(TestFunctional):
 
         self.server.submit(r2)
 
-        exp_attr = {'resv_nodes': '(%s:ncpus=1)' % self.momB.shortname,
+        exp_attr = {'resv_nodes': '(%s:ncpus=1)' % vnode,
                     'reserve_state': (MATCH_RE, 'RESV_DEGRADED|12'),
                     'reserve_substate': 12}
         self.server.expect(RESV, exp_attr, id=rid1)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
TestMaintenanceReservations.test_maintenance_progressive_degrade_reservation was failing in validating `resv_nodes` of a mom on a cpuset host.

#### Describe Your Change
if a mom has multiple vnodes, use the second.


#### Attach Test and Valgrind Logs/Output
[logfile-2020-12-09-231807.txt](https://github.com/openpbs/openpbs/files/5669365/logfile-2020-12-09-231807.txt)





<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
