### PR TITLE
PTL Fix: Unable to load snapshot data due to missing import

### DIFF
--- a/test/fw/ptl/lib/ptl_service.py
+++ b/test/fw/ptl/lib/ptl_service.py
@@ -61,6 +61,8 @@ from ptl.lib.ptl_error import (PbsInitServicesError, PbsServiceError,
                                PtlLogMatchError)
 from ptl.lib.ptl_object import PBSObject
 
+from ptl.lib.ptl_constants import (SERVER, VNODE, QUEUE, JOB, 
+                                    RESV, SCHED, HOOK)
 
 class PBSInitServices(object):
     """

--- a/test/fw/ptl/lib/ptl_service.py
+++ b/test/fw/ptl/lib/ptl_service.py
@@ -61,8 +61,9 @@ from ptl.lib.ptl_error import (PbsInitServicesError, PbsServiceError,
                                PtlLogMatchError)
 from ptl.lib.ptl_object import PBSObject
 
-from ptl.lib.ptl_constants import (SERVER, VNODE, QUEUE, JOB, 
-                                    RESV, SCHED, HOOK)
+from ptl.lib.ptl_constants import (SERVER, VNODE, QUEUE, JOB,
+                                   RESV, SCHED, HOOK)
+
 
 class PBSInitServices(object):
     """


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
The ptl constants have not been imported in the ptl_service.py file. This causes the pbs_stat command to fail when used with a snapshot.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Include the constants needed from the ptl_constants.py file.


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[changelog.log](https://github.com/openpbs/openpbs/files/5658009/changelog.log)
![TH_Out](https://user-images.githubusercontent.com/40992476/101772532-7ba7a800-3b11-11eb-8df8-1cce437c59bf.PNG)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
