### PR TITLE
Fix for crash while destroying entry in connection table

### DIFF
--- a/src/lib/Libifl/conn_table.c
+++ b/src/lib/Libifl/conn_table.c
@@ -218,7 +218,7 @@ destroy_connection(int fd)
 	if (INVALID_SOCK(fd))
 		return -1;
 
-	if (fd > curr_connection_sz || allocated_connection == 0)
+	if (fd >= curr_connection_sz || allocated_connection == 0)
 		return 0;
 
 	LOCK_TABLE(-1);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* Mom crash in child process when child tries to close connection via net_close(), crash happens when net_close() is try to destroy connection entry whose fd is equal to connection table size (aka curr_connection_sz)
* `=` is missing condition check while validating given fd (aka table index number) against connection table size as connection table will always have entries == (curr_connection_sz - 1), so trying to access entry at curr_connection_sz will crash mom as it will be unknown memory pointer

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* added `=` in condition check

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
* None

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
* Couldn't find any steps without use of gdb, which can generate this crash (either manually or automated test) - So no tests
* But with help of gdb we can reproduce crash as below:
  1. Setup 3 node cluster
  2. Submit interactive job which will request one chunk on each mom like `qsub -lselect=ncpus=1+ncpus=1+ncpus=1 -lplace=scatter`
      -- Put MS under gdb, and run `p curr_connection_sz` - at this point it will be 0
  3. Run `pbsdsh hostname` in job's terminal
      -- At this point curr_connection_sz will be 24
      -- Also `p connection[24]` will point to some junk pointer and `p connection[23]` will have null value
  4. In gdb terminal run `call destroy_connection(24)` -- This will generate crash and gdb will show SIGSEGV message

* Before fix:
```
(gdb) p curr_connection_sz
$1 = 0
(gdb) c
Continuing.
[Detaching after fork from child process 35763]
[Detaching after fork from child process 35821]
^C
Program received signal SIGINT, Interrupt.
0x0000145c3178dba7 in epoll_pwait () from /lib64/libc.so.6
(gdb) p curr_connection_sz
$2 = 24
(gdb) p connection[24]
$3 = (pbs_conn_t *) 0x1fc7c5f
(gdb) call destroy_connection(24)

Program received signal SIGSEGV, Segmentation fault.
0x0000145c31714aec in free () from /lib64/libc.so.6
The program being debugged was signaled while in a function called from GDB.
GDB remains in the frame where the signal was received.
To change this behavior use "set unwindonsignal on".
Evaluation of the expression containing the function
(destroy_connection) will be abandoned.
When the function is done executing, GDB will silently stop.
(gdb) bt
#0  0x0000145c31714aec in free () from /lib64/libc.so.6
#1  0x0000000000496908 in _destroy_connection (fd=24) at ../../../../src/lib/Libpbs/../Libifl/conn_table.c:158
#2  0x0000000000496ab0 in destroy_connection (fd=24) at ../../../../src/lib/Libpbs/../Libifl/conn_table.c:221
#3  <function called from gdb>
#4  0x0000145c3178dba7 in epoll_pwait () from /lib64/libc.so.6
#5  0x00000000004abf1e in tpp_em_pwait (em_ctx=0x1f60380, ev_array=0x7fffd178cda0, timeout=2000, 
    sigmask=0x7fffd178cca0) at ../../../../src/lib/Libpbs/../Libtpp/tpp_em.c:333
#6  0x000000000048c132 in wait_request (waittime=2, priority_context=0x0)
    at ../../../../src/lib/Libnet/net_server.c:569
#7  0x000000000045b89e in finish_loop (waittime=2) at ../../../src/resmom/mom_main.c:6511
#8  0x000000000046171f in main (argc=1, argv=0x7fffd178e228) at ../../../src/resmom/mom_main.c:9553
(gdb) p connection[23]
$4 = (pbs_conn_t *) 0x0
(gdb) 
```

* After fix:
```
(gdb) p curr_connection_sz
$1 = 0
(gdb) c
Continuing.
[Detaching after fork from child process 39984]
[Detaching after fork from child process 40042]
^C
Program received signal SIGINT, Interrupt.
0x00001510aac63ba7 in epoll_pwait () from /lib64/libc.so.6
(gdb) p curr_connection_sz
$2 = 24
(gdb) p connection[24]
$3 = (pbs_conn_t *) 0x485f746900000000
(gdb) call destroy_connection(24)
$4 = 0
(gdb) 
```


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
