### PR TITLE
Simplify TPP

### DIFF
--- a/src/include/avltree.h
+++ b/src/include/avltree.h
@@ -79,6 +79,7 @@ typedef struct {
 #define AVL_DUP_KEYS_OK 0x01 /* repeated key & rec cause an error message */
 #define AVL_CASE_CMP    0x02 /* case insensitive search */
 
+extern void avl_set_maxthreads(int n);
 extern void *get_avl_tls(void);
 extern int avl_create_index(AVL_IX_DESC *pix, int flags, int keylength);
 extern void avl_destroy_index(AVL_IX_DESC *pix);

--- a/src/include/log.h
+++ b/src/include/log.h
@@ -107,7 +107,6 @@ extern int set_msgdaemonname(char *ch);
 void set_log_conf(char *leafname, char *nodename,
 		  unsigned int islocallog, unsigned int sl_fac, unsigned int sl_svr,
 		  unsigned int log_highres);
-extern void *log_get_tls_data(void);
 
 extern struct log_net_info *get_if_info(char *msg);
 extern void free_if_info(struct log_net_info *ni);

--- a/src/include/pbs_internal.h
+++ b/src/include/pbs_internal.h
@@ -245,7 +245,6 @@ struct pbs_config
 	char *pbs_output_host_name;	/* name of host to which to stage std out/err */
 	unsigned pbs_use_compression:1;	/* whether pbs should compress communication data */
 	unsigned pbs_use_mcast:1;		/* whether pbs should multicast communication */
-	unsigned pbs_use_ft:1;		/* whether pbs should force use fault tolerant communications */
 	char *pbs_leaf_name;			/* non-default name of this leaf in the communication network */
 	char *pbs_leaf_routers;		/* for this leaf, the optional list of routers to talk to */
 	char *pbs_comm_name;			/* non-default name of this router in the communication network */
@@ -288,7 +287,6 @@ extern struct pbs_config pbs_conf;
 #define PBS_CONF_DATA_SERVICE_HOST           "PBS_DATA_SERVICE_HOST"
 #define PBS_CONF_USE_COMPRESSION     	     "PBS_USE_COMPRESSION"
 #define PBS_CONF_USE_MCAST		     "PBS_USE_MCAST"
-#define PBS_CONF_FORCE_FT_COMM		     "PBS_FORCE_FT_COMM"
 #define PBS_CONF_LEAF_NAME		     "PBS_LEAF_NAME"
 #define PBS_CONF_LEAF_ROUTERS		     "PBS_LEAF_ROUTERS"
 #define PBS_CONF_COMM_NAME		     "PBS_COMM_NAME"

--- a/src/include/svrfunc.h
+++ b/src/include/svrfunc.h
@@ -105,7 +105,9 @@ extern void mark_node_down(char *, char *);
 extern void mark_node_offline_by_mom(char *, char *);
 extern void clear_node_offline_by_mom(char *, char *);
 extern void mark_which_queues_have_nodes(void);
+#ifndef DEBUG
 extern void pbs_close_stdfiles(void);
+#endif
 extern int is_job_array(char *);
 extern int get_queued_subjobs_ct(job *);
 extern char *get_index_from_jid(char *);

--- a/src/include/tpp.h
+++ b/src/include/tpp.h
@@ -141,7 +141,7 @@ extern void tpp_router_shutdown(void);
 extern int tpp_mcast_open(void);
 extern int tpp_mcast_add_strm(int, int);
 extern int *tpp_mcast_members(int, int *);
-extern int tpp_mcast_send(int, void *, unsigned int, unsigned int, unsigned int);
+extern int tpp_mcast_send(int, void *, unsigned int, unsigned int);
 extern int tpp_mcast_close(int);
 
 /**********************************************************************/

--- a/src/include/tpp.h
+++ b/src/include/tpp.h
@@ -86,12 +86,6 @@ extern "C" {
 
 #endif
 
-#define	RPP_RETRY	10
-/*
- **	Default allowed number of outstanding pkts.
- */
-#define	RPP_HIGHWATER	1024
-
 /*
  * Default number of RPP packets to check every server iteration
  */
@@ -108,8 +102,6 @@ extern "C" {
 #define TPP_AUTH_NODE           4  /* authenticated, but yet unknown node type till a join happens */
 
 extern	int	tpp_fd;
-extern	int	rpp_retry;
-extern	int	rpp_highwater;
 struct tpp_config {
 	int    node_type; /* leaf, proxy */
 	char   **routers; /* other proxy names (and backups) to connect to */
@@ -122,7 +114,6 @@ struct tpp_config {
 	int    tcp_keep_probes;
 	int    tcp_user_timeout;
 	int    buf_limit_per_conn; /* buffer limit per physical connection */
-	int    force_fault_tolerance; /* by default disabled */
 	pbs_auth_config_t *auth_config;
 	char **supported_auth_methods;
 };
@@ -131,7 +122,7 @@ struct tpp_config {
 extern int tpp_init(struct tpp_config *);
 extern void tpp_set_app_net_handler(void (*app_net_down_handler)(void *), void (*app_net_restore_handler)(void *));
 extern void tpp_set_logmask(long);
-extern int set_tpp_config(void (*log_fn)(int, const char *, char *), struct pbs_config *, struct tpp_config *, char *, int, char *);
+extern int set_tpp_config(struct pbs_config *, struct tpp_config *, char *, int, char *);
 extern void DIS_tpp_funcs();
 extern int tpp_open(char *, unsigned int);
 extern int tpp_close(int);
@@ -142,7 +133,6 @@ extern void tpp_terminate(void);
 extern void tpp_shutdown(void);
 extern struct sockaddr_in *tpp_getaddr(int);
 extern void tpp_add_close_func(int, void (*func)(int));
-extern void (*tpp_log_func)(int, const char *, char *);
 extern char *tpp_parse_hostname(char *, int *);
 extern int tpp_init_router(struct tpp_config *);
 extern void tpp_router_shutdown(void);

--- a/src/lib/Libecl/ecl_verify_values.c
+++ b/src/lib/Libecl/ecl_verify_values.c
@@ -1132,7 +1132,7 @@ verify_value_credname(int batch_request, int parent_object, int cmd,
 
 /**
  * @brief
- *	 for some attributes which can have 0 or +ve values like ATTR_rpp_retry
+ *	 for some attributes which can have 0 or +ve values
  *
  * @see
  *
@@ -1338,7 +1338,7 @@ verify_value_preempt_targets(int batch_request, int parent_object, int cmd,
 
 /**
  * @brief
- *	for some attributes which can have only +ve values, eg, ATTR_rpp_highwater
+ *	for some attributes which can have only +ve values
  *
  * @see
  *

--- a/src/lib/Libifl/pbs_loadconf.c
+++ b/src/lib/Libifl/pbs_loadconf.c
@@ -120,7 +120,6 @@ struct pbs_config pbs_conf = {
 	NULL,					/* pbs_smtp_server_name */
 	1, 					/* use compression by default with TCP */
 	1,					/* use mcast by default with TCP */
-	0,					/* force fault tolerant comm disabled by default */
 	NULL,					/* default leaf name */
 	NULL,					/* for leaf, default communication routers list */
 	NULL,					/* default router name */
@@ -515,10 +514,6 @@ __pbs_loadconf(int reload)
 				if (sscanf(conf_value, "%u", &uvalue) == 1)
 					pbs_conf.pbs_use_mcast = ((uvalue > 0) ? 1 : 0);
 			}
-			else if (!strcmp(conf_name, PBS_CONF_FORCE_FT_COMM)) {
-				if (sscanf(conf_value, "%u", &uvalue) == 1)
-					pbs_conf.pbs_use_ft = ((uvalue > 0) ? 1 : 0);
-			}
 			else if (!strcmp(conf_name, PBS_CONF_LEAF_NAME)) {
 				if (pbs_conf.pbs_leaf_name)
 					free(pbs_conf.pbs_leaf_name);
@@ -816,10 +811,6 @@ __pbs_loadconf(int reload)
 	if ((gvalue = getenv(PBS_CONF_USE_MCAST)) != NULL) {
 		if (sscanf(gvalue, "%u", &uvalue) == 1)
 			pbs_conf.pbs_use_mcast = ((uvalue > 0) ? 1 : 0);
-	}
-	if ((gvalue = getenv(PBS_CONF_FORCE_FT_COMM)) != NULL) {
-		if (sscanf(gvalue, "%u", &uvalue) == 1)
-			pbs_conf.pbs_use_ft = ((uvalue > 0) ? 1 : 0);
 	}
 	if ((gvalue = getenv(PBS_CONF_LEAF_NAME)) != NULL) {
 		if (pbs_conf.pbs_leaf_name)

--- a/src/lib/Liblog/pbs_log.c
+++ b/src/lib/Liblog/pbs_log.c
@@ -1039,6 +1039,8 @@ log_record(int eventtype, int objclass, int sev, const char *objname, const char
 sigunblock:
 #ifndef WIN32
 	sigprocmask(SIG_SETMASK, &old_mask, NULL);
+#else
+	return;
 #endif
 }
 

--- a/src/lib/Liblog/pbs_log.c
+++ b/src/lib/Liblog/pbs_log.c
@@ -1003,8 +1003,8 @@ void
 log_record(int eventtype, int objclass, int sev, const char *objname, const char *text)
 {
 	ms_time mst;
-	char slogbuf[LOG_BUF_SIZE];
 #ifndef WIN32
+	char slogbuf[LOG_BUF_SIZE];
 	sigset_t block_mask;
 	sigset_t old_mask;
 

--- a/src/lib/Liblog/pbs_log.c
+++ b/src/lib/Liblog/pbs_log.c
@@ -295,12 +295,7 @@ static int
 log_mutex_lock()
 {
 	if (pthread_mutex_lock(&log_write_mutex) != 0) {
-		FILE *err;
-		err = fopen("/dev/console", "w");
-		if (err != NULL) {
-			fprintf(err, "PBS cannot lock its log, errno = %d", errno);
-			fclose(err);
-		}
+		log_console_error("PBS cannot lock its log");
 		return -1;
 	}
 	return 0;
@@ -324,12 +319,7 @@ static int
 log_mutex_unlock()
 {
 	if (pthread_mutex_unlock(&log_write_mutex) != 0) {
-		FILE *err;
-		err = fopen("/dev/console", "w");
-		if (err != NULL) {
-			fprintf(err, "PBS cannot unlock its log, errno = %d", errno);
-			fclose(err);
-		}
+		log_console_error("PBS cannot unlock its log");
 		return -1;
 	}
 	return 0;

--- a/src/lib/Libtpp/tpp_client.c
+++ b/src/lib/Libtpp/tpp_client.c
@@ -107,16 +107,6 @@
  */
 int		tpp_fd = -1;
 
-/**
- *	Number of retrys to for each packet.
- */
-int		rpp_retry = RPP_RETRY;
-
-/**
- *	Number of packets to send before gettin an ACK.
- */
-int		rpp_highwater = RPP_HIGHWATER;
-
 /*
  * app_mbox is the "monitoring mechanism" for the application
  * send notifications to the application about incoming data
@@ -126,8 +116,6 @@ int		rpp_highwater = RPP_HIGHWATER;
  * notification to wake up waiting app thread from select/poll.
  */
 tpp_mbox_t app_mbox;
-
-static int tpp_child_terminated = 0; /* whether a forked child called tpp_terminate or not? */
 
 /* counters for various statistics */
 int oopkt_cnt = 0;  /* number of out of order packets received */
@@ -139,87 +127,12 @@ static tpp_addr_t *leaf_addrs = NULL;
 static int leaf_addr_count = 0;
 
 /*
- * We maintain queues for acks. When we receive data, we queue an ack with a max
- * expiry time. The ack packet is sent out "piggy-backed" on a outgoing data
- * packet or is sent out by itself, if the timer had expired.
- *
- * While queueing, we add the ack_info to two types of queues.
- * One, the global queue of all acks/retries, another is a per-stream queue.
- * This is done to make the code efficient.
- * There are occasions when we need to walk the list of global
- * acks pending to be sent out to see which ones need to be sent out first. In
- * such a case we walk the global queue. In other cases (like when a stream is
- * being closed), we walk the retry/ack queue associated with
- * the stream to delete pending acks.
- *
- * The memory allocated for the ack or retry info is only one, the
- * pointer to this structure is placed in both the queues (per-stream one and
- * the global one). Consequently, when we remove a ack-info (or retry-info) from
- * one of the queues, we need to remove it from the other queue too. And to be
- * able to do that, we store locations of the structure in either of the queues
- * inside the structure info itself.
- *
- * The above description is true for retry information too.
- *
- */
-
-/*
- * The ack information that is queued to be sent later, possibly
- * piggy backed on an outgoing data packet.
- *
- * The ack info and the ack queues are worked up only by the IO thread.
- */
-typedef struct {
-	unsigned int sd;     /* the stream to which it belongs */
-	unsigned int seq_no; /* the sequence number being acknowledged */
-	time_t ack_time;     /* the latest time at which the ack must be sent out */
-	tpp_que_elem_t *global_ack_node; /*
-					       * pointer to location in a global
-					       * queue of all acks
-					       */
-	tpp_que_elem_t *strm_ack_node;   /*
-					       * pointer to location in a queue of
-					       * acks for this stream
-					       */
-} ack_info_t;
-tpp_que_t global_ack_queue;           /* global ack queue for all streams */
-
-/*
- * The retry information that is queued to be used later. When a data packet
- * is sent out, we do not know whether it will reach the destination for sure.
- * For resilience (in case of multiple routers) we save the data packet in a
- * retry structure. If we do not get an ack for the sent packet within a
- * specified amount of time, we resend the packet, incrementing the retry count.
- *
- * When a packet is "saved" for resending later, a retry_info structure is
- * attached to it.
- *
- * The retry info and the retry queues are worked up only by the IO thread.
- *
- */
-typedef struct {
-	time_t retry_time; /* time at which data packet must be resent */
-	short acked;       /* this packet is already ack'd, don't resend,
-			    * delete when its out of the transport layer
-			    */
-	short sent_to_transport; /* don't delete a retry packet if it was sent
-				  * to the transport layer
-				  */
-	tpp_packet_t *data_pkt; /* separate data (from hdr) pkt, mcast case */
-	short retry_count;           /* number of times this data packet was re-sent */
-	tpp_que_elem_t *global_retry_node;
-	tpp_que_elem_t *strm_retry_node;
-} retry_info_t;
-tpp_que_t global_retry_queue; /* global retry queue for all streams */
-
-/*
  * The structure to hold information about the multicast channel
  */
 typedef struct {
 	int num_fds;   /* number of streams that are part of mcast channel */
 	int num_slots; /* number of slots in the channel (for resizing) */
 	int *strms;    /* array of member stream descriptors */
-	int *seqs;     /* array of sequence number that were used to send */
 } mcast_data_t;
 
 /*
@@ -240,26 +153,16 @@ typedef struct {
 
 	short used_locally;      /* Whether this stream was accessed locally by the APP, APP thread only */
 
-	unsigned int send_seq_no; /* APP thread only, sequence number of the next packet to be sent */
-	unsigned int seq_no_expected; /* IO thread only, sequence number of the next packet expected */
-
 	unsigned short u_state;   /* stream state, APP thread updates, IO thread read-only */
 	unsigned short t_state;
 	short lasterr;            /* updated by IO thread only, for future use */
-
-	short num_unacked_pkts;   /* IO thread - number of unacked packets on wire */
 
 	tpp_addr_t src_addr;  /* address of the source host */
 	tpp_addr_t dest_addr; /* address of destination host - set by APP thread, read-only by IO thread */
 
 	void *user_data;            /* user data set by tpp_dis functions. Basically used for DIS encoding */
 
-	tpp_packet_t *part_recv_pkt; /* buffer to keeping part packets received - IO thread only */
-	tpp_que_t recv_queue; /* received packets - APP thread only */
-	tpp_que_t oo_queue; /* Out of order packets - IO thread only */
-
-	tpp_que_t ack_queue; /* queued acks - IO thread only */
-	tpp_que_t retry_queue; /* list of shelved packets - IO thread only */
+	tpp_que_t recv_queue; /* received packets - APP thread only, hence no lock */
 
 	mcast_data_t *mcast_data; /* multicast related data in case of multicast stream type */
 
@@ -278,7 +181,7 @@ typedef struct {
 	stream_t *strm; /* pointer to the stream structure at this slot */
 } stream_slot_t;
 stream_slot_t *strmarray = NULL; /* array of streams */
-pthread_mutex_t strmarray_lock;       /* global lock for the streams array */
+pthread_rwlock_t strmarray_lock;      /* global lock for the streams array and streams_idx (not for an individual stream) */
 unsigned int max_strms = 0;           /* total number of streams allocated */
 
 /* the following two variables are used to quickly find out a unused slot */
@@ -296,10 +199,9 @@ typedef struct {
 	void (*strm_action_func)(unsigned int);
 } strm_action_info_t;
 
-/* global queue of stream slots to be marked FREE after TPP_CLOSE_WAIT time,
- * or streams with OO packets that need to be closed due to inactivity
- */
+/* global queue of stream slots to be marked FREE after TPP_CLOSE_WAIT time */
 tpp_que_t strm_action_queue;
+pthread_mutex_t strm_action_queue_lock;
 
 /* leaf specific stream states */
 #define TPP_STRM_STATE_OPEN             1   /* stream is open */
@@ -312,70 +214,42 @@ tpp_que_t strm_action_queue;
 #define TPP_MCAST_SLOT_INC              100 /* inc members in mcast group */
 
 /* the physical connection to the router from this leaf */
-int router_tfd = -1;
-tpp_router_t **routers = NULL;
-int max_routers = 0;
-int active_router = -1;
-int app_thread_active_router = -1;
-int no_active_router = 1;
+static tpp_router_t **routers = NULL;
+static int max_routers = 0;
 
 /* forward declarations of functions used by this code file */
 
 /* function pointers */
 void (*the_app_net_down_handler)(void *data) = NULL;
 void (*the_app_net_restore_handler)(void *data) = NULL;
-time_t leaf_next_event_expiry(time_t now);
+time_t leaf_next_event_expiry(time_t now); /* IO thread only */
 
 /* static functions */
 static int connect_router(tpp_router_t *r);
-static int get_active_router(int index);
+static tpp_router_t *get_active_router();
 static stream_t *get_strm_atomic(unsigned int sd);
 static stream_t *get_strm(unsigned int sd);
 static stream_t *alloc_stream(tpp_addr_t *src_addr, tpp_addr_t *dest_addr);
 static void free_stream(unsigned int sd);
 static void free_stream_resources(stream_t *strm);
-static void del_retries(stream_t *);
-static void del_acks(stream_t *);
-static void check_pending_acks(time_t now);
-static void check_retries(time_t now);
-static void queue_strm_close(stream_t *);
-static void strm_timeout_action(unsigned int sd);
-static void enque_timeout_strm(stream_t *strm);
-static tpp_que_elem_t *enque_retry_sorted(tpp_que_t *q, tpp_packet_t *pkt);
-static void queue_strm_free(unsigned int sd);
+static void queue_strm_close(stream_t *); /* call only by APP thread, however inserts into strm_action_queue */
+static void queue_strm_free(unsigned int sd); /* invoked by IO thread only, via acting on the strm_action_queue */
 static void act_strm(time_t now, int force);
 static int send_app_strm_close(stream_t *strm, int cmd, int error);
-static int shelve_pkt(tpp_packet_t *pkt, tpp_packet_t *data_pkt, time_t retry_time);
-static int shelve_mcast_pkt(tpp_mcast_pkt_hdr_t *mcast_hdr, int tfd, int seq, tpp_packet_t *pkt);
-static int queue_ack(stream_t *strm, unsigned char type, unsigned int seq_no_recvd);
-static int send_ack_packet(ack_info_t *ack);
-static int send_retry_packet(tpp_packet_t *pkt);
-static int unshelve_pkt(stream_t *strm, int seq_no_acked);
-static void *add_part_packet(stream_t *strm, void *data, int sz);
-static int send_pkt_to_app(stream_t *strm, unsigned char type, void *data, int sz);
+static void *add_strm_packet(stream_t *strm, void *data, int sz, int totlen);
+static int send_pkt_to_app(stream_t *strm, unsigned char type, void *data, int sz, int totlen);
 static stream_t *find_stream_with_dest(tpp_addr_t *dest_addr, unsigned int dest_sd, unsigned int dest_magic);
 static int tpp_send_inner(int sd, void *data, int len, int full_len, int cmprsd_len);
 static int send_spl_packet(stream_t *strm, int type);
-static void flush_acks(stream_t *strm);
-static void tpp_clr_retry(tpp_packet_t *pkt, stream_t *strm);
-static int leaf_send_ctl_join(int tfd, void *data, void *c);
+static int leaf_send_ctl_join(int tfd, void *c);
+static int send_to_router(tpp_packet_t *pkt);
 
 /* externally called functions */
-int leaf_pkt_postsend_handler(int tfd, tpp_packet_t *pkt, void *extra);
-int leaf_pkt_presend_handler(int tfd, tpp_packet_t *pkt, void *extra);
+int leaf_pkt_presend_handler(int tfd, tpp_packet_t *pkt, void *ctx, void *extra);
 int leaf_pkt_handler(int tfd, void *data, int len, void *ctx, void *extra);
 int leaf_close_handler(int tfd, int error, void *ctx, void *extra);
 int leaf_timer_handler(time_t now);
-int leaf_post_connect_handler(int tfd, void *data, void *c, void *extra);
-
-/*
- * Whether tpp is in fault tolerant mode.
- * Must have multiple routers to be in fault tolerant mode
- * This variable is set to zero by tpp_init if it does not find > 1 routers
- * configured
- *
- */
-static int tpp_fault_tolerant_mode = 1;
+int leaf_post_connect_handler(int tfd, void *data, void *ctx, void *extra);
 
 /**
  * @brief
@@ -401,12 +275,15 @@ get_strm_atomic(unsigned int sd)
 {
 	stream_t *strm = NULL;
 
-	tpp_lock(&strmarray_lock);
+	if (tpp_child_terminated == 1)
+		return NULL;
+
+	tpp_read_lock(&strmarray_lock); /* walking the array, so read lock */
 	if (sd < max_strms) {
 		if (strmarray[sd].slot_state == TPP_SLOT_BUSY)
 			strm = strmarray[sd].strm;
 	}
-	tpp_unlock(&strmarray_lock);
+	tpp_unlock_rwlock(&strmarray_lock);
 
 	return strm;
 }
@@ -463,7 +340,6 @@ get_strm(unsigned int sd)
  *	For example, in the case of pbs_server, such a handler is "ping_nodes".
  *
  * @see
- *	leaf_pkt_postsend_handler
  *	leaf_close_handler
  *
  * @param[in] - app_net_down_handler - ptr to a function (in the calling APP)
@@ -490,47 +366,48 @@ tpp_set_app_net_handler(void (*app_net_down_handler)(void *data), void (*app_net
 }
 
 static int
-leaf_send_ctl_join(int tfd, void *data, void *c)
+leaf_send_ctl_join(int tfd, void *c)
 {
 	tpp_context_t *ctx = (tpp_context_t *) c;
 	tpp_router_t *r;
-	tpp_join_pkt_hdr_t hdr;
-	tpp_chunk_t chunks[2];
+	tpp_join_pkt_hdr_t *hdr = NULL;
+	tpp_packet_t *pkt = NULL;
+	int len;
+	int i;
 
 	if (!ctx)
 		return 0;
 
 	if (ctx->type == TPP_ROUTER_NODE) {
-		int len;
-		int i;
-
 		r = (tpp_router_t *) ctx->ptr;
 		r->state = TPP_ROUTER_STATE_CONNECTING;
 
 		/* send a TPP_CTL_JOIN message */
-		memset(&hdr, 0, sizeof(tpp_join_pkt_hdr_t)); /* only to satisfy valgrind */
-		hdr.type = TPP_CTL_JOIN;
-		hdr.node_type = tpp_conf->node_type;
-		hdr.hop = 1;
-		hdr.index = r->index;
-		hdr.num_addrs = leaf_addr_count;
+		pkt = tpp_bld_pkt(pkt, NULL, sizeof(tpp_join_pkt_hdr_t), 1, (void **) &hdr);
+		if (!pkt) {
+			tpp_log(LOG_CRIT, __func__, "Failed to build packet");
+			return -1;
+		}
+
+		hdr->type = TPP_CTL_JOIN;
+		hdr->node_type = tpp_conf->node_type;
+		hdr->hop = 1;
+		hdr->index = r->index;
+		hdr->num_addrs = leaf_addr_count;
 
 		/* log my own leaf name to help in troubleshooting later */
 		for(i = 0; i < leaf_addr_count; i++) {
-			sprintf(tpp_get_logbuf(), "Registering address %s to pbs_comm", tpp_netaddr(&leaf_addrs[i]));
-			tpp_log_func(LOG_CRIT, NULL, tpp_get_logbuf());
+			tpp_log(LOG_CRIT, NULL, "Registering address %s to pbs_comm", tpp_netaddr(&leaf_addrs[i]));
 		}
 
-		len = sizeof(tpp_join_pkt_hdr_t);
-		chunks[0].data = &hdr;
-		chunks[0].len = len;
+		len = leaf_addr_count * sizeof(tpp_addr_t);
+		if (!tpp_bld_pkt(pkt, leaf_addrs, len, 1, NULL)) {
+			tpp_log(LOG_CRIT, __func__, "Failed to build packet");
+			return -1;
+		}
 
-		chunks[1].data = leaf_addrs;
-		chunks[1].len = (leaf_addr_count * sizeof(tpp_addr_t));
-
-		if (tpp_transport_vsend(r->conn_fd, chunks, 2) != 0) {
-			snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tpp_transport_vsend failed, err=%d", errno);
-			tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+		if (tpp_transport_vsend(r->conn_fd, pkt) != 0) { /* this has to go irrespective of router state being down */
+			tpp_log(LOG_CRIT, __func__, "tpp_transport_vsend failed, err=%d", errno);
 			return -1;
 		}
 	}
@@ -625,12 +502,12 @@ leaf_post_connect_handler(int tfd, void *data, void *c, void *extra)
 	 * and we have completed authentication
 	 * so send TPP_CTL_JOIN
 	 */
-	return leaf_send_ctl_join(tfd, data, c);
+	return leaf_send_ctl_join(tfd, c);
 }
 
 /**
  * @brief
- *	The function initiates a connection from the leaf to a router.
+ *	The function initiates a connection from the leaf to a router
  *
  * @par Functionality:
  *	This function calls tpp_transport_connect (from the transport layer)
@@ -644,7 +521,7 @@ leaf_post_connect_handler(int tfd, void *data, void *c, void *extra)
  *
  * @see
  *	tpp_transport_connect
- *	tpp_transport_vsend
+ *	send_to_router
  *
  * @param[in] r - struct router - info of the router to connect to
  *
@@ -665,7 +542,7 @@ connect_router(tpp_router_t *r)
 
 	/* since we connected we should add a context */
 	if ((ctx = (tpp_context_t *) malloc(sizeof(tpp_context_t))) == NULL) {
-		tpp_log_func(LOG_CRIT, __func__, "Out of memory allocating tpp context");
+		tpp_log(LOG_CRIT, __func__, "Out of memory allocating tpp context");
 		return -1;
 	}
 	ctx->ptr = r;
@@ -673,46 +550,10 @@ connect_router(tpp_router_t *r)
 
 	/* initiate connections to the tpp router (single for now) */
 	if (tpp_transport_connect(r->router_name, r->delay, ctx, &(r->conn_fd)) == -1) {
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Connection to pbs_comm %s failed", r->router_name);
-		tpp_log_func(LOG_ERR, NULL, tpp_get_logbuf());
+		tpp_log(LOG_ERR, NULL, "Connection to pbs_comm %s failed", r->router_name);
 		return -1;
 	}
 	return 0;
-}
-
-/**
- * @brief
- *	tpp leaf atfork prepare handler
- *  It acquires all (currently only strmarray_lock) before fork
- */
-void
-tpp_client_prefork()
-{
-	tpp_lock(&strmarray_lock);
-}
-
-/**
- * @brief
- *	tpp leaf postfork parent handler
- *  It releases all (currently only strmarray_lock) after fork in the parent process
- */
-void
-tpp_client_postfork_parent()
-{
-	tpp_unlock(&strmarray_lock);
-}
-
-/**
- * @brief
- *	tpp leaf postfork child handler
- *  Initialize a new strmarray_lock for the child and
- *  then call tpp_terminate()
- */
-void
-tpp_client_postfork_child()
-{
-	tpp_init_lock(&strmarray_lock);
-	tpp_terminate();
 }
 
 /**
@@ -724,7 +565,7 @@ tpp_client_postfork_child()
  *	initializes the transport layer by calling tpp_transport_init.
  *	It initializes the various mutexes and global queues of structures.
  *	It also registers a set of "handlers" that the transport layer calls
- *	using the IO thread into the leaf logic code, to drive retries, acks
+ *	using the IO thread into the leaf logic code
  *	etc.
  *
  * @see
@@ -746,16 +587,16 @@ tpp_client_postfork_child()
 int
 tpp_init(struct tpp_config *cnf)
 {
-	int rc;
-	int i;
+	int rc, i;
 	int app_fd;
 
 	tpp_conf = cnf;
 	if (tpp_conf->node_name == NULL) {
-		snprintf(log_buffer, TPP_LOGBUF_SZ, "TPP leaf node name is NULL");
-		tpp_log_func(LOG_CRIT, NULL, log_buffer);
+		tpp_log(LOG_CRIT, NULL,  "TPP leaf node name is NULL");
 		return -1;
 	}
+
+	tpp_log(LOG_CRIT, __func__, "App Thread id is %d", pthread_self());
 
 	/* before doing anything else, initialize the key to the tls */
 	if (tpp_init_tls_key() != 0) {
@@ -764,35 +605,32 @@ tpp_init(struct tpp_config *cnf)
 		return -1;
 	}
 
-	snprintf(log_buffer, TPP_LOGBUF_SZ, "TPP leaf node names = %s", tpp_conf->node_name);
-	tpp_log_func(LOG_CRIT, NULL, log_buffer);
+	tpp_log(LOG_CRIT, NULL, "TPP leaf node names = %s", tpp_conf->node_name);
 
-	tpp_init_lock(&strmarray_lock);
-	if (tpp_mbox_init(&app_mbox) != 0) {
-		tpp_log_func(LOG_CRIT, __func__, "Failed to create application mbox");
+	tpp_init_rwlock(&strmarray_lock);
+	tpp_init_lock(&strm_action_queue_lock);
+
+	if (tpp_mbox_init(&app_mbox, "app_mbox", TPP_MAX_MBOX_SIZE) != 0) {
+		tpp_log(LOG_CRIT, __func__, "Failed to create application mbox");
 		return -1;
 	}
 
 	/* initialize the app_mbox */
 	app_fd = tpp_mbox_getfd(&app_mbox);
 
-	/* initialize the retry and ack queues */
-	TPP_QUE_CLEAR(&global_ack_queue);
-	TPP_QUE_CLEAR(&global_retry_queue);
 	TPP_QUE_CLEAR(&strm_action_queue);
 	TPP_QUE_CLEAR(&freed_sd_queue);
 
 	streams_idx = pbs_idx_create(PBS_IDX_DUPS_OK, sizeof(tpp_addr_t));
 	if (streams_idx == NULL) {
-		tpp_log_func(LOG_CRIT, __func__, "Failed to create index for leaves");
+		tpp_log(LOG_CRIT, __func__, "Failed to create index for leaves");
 		return -1;
 	}
 
 	/* get the addresses associated with this leaf */
 	leaf_addrs = tpp_get_addresses(tpp_conf->node_name, &leaf_addr_count);
 	if (!leaf_addrs) {
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Failed to resolve address, err=%d", errno);
-		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+		tpp_log(LOG_CRIT, __func__, "Failed to resolve address, err=%d", errno);
 		return -1;
 	}
 
@@ -800,13 +638,13 @@ tpp_init(struct tpp_config *cnf)
 	 * first register handlers with the transport, so these functions are called
 	 * from the IO thread from the transport layer
 	 */
-	tpp_transport_set_handlers(leaf_pkt_presend_handler, /* called before sending pkt */
-		leaf_pkt_postsend_handler, /* called after sending a packet */
+	tpp_transport_set_handlers(
+		leaf_pkt_presend_handler, /* called before sending chunk */
 		leaf_pkt_handler, /* called when a packet arrives */
 		leaf_close_handler, /* called when a connection closes */
 		leaf_post_connect_handler, /* called when connection restores */
 		leaf_timer_handler /* called after amt of time from previous handler */
-		);
+	);
 
 	/* initialize the tpp transport layer */
 	if ((rc = tpp_transport_init(tpp_conf)) == -1)
@@ -815,28 +653,22 @@ tpp_init(struct tpp_config *cnf)
 	max_routers = 0;
 	while (tpp_conf->routers[max_routers])
 		max_routers++; /* count max_routers */
+	
+	if (max_routers == 0) {
+		tpp_log(LOG_CRIT, NULL, "No pbs_comms configured, cannot start");
+		return -1;
+	}
 
 	if ((routers = calloc(max_routers, sizeof(tpp_router_t *))) == NULL) {
-		tpp_log_func(LOG_CRIT, __func__, "Out of memory allocating pbs_comms array");
+		tpp_log(LOG_CRIT, __func__, "Out of memory allocating pbs_comms array");
 		return -1;
 	}
 	routers[max_routers - 1] = NULL;
 
-	if (max_routers == 1 && cnf->force_fault_tolerance == 0) {
-		/*
-		 * If only a single router is found, we cannot do any fault
-		 * tolerance, so set tpp_fault_tolerant_mode to off.
-		 */
-		tpp_fault_tolerant_mode = 0;
-		tpp_log_func(LOG_WARNING, NULL, "Single pbs_comm configured, TPP Fault tolerant mode disabled");
-	}
-
-	i = 0;
-
 	/* initialize the router structures and initiate connections to them */
-	while (tpp_conf->routers[i]) {
+	for(i = 0; tpp_conf->routers[i]; i++) {
 		if ((routers[i] = malloc(sizeof(tpp_router_t))) == NULL)  {
-			tpp_log_func(LOG_CRIT, __func__, "Out of memory allocating pbs_comm structure");
+			tpp_log(LOG_CRIT, __func__, "Out of memory allocating pbs_comm structure");
 			return -1;
 		}
 
@@ -847,25 +679,29 @@ tpp_init(struct tpp_config *cnf)
 		routers[i]->index = i;
 		routers[i]->delay = 0;
 
-		sprintf(tpp_get_logbuf(), "Connecting to pbs_comm %s", routers[i]->router_name);
-		tpp_log_func(LOG_INFO, NULL, tpp_get_logbuf());
+		tpp_log(LOG_INFO, NULL, "Connecting to pbs_comm %s", routers[i]->router_name);
 
 		/* connect to router and send initial join packet */
 		if ((rc = connect_router(routers[i])) != 0)
 			return -1;
-
-		i++;
-	}
-
-	if (i == 0) {
-		tpp_log_func(LOG_CRIT, NULL, "No pbs_comms configured, cannot start");
-		return -1;
 	}
 
 #ifndef WIN32
+
+	/* 
+	 * As such atfork handlers are required since after a fork, fork() replicates
+	 * only calling thread that called fork() and TPP layer never calls fork. So, this
+	 * means that the TPP thread is always dead/unavailable in a child process.
+	 * 
+	 * We register only a post_fork child handler to set "tpp_child_terminated" flag
+	 * which renders TPP functions to return right away without doing anything, 
+	 * rendering TPP functionality "bypassed" in the child process.
+	 * 
+	 */
+
 	/* for unix, set a pthread_atfork handler */
-	if (pthread_atfork(tpp_client_prefork, tpp_client_postfork_parent, tpp_client_postfork_child)) {
-		tpp_log_func(LOG_CRIT, __func__, "TPP atfork handler registration failed");
+	if (pthread_atfork(NULL, NULL, tpp_terminate)) {
+		tpp_log(LOG_CRIT, __func__, "TPP client atfork handler registration failed");
 		return -1;
 	}
 #endif
@@ -900,13 +736,13 @@ tpp_eom(int fd)
 	if (fd < 0)
 		return -1;
 
-	TPP_DBPRT(("sd=%d", fd));
+	TPP_DBPRT("sd=%d", fd);
 	strm = get_strm(fd);
 	if (!strm) {
-		TPP_DBPRT(("Bad sd %d", fd));
+		TPP_DBPRT("Bad sd %d", fd);
 		return -1;
 	}
-	p = tpp_deque(&strm->recv_queue);
+	p = tpp_deque(&strm->recv_queue); /* only APP thread accesses this queue, hence no lock */
 	tpp_free_pkt(p);
 	tpp = tpp_get_user_data(fd);
 	if (tpp != NULL) {
@@ -950,21 +786,20 @@ tpp_open(char *dest_host, unsigned int port)
 	void *idx_ctx = NULL;
 
 	if ((dest = mk_hostname(dest_host, port)) == NULL) {
-		tpp_log_func(LOG_CRIT, __func__, "Out of memory opening stream");
+		tpp_log(LOG_CRIT, __func__, "Out of memory opening stream");
 		return -1;
 	}
 
 	addrs = tpp_get_addresses(dest, &count);
 	if (!addrs) {
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Failed to resolve address, err=%d", errno);
-		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+		tpp_log(LOG_CRIT, __func__, "Failed to resolve address, err=%d", errno);
 		free(dest);
 		return -1;
 	}
 	memcpy(&dest_addr, addrs, sizeof(tpp_addr_t));
 	free(addrs);
 
-	tpp_lock(&strmarray_lock);
+	tpp_read_lock(&strmarray_lock); /* walking the idx, so read lock */
 
 	/*
 	 * Just try to find a fully open stream to use, else fall through
@@ -976,21 +811,21 @@ tpp_open(char *dest_host, unsigned int port)
 		if (memcmp(pdest_addr, &dest_addr, sizeof(tpp_addr_t)) != 0)
 			break;
 		if (strm->u_state == TPP_STRM_STATE_OPEN && strm->t_state == TPP_TRNS_STATE_OPEN && strm->used_locally == 1) {
-			tpp_unlock(&strmarray_lock);
+			tpp_unlock_rwlock(&strmarray_lock);
 			pbs_idx_free_ctx(idx_ctx);
 
-			TPP_DBPRT(("Stream for dest[%s] returned = %u", dest, strm->sd));
+			TPP_DBPRT("Stream for dest[%s] returned = %u", dest, strm->sd);
 			free(dest);
 			return strm->sd;
 		}
 	}
 	pbs_idx_free_ctx(idx_ctx);
 
-	tpp_unlock(&strmarray_lock);
+	tpp_unlock_rwlock(&strmarray_lock);
 
 	/* by default use the first address of the host as the source address */
 	if ((strm = alloc_stream(&leaf_addrs[0], &dest_addr)) == NULL) {
-		tpp_log_func(LOG_CRIT, __func__, "Out of memory allocating stream");
+		tpp_log(LOG_CRIT, __func__, "Out of memory allocating stream");
 		free(dest);
 		return -1;
 	}
@@ -998,61 +833,24 @@ tpp_open(char *dest_host, unsigned int port)
 	/* set the used_locally flag, since the APP is aware of this fd */
 	strm->used_locally = 1;
 
-	TPP_DBPRT(("Stream for dest[%s] returned = %d", dest, strm->sd));
+	TPP_DBPRT("Stream for dest[%s] returned = %d", dest, strm->sd);
 	free(dest);
 
 	return strm->sd;
 }
 
-/**
- * @brief
- *	Increment a sequence number
- *
- * @par Functionality:
- *	Gets the next value of a sequence number, wrapping at MAX_SEQ_NUMBER.
- *
- * @param[in] seq_no - The current sequence number (of which we want the next)
- *
- * @return - The next value in the sequence
- *
- * @par Side Effects:
- *	None
- *
- * @par MT-safe: Yes
- *
- */
-static unsigned int
-get_next_seq(unsigned int seq_no)
-{
-	seq_no++;
-	if (seq_no >= MAX_SEQ_NUMBER)
-		seq_no = 1;
-
-	return seq_no;
-}
 
 /**
  * @brief
- *	Returns the index of the router which has an established TCP connection
+ *	Returns the active router which has an established TCP connection
  *
  * @par Functionality:
  *	Loops through the list of routers and returns the first one having
- *	an active TCP connection. Favors the first router index.
+ *	an active TCP connection. Favors the currently active router
  *
- *	Attempts to find a router that has been connected for a while. This is
- *	done to avoid switching back to a primary (first) router immediately on
- *	connection completion, to allow other connections to the router to complete
- *	before we start using that router.
- *
- *	In case no router is found that had been connected for a while, simply
- *	choose from the first available connected router, disregarding connection
- *	age.
- *
- * @param[in] index - The router index that was last used to send messages
- *
- * @return - The index of an active router.
- * @retval -1   - Function failed
- * @retval !=-1 - Success, the index of the active router is returned
+ * @return - The active router
+ * @retval NULL   - Function failed
+ * @retval !NULL - Success, the active router is returned
  *
  * @par Side Effects:
  *	None
@@ -1060,57 +858,30 @@ get_next_seq(unsigned int seq_no)
  * @par MT-safe: No
  *
  */
-static int
-get_active_router(int index)
+static tpp_router_t *
+get_active_router()
 {
 	int i;
-	int oldest_index = -1;
-	time_t oldest_time = 0;
-	time_t now = time(0);
+	static int index = 0;
 
 	if (routers == NULL)
-		return -1;
-
-	/*
-	 * If the primary (index 0) router is connected, check if the
-	 * router connection had aged enough time to ensure everything
-	 * else is connected to this router
-	 */
-	if (routers[0]->state == TPP_ROUTER_STATE_CONNECTED) {
-		if ((now - routers[0]->conn_time) > 5*TPP_CONNECT_RETRY_MAX) {
-			return 0;
-		}
-	}
+		return NULL;
 
 	/*
 	 * If we had already been using an alternate router it should be good to use
 	 * without checking connection age, since we were already using it
 	 */
 	if (index >= 0 && index < max_routers && routers[index] && routers[index]->state == TPP_ROUTER_STATE_CONNECTED)
-		return index;
+		return routers[index];
 
-	/*
-	 * Neither router @ index 0, nor last used router was good, so loop
-	 * to find out a router with the connection that has aged fully, or
-	 * in the process, find out the oldest connection.
-	 */
-	oldest_index = -1;
-	oldest_time = now + 3600; /* initialize to a future time stamp */
 	for (i = 0; i < max_routers; i++) {
 		if (routers[i]->state == TPP_ROUTER_STATE_CONNECTED) {
-			if ((now - routers[i]->conn_time) > 5*TPP_CONNECT_RETRY_MAX)
-				return i;
-			if (routers[i]->conn_time < oldest_time) {
-				oldest_time = routers[i]->conn_time;
-				oldest_index = i;
-			}
+			index = i;
+			return routers[index];
 		}
 	}
-	if (oldest_index > -1)
-		return oldest_index;
 
-	no_active_router = 1;
-	return -1;
+	return NULL;
 }
 
 /**
@@ -1125,9 +896,10 @@ get_active_router(int index)
  * @param[in] data - Pointer to the data block to be sent
  * @param[in] len - Length of the data block to be sent
  *
- * @return - The total length of data that was accepted to be sent
- * @retval -1   - Function failed
- * @retval !=-1 - Success, length of data that was accepted to be sent
+ * @return  Error code
+ * @retval  -1 - Failure
+ * @retval  -2 - transport buffers full
+ * @retval   >=0 - Success - amount of data sent
  *
  * @par Side Effects:
  *	None
@@ -1138,48 +910,50 @@ get_active_router(int index)
 int
 tpp_send(int sd, void *data, int len)
 {
+	int rc = -1;
 	int to_send;
-	void *p;
+	void *data_dup;
 	unsigned int cmprsd_len = 0;
-	tpp_packet_t *pkt = NULL;
 
 	if (!get_strm(sd)) {
-		TPP_DBPRT(("Bad sd %d", sd));
+		TPP_DBPRT("Bad sd %d", sd);
 		return -1;
 	}
 
-	TPP_DBPRT(("Sending: sd=%d, len=%d", sd, len));
+	TPP_DBPRT("Sending: sd=%d, len=%d", sd, len);
 
 	if ((tpp_conf->compress == 1) && (len > TPP_COMPR_SIZE)) {
-		void *outbuf;
-
-		outbuf = tpp_deflate(data, len, &cmprsd_len);
-		if (outbuf == NULL) {
-			tpp_log_func(LOG_CRIT, __func__, "tpp deflate failed");
+		data_dup = tpp_deflate(data, len, &cmprsd_len); /* creates a copy */
+		if (data_dup == NULL) {
+			tpp_log(LOG_CRIT, __func__, "tpp deflate failed");
 			return -1;
 		}
-		pkt = tpp_cr_pkt(outbuf, cmprsd_len, 0);
-		if (pkt == NULL) {
-			free(outbuf);
-			return -1;
-		}
-
-		p = pkt->data;
 		to_send = cmprsd_len;
 	} else {
-		p = data;
+		data_dup = malloc(len);
+		if (!data_dup) {
+			tpp_log(errno, __func__, "Failed to duplicate data");
+			return -1;
+		}
+		memcpy(data_dup, data, len);;
 		cmprsd_len = len;
 		to_send = len;
 	}
 
 	if (to_send > 0) {
-		if (tpp_send_inner(sd, p, to_send, len, cmprsd_len) != to_send) {
-			tpp_free_pkt(pkt);
-			return -1;
-		}
+		do {
+			rc = tpp_send_inner(sd, data_dup, to_send, len, cmprsd_len);
+			TPP_DBPRT("tpp_send_inner returned %d", rc);
+			if (rc == to_send) {
+				TPP_DBPRT("returning %d", len);
+				return len;
+			}
+			if (rc == -1)
+				usleep(200); /* sleep for 200 ms due to buffer full */
+		} while (rc == -2);
 	}
-	tpp_free_pkt(pkt);
-	return len;
+	
+	return rc; /* -1 */
 }
 
 /**
@@ -1194,13 +968,14 @@ tpp_send(int sd, void *data, int len)
  *
  * @param[in] sd - The stream descriptor to which to send data
  * @param[in] data - Pointer to the chunk of data
- * @param[in] len - Length of the chunk of data
+ * @param[in] to_send - Length of the chunk of data
  * @param[in] full_len - Length of the whole data block to be sent
  * @param[in] cmprsd_len - length of compressed data
  *
- * @return - The total length of data that was accepted to be sent
- * @retval -1   - Function failed
- * @retval !=-1 - Success, length of data that was accepted to be sent
+ * @return  Error code
+ * @retval  -1 - Failure
+ * @retval  -2 - transport buffers full
+ * @retval   >=0 - Success - amount of data sent
  *
  * @par Side Effects:
  *	None
@@ -1209,61 +984,53 @@ tpp_send(int sd, void *data, int len)
  *
  */
 static int
-tpp_send_inner(int sd, void *data, int len, int full_len, int cmprsd_len)
+tpp_send_inner(int sd, void *data, int to_send, int full_len, int cmprsd_len)
 {
 	stream_t *strm;
-	tpp_data_pkt_hdr_t dhdr;
-	tpp_chunk_t chunks[2];
+	tpp_data_pkt_hdr_t *dhdr = NULL;
+	tpp_packet_t *pkt;
+	int rc = -1;
 
 	strm = get_strm(sd);
 	if (!strm) {
-		TPP_DBPRT(("Bad sd %d", sd));
+		TPP_DBPRT("Bad sd %d", sd);
 		return -1;
 	}
 
-	TPP_DBPRT(("**** sd=%d, len=%d, compr_len=%d, totlen=%d, dest_sd=%u, seq=%u", sd, len, cmprsd_len, full_len, strm->dest_sd, strm->send_seq_no));
+	tpp_log(LOG_DEBUG, __func__, "**** sd=%d, to_send=%d, compr_len=%d, totlen=%d, dest_sd=%u", sd, to_send, cmprsd_len, full_len, strm->dest_sd);
 
 	if (strm->strm_type == TPP_STRM_MCAST) {
 		/* do other stuff */
-		return tpp_mcast_send(sd, data, len, full_len, cmprsd_len);
+		return tpp_mcast_send(sd, data, to_send, full_len, cmprsd_len);
 	}
-
-	/* this memset is not required, its only to satisfy valgrind */
-	memset(&dhdr, 0, sizeof(tpp_data_pkt_hdr_t));
-	dhdr.type = TPP_DATA;
-	dhdr.src_sd = htonl(sd);
-	dhdr.src_magic = htonl(strm->src_magic);
-	dhdr.dest_sd = htonl(strm->dest_sd);
-
-	dhdr.seq_no = htonl(strm->send_seq_no);
-	strm->send_seq_no = get_next_seq(strm->send_seq_no);
-
-	dhdr.ack_seq = htonl(UNINITIALIZED_INT);
-	dhdr.dup = 0;
-	dhdr.cmprsd_len = htonl(cmprsd_len);
-	dhdr.totlen = htonl(full_len);
-	memcpy(&dhdr.src_addr, &strm->src_addr, sizeof(tpp_addr_t));
-	memcpy(&dhdr.dest_addr, &strm->dest_addr, sizeof(tpp_addr_t));
-
-	chunks[0].data = &dhdr;
-	chunks[0].len = sizeof(tpp_data_pkt_hdr_t);
-
-	chunks[1].data = data;
-	chunks[1].len = len;
-
-	app_thread_active_router = get_active_router(app_thread_active_router);
-	if (app_thread_active_router == -1) {
-		TPP_DBPRT(("no active router, sending TPP_CMD_NET_CLOSE sd=%u", strm->sd));
-		send_app_strm_close(strm, TPP_CMD_NET_CLOSE, 0);
+	
+	pkt = tpp_bld_pkt(NULL, NULL, sizeof(tpp_data_pkt_hdr_t), 1, (void **) &dhdr);
+	if (!pkt) {
+		tpp_log(LOG_CRIT, __func__, "Failed to build packet");
+		return -1;
+	}
+	dhdr->type = TPP_DATA;
+	dhdr->src_sd = htonl(sd);
+	dhdr->src_magic = htonl(strm->src_magic);
+	dhdr->dest_sd = htonl(strm->dest_sd);
+	dhdr->totlen = htonl(full_len);
+	memcpy(&dhdr->src_addr, &strm->src_addr, sizeof(tpp_addr_t));
+	memcpy(&dhdr->dest_addr, &strm->dest_addr, sizeof(tpp_addr_t));
+	
+	if (!tpp_bld_pkt(pkt, data, cmprsd_len, 0, NULL)) { /* data is already a duplicate buffer */
+		tpp_log(LOG_CRIT, __func__, "Failed to build packet");
 		return -1;
 	}
 
-	if (tpp_transport_vsend(routers[app_thread_active_router]->conn_fd, chunks, 2) == 0)
-		return len;
+	rc = send_to_router(pkt);
+	if (rc == 0)
+		return to_send;
 
-	tpp_log_func(LOG_ERR, __func__, "tpp_transport_vsend failed in tpp_send");
-	send_app_strm_close(strm, TPP_CMD_NET_CLOSE, 0);
-	return -1;
+	if (rc == -1) {
+		tpp_log(LOG_ERR, __func__, "send_to_router failed in tpp_send");
+		send_app_strm_close(strm, TPP_CMD_NET_CLOSE, 0);
+	}
+	return rc;
 }
 
 /**
@@ -1324,6 +1091,7 @@ tpp_recv(int sd, void *data, int len)
 {
 	tpp_que_elem_t *n;
 	tpp_packet_t *cur_pkt = NULL;
+	tpp_chunk_t *chunk = NULL;
 	stream_t *strm;
 	int offset, avail_bytes, trnsfr_bytes;
 
@@ -1333,13 +1101,13 @@ tpp_recv(int sd, void *data, int len)
 
 	strm = get_strm(sd);
 	if (!strm) {
-		TPP_DBPRT(("Bad sd %d", sd));
+		TPP_DBPRT("Bad sd %d", sd);
 		return -1;
 	}
 
 	strm->used_locally = 1;
 
-	if ((n = TPP_QUE_HEAD(&strm->recv_queue)))
+	if ((n = TPP_QUE_HEAD(&strm->recv_queue))) /* only APP thread accesses this queue, hence no lock */
 		cur_pkt = TPP_QUE_DATA(n);
 
 	/* read from head */
@@ -1348,8 +1116,14 @@ tpp_recv(int sd, void *data, int len)
 		return -1; /* no data currently - would block */
 	}
 
-	offset = cur_pkt->pos - cur_pkt->data;
-	avail_bytes = cur_pkt->len - offset;
+	chunk = GET_NEXT(cur_pkt->chunks);
+	if (chunk == NULL) {
+		errno = EWOULDBLOCK;
+		return -1; /* no data currently - would block */
+	}
+
+	offset = chunk->pos - chunk->data;
+	avail_bytes = chunk->len - offset;
 	trnsfr_bytes = (len < avail_bytes) ? len : avail_bytes;
 
 	if (trnsfr_bytes == 0) {
@@ -1357,8 +1131,8 @@ tpp_recv(int sd, void *data, int len)
 		return -1; /* no data currently - would block */
 	}
 
-	memcpy(data, cur_pkt->pos, trnsfr_bytes);
-	cur_pkt->pos = cur_pkt->pos + trnsfr_bytes;
+	memcpy(data, chunk->pos, trnsfr_bytes);
+	chunk->pos = chunk->pos + trnsfr_bytes;
 
 	return trnsfr_bytes;
 }
@@ -1397,7 +1171,7 @@ alloc_stream(tpp_addr_t *src_addr, tpp_addr_t *dest_addr)
 
 	errno = 0;
 
-	tpp_lock(&strmarray_lock);
+	tpp_write_lock(&strmarray_lock); /* updating the array + adding to idx, so WRITE lock */
 
 	data = tpp_deque(&freed_sd_queue);
 	if (data) {
@@ -1412,7 +1186,7 @@ alloc_stream(tpp_addr_t *src_addr, tpp_addr_t *dest_addr)
 	} else {
 		sd = max_strms;
 
-		TPP_DBPRT(("***Searching for a free slot"));
+		TPP_DBPRT("***Searching for a free slot");
 		/* search for a free sd */
 		for (i = 0; i < max_strms; i++) {
 			if (strmarray[i].slot_state == TPP_SLOT_FREE) {
@@ -1428,13 +1202,12 @@ alloc_stream(tpp_addr_t *src_addr, tpp_addr_t *dest_addr)
 
 	strm = calloc(1, sizeof(stream_t));
 	if (!strm) {
-		tpp_unlock(&strmarray_lock);
-		tpp_log_func(LOG_CRIT, __func__, "Out of memory allocating stream");
+		tpp_unlock_rwlock(&strmarray_lock);
+		tpp_log(LOG_CRIT, __func__, "Out of memory allocating stream");
 		return NULL;
 	}
 	strm->strm_type = TPP_STRM_NORMAL;
 	strm->sd = sd;
-	strm->send_seq_no = 0; /* start with special zero */
 	strm->dest_sd = UNINITIALIZED_INT;
 	strm->dest_magic = UNINITIALIZED_INT;
 	if (src_addr)
@@ -1448,10 +1221,7 @@ alloc_stream(tpp_addr_t *src_addr, tpp_addr_t *dest_addr)
 	strm->close_func = NULL;
 	strm->timeout_node = NULL;
 
-	TPP_QUE_CLEAR(&strm->recv_queue);
-	TPP_QUE_CLEAR(&strm->oo_queue);
-	TPP_QUE_CLEAR(&strm->ack_queue);
-	TPP_QUE_CLEAR(&strm->retry_queue);
+	TPP_QUE_CLEAR(&strm->recv_queue); /* only APP thread accesses this queue, once created here, hence no lock */
 
 	/* set to stream array */
 	if (max_strms == 0 || sd > max_strms - 1) {
@@ -1463,8 +1233,8 @@ alloc_stream(tpp_addr_t *src_addr, tpp_addr_t *dest_addr)
 		p = realloc(strmarray, sizeof(stream_slot_t) * newsize);
 		if (!p) {
 			free(strm);
-			tpp_unlock(&strmarray_lock);
-			tpp_log_func(LOG_CRIT, __func__, "Out of memory resizing stream array");
+			tpp_unlock_rwlock(&strmarray_lock);
+			tpp_log(LOG_CRIT, __func__, "Out of memory resizing stream array");
 			return NULL;
 		}
 		strmarray = (stream_slot_t *) p;
@@ -1478,17 +1248,16 @@ alloc_stream(tpp_addr_t *src_addr, tpp_addr_t *dest_addr)
 	if (dest_addr) {
 		/* also add stream to the streams_idx with the dest as key */
 		if (pbs_idx_insert(streams_idx, &strm->dest_addr, strm) != PBS_IDX_RET_OK) {
-			sprintf(tpp_get_logbuf(), "Failed to add strm with sd=%u to streams", strm->sd);
-			tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+			tpp_log(LOG_CRIT, __func__, "Failed to add strm with sd=%u to streams", strm->sd);
 			free(strm);
-			tpp_unlock(&strmarray_lock);
+			tpp_unlock_rwlock(&strmarray_lock);
 			return NULL;
 		}
 	}
 
-	TPP_DBPRT(("*** Allocated new stream, sd=%u, src_magic=%u", strm->sd, strm->src_magic));
+	TPP_DBPRT("*** Allocated new stream, sd=%u, src_magic=%u", strm->sd, strm->src_magic);
 
-	tpp_unlock(&strmarray_lock);
+	tpp_unlock_rwlock(&strmarray_lock);
 
 	return strm;
 }
@@ -1559,29 +1328,6 @@ tpp_getaddr(int fd)
 
 /**
  * @brief
- *	Convenience function to free router strutures
- *
- * @par MT-safe: yes
- *
- */
-static void
-free_routers()
-{
-	int i;
-
-	for (i = 0; i < max_routers; i++)
-		free(routers[i]);
-	free(routers);
-
-	free(tpp_conf->node_name);
-	for (i = 0; tpp_conf->routers[i]; i++)
-		free(tpp_conf->routers[i]);
-
-	free(tpp_conf->routers);
-}
-
-/**
- * @brief
  *	Shuts down the tpp library gracefully
  *
  * @par Functionality
@@ -1600,17 +1346,17 @@ tpp_shutdown()
 	unsigned int i;
 	unsigned int sd;
 
-	TPP_DBPRT(("from pid = %d", getpid()));
+	TPP_DBPRT("from pid = %d", getpid());
 
-	tpp_mbox_destroy(&app_mbox, 1);
+	tpp_mbox_destroy(&app_mbox);
 
 	tpp_going_down = 1;
 
 	tpp_transport_shutdown();
+	/* all threads are dead by now, so no locks required */
 
 	DIS_tpp_funcs();
 
-	tpp_lock(&strmarray_lock);
 	for (i = 0; i < max_strms; i++) {
 		if (strmarray[i].slot_state == TPP_SLOT_BUSY) {
 			sd = strmarray[i].strm->sd;
@@ -1619,12 +1365,10 @@ tpp_shutdown()
 			free_stream(sd);
 		}
 	}
-	tpp_unlock(&strmarray_lock);
+
 	if (strmarray)
 		free(strmarray);
-	tpp_destroy_lock(&strmarray_lock);
-
-	free_routers();
+	tpp_destroy_rwlock(&strmarray_lock);
 }
 
 /**
@@ -1647,9 +1391,8 @@ tpp_terminate()
 {
 	/* Warning: Do not attempt to destroy any lock
 	 * This is not required since our library is effectively
-	 * not used after a fork. The function tpp_mbox_destroy
-	 * calls pthread_mutex_destroy, so don't call them.
-	 * Also never log anything from a terminate handler.
+	 * not used after a fork. 
+	 * Also never log anything from (or after) a terminate handler.
 	 *
 	 * Don't bother to free any TPP data as well, as the forked
 	 * process is usually short lived and no point spending time
@@ -1673,7 +1416,7 @@ tpp_terminate()
 
 	tpp_transport_terminate();
 
-	tpp_mbox_destroy(&app_mbox, 0);
+	tpp_mbox_destroy(&app_mbox);
 }
 
 /**
@@ -1718,44 +1461,42 @@ tpp_ready_fds(int *sds, int len)
 		if (cmd == TPP_CMD_NET_DATA) {
 			tpp_packet_t *pkt = data;
 			if ((strm = get_strm_atomic(sd))) {
-				TPP_DBPRT(("sd=%u, cmd=%d, u_state=%d, t_state=%d, len=%d, dest_sd=%u", sd, cmd, strm->u_state, strm->t_state, pkt->len, strm->dest_sd));
+				TPP_DBPRT("sd=%u, cmd=%d, u_state=%d, t_state=%d, len=%d, dest_sd=%u", sd, cmd, strm->u_state, strm->t_state, pkt->totlen, strm->dest_sd);
 
 				if (strm->u_state == TPP_STRM_STATE_OPEN) {
 					/* add packet to recv queue */
-					if (tpp_enque(&strm->recv_queue, pkt) == NULL) {
-						tpp_log_func(LOG_CRIT, __func__, "Failed to queue received pkt");
+					if (tpp_enque(&strm->recv_queue, pkt) == NULL) { /* only APP thread accesses this queue, hence not lock */
+						tpp_log(LOG_CRIT, __func__, "Failed to queue received pkt");
 						tpp_free_pkt(pkt);
 						return -1;
 					}
 					sds[strms_found++] = sd;
 				} else {
-					TPP_DBPRT(("Data recvd on closed stream %u discarded", sd));
+					TPP_DBPRT("Data recvd on closed stream %u discarded", sd);
 					tpp_free_pkt(pkt);
-					/* respond back by sending the close packet once more
-					 * does not matter if it is a retry anyway
-					 */
+					/* respond back by sending the close packet once more */
 					send_spl_packet(strm, TPP_CLOSE_STRM);
 				}
 			} else {
-				TPP_DBPRT(("Data recvd on deleted stream %u discarded", sd));
+				TPP_DBPRT("Data recvd on deleted stream %u discarded", sd);
 				tpp_free_pkt(pkt);
 			}
 		} else if (cmd == TPP_CMD_PEER_CLOSE || cmd == TPP_CMD_NET_CLOSE) {
 
 			if ((strm = get_strm_atomic(sd))) {
-				TPP_DBPRT(("sd=%u, cmd=%d, u_state=%d, t_state=%d, data=%p", sd, cmd, strm->u_state, strm->t_state, data));
+				TPP_DBPRT("sd=%u, cmd=%d, u_state=%d, t_state=%d, data=%p", sd, cmd, strm->u_state, strm->t_state, data);
 
 				if (strm->u_state == TPP_STRM_STATE_OPEN) {
 					if (cmd == TPP_CMD_PEER_CLOSE) {
 						/* ask app to close stream */
-						TPP_DBPRT(("Sent peer close to stream sd=%u", sd));
+						TPP_DBPRT("Sent peer close to stream sd=%u", sd);
 						sds[strms_found++] = sd;
 
 					} else if (cmd == TPP_CMD_NET_CLOSE) {
 						/* network closed, so clear all pending data to be
 						 * received, and signal that sd
 						 */
-						TPP_DBPRT(("Sent net close stream sd=%u", sd));
+						TPP_DBPRT("Sent net close stream sd=%u", sd);
 						sds[strms_found++] = sd;
 					}
 				} else {
@@ -1845,8 +1586,7 @@ tpp_set_user_data(int sd, void *user_data)
 	strm = get_strm_atomic(sd);
 	if (!strm) {
 		errno = ENOTCONN;
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Slot %d freed!", sd);
-		tpp_log_func(LOG_WARNING, __func__, tpp_get_logbuf());
+		tpp_log(LOG_WARNING, __func__, "Slot %d freed!", sd);
 		return -1;
 	}
 	strm->user_data = user_data;
@@ -1883,9 +1623,7 @@ tpp_add_close_func(int sd, void (*func)(int))
 	if (!strm)
 		return;
 
-	tpp_lock(&strmarray_lock);
 	strm->close_func = func;
-	tpp_unlock(&strmarray_lock);
 }
 
 /**
@@ -1926,17 +1664,13 @@ tpp_close(int sd)
 	if (strm->close_func)
 		strm->close_func(sd);
 
-	tpp_lock(&strmarray_lock);
-
-	TPP_DBPRT(("Closing sd=%d", sd));
+	TPP_DBPRT("Closing sd=%d", sd);
 	/* free the recv_queue also */
-	while ((p = tpp_deque(&strm->recv_queue)))
+	while ((p = tpp_deque(&strm->recv_queue))) /* only APP thread accesses this queue, hence no lock */
 		tpp_free_pkt(p);
 
 	/* send a close packet */
 	strm->u_state = TPP_STRM_STATE_CLOSE;
-
-	tpp_unlock(&strmarray_lock);
 
 	DIS_tpp_funcs();
 	dis_destroy_chan(strm->sd);
@@ -1975,7 +1709,7 @@ tpp_mcast_open(void)
 		return -1;
 	}
 
-	TPP_DBPRT(("tpp_mcast_open called with fd=%u", strm->sd));
+	TPP_DBPRT("tpp_mcast_open called with fd=%u", strm->sd);
 
 	strm->used_locally = 1;
 	strm->strm_type = TPP_STRM_MCAST;
@@ -2021,28 +1755,23 @@ tpp_mcast_add_strm(int mtfd, int tfd)
 	if (!mstrm->mcast_data) {
 		mstrm->mcast_data = malloc(sizeof(mcast_data_t));
 		if (!mstrm->mcast_data) {
-			tpp_log_func(LOG_CRIT, __func__, "Out of memory allocating mcast data");
+			tpp_log(LOG_CRIT, __func__, "Out of memory allocating mcast data");
 			return -1;
 		}
-		mstrm->mcast_data->seqs = NULL;
+
 		mstrm->mcast_data->strms = malloc(TPP_MCAST_SLOT_INC * sizeof(int));
 		if (!mstrm->mcast_data->strms) {
 			free(mstrm->mcast_data);
-			snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ,
-				"Out of memory allocating strm array of %lu bytes",
+			tpp_log(LOG_CRIT, __func__, "Out of memory allocating strm array of %lu bytes",
 				(unsigned long)(TPP_MCAST_SLOT_INC * sizeof(int)));
-			tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
 			return -1;
 		}
 		mstrm->mcast_data->num_slots = TPP_MCAST_SLOT_INC;
 		mstrm->mcast_data->num_fds = 0;
 	} else if (mstrm->mcast_data->num_fds >= mstrm->mcast_data->num_slots) {
 		p = realloc(mstrm->mcast_data->strms, (mstrm->mcast_data->num_slots + TPP_MCAST_SLOT_INC) * sizeof(int));
-		if (!p) {
-			snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ,
-				"Out of memory resizing strm array to %lu bytes",
-				(mstrm->mcast_data->num_slots + TPP_MCAST_SLOT_INC) * sizeof(int));
-			tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+		if (!p) {				
+			tpp_log(LOG_CRIT, __func__, "Out of memory resizing strm array to %lu bytes", (mstrm->mcast_data->num_slots + TPP_MCAST_SLOT_INC) * sizeof(int));
 			return -1;
 		}
 		mstrm->mcast_data->strms = p;
@@ -2089,48 +1818,6 @@ tpp_mcast_members(int mtfd, int *count)
 
 /**
  * @brief
- *	Duplicate a mcast_data structure
- *
- * @param[in]  m - The mcast data structure to clone
- *
- * @return	Pointer of the duplicate mcast_data structure
- * @retval 	NULL  - Failure (Out of memory)
- * @retval 	!NULL - Success
- *
- * @par Side Effects:
- *	None
- *
- * @par MT-safe: Yes
- *
- */
-mcast_data_t *
-dup_mcast_data(mcast_data_t *m)
-{
-	mcast_data_t *d = malloc(sizeof(mcast_data_t));
-	if (!d)
-		return NULL;
-
-	d->strms = malloc(sizeof(unsigned int) * m->num_fds);
-	if (!d->strms) {
-		free(d);
-		return NULL;
-	}
-	memcpy(d->strms, m->strms, m->num_fds * sizeof(unsigned int));
-
-	d->seqs = calloc(sizeof(unsigned int), m->num_fds);
-	if (!d->seqs) {
-		free(d->strms);
-		free(d);
-		return NULL;
-	}
-
-	d->num_fds = m->num_fds;
-	d->num_slots = m->num_fds;
-	return d;
-}
-
-/**
- * @brief
  *	Send a command notification to all member streams
  *
  * @param[in]  mtfd - The mcast stream
@@ -2172,14 +1859,15 @@ tpp_mcast_notify_members(int mtfd, int cmd)
  *
  * @param[in] mtfd - The multicast channel to which to send data
  * @param[in] data - The pointer to the block of data to send
- * @param[in] len  - Length of the data to send
+ * @param[in] to_send  - Length of the data to send
  * @param[in] full_len - In case of large packets data is sent in chunks,
  *			 full_len is the total length of the data
  * @param[in] comprsd_len - Length of compressed data (if compressed)
  *
- * @return	Error code
- * @retval   -1 - Failure
- * @retval    0 - Success
+ * @return  Error code
+ * @retval  -1 - Failure
+ * @retval  -2 - transport buffers full
+ * @retval   >=0 - Success - amount of data sent
  *
  * @par Side Effects:
  *	None
@@ -2188,21 +1876,22 @@ tpp_mcast_notify_members(int mtfd, int cmd)
  *
  */
 int
-tpp_mcast_send(int mtfd, void *data, unsigned int len, unsigned int full_len, unsigned int cmprsd_len)
+tpp_mcast_send(int mtfd, void *data, unsigned int to_send, unsigned int full_len, unsigned int cmprsd_len)
 {
-	stream_t *mstrm;
-	stream_t *strm;
-	mcast_data_t *d = NULL;
-	int i, totlen = 0;
-	tpp_chunk_t chunks[3];
-	tpp_mcast_pkt_hdr_t mhdr;
-	tpp_mcast_pkt_info_t *minfo;
+	stream_t *mstrm = NULL;
+	stream_t *strm = NULL;
+	int i;
+	int rc = -1;
+	tpp_mcast_pkt_hdr_t *mhdr = NULL;
+	tpp_mcast_pkt_info_t *minfo = NULL;
 	tpp_mcast_pkt_info_t tmp_minfo;
+	tpp_packet_t *pkt = NULL;
 	unsigned int cmpr_len = 0;
 	void *minfo_buf = NULL;
 	int minfo_len;
 	int ret;
 	int finish;
+	int num_fds;
 	void *def_ctx = NULL;
 
 	mstrm = get_strm_atomic(mtfd);
@@ -2211,32 +1900,23 @@ tpp_mcast_send(int mtfd, void *data, unsigned int len, unsigned int full_len, un
 		return -1;
 	}
 
-	d = dup_mcast_data(mstrm->mcast_data);
-	if (!d) {
-		tpp_log_func(LOG_CRIT, __func__, "Out of memory duplicating mcast data");
-		goto err;
-	}
+	num_fds = mstrm->mcast_data->num_fds;
 
-	minfo_len = sizeof(tpp_mcast_pkt_info_t) * d->num_fds;
-
-#ifdef DEBUG
-	/* in debug mode satisfy valgrind by initializing header memory */
-	memset(&mhdr, 0, sizeof(mhdr));
-#endif
+	minfo_len = sizeof(tpp_mcast_pkt_info_t) * num_fds;
 
 	/* header data */
-	memset(&mhdr, 0, sizeof(tpp_mcast_pkt_hdr_t)); /* only to satisfy valgrind */
-	mhdr.type = TPP_MCAST_DATA;
-	mhdr.hop = 0;
-	mhdr.data_cmprsd_len = htonl(cmprsd_len);
-	mhdr.totlen = htonl(full_len);
-	memcpy(&mhdr.src_addr, &mstrm->src_addr, sizeof(tpp_addr_t));
-	mhdr.num_streams = htonl(d->num_fds);
-	mhdr.info_len = htonl(minfo_len);
-
-	chunks[0].data = &mhdr;
-	chunks[0].len = sizeof(tpp_mcast_pkt_hdr_t);
-	totlen = chunks[0].len;
+	pkt = tpp_bld_pkt(NULL, NULL, sizeof(tpp_mcast_pkt_hdr_t), 1, (void **) &mhdr);
+	if (!pkt) {
+		tpp_log(LOG_CRIT, __func__, "Failed to build packet");
+		return -1;
+	}
+	mhdr->type = TPP_MCAST_DATA;
+	mhdr->hop = 0;
+	mhdr->data_cmprsd_len = htonl(cmprsd_len);
+	mhdr->totlen = htonl(full_len);
+	memcpy(&mhdr->src_addr, &mstrm->src_addr, sizeof(tpp_addr_t));
+	mhdr->num_streams = htonl(num_fds);
+	mhdr->info_len = htonl(minfo_len);
 
 	if (tpp_conf->compress == 1 && minfo_len > TPP_COMPR_SIZE) {
 		def_ctx = tpp_multi_deflate_init(minfo_len);
@@ -2245,18 +1925,15 @@ tpp_mcast_send(int mtfd, void *data, unsigned int len, unsigned int full_len, un
 	} else {
 		minfo_buf = malloc(minfo_len);
 		if (!minfo_buf) {
-			snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ,
-				"Out of memory allocating mcast buffer of %d bytes", minfo_len);
-			tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+			tpp_log(LOG_CRIT, __func__, "Out of memory allocating mcast buffer of %d bytes", minfo_len);
 			goto err;
 		}
 	}
 
-	for (i = 0; i < d->num_fds; i++) {
-		strm = get_strm_atomic(d->strms[i]);
+	for (i = 0; i < num_fds; i++) {
+		strm = get_strm_atomic(mstrm->mcast_data->strms[i]);
 		if (!strm) {
-			snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Stream %d is not open", d->strms[i]);
-			tpp_log_func(LOG_ERR, NULL, tpp_get_logbuf());
+			tpp_log(LOG_ERR, NULL, "Stream %d is not open", mstrm->mcast_data->strms[i]);
 			goto err;
 		}
 
@@ -2264,19 +1941,16 @@ tpp_mcast_send(int mtfd, void *data, unsigned int len, unsigned int full_len, un
 		tmp_minfo.src_sd = htonl(strm->sd);
 		tmp_minfo.src_magic = htonl(strm->src_magic);
 		tmp_minfo.dest_sd = htonl(strm->dest_sd);
-		tmp_minfo.seq_no = htonl(strm->send_seq_no);
-		d->seqs[i] = strm->send_seq_no; /* store seq in packet for retry case */
+	
+		TPP_DBPRT("MCAST src_sd=%u, dest_sd=%u", strm->sd, strm->dest_sd);
 
-		TPP_DBPRT(("*** src_sd=%u, dest_sd=%u, seq_no_sent=%u", strm->sd, strm->dest_sd, strm->send_seq_no));
-
-		strm->send_seq_no = get_next_seq(strm->send_seq_no);
 		memcpy(&tmp_minfo.dest_addr, &strm->dest_addr, sizeof(tpp_addr_t));
 
 		if (def_ctx == NULL) { /* no compression */
 			minfo = (tpp_mcast_pkt_info_t *)((char *) minfo_buf + (i * sizeof(tpp_mcast_pkt_info_t)));
 			memcpy(minfo, &tmp_minfo, sizeof(tpp_mcast_pkt_info_t));
 		} else {
-			finish = (i == (d->num_fds - 1)) ? 1 : 0;
+			finish = (i == (num_fds - 1)) ? 1 : 0;
 
 			ret = tpp_multi_deflate_do(def_ctx, finish, &tmp_minfo, sizeof(tpp_mcast_pkt_info_t));
 			if (ret != 0)
@@ -2289,37 +1963,32 @@ tpp_mcast_send(int mtfd, void *data, unsigned int len, unsigned int full_len, un
 		if (minfo_buf == NULL)
 			goto err;
 
-		TPP_DBPRT(("*** mcast_send hdr orig=%d, cmprsd=%u", minfo_len, cmpr_len));
-
-		chunks[1].data = minfo_buf;
-		chunks[1].len = cmpr_len;
-		totlen += chunks[1].len;
-		mhdr.info_cmprsd_len = htonl(cmpr_len);
+		TPP_DBPRT("*** mcast_send hdr orig=%d, cmprsd=%u", minfo_len, cmpr_len);
+		mhdr->info_cmprsd_len = htonl(cmpr_len);
 	} else {
-		TPP_DBPRT(("*** mcast_send uncompressed hdr orig=%d", minfo_len));
-		chunks[1].data = minfo_buf;
-		chunks[1].len = minfo_len;
-		totlen += chunks[1].len;
-		mhdr.info_cmprsd_len = 0;
+		TPP_DBPRT("*** mcast_send uncompressed hdr orig=%d", minfo_len);
+		mhdr->info_cmprsd_len = 0;
+		cmpr_len = minfo_len;
 	}
 	def_ctx = NULL; /* done with compression */
 
-	chunks[2].data = data;
-	chunks[2].len = len;
-	totlen += chunks[2].len;
-
-	app_thread_active_router = get_active_router(app_thread_active_router);
-	if (app_thread_active_router == -1) {
-		tpp_log_func(LOG_ERR, __func__, "No active router");
-		goto err;
+	if (!tpp_bld_pkt(pkt, minfo_buf, cmpr_len, 0, NULL)) { /* add minfo chunk */
+		tpp_log(LOG_CRIT, __func__, "Failed to build packet");
+		return -1;
 	}
 
-	TPP_DBPRT(("*** sending %d totlen", totlen));
-	if (tpp_transport_vsend_extra(routers[app_thread_active_router]->conn_fd, chunks, 3, d) == 0) {
-		free(minfo_buf);
-		return len;
+	if (!tpp_bld_pkt(pkt, data, to_send, 0, NULL)) { /* add data chunk */
+		tpp_log(LOG_CRIT, __func__, "Failed to build packet");
+		return -1;
 	}
-	tpp_log_func(LOG_ERR, __func__, "tpp_transport_vsend failed in tpp_mcast_send"); /* fall through */
+
+	TPP_DBPRT("*** sending %d totlen", pkt->totlen);
+	
+	rc = send_to_router(pkt);
+	if (rc == 0)
+		return to_send;
+
+	tpp_log(LOG_ERR, __func__, "send_to_router failed in tpp_mcast_send"); /* fall through */
 
 err:
 	tpp_mcast_notify_members(mtfd, TPP_CMD_NET_CLOSE);
@@ -2328,15 +1997,7 @@ err:
 
 	if (minfo_buf)
 		free(minfo_buf);
-
-	if (d) {
-		if (d->strms)
-			free(d->strms);
-		if (d->seqs)
-			free(d->seqs);
-		free(d);
-	}
-	return -1;
+	return rc;
 }
 
 /**
@@ -2375,22 +2036,12 @@ tpp_mcast_close(int mtfd)
 	return 0;
 }
 
-/*
- * ============================================================================
- *
- * Functions below this are mostly driven by the IO thread. Some of them could
- * be accessed by both the IO and the App threads (and such functions need
- * synchronization)
- *
- * ============================================================================
- */
-
 /**
  * @brief
  *	Add the stream to a queue of streams to be closed by the transport thread.
  *
  * @par Functionality
- *	Even of the app thread wants to free a stream, it adds the stream to this
+ *	Even if the app thread wants to free a stream, it adds the stream to this
  *	queue, so that the transport thread frees it, eliminating any thread
  *	races.
  *
@@ -2406,38 +2057,52 @@ static void
 queue_strm_close(stream_t *strm)
 {
 	strm_action_info_t *c;
+	tpp_router_t *r = get_active_router();
 
-	tpp_lock(&strmarray_lock); /* already under lock, dont need get_strm_atomic */
+	if (!r)
+		return;
+
+	tpp_write_lock(&strmarray_lock); /* already under lock, dont need get_strm_atomic */
 
 	if (strmarray[strm->sd].slot_state != TPP_SLOT_BUSY) {
-		tpp_unlock(&strmarray_lock);
+		tpp_unlock_rwlock(&strmarray_lock);
 		return;
 	}
-
 	strmarray[strm->sd].slot_state = TPP_SLOT_DELETED;
-	TPP_DBPRT(("Marked sd=%u DELETED", strm->sd));
+	tpp_unlock_rwlock(&strmarray_lock);
+
+	TPP_DBPRT("Marked sd=%u DELETED", strm->sd);
 
 	if ((c = malloc(sizeof(strm_action_info_t))) == NULL) {
-		tpp_log_func(LOG_CRIT, __func__, "Out of memory allocating stream free info");
-		tpp_unlock(&strmarray_lock);
+		tpp_log(LOG_CRIT, __func__, "Out of memory allocating stream free info");
 		return;
 	}
 	c->strm_action_time = time(0); /* asap */
 	c->strm_action_func = queue_strm_free;
 	c->sd = strm->sd;
 
+	tpp_lock(&strm_action_queue_lock);
 	if (tpp_enque(&strm_action_queue, c) == NULL)
-		tpp_log_func(LOG_CRIT, __func__, "Failed to Queue close");
+		tpp_log(LOG_CRIT, __func__, "Failed to Queue close");
+		
+	tpp_unlock(&strm_action_queue_lock);
 
-	TPP_DBPRT(("Enqueued strm close for sd=%u", strm->sd));
+	TPP_DBPRT("Enqueued strm close for sd=%u", strm->sd);
 
-	tpp_unlock(&strmarray_lock);
-
-	if ((app_thread_active_router = get_active_router(app_thread_active_router)) != -1) {
-		tpp_transport_wakeup_thrd(routers[app_thread_active_router]->conn_fd);
-	}
+	tpp_transport_wakeup_thrd(r->conn_fd);
 	return;
 }
+
+/*
+ * ============================================================================
+ *
+ * Functions below this are mostly driven by the IO thread. Some of them could
+ * be accessed by both the IO and the App threads (and such functions need
+ * synchronization)
+ *
+ * ============================================================================
+ */
+
 
 /**
  * @brief
@@ -2447,9 +2112,7 @@ queue_strm_close(stream_t *strm)
  * @par Functionality
  *	The slot is not marked free immediately, rather after a period. This is to
  *	ensure that wandering/delayed messages do not cause havoc.
- *	Additionally deletes the stream's entry in the Stream index. This
- *	function is called from both the APP thread and the IO thread, so it
- *	synchronizes using the strmarray_lock mutex.
+ *	Additionally deletes the stream's entry in the Stream index. 
  *
  * @param[in] sd - The stream descriptor
  *
@@ -2465,113 +2128,26 @@ queue_strm_free(unsigned int sd)
 	strm_action_info_t *c;
 	stream_t *strm;
 
-	tpp_lock(&strmarray_lock);
+	strm = get_strm_atomic(sd);
+	if (!strm)
+		return;
 
-	strm = strmarray[sd].strm;
-
-	flush_acks(strm);
 	free_stream_resources(strm);
-	TPP_DBPRT(("Freed sd=%u resources", sd));
+	TPP_DBPRT("Freed sd=%u resources", sd);
 
 	if ((c = malloc(sizeof(strm_action_info_t))) == NULL) {
-		tpp_log_func(LOG_CRIT, __func__, "Out of memory allocating stream action info");
-		tpp_unlock(&strmarray_lock);
+		tpp_log(LOG_CRIT, __func__, "Out of memory allocating stream action info");
 		return;
 	}
 	c->strm_action_time = time(0) + TPP_CLOSE_WAIT; /* time to close */
 	c->strm_action_func = free_stream;
 	c->sd = sd;
 
+	tpp_lock(&strm_action_queue_lock);
 	if (tpp_enque(&strm_action_queue, c) == NULL)
-		tpp_log_func(LOG_CRIT, __func__, "Failed to Queue Free");
+		tpp_log(LOG_CRIT, __func__, "Failed to Queue Free");
+	tpp_unlock(&strm_action_queue_lock);
 
-	tpp_unlock(&strmarray_lock);
-
-	return;
-}
-
-/**
- * @brief
- *	Send close to the app for a stream with out of order packets
- *	that passed its timeout value
- *
- * @par Functionality
- *	Send a stream close to the app, so that the app will close it
- *	eventually. This stream has not received a data packet in sequence
- *	for the timeout period and is therefore assumed to be abandoned.
- *
- * @param[in] sd - The stream descriptor
- *
- * @par Side Effects:
- *	None
- *
- * @par MT-safe: Yes
- *
- */
-static void
-strm_timeout_action(unsigned int sd)
-{
-	stream_t *strm;
-
-	tpp_lock(&strmarray_lock);
-	strm = strmarray[sd].strm;
-
-	TPP_DBPRT(("*** sd=%u timed out, closing", sd));
-
-	send_app_strm_close(strm, TPP_CMD_NET_CLOSE, 0);
-	tpp_unlock(&strmarray_lock);
-}
-
-/**
- * @brief
- *	Add the stream to a queue of streams that has out of order packets
- *
- * @par Functionality
- *	If a stream receives a packet out of order, we add to a queue of
- *	such streams with a timeout, so that if the stream does not get
- *	out of the out-of-order mode, then we close it automatically. This
- *	is to close all such abandoned streams, though the cases of such
- *	occurrences are very minimal
- *
- * @param[in] strm - The stream pointer
- *
- * @par Side Effects:
- *	None
- *
- * @par MT-safe: Yes
- *
- */
-static void
-enque_timeout_strm(stream_t *strm)
-{
-	strm_action_info_t *c;
-
-	tpp_lock(&strmarray_lock);
-
-	if (strmarray[strm->sd].slot_state != TPP_SLOT_BUSY) {
-		tpp_unlock(&strmarray_lock);
-		return;
-	}
-
-	TPP_DBPRT(("Add sd=%u to timeout streams queue", strm->sd));
-
-	if ((c = malloc(sizeof(strm_action_info_t))) == NULL) {
-		tpp_log_func(LOG_CRIT, __func__, "Out of memory allocating stream free info");
-		tpp_unlock(&strmarray_lock);
-		return;
-	}
-	c->strm_action_time = time(0) + TPP_STRM_TIMEOUT;
-	c->strm_action_func = strm_timeout_action;
-	c->sd = strm->sd;
-
-	if ((strm->timeout_node = tpp_enque(&strm_action_queue, c)) == NULL)
-		tpp_log_func(LOG_CRIT, __func__, "Failed to Queue OO strm");
-
-	tpp_unlock(&strmarray_lock);
-
-	if ((app_thread_active_router = get_active_router(app_thread_active_router)) != -1) {
-		tpp_transport_wakeup_thrd(routers[app_thread_active_router]->conn_fd);
-	}
 	return;
 }
 
@@ -2583,9 +2159,7 @@ enque_timeout_strm(stream_t *strm)
  *	If this side had already called close, then instead of sending a
  *	notification to the app, it queues a close operation.
  *	If a NET_CLOSE happened (network between leaf and router broke), then
- *	delete all retry and ack packets and then send notification to APP.
- *	For PEER_CLOSE, don't delete retries and acks, just send notification to
- *	APP.
+ *	send notification to APP.
  *
  * @param[in] strm - Pointer to the stream
  * @param[in] cmd - TPP_CMD_NET_CLOSE - network closed between leaf & router
@@ -2610,8 +2184,8 @@ send_app_strm_close(stream_t *strm, int cmd, int error)
 	strm->lasterr = error;
 	strm->t_state = TPP_TRNS_STATE_NET_CLOSED;
 
-	if (tpp_mbox_post(&app_mbox, strm->sd, cmd, NULL) != 0) {
-		tpp_log_func(LOG_CRIT, __func__, "Error writing to app mbox");
+	if (tpp_mbox_post(&app_mbox, strm->sd, cmd, NULL, 0) != 0) {
+		tpp_log(LOG_CRIT, __func__, "Error writing to app mbox");
 		return -1;
 	}
 
@@ -2654,7 +2228,7 @@ find_stream_with_dest(tpp_addr_t *dest_addr, unsigned int dest_sd, unsigned int 
 	while (pbs_idx_find(streams_idx, &idx_nkey, (void **)&strm, &idx_ctx) == PBS_IDX_RET_OK) {
 		if (memcmp(idx_nkey, dest_addr, sizeof(tpp_addr_t)) != 0)
 			break;
-		TPP_DBPRT(("sd=%u, dest_sd=%u, u_state=%d, t-state=%d, dest_magic=%u", strm->sd, strm->dest_sd, strm->u_state, strm->t_state, strm->dest_magic));
+		TPP_DBPRT("sd=%u, dest_sd=%u, u_state=%d, t-state=%d, dest_magic=%u", strm->sd, strm->dest_sd, strm->u_state, strm->t_state, strm->dest_magic);
 		if (strm->dest_sd == dest_sd && strm->dest_magic == dest_magic) {
 			pbs_idx_free_ctx(idx_ctx);
 			return strm;
@@ -2662,496 +2236,6 @@ find_stream_with_dest(tpp_addr_t *dest_addr, unsigned int dest_sd, unsigned int 
 	}
 	pbs_idx_free_ctx(idx_ctx);
 	return NULL;
-}
-
-/**
- * @brief
- *	Queue a retry packet into the retry queue in a
- *	sorted manner.
- *
- * @param[in] q - Address of the queue to which to insert
- * @param[in] pkt- The retry packet that has to be inserted
- *
- * @return Ptr to the location where it was inserted
- * @retval NULL - If the insertion failed
- * @retval !NULL - The location where the packet was inserted
- *
- * @par Side Effects:
- *	None
- *
- * @par MT-safe: No
- *
- */
-static tpp_que_elem_t *
-enque_retry_sorted(tpp_que_t *q, tpp_packet_t *pkt)
-{
-	tpp_que_elem_t *n = NULL;
-	tpp_packet_t *pkt_queued = NULL;
-	retry_info_t *rt = NULL;
-	time_t time;
-
-	if (!pkt->extra_data)
-		return NULL;
-
-	time = ((retry_info_t *) pkt->extra_data)->retry_time;
-
-	n = TPP_QUE_TAIL(q);
-	while (n) {
-		pkt_queued = TPP_QUE_DATA(n);
-		rt = (retry_info_t *) pkt_queued->extra_data;
-		if (rt->retry_time <= time)
-			break;
-		n = n->prev;
-	}
-	if (n)
-		return (tpp_que_ins_elem(q, n, pkt, 0));
-	else
-		return (tpp_enque(q, pkt));
-}
-
-/**
- * @brief
- *	Shelve a data packet so that it can be retried later again.
- *
- * @par Functionality
- *	If fault tolerant mode is enabled (multiple proxies), then after each
- *	data packet is sent out, the packet is shelved. This function is called
- *	by leaf_pkt_postsend_handler. A retry structure is created and populated
- *	with the retry_time, and added to the extra_data ptr of the data pkt.
- *
- * @param[in] pkt - The hdr packet (+data for regular pkts) to be shelved
- * @param[in] data_pkt - The data pkt, separate from hdr, in mcast cases
- * @param[in] retry_time - The time by which the retry packet must be resent
- *
- * @return Error code
- * @retval -1 - Failure
- * @retval  0 - Success
- *
- * @par Side Effects:
- *	None
- *
- * @par MT-safe: No
- *
- */
-static int
-shelve_pkt(tpp_packet_t *pkt, tpp_packet_t *data_pkt, time_t retry_time)
-{
-	tpp_data_pkt_hdr_t *data = (tpp_data_pkt_hdr_t *)(pkt->data + sizeof(int));
-	retry_info_t *rt;
-	int sd = ntohl(data->src_sd);
-
-	stream_t *strm = get_strm_atomic(sd);
-	if (!strm) {
-		tpp_log_func(LOG_ERR, __func__, "Could not find stream");
-		return -1;
-	}
-
-	rt = (retry_info_t *) pkt->extra_data;
-	if (rt) {
-		if (rt->acked == 1) {
-			/* this packet was already acked from a previous (re)try */
-			/* so release this packet */
-			tpp_clr_retry(pkt, strm);
-
-			tpp_free_pkt(rt->data_pkt);
-			tpp_free_pkt(pkt);
-
-			return 0;
-		}
-		rt->retry_time = retry_time;
-		rt->sent_to_transport = 0;
-		TPP_DBPRT(("Packet already shelved for stream %d, retry_info=%p", sd, rt));
-		return 0;
-	}
-
-	if ((rt = malloc(sizeof(retry_info_t))) == NULL) {
-		tpp_log_func(LOG_CRIT, __func__, "Out of memory allocating retry info");
-		free(rt);
-		return -1;
-	}
-
-	rt->data_pkt = data_pkt;
-	rt->acked = 0;
-	rt->retry_time = retry_time;
-	rt->retry_count = 0;
-	rt->sent_to_transport = 0;
-	pkt->extra_data = rt;
-
-	/* enqueue in a time sorted manner */
-	if ((rt->global_retry_node = enque_retry_sorted(&global_retry_queue, pkt)) == NULL) {
-		tpp_log_func(LOG_CRIT, __func__, "Failed to shelve data packet");
-		free(rt);
-		pkt->extra_data = NULL;
-		return -1;
-	}
-	if ((rt->strm_retry_node = enque_retry_sorted(&strm->retry_queue, pkt)) == NULL) {
-		tpp_log_func(LOG_CRIT, __func__, "Failed to shelve data packet");
-		tpp_que_del_elem(&global_retry_queue, rt->global_retry_node);
-		free(rt);
-		pkt->extra_data = NULL;
-		return -1;
-	}
-	TPP_DBPRT(("Shelved packet for stream %d, retry_info=%p, pkt=%p, data=%p, pos=%p, data_pkt=%p", sd, rt, pkt, pkt->data, pkt->pos, data_pkt));
-
-	return 0;
-}
-
-/**
- * @brief
- *	Shelve a mcast data packet so that it can be retried later again.
- *
- * @par Functionality
- *	If fault tolerant mode is enabled (multiple proxies), then after each
- *	data packet is sent out, the packet is shelved. This function is called
- *	by leaf_pkt_postsend_handler. A retry structure is created and populated
- *	with the retry_time, and added to the extra_data ptr of the data pkt.
- *
- * @param[in] pkt - The data packet that has to be shelved
- * @param[in] retry_time - The time by which the retry packet must be resent
- *
- * @return Error code
- * @retval -1 - Failure
- * @retval  0 - Success
- *
- * @par Side Effects:
- *	None
- *
- * @par MT-safe: No
- *
- */
-static int
-shelve_mcast_pkt(tpp_mcast_pkt_hdr_t *mcast_hdr, int sd, int seq, tpp_packet_t *pkt)
-{
-	tpp_data_pkt_hdr_t indiv_dhdr;
-	tpp_packet_t *indiv_pkt;
-	stream_t *strm;
-	int ntotlen;
-	time_t now = time(0);
-
-	strm = get_strm_atomic(sd);
-	if (!strm)
-		return -1;
-
-	memset(&indiv_dhdr, 0, sizeof(tpp_data_pkt_hdr_t)); /* only to satisfy valgrind */
-	indiv_dhdr.type = TPP_DATA;
-	indiv_dhdr.src_sd = htonl(strm->sd);
-	indiv_dhdr.src_magic = htonl(strm->src_magic);
-	indiv_dhdr.dest_sd = htonl(strm->dest_sd);
-	indiv_dhdr.seq_no = htonl(seq);
-
-	indiv_dhdr.ack_seq = htonl(UNINITIALIZED_INT);
-	indiv_dhdr.dup = 1;
-
-	indiv_dhdr.cmprsd_len = mcast_hdr->data_cmprsd_len;
-	indiv_dhdr.totlen = mcast_hdr->totlen;
-	memcpy(&indiv_dhdr.src_addr, &strm->src_addr, sizeof(tpp_addr_t));
-	memcpy(&indiv_dhdr.dest_addr, &strm->dest_addr, sizeof(tpp_addr_t));
-
-	indiv_pkt = tpp_cr_pkt(NULL, sizeof(int) + sizeof(tpp_data_pkt_hdr_t), 1);
-	if (!indiv_pkt)
-		return -1;
-
-	ntotlen = htonl(sizeof(tpp_data_pkt_hdr_t));
-	memcpy(indiv_pkt->data, &ntotlen, sizeof(int));
-	memcpy(indiv_pkt->data + sizeof(int), &indiv_dhdr, sizeof(tpp_data_pkt_hdr_t));
-
-	pkt->ref_count++;
-
-	shelve_pkt(indiv_pkt, pkt, now + TPP_MAX_RETRY_DELAY);
-
-	return 0;
-}
-
-/**
- * @brief
- *	Queue a acknowledgment packet to be sent out later
- *
- * @param[in] strm - Ptr to the stream to which this ack belongs
- * @param[in] type - The type of the incoming packet thats to be acked (unused)
- * @param[in] seq_no_recvd - The sequence number of the packet recvd.
- *
- * @return Error code
- * @retval -1 - Failure
- * @retval  0 - Success
- *
- * @par Side Effects:
- *	None
- *
- * @par MT-safe: No
- *
- */
-static int
-queue_ack(stream_t *strm, unsigned char type, unsigned int seq_no_recvd)
-{
-	ack_info_t *ack;
-
-	ack = malloc(sizeof(ack_info_t));
-	if (!ack) {
-		tpp_log_func(LOG_CRIT, __func__, "Out of memory allocating ack info");
-		return -1;
-	}
-
-	ack->sd = strm->sd;
-	ack->ack_time = time(0) + TPP_MAX_ACK_DELAY;
-	TPP_DBPRT(("Queueing ack for received sd=%u seq_no=%u", ack->sd, seq_no_recvd));
-	ack->seq_no = seq_no_recvd;
-
-	if ((ack->strm_ack_node = tpp_enque(&strm->ack_queue, ack)) == NULL) {
-		tpp_log_func(LOG_CRIT, __func__, "Failed to queue received pkt");
-		free(ack);
-		return -1;
-	}
-	if ((ack->global_ack_node = tpp_enque(&global_ack_queue, ack)) == NULL) {
-		tpp_log_func(LOG_CRIT, __func__, "Failed to queue received pkt");
-		tpp_que_del_elem(&strm->ack_queue, ack->strm_ack_node);
-		free(ack);
-		return -1;
-	}
-	return 0;
-}
-
-/**
- * @brief
- *	Send an ack packet to the destination stream set in the ack packet
- *
- * @param[in] ack - Ack packet
- *
- * @return Error code
- * @retval -1 - Failure
- * @retval  0 - Success
- *
- * @par Side Effects:
- *	None
- *
- * @par MT-safe: No
- *
- */
-static int
-send_ack_packet(ack_info_t *ack)
-{
-	tpp_data_pkt_hdr_t dhdr;
-	stream_t *strm;
-
-	tpp_lock(&strmarray_lock);
-	strm = strmarray[ack->sd].strm;
-	if (!strm || strmarray[ack->sd].slot_state == TPP_SLOT_FREE) {
-		tpp_unlock(&strmarray_lock);
-		return -1;
-	}
-	tpp_unlock(&strmarray_lock);
-
-	memset(&dhdr, 0, sizeof(tpp_data_pkt_hdr_t)); /* only for valgrind */
-	dhdr.type = TPP_DATA;
-	dhdr.cmprsd_len = 0;
-	dhdr.src_sd = htonl(ack->sd);
-	dhdr.src_magic = htonl(strm->src_magic);
-	dhdr.dest_sd = htonl(strm->dest_sd);
-	dhdr.seq_no = htonl(ack->seq_no); /* seq no to ack */
-	dhdr.ack_seq = dhdr.seq_no; /* same as seq_no */
-	dhdr.dup = 0;
-	memcpy(&dhdr.src_addr, &strm->src_addr, sizeof(tpp_addr_t));
-	memcpy(&dhdr.dest_addr, &strm->dest_addr, sizeof(tpp_addr_t));
-
-	active_router = get_active_router(active_router);
-	if (active_router == -1) {
-		return -1;
-	}
-
-	if (tpp_transport_send(routers[active_router]->conn_fd, &dhdr, sizeof(tpp_data_pkt_hdr_t)) != 0) {
-		tpp_log_func(LOG_ERR, __func__, "tpp_transport_send failed");
-		return -1;
-	}
-	return 0;
-}
-
-/**
- * @brief
- *	Send an retry packet to the destination stream set in the retry packet
- *
- * @param[in] pkt - The data packet. The packet should have retry information
- *		    in pkt->extra_data
- *
- * @return Error code
- * @retval -1 - Failure
- * @retval  0 - Success
- *
- * @par Side Effects:
- *	None
- *
- * @par MT-safe: No
- *
- */
-static int
-send_retry_packet(tpp_packet_t *pkt)
-{
-	tpp_data_pkt_hdr_t *dhdr = (tpp_data_pkt_hdr_t *)(pkt->data + sizeof(int));
-	int sd = ntohl(dhdr->src_sd);
-	retry_info_t *rt;
-	stream_t *strm;
-	void *p;
-	int totlen;
-
-	if (!pkt->extra_data)
-		return -1;
-
-	strm = get_strm_atomic(sd);
-	if (!strm){
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Bad stream pointer for stream=%d", sd);
-		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
-		return -1;
-	}
-
-	rt = (retry_info_t *) pkt->extra_data;
-	if (rt->retry_count > rpp_retry) {
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Too many retries for stream=%d", sd);
-		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
-		return -1;
-	}
-
-	/*
-	 * Right before sending lets see if we can set the dest_sd to improve
-	 * receiver performance
-	 */
-	if (ntohl(dhdr->dest_sd) == UNINITIALIZED_INT) {
-		dhdr->dest_sd = htonl(strm->dest_sd);
-	}
-
-	active_router = get_active_router(active_router);
-	if (active_router == -1) {
-		tpp_log_func(LOG_CRIT, __func__, "No active router");
-		return -1;
-	}
-
-	/* in case of mcast shelved packets, we need to handle the common data
-	 * from the rt->data_pkt and make it part of the packet itself
-	 */
-	if (rt->data_pkt != NULL) {
-		totlen = pkt->len + rt->data_pkt->len;
-		p = realloc(pkt->data, totlen);
-		if (!p)
-			return -1;
-
-		pkt->data = p;
-		pkt->pos = pkt->data + pkt->len;
-		pkt->len = totlen;
-		totlen = htonl(pkt->len - sizeof(int)); /* the length of the whole packet without the leading int */
-		memcpy(pkt->data, &totlen, sizeof(int)); /* update length in pkt */
-		memcpy(pkt->pos, rt->data_pkt->data, rt->data_pkt->len);
-		tpp_free_pkt(rt->data_pkt);
-		rt->data_pkt = NULL;
-	}
-
-	/* reset the send pointer to the top of data for a resend */
-	pkt->pos = pkt->data;
-
-	/*
-	 * Set rt properties before sending, cause send could delete the
-	 * packet itself
-	 */
-	rt->retry_count++;
-	rt->sent_to_transport = 1;
-
-	if (tpp_transport_send_raw(routers[active_router]->conn_fd, pkt) != 0) {
-		tpp_log_func(LOG_ERR, __func__, "tpp_transport_send_raw failed");
-		return -1;
-	}
-
-	return 0;
-}
-
-/**
- * @brief
- *	Walk the sorted global ack queue to send ack packets that have a send
- *	time < now
- *
- * @param[in] now - The current time
- *
- * @par Side Effects:
- *	None
- *
- * @par MT-safe: No
- *
- */
-static void
-check_pending_acks(time_t now)
-{
-	tpp_que_elem_t *n = NULL;
-	stream_t *strm;
-	int rc;
-
-	while ((n = TPP_QUE_HEAD(&global_ack_queue))) {
-		ack_info_t *ack;
-
-		ack = TPP_QUE_DATA(n);
-		if (ack && (ack->ack_time <= now)) {
-			n = tpp_que_del_elem(&global_ack_queue, n);
-			ack->global_ack_node = NULL;
-
-			/* get the strm pointer irrespective of slot state,
-			 * thus get it directly instead of calling get_strm_atomic
-			 */
-			tpp_lock(&strmarray_lock);
-			strm = strmarray[ack->sd].strm;
-			tpp_unlock(&strmarray_lock);
-
-			if (!strm)
-				continue;
-
-			if (ack->strm_ack_node) {
-				tpp_que_del_elem(&strm->ack_queue, ack->strm_ack_node);
-				ack->strm_ack_node = NULL;
-			}
-
-			TPP_DBPRT(("Sending delayed ack packet sd=%u seq=%u", ack->sd, ack->seq_no));
-			rc = send_ack_packet(ack);
-
-			if (rc != 0)
-				send_app_strm_close(strm, TPP_CMD_NET_CLOSE, 0);
-
-			free(ack);
-		} else
-			break; /* stop if we found an ack thats not yet ready */
-	}
-}
-
-/**
- * @brief
- *	Walk the strms ack list and send the acks right away
- *
- * @param[in] strm - the stream whose acks we need to flush out
- *
- * @par Side Effects:
- *	None
- *
- * @par MT-safe: yes
- *
- */
-static void
-flush_acks(stream_t *strm)
-{
-	tpp_que_elem_t *n = NULL;
-	ack_info_t *ack;
-	int rc;
-
-	while ((n = TPP_QUE_HEAD(&strm->ack_queue))) {
-		ack = TPP_QUE_DATA(n);
-		if (ack) {
-			n = tpp_que_del_elem(&strm->ack_queue, n);
-			ack->strm_ack_node = NULL;
-
-			if (ack->global_ack_node) {
-				tpp_que_del_elem(&global_ack_queue, ack->global_ack_node);
-				ack->global_ack_node = NULL;
-			}
-
-			TPP_DBPRT(("Flushing ack packet sd=%u seq=%u", ack->sd, ack->seq_no));
-			rc = send_ack_packet(ack);
-			if (rc != 0)
-				send_app_strm_close(strm, TPP_CMD_NET_CLOSE, 0);
-
-			free(ack);
-		}
-	}
 }
 
 /**
@@ -3170,15 +2254,20 @@ act_strm(time_t now, int force)
 {
 	tpp_que_elem_t *n = NULL;
 
-	tpp_lock(&strmarray_lock);
+	tpp_lock(&strm_action_queue_lock);
 	while ((n = TPP_QUE_NEXT(&strm_action_queue, n))) {
 		strm_action_info_t *c;
 
 		c = TPP_QUE_DATA(n);
 		if (c && ((c->strm_action_time <= now) || (force == 1))) {
 			n = tpp_que_del_elem(&strm_action_queue, n);
-			TPP_DBPRT(("Calling action function for stream %u", c->sd));
+			TPP_DBPRT("Calling action function for stream %u", c->sd);
+			tpp_unlock(&strm_action_queue_lock);
+
+			/* unlock and call action function, then reacquire lock */
 			c->strm_action_func(c->sd);
+			
+			tpp_lock(&strm_action_queue_lock);
 			if (c->strm_action_func == free_stream) {
 				/* free stream itself clears elements from the strm_action_queue
 				 * so restart walking from the head of strm_action_queue
@@ -3188,169 +2277,7 @@ act_strm(time_t now, int force)
 			free(c);
 		}
 	}
-	tpp_unlock(&strmarray_lock);
-}
-
-/**
- * @brief
- *	Walk the sorted global retry queue to send retry packets that have send
- *	time < now
- *
- * @param[in] now - The current time
- *
- * @par Side Effects:
- *	None
- *
- * @par MT-safe: No
- *
- */
-static void
-check_retries(time_t now)
-{
-	tpp_que_elem_t *n = NULL;
-	int sd;
-	stream_t *strm;
-	tpp_data_pkt_hdr_t *dhdr;
-	int count_sent_to_transport = 0;
-
-	while ((n = TPP_QUE_NEXT(&global_retry_queue, n))) {
-		tpp_packet_t *pkt;
-		retry_info_t *rt;
-
-		pkt = TPP_QUE_DATA(n);
-		rt = (retry_info_t *) pkt->extra_data;
-		if (rt && (rt->retry_time <= now)) {
-			if (rt->sent_to_transport == 1) {
-				count_sent_to_transport++;
-				if (count_sent_to_transport > 1000) {
-					sprintf(tpp_get_logbuf(),
-					        "Count of sent_to_transport retry packet reached 1000, doing IO now");
-					tpp_log_func(LOG_INFO, __func__, tpp_get_logbuf());
-					break;
-				}
-				continue;
-			}
-
-			dhdr = (tpp_data_pkt_hdr_t *)(pkt->data + sizeof(int));
-			sd = ntohl(dhdr->src_sd);
-
-			/* get the strm in whatever state it is in */
-			tpp_lock(&strmarray_lock);
-			strm = strmarray[sd].strm;
-			tpp_unlock(&strmarray_lock);
-
-			if (strm && strm->t_state == TPP_TRNS_STATE_OPEN) {
-
-				TPP_DBPRT(("Sending retry packet for sd=%d seq=%u retry_time=%ld, pkt=%p",
-						sd, ntohl(dhdr->seq_no), rt->retry_time, pkt));
-
-				if (send_retry_packet(pkt) != 0) {
-					sprintf(tpp_get_logbuf(), "Could not send retry, sending net_close for sd=%u", strm->sd);
-					tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
-					send_app_strm_close(strm, TPP_CMD_NET_CLOSE, 0);
-				} else {
-					/*
-					 * in case of non fault tolerant mode
-					 * packet and retry will be deleted in
-					 * postsend handler
-					 */
-					if (tpp_fault_tolerant_mode == 1)
-						rt->retry_time = time(0) + TPP_MAX_RETRY_DELAY;
-				}
-				n = NULL; /* list could be modified by send_retry_packet */
-			} else {
-				/* delete this */
-				n = tpp_que_del_elem(&global_retry_queue, n);
-				rt->global_retry_node = NULL;
-
-				if (strm && rt->strm_retry_node) {
-					tpp_que_del_elem(&strm->retry_queue, rt->strm_retry_node);
-					rt->strm_retry_node = NULL;
-				}
-
-				if (rt->sent_to_transport == 0) {
-					tpp_free_pkt(rt->data_pkt); /* for mcast data */
-					tpp_free_pkt(pkt);
-				}
-			}
-		} else
-			break;
-	}
-}
-
-/**
- * @brief
- *	Delete all queued ack packets belonging to a particular stream
- *
- * @param[in] strm - The stream pointer
- *
- * @par Side Effects:
- *	None
- *
- * @par MT-safe: No
- *
- */
-static void
-del_acks(stream_t *strm)
-{
-	tpp_que_elem_t *n = NULL;
-	ack_info_t *ack;
-
-	while ((n = TPP_QUE_NEXT(&strm->ack_queue, n))) {
-		ack = TPP_QUE_DATA(n);
-		if (ack) {
-			n = tpp_que_del_elem(&strm->ack_queue, n);
-			ack->strm_ack_node = NULL;
-
-			if (ack->global_ack_node) {
-				tpp_que_del_elem(&global_ack_queue, ack->global_ack_node);
-				ack->global_ack_node = NULL;
-			}
-
-			free(ack);
-		}
-	}
-}
-
-/**
- * @brief
- *	Delete all queued retry packets belonging to a particular stream
- *
- * @param[in] strm - The stream pointer
- *
- * @par Side Effects:
- *	None
- *
- * @par MT-safe: No
- *
- */
-static void
-del_retries(stream_t *strm)
-{
-	tpp_que_elem_t *n = NULL;
-	retry_info_t *rt;
-	tpp_packet_t *pkt;
-
-	while ((n = TPP_QUE_NEXT(&strm->retry_queue, n))) {
-		pkt = TPP_QUE_DATA(n);
-		n = tpp_que_del_elem(&strm->retry_queue, n);
-
-		if (pkt && pkt->extra_data) {
-			rt = (retry_info_t *) pkt->extra_data;
-
-			rt->strm_retry_node = NULL;
-
-			if (rt->global_retry_node) {
-				tpp_que_del_elem(&global_retry_queue, rt->global_retry_node);
-				rt->global_retry_node = NULL;
-			}
-			rt->acked = 1;
-			if (rt->sent_to_transport == 0) {
-				tpp_free_pkt(rt->data_pkt); /* for mcast packets */
-				tpp_free_pkt(pkt);
-			}
-		}
-	}
+	tpp_unlock(&strm_action_queue_lock);
 }
 
 /**
@@ -3360,7 +2287,7 @@ del_retries(stream_t *strm)
  * @par Functionality
  *	This function is called periodically (after the amount of time as
  *	specified by leaf_next_event_expiry() function) by the IO thread. This
- *	drives the delayed ack, retry, close packets to be acted upon in time.
+ *	drives the close packets to be acted upon in time.
  *
  * @retval  - Time of next event expriry
  *
@@ -3373,8 +2300,6 @@ del_retries(stream_t *strm)
 int
 leaf_timer_handler(time_t now)
 {
-	check_pending_acks(now);
-	check_retries(now);
 	act_strm(now, 0);
 
 	return leaf_next_event_expiry(now);
@@ -3383,9 +2308,8 @@ leaf_timer_handler(time_t now)
 /**
  * @brief
  *	This function returns the amt of time after which the nearest event
- *	happens (event = ack, retry, close etc). The IO thread calls this
- *	function to determine how much time to sleep before calling the
- *	timer_handler function.
+ *	happens (close etc). The IO thread calls this function to determine
+ *	how much time to sleep before calling the timer_handler function
  *
  * @par Side Effects:
  *	None
@@ -3401,32 +2325,15 @@ leaf_next_event_expiry(time_t now)
 	time_t rc3 = -1;
 	time_t res = -1;
 	tpp_que_elem_t *n;
-	retry_info_t *rt;
-	ack_info_t *ack;
-	tpp_packet_t *pkt;
 	strm_action_info_t *f;
 
-	tpp_lock(&strmarray_lock);
-
-	if ((n = TPP_QUE_HEAD(&global_ack_queue))) {
-		if ((ack = TPP_QUE_DATA(n)))
-			rc1 = ack->ack_time;
-	}
-
-	if ((n = TPP_QUE_HEAD(&global_retry_queue))) {
-		if ((pkt = TPP_QUE_DATA(n))) {
-			if (pkt->extra_data) {
-				rt = (retry_info_t *) pkt->extra_data;
-				rc2 = rt->retry_time;
-			}
-		}
-	}
+	tpp_lock(&strm_action_queue_lock);
 
 	if ((n = TPP_QUE_HEAD(&strm_action_queue))) {
 		if ((f = TPP_QUE_DATA(n)))
 			rc3 = f->strm_action_time;
 	}
-	tpp_unlock(&strmarray_lock);
+	tpp_unlock(&strm_action_queue_lock);
 
 	if (rc1 > 0)
 		res = rc1;
@@ -3445,80 +2352,6 @@ leaf_next_event_expiry(time_t now)
 
 /**
  * @brief
- *	When a prior sent data packet is acked, this function is called to
- *	release it from the list of shelved packets.
- *
- *	Remove from stream's retry queue as well as from the global queue of
- *	retry packets.
- *
- * @param[in] seq_no_acked - The sequence number that was acked
- * @param[in] strm - Pointer to the stream to which ack packet arrived
- *
- * @par Side Effects:
- *	None
- *
- * @par MT-safe: No
- *
- */
-static int
-unshelve_pkt(stream_t *strm, int seq_no_acked)
-{
-	tpp_que_elem_t *n = NULL;
-	retry_info_t *rt;
-	tpp_packet_t *pkt;
-	tpp_data_pkt_hdr_t *dhdr;
-	/* let go of the hanging data since it is now acked */
-
-	TPP_DBPRT(("release acked: num_unacked = %d", strm->num_unacked_pkts));
-
-	if (tpp_fault_tolerant_mode == 0) {
-		/*
-		 * first account for the number of packets on wire
-		 * for flow control
-		 */
-		strm->num_unacked_pkts--;
-		if (strm->num_unacked_pkts < 0)
-			strm->num_unacked_pkts = 0;
-		return 0;
-	}
-
-	while ((n = TPP_QUE_NEXT(&strm->retry_queue, n))) {
-		if ((pkt = TPP_QUE_DATA(n))) {
-			rt = (retry_info_t *) pkt->extra_data;
-			dhdr = (tpp_data_pkt_hdr_t *)(pkt->data + sizeof(int));
-			if (ntohl(dhdr->seq_no) == seq_no_acked) {
-				rt->acked = 1;
-				TPP_DBPRT(("Releasing shelved packet sd=%u seq_no=%d type=%d", strm->sd, seq_no_acked, dhdr->type));
-
-				strm->num_unacked_pkts--;
-				if (strm->num_unacked_pkts < 0)
-					strm->num_unacked_pkts = 0;
-
-				if (rt->sent_to_transport == 0) {
-					/* need to free this, since ack is received */
-					n = tpp_que_del_elem(&strm->retry_queue, n);
-					rt->strm_retry_node = NULL;
-
-					if (rt->global_retry_node) {
-						tpp_que_del_elem(&global_retry_queue, rt->global_retry_node);
-						rt->global_retry_node = NULL;
-					}
-
-					if (rt->data_pkt) {
-						tpp_free_pkt(rt->data_pkt);
-						rt->data_pkt = NULL;
-					}
-					tpp_free_pkt(pkt);
-				} /* else delete will be done by post_send */
-				return 0;
-			}
-		}
-	}
-	return 0;
-}
-
-/**
- * @brief
  *	Adds part of a received packet to the received buffer
  *
  * @par Functionality
@@ -3528,6 +2361,7 @@ unshelve_pkt(stream_t *strm, int seq_no_acked)
  * @param[in] sd - The descriptor of the stream
  * @param[in] data - The data that has to be stored
  * @param[in] sz - The size of the data
+ * @param[in] totlen - Total data size
  *
  * @par Side Effects:
  *	None
@@ -3536,59 +2370,35 @@ unshelve_pkt(stream_t *strm, int seq_no_acked)
  *
  */
 static void *
-add_part_packet(stream_t *strm, void *data, int sz)
+add_strm_packet(stream_t *strm, void *data, int sz, int totlen)
 {
-	tpp_packet_t *pkt;
-	char *q;
-	tpp_data_pkt_hdr_t *dhdr;
-	int totlen;
-	unsigned int cmprsd_len;
 	tpp_packet_t *obj;
+	void *tmp;
 
-	dhdr = data;
-	totlen = ntohl(dhdr->totlen);
-	cmprsd_len = ntohl(dhdr->cmprsd_len);
-
-	q = (char *) data + sizeof(tpp_data_pkt_hdr_t);
-
-	pkt = strm->part_recv_pkt;
-	TPP_DBPRT(("*** pkt=%p, sd=%u, sz=%d, totlen=%d, cmprsd_len=%u", (void *) pkt, strm->sd, sz, totlen, cmprsd_len));
-	if (!pkt) {
-		/* some rare cases, compressed size can be larger than orig size, hence use the larger value */
-		pkt = tpp_cr_pkt(NULL, totlen > sz ? totlen : sz, 1);
-		if (!pkt)
-			return NULL;
-		TPP_DBPRT(("Total length = %d, sz=%d", totlen, sz));
-		strm->part_recv_pkt = pkt;
-	}
-	memcpy(pkt->pos, q, sz);
-	pkt->pos += sz;
+	TPP_DBPRT("*** buf=%p, sd=%u, sz=%d, totlen=%d", data, strm->sd, sz, totlen);
 
 	/* in case of uncompressed packets, totlen == compressed_len
 	 * so amount of data on wire is compressed len, so allways check against
 	 * compressed_len
 	 */
-	if (strm->part_recv_pkt->pos - strm->part_recv_pkt->data == cmprsd_len) {
-		strm->part_recv_pkt->pos = strm->part_recv_pkt->data;
-		obj = strm->part_recv_pkt;
-		strm->part_recv_pkt = NULL; /* reset */
-		if (cmprsd_len != totlen) {
-			tpp_packet_t *tmp = obj;
-			void *uncmpr_data;
-
-			if ((uncmpr_data = tpp_inflate(tmp->data, cmprsd_len, totlen))) {
-				obj = tpp_cr_pkt(uncmpr_data, totlen, 0);
-				if (!obj)
-					free(uncmpr_data);
-			} else {
-				tpp_log_func(LOG_CRIT, __func__, "Decompression failed");
-				obj = NULL;
-			}
-			tpp_free_pkt(tmp);
+	if (sz != totlen) {
+		if (!(tmp = tpp_inflate(data, sz, totlen))) {
+			tpp_log(LOG_CRIT, __func__, "Decompression failed");
+			return NULL;
 		}
-		return obj; /* packet complete */
+		data = tmp;
+	} else {
+		/* this is still the pointer to the data part of original buffer, must make copy */
+		tmp = malloc(totlen);
+		memcpy(tmp, data, totlen);
+		data = tmp;
 	}
-	return NULL;
+
+	obj = tpp_bld_pkt(NULL, data, totlen, 0, NULL);
+	if (!obj)
+		tpp_log(LOG_CRIT, __func__, "Failed to build packet");
+	
+	return obj; /* packet complete */
 }
 
 /**
@@ -3601,12 +2411,14 @@ add_part_packet(stream_t *strm, void *data, int sz)
  *
  * @param[in] sd - The descriptor of the stream
  * @param[in] type - The type of the data packet (data, close etc)
- * @param[in] data - The data that has to be stored
+ * @param[in] buf - The data that has to be stored
  * @param[in] sz - The size of the data
+ * @param[in] totlen - Total data size
  *
  * @return Error code
  * @retval 0 - Success
  * @retval -1 - Failure
+ * @retval -2 - App mbox full
  *
  * @par Side Effects:
  *	None
@@ -3615,13 +2427,14 @@ add_part_packet(stream_t *strm, void *data, int sz)
  *
  */
 static int
-send_pkt_to_app(stream_t *strm, unsigned char type, void *data, int sz)
+send_pkt_to_app(stream_t *strm, unsigned char type, void *data, int sz, int totlen)
 {
+	int rc;
 	int cmd;
 	tpp_packet_t *obj;
 
 	if (type == TPP_DATA) {
-		obj = add_part_packet(strm, data, sz);
+		obj = add_strm_packet(strm, data, sz, totlen);
 		if (obj == NULL)
 			return 0; /* more data required */
 		cmd = TPP_CMD_NET_DATA;
@@ -3631,16 +2444,19 @@ send_pkt_to_app(stream_t *strm, unsigned char type, void *data, int sz)
 		obj = NULL;
 	}
 
-	TPP_DBPRT(("Sending cmd=%d to sd=%u", cmd, strm->sd));
+	TPP_DBPRT("Sending cmd=%d to sd=%u", cmd, strm->sd);
 
 	/* since we received one packet, send notification to app */
-	if (tpp_mbox_post(&app_mbox, strm->sd, cmd, obj) != 0) {
-		tpp_log_func(LOG_CRIT, __func__, "Error writing to app mbox");
+	rc = tpp_mbox_post(&app_mbox, strm->sd, cmd, obj, sz);
+	if (rc != 0) {
 		if (obj)
 			tpp_free_pkt(obj);
-		return -1;
+		if (rc == -1)
+			tpp_log(LOG_CRIT, __func__, "Error writing to app mbox");
+		else if (rc == -2)
+			tpp_log(LOG_CRIT, __func__, "App mbox is full");
 	}
-	return 0;
+	return rc;
 }
 
 /**
@@ -3659,40 +2475,27 @@ send_pkt_to_app(stream_t *strm, unsigned char type, void *data, int sz)
 static int
 send_spl_packet(stream_t *strm, int type)
 {
-	tpp_data_pkt_hdr_t dhdr;
-	tpp_chunk_t chunks[2];
+	tpp_data_pkt_hdr_t *dhdr = NULL;
+	tpp_packet_t *pkt = NULL;
 
-	TPP_DBPRT(("Sending CLOSE packet sd=%u, seq_id=%u, dest_sd=%u",
-			strm->sd, strm->send_seq_no, strm->dest_sd));
+	TPP_DBPRT("Sending CLOSE packet sd=%u, dest_sd=%u", strm->sd, strm->dest_sd);
 
-	/* this memset is not required, its only to satisfy valgrind */
-	memset(&dhdr, 0, sizeof(tpp_data_pkt_hdr_t));
-	dhdr.type = type;
-	dhdr.cmprsd_len = 0;
-	dhdr.src_sd = htonl(strm->sd);
-	dhdr.src_magic = htonl(strm->src_magic);
-	dhdr.dest_sd = htonl(strm->dest_sd);
-	dhdr.seq_no = htonl(strm->send_seq_no);
-
-	/* don't increment seq number if close packet is being sent out */
-	if (type != TPP_CLOSE_STRM)
-		strm->send_seq_no = get_next_seq(strm->send_seq_no);
-
-	dhdr.ack_seq = htonl(UNINITIALIZED_INT);
-	dhdr.dup = 0;
-	memcpy(&dhdr.src_addr, &strm->src_addr, sizeof(tpp_addr_t));
-	memcpy(&dhdr.dest_addr, &strm->dest_addr, sizeof(tpp_addr_t));
-
-	chunks[0].data = &dhdr;
-	chunks[0].len = sizeof(tpp_data_pkt_hdr_t);
-
-	app_thread_active_router = get_active_router(app_thread_active_router);
-	if (app_thread_active_router == -1) {
+	pkt = tpp_bld_pkt(NULL, dhdr, sizeof(tpp_data_pkt_hdr_t), 1, (void **) &dhdr);
+	if (!pkt) {
+		tpp_log(LOG_CRIT, __func__, "Failed to build packet");
 		return -1;
 	}
 
-	if (tpp_transport_vsend(routers[app_thread_active_router]->conn_fd, chunks, 1) != 0) {
-		tpp_log_func(LOG_ERR, __func__, "tpp_transport_vsend failed");
+	dhdr->type = type;
+	dhdr->src_sd = htonl(strm->sd);
+	dhdr->src_magic = htonl(strm->src_magic);
+	dhdr->dest_sd = htonl(strm->dest_sd);
+
+	memcpy(&dhdr->src_addr, &strm->src_addr, sizeof(tpp_addr_t));
+	memcpy(&dhdr->dest_addr, &strm->dest_addr, sizeof(tpp_addr_t));
+
+	if (send_to_router(pkt) != 0) {
+		tpp_log(LOG_ERR, __func__, "send_to_router failed");
 		return -1;
 	}
 	return 0;
@@ -3700,7 +2503,7 @@ send_spl_packet(stream_t *strm, int type)
 
 /**
  * @brief
- *	Clear all retries, acks and destroy the stream finally
+ *	destroy the stream finally
  *
  * @param[in] strm - The stream that needs to be freed
  *
@@ -3713,35 +2516,20 @@ send_spl_packet(stream_t *strm, int type)
 static void
 free_stream_resources(stream_t *strm)
 {
-	tpp_packet_t *p;
-
 	if (!strm)
 		return;
 
-	tpp_lock(&strmarray_lock);
+	tpp_write_lock(&strmarray_lock);
 
-	TPP_DBPRT(("Freeing stream resources for sd=%u", strm->sd));
-
-	while ((p = tpp_deque(&strm->oo_queue)))
-		tpp_free_pkt(p);
-
-	if (strm->part_recv_pkt)
-		tpp_free_pkt(strm->part_recv_pkt);
-	strm->part_recv_pkt = NULL;
-
-	/* delete all pending acks and retries */
-	del_retries(strm);
-	del_acks(strm);
+	TPP_DBPRT("Freeing stream resources for sd=%u", strm->sd);
 
 	strmarray[strm->sd].slot_state = TPP_SLOT_DELETED;
 
-	tpp_unlock(&strmarray_lock);
+	tpp_unlock_rwlock(&strmarray_lock);
 
 	if (strm->mcast_data) {
 		if (strm->mcast_data->strms)
 			free(strm->mcast_data->strms);
-		if (strm->mcast_data->seqs)
-			free(strm->mcast_data->seqs);
 		free(strm->mcast_data);
 	}
 }
@@ -3765,9 +2553,9 @@ free_stream(unsigned int sd)
 	tpp_que_elem_t *n = NULL;
 	strm_action_info_t *c;
 
-	TPP_DBPRT(("Freeing stream %u", sd));
+	TPP_DBPRT("Freeing stream %u", sd);
 
-	tpp_lock(&strmarray_lock);
+	tpp_write_lock(&strmarray_lock); /* updating stream, idx, so WRITE lock */
 
 	strm = strmarray[sd].strm;
 	if (strm->strm_type != TPP_STRM_MCAST) {
@@ -3787,24 +2575,14 @@ free_stream(unsigned int sd)
 
 		if (!found) {
 			/* this should not happen ever */
-			sprintf(tpp_get_logbuf(), "Failed finding strm with dest=%s, strm=%p, sd=%u", tpp_netaddr(&strm->dest_addr), strm, strm->sd);
-			tpp_log_func(LOG_ERR, __func__, tpp_get_logbuf());
-			tpp_unlock(&strmarray_lock);
+			tpp_log(LOG_ERR, __func__, "Failed finding strm with dest=%s, strm=%p, sd=%u", tpp_netaddr(&strm->dest_addr), strm, strm->sd);
+			tpp_unlock_rwlock(&strmarray_lock);
 			pbs_idx_free_ctx(idx_ctx);
 			return;
 		}
 
 		pbs_idx_delete_byctx(idx_ctx);
 		pbs_idx_free_ctx(idx_ctx);
-	}
-
-	/* empty all strm actions from the strm action queue */
-	while ((n = TPP_QUE_NEXT(&strm_action_queue, n))) {
-		c = TPP_QUE_DATA(n);
-		if (c && (c->sd == sd)) {
-			n = tpp_que_del_elem(&strm_action_queue, n);
-			free(c);
-		}
 	}
 
 	strmarray[sd].slot_state = TPP_SLOT_FREE;
@@ -3816,7 +2594,18 @@ free_stream(unsigned int sd)
 		freed_queue_count++;
 	}
 
-	tpp_unlock(&strmarray_lock);
+	tpp_unlock_rwlock(&strmarray_lock);
+
+	tpp_lock(&strm_action_queue_lock);
+	/* empty all strm actions from the strm action queue */
+	while ((n = TPP_QUE_NEXT(&strm_action_queue, n))) {
+		c = TPP_QUE_DATA(n);
+		if (c && (c->sd == sd)) {
+			n = tpp_que_del_elem(&strm_action_queue, n);
+			free(c);
+		}
+	}
+	tpp_unlock(&strm_action_queue_lock);
 }
 
 /**
@@ -3825,10 +2614,7 @@ free_stream(unsigned int sd)
  *
  * @par Functionality
  *	When the IO thread is ready to send out a packet over the wire, it calls
- *	a prior registered "pre-send" handler. This pre-send handler (for leaves)
- *	piggy-backs any pending acks to this data packet. This function is also
- *	used to do the flow control (throttling) - by checking number of unacked
- *	packets against the setting "rpp_highwater"
+ *	a prior registered "pre-send" handler
  *
  * @param[in] tfd - The actual IO connection on which data was about to be
  *			sent (unused)
@@ -3845,90 +2631,36 @@ free_stream(unsigned int sd)
  *
  */
 int
-leaf_pkt_presend_handler(int tfd, tpp_packet_t *pkt, void *extra)
+leaf_pkt_presend_handler(int tfd, tpp_packet_t *pkt, void *c, void *extra)
 {
-	tpp_data_pkt_hdr_t *data = (tpp_data_pkt_hdr_t *)(pkt->data + sizeof(int));
-	unsigned char type = data->type;
-	int len = *((int *)(pkt->data));
-	stream_t *strm;
-	time_t now = time(0);
 	conn_auth_t *authdata = (conn_auth_t *)extra;
+	tpp_context_t *ctx = (tpp_context_t *) c;
+	tpp_router_t *r;
+	tpp_data_pkt_hdr_t *data;
+	tpp_chunk_t *first_chunk;
+	unsigned char type;
 
-	if (type == TPP_AUTH_CTX && ((tpp_auth_pkt_hdr_t *)data)->for_encrypt == FOR_ENCRYPT)
+	first_chunk = GET_NEXT(pkt->chunks);
+	if (!first_chunk)
 		return 0;
 
-	len = ntohl(len) - sizeof(tpp_data_pkt_hdr_t);
+	data = (tpp_data_pkt_hdr_t *) first_chunk->data;
+	type = data->type;
 
-	if (type == TPP_CLOSE_STRM || (type == TPP_DATA && len > 0)) {
-		unsigned int sd;
-		unsigned int ack_no;
+	/* Set router's state to connected, if a join packet was successfully sent */
+	if (type == TPP_CTL_JOIN) {
+		r = (tpp_router_t *) ctx->ptr;
+		r->state = TPP_ROUTER_STATE_CONNECTED;
+		r->delay = 0; /* reset connection retry time to 0 */
+		r->conn_time = time(0); /* record connect time */
 
-		sd = ntohl(data->src_sd);
-		ack_no = ntohl(data->ack_seq);
-		strm = get_strm_atomic(sd);
-		if (!strm) {
-			TPP_DBPRT(("Sending data on free/deleted slot sd=%u, seq=%u", sd, ack_no));
-			tpp_clr_retry(pkt, strm);
-			tpp_free_pkt(pkt);
+		tpp_log(LOG_CRIT, __func__, "Connected to pbs_comm %s", r->router_name);
+
+		TPP_DBPRT("Sending cmd to call App net restore handler");
+		if (tpp_mbox_post(&app_mbox, UNINITIALIZED_INT, TPP_CMD_NET_RESTORE, NULL, 0) != 0) {
+			tpp_log(LOG_CRIT, __func__, "Error writing to app mbox");
 			return -1;
 		}
-
-		if (strm->t_state != TPP_TRNS_STATE_OPEN) {
-			/* remove pkt from retry list in case its linked there */
-			if (pkt->extra_data) {
-				retry_info_t *rt = pkt->extra_data;
-				tpp_free_pkt(rt->data_pkt); /* mcast data */
-			}
-			tpp_clr_retry(pkt, strm);
-
-			/* delete the packet and return -1 so no data is sent out */
-			tpp_free_pkt(pkt);
-			return -1;
-		}
-
-		/*
-		 * both in the case of net or peer closed, it means the receiver
-		 * is not expecting (or cannot) receive a packet, so never send it
-		 * a data packet (ack packets are fine).
-		 */
-
-		/* if packet cannot be sent now then shelve them */
-		if (strm->num_unacked_pkts > rpp_highwater) {
-			snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ,
-				"Stream %u reached highwater, %d, throttling, seq=%d", sd,
-				strm->num_unacked_pkts, ntohl(data->seq_no));
-			tpp_log_func(LOG_CRIT, NULL, tpp_get_logbuf());
-			if (shelve_pkt(pkt, NULL, now + TPP_THROTTLE_RETRY) != 0) {
-				tpp_free_pkt(pkt);
-			}
-
-			/*
-			 * return -1, so transport does not send packet,
-			 * but do not delete packet
-			 */
-			return -1;
-		}
-
-		/* add an ack packet to the data packet if available */
-		if (ack_no == UNINITIALIZED_INT) {
-			ack_info_t *ack = tpp_deque(&strm->ack_queue);
-			if (ack) {
-				ack->strm_ack_node = NULL; /* since we dequeued from strm */
-
-				ack_no = ack->seq_no;
-				TPP_DBPRT(("Setting piggyback ack sd=%u, seq=%u", sd, ack_no));
-				data->ack_seq = htonl(ack_no);
-
-				/* since we dequeued the ack, also remove from global list */
-				if (ack->global_ack_node) {
-					tpp_que_del_elem(&global_ack_queue, ack->global_ack_node);
-					ack->global_ack_node = NULL;
-				}
-
-				free(ack);
-			}
-		}
-		/* Fall through below so we can encrypt data packet */
 	}
 
 	/*
@@ -3939,268 +2671,10 @@ leaf_pkt_presend_handler(int tfd, tpp_packet_t *pkt, void *extra)
 	if (authdata == NULL)
 		return 0;
 
-	if (authdata->encryptdef) {
-		char *msgbuf = NULL;
-		void *data_out = NULL;
-		size_t len_out = 0;
-		size_t newpktlen = 0;
-		char *pktdata = NULL;
-		size_t npktlen = 0;
-
-		if (authdata->cleartext != NULL)
-			free(authdata->cleartext);
-
-		authdata->cleartext = malloc(pkt->len);
-		if (authdata->cleartext == NULL) {
-			tpp_log_func(LOG_CRIT, __func__, "malloc failure");
-			return -1;
-		}
-		memcpy(authdata->cleartext, pkt->data, pkt->len);
-		authdata->cleartext_len = pkt->len;
-
-		if (authdata->encryptdef->encrypt_data(authdata->encryptctx, (void *)pkt->data, (size_t)pkt->len, &data_out, &len_out) != 0) {
-			return -1;
-		}
-
-		if (pkt->len > 0 && len_out <= 0) {
-			pbs_asprintf(&msgbuf, "invalid encrypted data len: %d, pktlen: %d", len_out, pkt->len);
-			tpp_log_func(LOG_CRIT, __func__, msgbuf);
-			free(msgbuf);
-			return -1;
-		}
-
-		/* + sizeof(int) for npktlen and + 1 for TPP_ENCRYPTED_DATA */
-		newpktlen = len_out + sizeof(int) + 1;
-		pktdata = malloc(newpktlen);
-		if (pktdata != NULL) {
-			free(pkt->data);
-			pkt->data = pktdata;
-		} else {
-			free(data_out);
-			tpp_log_func(LOG_CRIT, __func__, "malloc failure");
-			return -1;
-		}
-
-		pkt->pos = pkt->data;
-
-		npktlen = htonl(len_out + 1);
-		memcpy(pkt->pos, &npktlen, sizeof(int));
-		pkt->pos = pkt->pos + sizeof(int);
-
-		*pkt->pos = (char)TPP_ENCRYPTED_DATA;
-		pkt->pos++;
-		memcpy(pkt->pos, data_out, len_out);
-
-		pkt->pos = pkt->data;
-		pkt->len = newpktlen;
-
-		free(data_out);
-	}
-	return 0;
-}
-
-/**
- * @brief
- *	The post-send handler registered with the IO thread.
- *
- * @par Functionality
- *	After the IO thread has sent out a packet over the wire, it calls
- *	a prior registered "post-send" handler. This handler (for leaves)
- *	takes care of shelving the packets into a retry queue, so that in case
- *	no acks are received after a while, the packet can be resent again.
- *	Shelving the data packet happens only if fault_tolerant mode is enabled,
- *	ie, if more than one routers are available for this leaf.
- *
- * @param[in] tfd - The actual IO connection on which data was sent (unused)
- * @param[in] pkt - The data packet that is sent out by the IO thrd
- * @param[in] extra - The extra data associated with IO connection
- *
- * @par Side Effects:
- *	None
- *
- * @par MT-safe: No
- *
- */
-int
-leaf_pkt_postsend_handler(int tfd, tpp_packet_t *pkt, void *extra)
-{
-	tpp_data_pkt_hdr_t *data = (tpp_data_pkt_hdr_t *)(pkt->data + sizeof(int));
-	int len = *((int *)(pkt->data));
-	unsigned char type = data->type;
-	time_t now = time(0);
-	tpp_packet_t *shlvd_pkt = NULL;
-	stream_t *strm;
-
-	if (type == TPP_ENCRYPTED_DATA) {
-		conn_auth_t *authdata = (conn_auth_t *)extra;
-
-		if (authdata->cleartext == NULL) {
-			tpp_log_func(LOG_CRIT, __func__, "postsend called with encrypted data but no saved cleartext data in tls");
-			return -1;
-		}
-
-		free(pkt->data);
-		pkt->data = authdata->cleartext;
-		pkt->len = authdata->cleartext_len;
-		pkt->pos = pkt->data;
-
-		authdata->cleartext = NULL;
-		authdata->cleartext_len = 0;
-
-		/* re-calculate data, len and type as pkt changed */
-		data = (tpp_data_pkt_hdr_t *)(pkt->data + sizeof(int));
-		type = data->type;
-		len = *((int *)(pkt->data));
-	}
-
-	if (type == TPP_AUTH_CTX) {
-		tpp_free_pkt(pkt);
-		return 0;
-	}
-
-	len = ntohl(len) - sizeof(tpp_data_pkt_hdr_t);
-
-	/*
-	 * Set routers state to connected, if a join packet was successfully
-	 * sent
-	 */
-	if (type == TPP_CTL_JOIN) {
-		int i;
-		for (i = 0; i < max_routers; i++) {
-			if (routers[i]->conn_fd == tfd) {
-				routers[i]->state = TPP_ROUTER_STATE_CONNECTED;
-				routers[i]->delay = 0; /* reset connection retry time to 0 */
-				routers[i]->conn_time = time(0); /* record connect time */
-				snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Connected to pbs_comm %s", routers[i]->router_name);
-				tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
-				break;
-			}
-		}
-
-		/* since we have atleast one router who connected now, do app restore */
-		if (no_active_router == 1) {
-			TPP_DBPRT(("Sending cmd to call App net restore handler"));
-			if (tpp_mbox_post(&app_mbox, UNINITIALIZED_INT, TPP_CMD_NET_RESTORE, NULL) != 0) {
-				tpp_log_func(LOG_CRIT, __func__, "Error writing to app mbox");
-				tpp_free_pkt(pkt);
-				return -1;
-			}
-			no_active_router = 0;
-		}
-	} else if (type == TPP_CLOSE_STRM || (type == TPP_DATA && len > 0)) {
-		unsigned int sd;
-
-		sd = ntohl(data->src_sd);
-		strm = get_strm_atomic(sd);
-		if (!strm) {
-			tpp_clr_retry(pkt, strm);
-			tpp_free_pkt(pkt);
-			return -1;
-		}
-
-		/* increment number of pkts on the wire, since its not a dup packet */
-		if (data->dup == 0)
-			strm->num_unacked_pkts++;
-
-		/* also shelve the packet now for retrying */
-		if (tpp_fault_tolerant_mode == 1) {
-			data->dup = 1;
-			if (shelve_pkt(pkt, NULL, now + TPP_MAX_RETRY_DELAY) != 0)
-				return -1;
-
-			return 0; /* don't free packet, it could be retried */
-		} else {
-			/* since no fault tolerance, it should be removed from
-			 * global retry list in case it was there due to flow
-			 * control
-			 */
-			tpp_clr_retry(pkt, strm);
-
-			/* pkt itself is deleted at the end of the function
-			 * so just fall through to the end
-			 */
-		}
-	} else if (type == TPP_MCAST_DATA) {
-		/* incr number of unacked packets for each member stream */
-		int i;
-		tpp_mcast_pkt_hdr_t *mcast_hdr = (tpp_mcast_pkt_hdr_t *)(pkt->data + sizeof(int));
-		mcast_data_t *d = (mcast_data_t *) pkt->extra_data;
-		int info_cmprsd_len = ntohl(mcast_hdr->info_cmprsd_len);
-		int info_len = ntohl(mcast_hdr->info_len);
-		/* int num_streams = ntohl(mcast_hdr->num_streams); */
-		void *payload;
-		int payload_len;
-
-		len = *((int *)(pkt->data));
-		len = ntohl(len); /* overall mcast packet length */
-
-		if (info_cmprsd_len > 0) {
-			payload_len = len - sizeof(tpp_mcast_pkt_hdr_t) - info_cmprsd_len;
-			payload = ((char *) mcast_hdr) + sizeof(tpp_mcast_pkt_hdr_t) + info_cmprsd_len;
-		} else {
-			payload_len = len - sizeof(tpp_mcast_pkt_hdr_t) - info_len;
-			payload = ((char *) mcast_hdr) + sizeof(tpp_mcast_pkt_hdr_t) + info_len;
-		}
-
-		if (tpp_fault_tolerant_mode == 1) {
-			shlvd_pkt = tpp_cr_pkt(payload, payload_len, 1);
-			if (!shlvd_pkt) {
-				if (d->strms)
-					free(d->strms);
-				if (d->seqs)
-					free(d->seqs);
-				tpp_free_pkt(pkt);
-				return -1;
-			}
-			shlvd_pkt->ref_count = 0;
-		}
-
-		for (i = 0; i < d->num_fds; i++) {
-			strm = get_strm_atomic(d->strms[i]);
-			if (!strm) {
-				TPP_DBPRT(("post handler on deleted stream"));
-				if (d->strms)
-					free(d->strms);
-				if (d->seqs)
-					free(d->seqs);
-
-				/* in fault_tolerant mode, free the shared packet only if not shelved even once yet */
-				if (tpp_fault_tolerant_mode == 1 && i == 0)
-					tpp_free_pkt(shlvd_pkt);
-
-				tpp_free_pkt(pkt);
-				return -1;
-			}
-			strm->num_unacked_pkts++;
-
-			/* also shelve the packet now for retrying */
-			if (tpp_fault_tolerant_mode == 1) {
-				TPP_DBPRT(("Shelving MCAST packet for strm=%d, seq=%d, mcast_hdr=%p, shlvd_pkt=%p",
-						d->strms[i], d->seqs[i], mcast_hdr, shlvd_pkt));
-				if (shelve_mcast_pkt(mcast_hdr, d->strms[i], d->seqs[i], shlvd_pkt) != 0) {
-					/* free the shared packet only if not shelved even once yet */
-					if (i == 0)
-						tpp_free_pkt(shlvd_pkt);
-
-					tpp_free_pkt(pkt);
-					return -1;
-				}
-			}
-		}
-
-		if (d->strms)
-			free(d->strms);
-		if (d->seqs)
-			free(d->seqs);
-
-		/* let it fall through and free the packet */
-	}
-
-	if (type != TPP_MCAST_DATA)
-		tpp_clr_retry(pkt, NULL); /* for mcast packet, extra_data is mcast related data */
-
-	tpp_free_pkt(pkt);
-	return 0;
+	if (authdata->encryptdef == NULL)
+		return 0; /* no encryption set, so no need to encrypt packets */
+	
+	return (tpp_encrypt_pkt(authdata, pkt));
 }
 
 /**
@@ -4211,6 +2685,8 @@ leaf_pkt_postsend_handler(int tfd, tpp_packet_t *pkt, void *extra)
  * @param[in] src_sd - The stream with which to match
  * @param[in] dest_addr - address of the destination
  * @param[in] dest_sd   - The descriptor of the destination stream
+ * @paarm[in] msg - point to buf to return message
+ * @param[in] sz - length of message buffer
  *
  * @return stream ptr of the stream info matches passed params
  * @retval NULL - If a matching stream was not found, or passed params do not match
@@ -4223,33 +2699,30 @@ leaf_pkt_postsend_handler(int tfd, tpp_packet_t *pkt, void *extra)
  *
  */
 static stream_t *
-check_strm_valid(unsigned int src_sd, tpp_addr_t *dest_addr, int dest_sd)
+check_strm_valid(unsigned int src_sd, tpp_addr_t *dest_addr, int dest_sd, char *msg, int sz)
 {
 	stream_t *strm = NULL;
 
 	if (strmarray == NULL || src_sd >= max_strms) {
-		TPP_DBPRT(("Must be data for old instance, ignoring"));
+		TPP_DBPRT("Must be data for old instance, ignoring");
 		return NULL;
 	}
 
 	if (strmarray[src_sd].slot_state != TPP_SLOT_BUSY) {
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Data to sd=%u which is %s", src_sd,
-		         (strmarray[src_sd].slot_state == TPP_SLOT_DELETED ? "deleted":"freed"));
+		snprintf(msg, sz, "Data to sd=%u which is %s", src_sd, (strmarray[src_sd].slot_state == TPP_SLOT_DELETED ? "deleted" : "freed"));
 		return NULL;
 	}
 
 	strm = strmarray[src_sd].strm;
 
 	if (strm->t_state != TPP_TRNS_STATE_OPEN) {
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Data to sd=%u whose transport is not open (t_state=%d)",
-				 src_sd, strm->t_state);
+		snprintf(msg, sz, "Data to sd=%u whose transport is not open (t_state=%d)", src_sd, strm->t_state);
 		send_app_strm_close(strm, TPP_CMD_NET_CLOSE, 0);
 		return NULL;
 	}
 
-	if ((strm->dest_sd != UNINITIALIZED_INT && strm->dest_sd != dest_sd) ||
-			memcmp(&strm->dest_addr, dest_addr, sizeof(tpp_addr_t)) != 0) {
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Data to sd=%u mismatch dest info in stream", src_sd);
+	if ((strm->dest_sd != UNINITIALIZED_INT && strm->dest_sd != dest_sd) || memcmp(&strm->dest_addr, dest_addr, sizeof(tpp_addr_t)) != 0) {
+		snprintf(msg, sz, "Data to sd=%u mismatch dest info in stream", src_sd);
 		return NULL;
 	}
 
@@ -4262,7 +2735,7 @@ check_strm_valid(unsigned int src_sd, tpp_addr_t *dest_addr, int dest_sd)
  *
  * @par Functionality
  *	When the IO thread is received a packet over the wire, it calls
- *	a prior registered "pkt-send" handler. This handler is responsible to
+ *	a prior registered "chunk-send" handler. This handler is responsible to
  *	decode the data in the packet and do the needful. This handler for the
  *	leaf checks whether data came in order, or is a duplicate packet. If
  *	OOO data arrived, then it is queued in a OOO queue, else the data is
@@ -4287,144 +2760,124 @@ check_strm_valid(unsigned int src_sd, tpp_addr_t *dest_addr, int dest_sd)
  *
  */
 int
-leaf_pkt_handler(int tfd, void *data, int len, void *ctx, void *extra)
+leaf_pkt_handler(int tfd, void *buf, int len, void *ctx, void *extra)
 {
 	stream_t *strm;
-	unsigned int sd = UNINITIALIZED_INT;
-	unsigned char type;
-	void *data_out = NULL;
-	size_t len_out = 0;
+	enum TPP_MSG_TYPES type;
+	tpp_data_pkt_hdr_t *dhdr = buf;
 	conn_auth_t *authdata = (conn_auth_t *)extra;
+	int totlen;
+	int rc;
 
-	type = *((char *) data);
+again:
+	totlen = ntohl(dhdr->totlen);
+	type = dhdr->type;
 	errno = 0;
 
-	if (type == TPP_ENCRYPTED_DATA) {
-		char *msgbuf = NULL;
+	if(type >= TPP_LAST_MSG)
+		return -1;
 
-		if (authdata == NULL) {
-			snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tfd=%d, No auth data found", tfd);
-			tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
-			return -1;
-		}
-
-		if (authdata->encryptdef == NULL) {
-			tpp_log_func(LOG_CRIT, __func__, "connetion doesn't support decryption of data");
-			return -1;
-		}
-
-		if (authdata->encryptdef->decrypt_data(authdata->encryptctx, (void *)((char *)data + 1), (size_t)len - 1, &data_out, &len_out) != 0) {
-			return -1;
-		}
-
-		if (len_out == 0) {
-			pbs_asprintf(&msgbuf, "invalid decrypted data len: %d, pktlen: %d", len_out, len - 1);
-			tpp_log_func(LOG_CRIT, __func__, msgbuf);
-			free(msgbuf);
-			return -1;
-		}
-
-		data = (char *)data_out + sizeof(int);
-		len = len_out - sizeof(int);
-
-		/* re-calculate type as data changed */
-		type = *((char *) data);
-	}
-
-	if (type == TPP_AUTH_CTX) {
-		tpp_auth_pkt_hdr_t ahdr = {0};
-		size_t len_in = 0;
-		void *data_in = NULL;
-		int rc = 0;
-
-		memcpy(&ahdr, data, sizeof(tpp_auth_pkt_hdr_t));
-		len_in = (size_t)len - sizeof(tpp_auth_pkt_hdr_t);
-		data_in = calloc(1, len_in);
-		if (data_in == NULL) {
-			tpp_log_func(LOG_CRIT, __func__, "Out of memory");
-			return -1;
-		}
-		memcpy(data_in, (char *)data + sizeof(tpp_auth_pkt_hdr_t), len_in);
-
-		rc = tpp_handle_auth_handshake(tfd, tfd, authdata, ahdr.for_encrypt, data_in, len_in);
-		if (rc != 1) {
-			free(data_in);
-			return rc;
-		}
-
-		free(data_in);
-
-		if (ahdr.for_encrypt == FOR_ENCRYPT && strcmp(authdata->config->auth_method, AUTH_RESVPORT_NAME) != 0) {
-			if (strcmp(authdata->config->auth_method, authdata->config->encrypt_method) != 0) {
-				rc = tpp_handle_auth_handshake(tfd, tfd, authdata, FOR_AUTH, NULL, 0);
-				if (rc != 1) {
-					return rc;
-				}
-			} else {
-				authdata->authctx = authdata->encryptctx;
-				authdata->authdef = authdata->encryptdef;
-				tpp_transport_set_conn_extra(tfd, authdata);
-			}
-		}
-
-		/* send TPP_CTL_JOIN msg to router */
-		return leaf_send_ctl_join(tfd, data, ctx);
-	}
-
-	/* analyze data and see what message it is
-	 * it could be a ctl message (node join/leave)
-	 * or it could be a data message (for a particular stream fd).
-	 */
 	switch (type) {
+		case TPP_ENCRYPTED_DATA: {
+			int sz = sizeof(tpp_encrypt_hdr_t);
+			int len_out;
+
+			if (authdata == NULL) {
+				tpp_log(LOG_CRIT, __func__, "tfd=%d, No auth data found", tfd);
+				return -1;
+			}
+
+			if (authdata->encryptdef == NULL) {
+				tpp_log(LOG_CRIT, __func__, "connetion doesn't support decryption of data");
+				return -1;
+			}
+
+			if (authdata->encryptdef->decrypt_data(authdata->encryptctx, (void *)((char *)buf + sz), (size_t)len - sz, (void *) &dhdr, (size_t *)&len_out) != 0) {
+				return -1;
+			}
+
+			if (len_out == 0) {
+				tpp_log(LOG_CRIT, __func__, "invalid decrypted data len: %d, pktlen: %d", len_out, len - sz);
+				return -1;
+			}
+			goto again;
+		}
+		break;
+
+		case TPP_AUTH_CTX: {
+			tpp_auth_pkt_hdr_t ahdr = {0};
+			size_t len_in = 0;
+			void *data_in = NULL;
+			int rc = 0;
+
+			memcpy(&ahdr, buf, sizeof(tpp_auth_pkt_hdr_t));
+			len_in = (size_t)len - sizeof(tpp_auth_pkt_hdr_t);
+			data_in = calloc(1, len_in);
+			if (data_in == NULL) {
+				tpp_log(LOG_CRIT, __func__, "Out of memory");
+				return -1;
+			}
+			memcpy(data_in, (char *)buf + sizeof(tpp_auth_pkt_hdr_t), len_in);
+
+			rc = tpp_handle_auth_handshake(tfd, tfd, authdata, ahdr.for_encrypt, data_in, len_in);
+			if (rc != 1) {
+				free(data_in);
+				return rc;
+			}
+
+			free(data_in);
+
+			if (ahdr.for_encrypt == FOR_ENCRYPT && strcmp(authdata->config->auth_method, AUTH_RESVPORT_NAME) != 0) {
+				if (strcmp(authdata->config->auth_method, authdata->config->encrypt_method) != 0) {
+					rc = tpp_handle_auth_handshake(tfd, tfd, authdata, FOR_AUTH, NULL, 0);
+					if (rc != 1) {
+						return rc;
+					}
+				} else {
+					authdata->authctx = authdata->encryptctx;
+					authdata->authdef = authdata->encryptdef;
+					tpp_transport_set_conn_extra(tfd, authdata);
+				}
+			}
+
+			/* send TPP_CTL_JOIN msg to router */
+			return leaf_send_ctl_join(tfd, ctx);
+		}
+		break; /* TPP_AUTH_CTX */
+
 		case TPP_CTL_MSG: {
-			tpp_ctl_pkt_hdr_t *hdr = (tpp_ctl_pkt_hdr_t *) data;
+			tpp_ctl_pkt_hdr_t *hdr = (tpp_ctl_pkt_hdr_t *) buf;
 			int code = hdr->code;
 
 			if (code == TPP_MSG_NOROUTE) {
 				unsigned int src_sd = ntohl(hdr->src_sd);
 				strm = get_strm_atomic(src_sd);
 				if (strm) {
-					char *msg = ((char *) data) + sizeof(tpp_ctl_pkt_hdr_t);
-					snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "sd %u, Received noroute to dest %s, msg=\"%s\"", src_sd,
-								tpp_netaddr(&hdr->src_addr), msg);
-#ifdef NAS /* localmod 149 */
-					tpp_log_func(LOG_DEBUG, NULL, tpp_get_logbuf());
-#else
-					tpp_log_func(LOG_INFO, NULL, tpp_get_logbuf());
-#endif /* localmod 149 */
-
-					TPP_DBPRT(("received noroute, sending TPP_CMD_NET_CLOSE to %u", strm->sd));
+					char *msg = ((char *) buf) + sizeof(tpp_ctl_pkt_hdr_t);
+					tpp_log(LOG_DEBUG, NULL, "sd %u, Received noroute to dest %s, msg=\"%s\"", src_sd, tpp_netaddr(&hdr->src_addr), msg);
 					send_app_strm_close(strm, TPP_CMD_NET_CLOSE, 0);
 				}
-				if (data_out)
-					free(data_out);
 				return 0;
 			}
 
 			if (code == TPP_MSG_UPDATE) {
-				tpp_log_func(LOG_INFO, NULL, "Received UPDATE from pbs_comm");
-				if (tpp_mbox_post(&app_mbox, UNINITIALIZED_INT, TPP_CMD_NET_RESTORE, NULL) != 0) {
-					tpp_log_func(LOG_CRIT, __func__, "Error writing to app mbox");
+				tpp_log(LOG_INFO, NULL, "Received UPDATE from pbs_comm");
+				if (tpp_mbox_post(&app_mbox, UNINITIALIZED_INT, TPP_CMD_NET_RESTORE, NULL, 0) != 0) {
+					tpp_log(LOG_CRIT, __func__, "Error writing to app mbox");
 				}
-				if (data_out)
-					free(data_out);
 				return 0;
 			}
 
 			if (code == TPP_MSG_AUTHERR) {
-				char *msg = ((char *) data) + sizeof(tpp_ctl_pkt_hdr_t);
-				snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tfd %d, Received authentication error from router %s, err=%d, msg=\"%s\"", tfd,
-							tpp_netaddr(&hdr->src_addr), hdr->error_num, msg);
-				tpp_log_func(LOG_CRIT, NULL, tpp_get_logbuf());
-				if (data_out)
-					free(data_out);
+				char *msg = ((char *) buf) + sizeof(tpp_ctl_pkt_hdr_t);
+				tpp_log(LOG_CRIT, NULL, "tfd %d, Received authentication error from router %s, err=%d, msg=\"%s\"", tfd, tpp_netaddr(&hdr->src_addr), hdr->error_num, msg);
 				return -1; /* close connection */
 			}
 		}
 		break; /* TPP_CTL_MSG */
 
 		case TPP_CTL_LEAVE: {
-			tpp_leave_pkt_hdr_t *hdr = (tpp_leave_pkt_hdr_t *) data;
+			tpp_leave_pkt_hdr_t *hdr = (tpp_leave_pkt_hdr_t *) buf;
 			tpp_que_t send_close_queue;
 			tpp_addr_t *addrs;
 			int i;
@@ -4432,11 +2885,11 @@ leaf_pkt_handler(int tfd, void *data, int len, void *ctx, void *extra)
 			PRTPKTHDR(__func__, hdr, 0);
 
 			/* bother only about leave */
-			tpp_lock(&strmarray_lock);
+			tpp_read_lock(&strmarray_lock); /* walking stream idx, so read lock */
 			TPP_QUE_CLEAR(&send_close_queue);
 
 			/* go past the header and point to the list of addresses following it */
-			addrs = (tpp_addr_t *) (((char *) data) + sizeof(tpp_leave_pkt_hdr_t));
+			addrs = (tpp_addr_t *) (((char *) buf) + sizeof(tpp_leave_pkt_hdr_t));
 			for(i = 0; i < hdr->num_addrs; i++) {
 				void *idx_ctx = NULL;
 				void *paddr = &addrs[i];
@@ -4448,26 +2901,21 @@ leaf_pkt_handler(int tfd, void *data, int len, void *ctx, void *extra)
 					/* under lock already, can access directly */
 					if (strmarray[strm->sd].slot_state == TPP_SLOT_BUSY) {
 						if (tpp_enque(&send_close_queue, strm) == NULL) {
-							tpp_log_func(LOG_CRIT, __func__, "Out of memory enqueing to send close queue");
-							tpp_unlock(&strmarray_lock);
+							tpp_log(LOG_CRIT, __func__, "Out of memory enqueing to send close queue");
+							tpp_unlock_rwlock(&strmarray_lock);
 							pbs_idx_free_ctx(idx_ctx);
-							if (data_out)
-								free(data_out);
 							return -1;
 						}
 					}
 				}
 				pbs_idx_free_ctx(idx_ctx);
 			}
-			tpp_unlock(&strmarray_lock);
+			tpp_unlock_rwlock(&strmarray_lock);
 
 			while ((strm = (stream_t *) tpp_deque(&send_close_queue))) {
-				TPP_DBPRT(("received TPP_CTL_LEAVE, sending TPP_CMD_NET_CLOSE sd=%u", strm->sd));
+				TPP_DBPRT("received TPP_CTL_LEAVE, sending TPP_CMD_NET_CLOSE sd=%u", strm->sd);
 				send_app_strm_close(strm, TPP_CMD_NET_CLOSE, hdr->ecode);
 			}
-
-			if (data_out)
-				free(data_out);
 
 			return 0;
 		}
@@ -4476,75 +2924,61 @@ leaf_pkt_handler(int tfd, void *data, int len, void *ctx, void *extra)
 
 		case TPP_DATA:
 		case TPP_CLOSE_STRM: {
-			tpp_data_pkt_hdr_t *p = (tpp_data_pkt_hdr_t *) data;
-			unsigned int seq_no_recvd;
-			unsigned int seq_no_expected;
-			unsigned int seq_no_acked;
-			unsigned char dup;
+			char msg[TPP_GEN_BUF_SZ];
 			unsigned int src_sd;
 			unsigned int dest_sd;
 			unsigned int src_magic;
 			unsigned int sz = len - sizeof(tpp_data_pkt_hdr_t);
+			void *data = buf + sizeof(tpp_data_pkt_hdr_t);
 
-			src_sd = ntohl(p->src_sd);
-			dest_sd = ntohl(p->dest_sd);
-			src_magic = ntohl(p->src_magic);
-			seq_no_recvd = ntohl(p->seq_no);
-			seq_no_acked = ntohl(p->ack_seq);
-			dup = p->dup;
+			src_sd = ntohl(dhdr->src_sd);
+			dest_sd = ntohl(dhdr->dest_sd);
+			src_magic = ntohl(dhdr->src_magic);
 
-			PRTPKTHDR(__func__, p, sz);
+			PRTPKTHDR(__func__, dhdr, sz);
 
 			if (dest_sd == UNINITIALIZED_INT && type != TPP_CLOSE_STRM && sz == 0) {
-				tpp_log_func(LOG_ERR, NULL, "ack packet without dest_sd set!!!");
-				if (data_out)
-					free(data_out);
+				tpp_log(LOG_ERR, NULL, "ack packet without dest_sd set!!!");
 				return -1;
 			}
 
 			if (dest_sd == UNINITIALIZED_INT) {
-				tpp_lock(&strmarray_lock);
-				strm = find_stream_with_dest(&p->src_addr, src_sd, src_magic);
-				tpp_unlock(&strmarray_lock);
+				tpp_read_lock(&strmarray_lock); /* walking stream idx, so read lock */
+				strm = find_stream_with_dest(&dhdr->src_addr, src_sd, src_magic);
+				tpp_unlock_rwlock(&strmarray_lock);
 				if (strm == NULL) {
-					TPP_DBPRT(("No stream associated, Opening new stream"));
+					TPP_DBPRT("No stream associated, Opening new stream");
 					/*
 					 * packet's destination address = stream's source address at our end
 					 * packet's source address = stream's destination address at our end
 					 */
-					if ((strm = alloc_stream(&p->dest_addr, &p->src_addr)) == NULL) {
-						tpp_log_func(LOG_CRIT, __func__, "Out of memory allocating stream");
-						if (data_out)
-							free(data_out);
+					if ((strm = alloc_stream(&dhdr->dest_addr, &dhdr->src_addr)) == NULL) {
+						tpp_log(LOG_CRIT, __func__, "Out of memory allocating stream");
 						return -1;
 					}
 				} else {
-					TPP_DBPRT(("Stream sd=%u, u_state=%d, t_state=%d", strm->sd, strm->u_state, strm->t_state));
+					TPP_DBPRT("Stream sd=%u, u_state=%d, t_state=%d", strm->sd, strm->u_state, strm->t_state);
 				}
 				dest_sd = strm->sd;
 			} else {
-				TPP_DBPRT(("Stream found from index in packet = %u", dest_sd));
+				TPP_DBPRT("Stream found from index in packet = %u", dest_sd);
 			}
 
 			/* In any case, check for the stream's validity */
-			tpp_lock(&strmarray_lock);
-			strm = check_strm_valid(dest_sd, &p->src_addr, src_sd);
-			tpp_unlock(&strmarray_lock);
+			tpp_read_lock(&strmarray_lock); /* walking stream idx, so read lock */
+			strm = check_strm_valid(dest_sd, &dhdr->src_addr, src_sd, msg, sizeof(msg));
+			tpp_unlock_rwlock(&strmarray_lock);
 			if (strm == NULL) {
-				if (type != TPP_CLOSE_STRM && sz == 0) {
-					if (data_out)
-						free(data_out);
+				if (type != TPP_CLOSE_STRM && sz == 0)
 					return 0; /* it is an ack packet, don't send noroute */
-				}
-				tpp_log_func(LOG_WARNING, __func__, tpp_get_logbuf());
-				tpp_send_ctl_msg(tfd, TPP_MSG_NOROUTE, &p->src_addr, &p->dest_addr, src_sd, 0, tpp_get_logbuf());
-				if (data_out)
-					free(data_out);
+
+				tpp_log(LOG_WARNING, __func__, msg);
+				tpp_send_ctl_msg(tfd, TPP_MSG_NOROUTE, &dhdr->src_addr, &dhdr->dest_addr, src_sd, 0, msg);
 				return 0;
 			}
 
 			/*
-			 * this should be set even from ack and close packets since
+			 * this should be set even close packets since
 			 * we could have opened a stream locally, sent a packet
 			 * and the ack carries the other sides sd, which we must store
 			 * and use in the next send out.
@@ -4552,185 +2986,17 @@ leaf_pkt_handler(int tfd, void *data, int len, void *ctx, void *extra)
 			strm->dest_sd = src_sd; /* next time outgoing will have dest_fd */
 			strm->dest_magic = src_magic; /* used for matching next time onwards */
 
-			seq_no_expected = strm->seq_no_expected;
-			TPP_DBPRT(("sequence_no expected = %u", seq_no_expected));
+			rc = send_pkt_to_app(strm, type, data, sz, totlen);
 
-			sd = strm->sd;
-
-			if (seq_no_acked != UNINITIALIZED_INT) {
-				unshelve_pkt(strm, seq_no_acked);
-				/*
-				 * if app u_state == TPP_STRM_STATE_CLOSE means an CLOSE packet was sent out
-				 * and the strm's send_seq_no was the last sequence sent out, and it will not be
-				 * incremented any more. If CLOSE is acked, then queue the stream for deletion
-				 */
-				if (strm->u_state == TPP_STRM_STATE_CLOSE && seq_no_acked == strm->send_seq_no) {
-					TPP_DBPRT(("sd=%u PEER acked CLOSE, sending CLOSE to APP", strm->sd));
-					send_pkt_to_app(strm, TPP_CLOSE_STRM, NULL, 0);
-				}
-			}
-
-			if (type != TPP_CLOSE_STRM && sz == 0) {
-				if (data_out)
-					free(data_out);
-				return 0; /* it is an ack packet, everything is done by now */
-			}
-
-			/* always ack data packets, even if duplicate */
-			queue_ack(strm, type, seq_no_recvd);
-
-			if (seq_no_recvd == seq_no_expected) {
-				tpp_que_elem_t *n;
-				int oo_cleared = 1;
-
-				TPP_DBPRT(("Sending in sequence to app, sd=%u, seq=%u", sd, seq_no_expected));
-				send_pkt_to_app(strm, type, data, sz);
-				seq_no_expected = get_next_seq(seq_no_expected);
-
-				/*
-				 * also go through the hanged off list of out of order packets and
-				 * send all those to app that now fall in sequence.
-				 */
-				n = NULL;
-				while ((n = TPP_QUE_NEXT(&strm->oo_queue, n))) {
-					tpp_packet_t *oo_pkt = (tpp_packet_t *) TPP_QUE_DATA(n);
-					if (oo_pkt) {
-						tpp_data_pkt_hdr_t *dhdr = (tpp_data_pkt_hdr_t *) oo_pkt->data;
-						if (ntohl(dhdr->seq_no) == seq_no_expected) {
-
-							n = tpp_que_del_elem(&strm->oo_queue, n);
-
-							snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Sending OO packets to app, sd=%u, seq=%u", sd, seq_no_expected);
-							tpp_log_func(LOG_INFO, NULL, tpp_get_logbuf());
-
-							send_pkt_to_app(strm, dhdr->type, oo_pkt->data, oo_pkt->len - sizeof(tpp_data_pkt_hdr_t));
-							seq_no_expected = get_next_seq(seq_no_expected);
-
-							tpp_free_pkt(oo_pkt);
-						} else {
-							oo_cleared = 0;
-							break;
-						}
-					}
-				}
-
-				/* if no out of order packets remained, clear this stream from the queue of OO strms */
-				if (oo_cleared == 1) {
-					if (strm->timeout_node) {
-						tpp_lock(&strmarray_lock);
-						tpp_que_del_elem(&strm_action_queue, strm->timeout_node);
-						strm->timeout_node = NULL;
-						tpp_unlock(&strmarray_lock);
-					}
-				}
-
-				strm->seq_no_expected = seq_no_expected;
-				if (data_out)
-					free(data_out);
-				return 0;
-			} else {
-				tpp_que_elem_t *n;
-				tpp_packet_t *full_pkt;
-				int seq_no_diff;
-
-				/*
-				* Check the sequence number in the packet, if duplicate drop it,
-				* if out of order store it, if fine, let know app
-				*/
-				seq_no_diff = abs(seq_no_expected - seq_no_recvd);
-				if ((seq_no_recvd < seq_no_expected && seq_no_diff < MAX_SEQ_NUMBER / 4)
-					|| (seq_no_recvd > seq_no_expected && seq_no_diff > MAX_SEQ_NUMBER / 4)) {
-					/* duplicate packet, drop it, ack was already sent */
-					if (dup > 0) {
-						snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ,
-							"Received duplicate packet with seq_no = %d", seq_no_recvd);
-						tpp_log_func(LOG_DEBUG, NULL, tpp_get_logbuf());
-					} else {
-						snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ,
-							"Duplicate packet? with seq_no = %d without dup flag set", seq_no_recvd);
-						tpp_log_func(LOG_DEBUG, NULL, tpp_get_logbuf());
-					}
-					duppkt_cnt++;
-					if (data_out)
-						free(data_out);
-					return 0;
-				}
-
-				if (strm->timeout_node == NULL) {
-					enque_timeout_strm(strm);
-				}
-
-				/*
-				 * 1. Hang it off a out of order list on the stream
-				 * 2. The sender would realize this and retransmit this.
-				 */
-				oopkt_cnt++;
-				snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "OO pkt sd=%u seq=%u exp=%u u_state=%d t_state=%d dest=%s src_sd=%u, dest_sd=%u",
-					strm->sd, seq_no_recvd, seq_no_expected, strm->u_state, strm->t_state, tpp_netaddr(&strm->dest_addr), src_sd,
-					dest_sd);
-				tpp_log_func(LOG_WARNING, NULL, tpp_get_logbuf());
-
-				full_pkt = tpp_cr_pkt(data, len, 1);
-				if (full_pkt == NULL) {
-					if (data_out)
-						free(data_out);
-					return -1;
-				}
-
-				n = NULL;
-				while ((n = TPP_QUE_NEXT(&strm->oo_queue, n))) {
-					tpp_packet_t *oo_pkt = TPP_QUE_DATA(n);
-					if (oo_pkt) {
-						tpp_data_pkt_hdr_t *shdr = (tpp_data_pkt_hdr_t *) oo_pkt->data;
-						unsigned int seq_no = (unsigned int) ntohl(shdr->seq_no);
-						if (seq_no == seq_no_recvd) {
-							/* duplicate packet */
-							snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Recvd duplicate packet seq_no=%u, dup=%d", seq_no_recvd, shdr->dup);
-							tpp_log_func(LOG_CRIT, NULL, tpp_get_logbuf());
-
-							tpp_free_pkt(full_pkt);
-							if (data_out)
-								free(data_out);
-							return 0;
-						} else if (seq_no > seq_no_recvd) {
-
-							/* insert it here and return */
-							n = tpp_que_ins_elem(&strm->oo_queue, n, full_pkt, 1);
-							snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Inserted OO packet with seq_no = %u for sd=%u", seq_no_recvd,
-								strm->sd);
-							tpp_log_func(LOG_INFO, NULL, tpp_get_logbuf());
-							if (data_out)
-								free(data_out);
-							return 0;
-						}
-					}
-				}
-				/* if it came here then packet was not inserted, so insert at end */
-				if (tpp_enque(&strm->oo_queue, full_pkt) == NULL) {
-					snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Failed to enque OO packet for sd = %u, Out of memory", strm->sd);
-					tpp_log_func(LOG_CRIT, NULL, tpp_get_logbuf());
-					if (data_out)
-						free(data_out);
-					return -1;
-				}
-				if (data_out)
-					free(data_out);
-				return 0;
-			}
-			if (data_out)
-				free(data_out);
-			return 0;
+			return rc; /* 0 - success, -1 failed, -2 app mbox full */
 		}
 		break; /* TPP_DATA, TPP_CLOSE_STRM */
 
 		default:
-			snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Bad header for incoming packet on fd %d, header = %d", tfd, type);
-			tpp_log_func(LOG_ERR, NULL, tpp_get_logbuf());
+			tpp_log(LOG_ERR, NULL,  "Bad header for incoming packet on fd %d, header = %d, len = %d", tfd, type, len);
 
 	} /* switch */
 
-	if (data_out)
-		free(data_out);
 	return -1;
 }
 
@@ -4741,11 +3007,7 @@ leaf_pkt_handler(int tfd, void *data, int len, void *ctx, void *extra)
  * @par Functionality
  *	When the connection between this leaf and a router is dropped, the IO
  *	thread first calls this (prior registered) function to notify the leaf
- *	layer of the fact that a connection was dropped. If not other routes
- *	are up (no other routers) or all other router connections down, then
- *	all streams that are currently open on this leaf are sent a close
- *	message. (The APP eventually reads the close message and calls tpp_close
- *	on those streams)
+ *	layer of the fact that a connection was dropped.
  *
  * @param[in] tfd - The actual IO connection on which data was about to be
  *			sent (unused)
@@ -4772,8 +3034,6 @@ leaf_close_handler(int tfd, int error, void *c, void *extra)
 			authdata->authdef->destroy_ctx(authdata->authctx);
 		if (authdata->authdef != authdata->encryptdef && authdata->encryptctx && authdata->encryptdef)
 			authdata->encryptdef->destroy_ctx(authdata->encryptctx);
-		if (authdata->cleartext)
-			free(authdata->cleartext);
 		if (authdata->config)
 			free_auth_config(authdata->config);
 		/* DO NOT free authdef here, it will be done in unload_auths() */
@@ -4801,47 +3061,43 @@ leaf_close_handler(int tfd, int error, void *c, void *extra)
 	r->conn_fd = -1;
 
 	if (last_state == TPP_ROUTER_STATE_CONNECTED) {
+		unsigned int i;
 		/* log disconnection message */
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Connection to pbs_comm %s down", r->router_name);
-		tpp_log_func(LOG_CRIT, NULL, tpp_get_logbuf());
+		tpp_log(LOG_CRIT, NULL, "Connection to pbs_comm %s down", r->router_name);
 
-		if (app_thread_active_router >= 0 && routers[app_thread_active_router] == r) {
-			/* the current global index went down, set the index to -1 so its deduced again */
-			app_thread_active_router = -1;
+		if (!the_app_net_down_handler) {
+			/* send individual net close messages to app */
+			tpp_read_lock(&strmarray_lock); /* walking stream idx, so read lock */
+			for (i = 0; i < max_strms; i++) {
+				if (strmarray[i].slot_state == TPP_SLOT_BUSY) {
+					strmarray[i].strm->t_state = TPP_TRNS_STATE_NET_CLOSED;
+					TPP_DBPRT("net down, sending TPP_CMD_NET_CLOSE sd=%u", strmarray[i].strm->sd);
+					send_app_strm_close(strmarray[i].strm, TPP_CMD_NET_CLOSE, 0);
+				}
+			}
+			tpp_unlock_rwlock(&strmarray_lock);
+		} else {
+			tpp_read_lock(&strmarray_lock); /* walking stream idx, so read lock */
+			for (i = 0; i < max_strms; i++) {
+				if (strmarray[i].slot_state == TPP_SLOT_BUSY) {
+					strmarray[i].strm->t_state = TPP_TRNS_STATE_NET_CLOSED;
+					TPP_DBPRT("net down, sending TPP_CMD_NET_CLOSE sd=%u", strmarray[i].strm->sd);
+					send_app_strm_close(strmarray[i].strm, TPP_CMD_NET_CLOSE, 0);
+				}
+			}
+			tpp_unlock_rwlock(&strmarray_lock);
+			if (tpp_mbox_post(&app_mbox, UNINITIALIZED_INT, TPP_CMD_NET_DOWN, NULL, 0) != 0) {
+				tpp_log(LOG_CRIT, __func__, "Error writing to app mbox");
+				return -1;
+			}
 		}
 
-		active_router = get_active_router(active_router);
-		if (active_router == -1) {
-			unsigned int i;
-
-			/*
-			 * No routers available, let app know of this
-			 */
-			if (!the_app_net_down_handler) {
-				/* send individual net close messages to app */
-				tpp_lock(&strmarray_lock);
-				for (i = 0; i < max_strms; i++) {
-					if (strmarray[i].slot_state == TPP_SLOT_BUSY) {
-						strmarray[i].strm->t_state = TPP_TRNS_STATE_NET_CLOSED;
-						TPP_DBPRT(("net down, sending TPP_CMD_NET_CLOSE sd=%u", strmarray[i].strm->sd));
-						send_app_strm_close(strmarray[i].strm, TPP_CMD_NET_CLOSE, 0);
-					}
-				}
-				tpp_unlock(&strmarray_lock);
-			} else {
-				tpp_lock(&strmarray_lock);
-				for (i = 0; i < max_strms; i++) {
-					if (strmarray[i].slot_state == TPP_SLOT_BUSY) {
-						strmarray[i].strm->t_state = TPP_TRNS_STATE_NET_CLOSED;
-						TPP_DBPRT(("net down, sending TPP_CMD_NET_CLOSE sd=%u", strmarray[i].strm->sd));
-						send_app_strm_close(strmarray[i].strm, TPP_CMD_NET_CLOSE, 0);
-					}
-				}
-				tpp_unlock(&strmarray_lock);
-				if (tpp_mbox_post(&app_mbox, UNINITIALIZED_INT, TPP_CMD_NET_DOWN, NULL) != 0) {
-					tpp_log_func(LOG_CRIT, __func__, "Error writing to app mbox");
-					return -1;
-				}
+		/* if we are connected to another router, make app layer realize they need to restart streams */
+		/* send a connection restore message, so app restarts streams on the alternate route */
+		if (get_active_router()) {
+			if (tpp_mbox_post(&app_mbox, UNINITIALIZED_INT, TPP_CMD_NET_RESTORE, NULL, 0) != 0) {
+				tpp_log(LOG_CRIT, __func__, "Error writing to app mbox");
+				return -1;
 			}
 		}
 	}
@@ -4859,42 +3115,28 @@ leaf_close_handler(int tfd, int error, void *c, void *extra)
 	if ((rc = connect_router(r)) != 0)
 		return -1;
 
-	if (active_router != -1) {
-		check_retries(-1);
-		check_pending_acks(-1);
-	}
 	return 0;
 }
 
-/**
- * @brief
- * 	Utility function to clear the retry related information from the packet
- *
- * @param[in] pkt  - pointer to the packet structure
- * @param[in] strm - if a stream is associated, then pointer to it, so that pkt
- *                   can be removed from the stream level retry queue
- *
- * @par Side Effects:
- *	None
- *
- * @par MT-safe: No
- *
+/* @brief 
+ * wrapper routine that checks the router connection status before calling
+ * tpp_transport_send(). This function can check not just the router fd
+ * but that the connection  is actually in fully connected state
+ * 
+ * @return  Error code
+ * @retval  -1 - Failure
+ * @retval  -2 - transport buffers full
+ * @retval   0 - Success
+ * 
  */
-static void
-tpp_clr_retry(tpp_packet_t *pkt, stream_t *strm)
+static int 
+send_to_router(tpp_packet_t *pkt)
 {
-	if (pkt->extra_data) {
-		retry_info_t *rt = pkt->extra_data;
-		if (rt->global_retry_node) {
-			tpp_que_del_elem(&global_retry_queue, rt->global_retry_node);
-			rt->global_retry_node = NULL;
-		}
-
-		if (rt->strm_retry_node) {
-			if (strm)
-				tpp_que_del_elem(&strm->retry_queue, rt->strm_retry_node);
-
-			rt->strm_retry_node = NULL;
-		}
+	tpp_router_t *router = get_active_router();
+	if ((router == NULL) || (router->conn_fd == -1) || (router->state != TPP_ROUTER_STATE_CONNECTED)) {
+		tpp_log(LOG_ERR, __func__, "No active router");
+		return -1;
 	}
+
+	return (tpp_transport_vsend(router->conn_fd, pkt));
 }

--- a/src/lib/Libtpp/tpp_client.c
+++ b/src/lib/Libtpp/tpp_client.c
@@ -394,7 +394,7 @@ leaf_send_ctl_join(int tfd, void *c)
 		hdr->num_addrs = leaf_addr_count;
 
 		/* log my own leaf name to help in troubleshooting later */
-		for(i = 0; i < leaf_addr_count; i++) {
+		for (i = 0; i < leaf_addr_count; i++) {
 			tpp_log(LOG_CRIT, NULL, "Registering address %s to pbs_comm %s", tpp_netaddr(&leaf_addrs[i]), r->router_name);
 		}
 
@@ -663,7 +663,7 @@ tpp_init(struct tpp_config *cnf)
 	routers[max_routers - 1] = NULL;
 
 	/* initialize the router structures and initiate connections to them */
-	for(i = 0; tpp_conf->routers[i]; i++) {
+	for (i = 0; tpp_conf->routers[i]; i++) {
 		if ((routers[i] = malloc(sizeof(tpp_router_t))) == NULL)  {
 			tpp_log(LOG_CRIT, __func__, "Out of memory allocating pbs_comm structure");
 			return -1;
@@ -2800,7 +2800,7 @@ again:
 
 			/* go past the header and point to the list of addresses following it */
 			addrs = (tpp_addr_t *) (((char *) buf) + sizeof(tpp_leave_pkt_hdr_t));
-			for(i = 0; i < hdr->num_addrs; i++) {
+			for (i = 0; i < hdr->num_addrs; i++) {
 				void *idx_ctx = NULL;
 				void *paddr = &addrs[i];
 

--- a/src/lib/Libtpp/tpp_client.c
+++ b/src/lib/Libtpp/tpp_client.c
@@ -2837,7 +2837,7 @@ again:
 			unsigned int dest_sd;
 			unsigned int src_magic;
 			unsigned int sz = len - sizeof(tpp_data_pkt_hdr_t);
-			void *data = buf + sizeof(tpp_data_pkt_hdr_t);
+			void *data = (char *) buf + sizeof(tpp_data_pkt_hdr_t);
 
 			src_sd = ntohl(dhdr->src_sd);
 			dest_sd = ntohl(dhdr->dest_sd);

--- a/src/lib/Libtpp/tpp_client.c
+++ b/src/lib/Libtpp/tpp_client.c
@@ -395,7 +395,7 @@ leaf_send_ctl_join(int tfd, void *c)
 
 		/* log my own leaf name to help in troubleshooting later */
 		for(i = 0; i < leaf_addr_count; i++) {
-			tpp_log(LOG_CRIT, NULL, "Registering address %s to pbs_comm", tpp_netaddr(&leaf_addrs[i]));
+			tpp_log(LOG_CRIT, NULL, "Registering address %s to pbs_comm %s", tpp_netaddr(&leaf_addrs[i]), r->router_name);
 		}
 
 		len = leaf_addr_count * sizeof(tpp_addr_t);

--- a/src/lib/Libtpp/tpp_em.c
+++ b/src/lib/Libtpp/tpp_em.c
@@ -947,8 +947,7 @@ tpp_mbox_init(tpp_mbox_t *mbox, char *name, int size)
 	 * Use the self-pipe trick!
 	 */
 	if (tpp_pipe_cr(mbox->mbox_pipe) != 0) {
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "pipe() error, errno=%d", errno);
-		tpp_log(LOG_CRIT, __func__, tpp_get_logbuf());
+		tpp_log(LOG_CRIT, __func__, "pipe() error, errno=%d", errno);
 		return -1;
 	}
 	/* set the cmd pipe to nonblocking now

--- a/src/lib/Libtpp/tpp_em.c
+++ b/src/lib/Libtpp/tpp_em.c
@@ -911,6 +911,7 @@ tpp_em_wait_win(void *em_ctx, em_event_t **ev_array, int timeout)
  *	Initialize an mbox
  *
  * @param[in] - mbox   - The mbox to read from
+ * @param[in] - size   - The total size allowed, or -1 for inifinite
  *
  * @return  Error code
  * @retval  -1 - Failure
@@ -923,15 +924,18 @@ tpp_em_wait_win(void *em_ctx, em_event_t **ev_array, int timeout)
  *
  */
 int
-tpp_mbox_init(tpp_mbox_t *mbox)
+tpp_mbox_init(tpp_mbox_t *mbox, char *name, int size)
 {
 	tpp_init_lock(&mbox->mbox_mutex);
 	TPP_QUE_CLEAR(&mbox->mbox_queue);
 
+	snprintf(mbox->mbox_name, sizeof(mbox->mbox_name), "%s", name);
+	mbox->mbox_size = 0;
+	mbox->max_size = size;
+
 #ifdef HAVE_SYS_EVENTFD_H
 	if ((mbox->mbox_eventfd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK)) == -1) {
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "eventfd() error, errno=%d", errno);
-		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+		tpp_log(LOG_CRIT, __func__, "eventfd() error, errno=%d", errno);
 		return -1;
 	}
 #else
@@ -944,7 +948,7 @@ tpp_mbox_init(tpp_mbox_t *mbox)
 	 */
 	if (tpp_pipe_cr(mbox->mbox_pipe) != 0) {
 		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "pipe() error, errno=%d", errno);
-		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+		tpp_log(LOG_CRIT, __func__, tpp_get_logbuf());
 		return -1;
 	}
 	/* set the cmd pipe to nonblocking now
@@ -996,7 +1000,7 @@ tpp_mbox_getfd(tpp_mbox_t *mbox)
  *
  */
 void
-tpp_mbox_destroy(tpp_mbox_t *mbox, int destroy_lock)
+tpp_mbox_destroy(tpp_mbox_t *mbox)
 {
 #ifdef HAVE_SYS_EVENTFD_H
 	close(mbox->mbox_eventfd);
@@ -1006,8 +1010,6 @@ tpp_mbox_destroy(tpp_mbox_t *mbox, int destroy_lock)
 	if (mbox->mbox_pipe[1] > -1)
 		tpp_pipe_close(mbox->mbox_pipe[1]);
 #endif
-	if (destroy_lock)
-		tpp_destroy_lock(&mbox->mbox_mutex);
 }
 
 /**
@@ -1032,21 +1034,11 @@ tpp_mbox_destroy(tpp_mbox_t *mbox, int destroy_lock)
 int
 tpp_mbox_monitor(void *em_ctx, tpp_mbox_t *mbox)
 {
-#ifdef HAVE_SYS_EVENTFD_H
 	/* add eventfd to the poll set */
-	if (tpp_em_add_fd(em_ctx, mbox->mbox_eventfd, EM_IN) == -1) {
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "em_add_fd() error, errno=%d", errno);
-		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+	if (tpp_em_add_fd(em_ctx, tpp_mbox_getfd(mbox), EM_IN) == -1) {
+		tpp_log(LOG_CRIT, __func__, "em_add_fd() error for mbox=%s, errno=%d", mbox->mbox_name, errno);
 		return -1;
 	}
-#else
-	/* add the pipe to the poll set */
-	if (tpp_em_add_fd(em_ctx, mbox->mbox_pipe[0], EM_IN) == -1) {
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "em_add_fd() error, errno=%d", errno);
-		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
-		return -1;
-	}
-#endif
 
 	return 0;
 }
@@ -1080,7 +1072,9 @@ tpp_mbox_read(tpp_mbox_t *mbox, unsigned int *tfd, int *cmdval, void **data)
 #endif
 	tpp_cmd_t *cmd = NULL;
 
-	*cmdval = -1;
+	if (cmdval)
+		*cmdval = -1;
+
 	errno = 0;
 
 	tpp_lock(&mbox->mbox_mutex);
@@ -1095,6 +1089,14 @@ tpp_mbox_read(tpp_mbox_t *mbox, unsigned int *tfd, int *cmdval, void **data)
 #else
 		while (tpp_pipe_read(mbox->mbox_pipe[0], &b, sizeof(char)) == sizeof(char));
 #endif
+	} else {
+		/* reduce from mbox size during read */
+		mbox->mbox_size -= cmd->sz;
+#ifdef DEBUG
+		if ((mbox->max_size != -1) && (cmd->sz > 0)) {
+			TPP_DBPRT("Mbox %s, after reading %d size = %d", mbox->mbox_name, cmd->sz, mbox->mbox_size);
+		}
+#endif
 	}
 
 	tpp_unlock(&mbox->mbox_mutex);
@@ -1104,8 +1106,12 @@ tpp_mbox_read(tpp_mbox_t *mbox, unsigned int *tfd, int *cmdval, void **data)
 		return -1;
 	}
 
-	*tfd = cmd->tfd;
-	*cmdval = cmd->cmdval;
+	if (tfd)
+		*tfd = cmd->tfd;
+
+	if (cmdval)
+		*cmdval = cmd->cmdval;
+
 	*data = cmd->data;
 
 	free(cmd);
@@ -1133,7 +1139,7 @@ tpp_mbox_read(tpp_mbox_t *mbox, unsigned int *tfd, int *cmdval, void **data)
  *
  */
 int
-tpp_mbox_clear(tpp_mbox_t *mbox, tpp_que_elem_t **n, unsigned int tfd, int *cmdval, void **data)
+tpp_mbox_clear(tpp_mbox_t *mbox, tpp_que_elem_t **n, unsigned int tfd, short *cmdval, void **data)
 {
 	tpp_cmd_t *cmd;
 	int ret = -1;
@@ -1145,13 +1151,15 @@ tpp_mbox_clear(tpp_mbox_t *mbox, tpp_que_elem_t **n, unsigned int tfd, int *cmdv
 		cmd = TPP_QUE_DATA(*n);
 		if (cmd && cmd->tfd == tfd) {
 			*n = tpp_que_del_elem(&mbox->mbox_queue, *n);
-			*cmdval = cmd->cmdval;
+			if (cmdval)
+				*cmdval = cmd->cmdval;
 			*data = cmd->data;
 			free(cmd);
 			ret = 0;
 			break;
 		}
 	}
+	mbox->mbox_size = 0;
 
 	tpp_unlock(&mbox->mbox_mutex);
 
@@ -1166,6 +1174,7 @@ tpp_mbox_clear(tpp_mbox_t *mbox, tpp_que_elem_t **n, unsigned int tfd, int *cmdv
  * @param[in] - cmdval - The command or operation
  * @param[in] - tfd    - The Virtual file descriptor
  * @param[in] - data   - Any data pointer associated, if any (or NULL)
+ * @param[in] - sz     - size of the data
  *
  * @return Error code
  * @retval -1 Failure
@@ -1178,7 +1187,7 @@ tpp_mbox_clear(tpp_mbox_t *mbox, tpp_que_elem_t **n, unsigned int tfd, int *cmdv
  *
  */
 int
-tpp_mbox_post(tpp_mbox_t *mbox, unsigned int tfd, int cmdval, void *data)
+tpp_mbox_post(tpp_mbox_t *mbox, unsigned int tfd, char cmdval, void *data, int sz)
 {
 	tpp_cmd_t *cmd;
 	ssize_t s;
@@ -1191,22 +1200,41 @@ tpp_mbox_post(tpp_mbox_t *mbox, unsigned int tfd, int cmdval, void *data)
 	errno = 0;
 	cmd = malloc(sizeof(tpp_cmd_t));
 	if (!cmd) {
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Out of memory in em_mbox_post");
-		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+		tpp_log(LOG_CRIT, __func__, "Out of memory in em_mbox_post for mbox=%s", mbox->mbox_name);
 		return -1;
 	}
 	cmd->cmdval = cmdval;
 	cmd->tfd = tfd;
 	cmd->data = data;
+	cmd->sz = sz;
 
 	/* add the cmd to the threads queue */
 	tpp_lock(&mbox->mbox_mutex);
+
+	if ((mbox->max_size != -1) && (sz + mbox->mbox_size > mbox->max_size)) {
+		tpp_unlock(&mbox->mbox_mutex);
+		free(cmd);
+		tpp_log(LOG_CRIT, __func__, "mbox size limit reached for mbox=%s", mbox->mbox_name);
+		errno = EWOULDBLOCK;
+		return -2;
+	}
+
 	if (tpp_enque(&mbox->mbox_queue, cmd) == NULL) {
 		tpp_unlock(&mbox->mbox_mutex);
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Out of memory in em_mbox_post");
-		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+		free(cmd);
+		tpp_log(LOG_CRIT, __func__, "Out of memory in em_mbox_post for mbox=%s", mbox->mbox_name);
 		return -1;
 	}
+	
+	/* add to the size to global size during enque */
+	mbox->mbox_size += sz;
+
+#ifdef DEBUG
+	if ((mbox->max_size != -1) && (sz > 0)) {
+		TPP_DBPRT("Mbox %s, after adding %d  size = %d",  mbox->mbox_name, sz, mbox->mbox_size);
+	}
+#endif
+
 	tpp_unlock(&mbox->mbox_mutex);
 
 	while (1) {
@@ -1227,8 +1255,7 @@ tpp_mbox_post(tpp_mbox_t *mbox, unsigned int tfd, int cmdval, void *data)
 				/* pipe is full, which is fine, anyway we behave like edge triggered */
 				break;
 			} else if (errno != EINTR) {
-				snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "mbox post failed, errno=%d", errno);
-				tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+				tpp_log(LOG_CRIT, __func__, "mbox post failed for mbox=%s, errno=%d", mbox->mbox_name, errno);
 				return -1;
 			}
 		}

--- a/src/lib/Libtpp/tpp_internal.h
+++ b/src/lib/Libtpp/tpp_internal.h
@@ -601,12 +601,15 @@ int tpp_mbox_getfd(tpp_mbox_t *);
 extern int tpp_going_down;
 /**********************************************************************/
 
-/*
- *	Different print macros for use in debugging.
+/* 
+ * use TPPDEBUG instead of DEBUG, since DEBUG makes daemons not fork
+ * and that does not work well with init scripts. Sometimes we need to
+ * debug TPP in a PTL run where forked daemons are required
+ * Hence use a separate macro
  */
-#ifdef  DEBUG
+#ifdef  TPPDEBUG
 
-#define TPP_DBPRT(...) tpp_log(LOG_DEBUG, __func__,  __VA_ARGS__)
+#define TPP_DBPRT(...) tpp_log(LOG_CRIT, __func__,  __VA_ARGS__)
 
 void print_packet_hdr(const char *, void *, int);
 #define PRTPKTHDR(id, data, len) print_packet_hdr(id, data, len);

--- a/src/lib/Libtpp/tpp_internal.h
+++ b/src/lib/Libtpp/tpp_internal.h
@@ -176,8 +176,8 @@ typedef struct {
 typedef struct {
 	int ntotlen;
 	unsigned char type;         /* type packet, JOIN, LEAVE etc */
-	unsigned char node_type;    /* node type - leaf or router */
 	unsigned char hop;          /* hop count */
+	unsigned char node_type;    /* node type - leaf or router */
 	unsigned char index;        /* in case of leaves, primary connection or backup */
 	unsigned char num_addrs;    /* number of addresses of source joining, max 128 */
 } tpp_join_pkt_hdr_t;
@@ -220,7 +220,7 @@ typedef struct {
 	unsigned int src_sd;       /* source stream descriptor */
 	unsigned int dest_sd;      /* destination stream descriptor */
 
-	unsigned int totlen;       /* total pkt len (in case of fragmented pkts)*/
+	unsigned int totlen;       /* total pkt len */
 
 	tpp_addr_t src_addr;  /* src host address */
 	tpp_addr_t dest_addr; /* dest host address */
@@ -237,7 +237,6 @@ typedef struct {
 	unsigned int info_len;    /* total length of info */
 	unsigned int info_cmprsd_len; /* compressed length of info */
 	unsigned int totlen;          /* total pkt len (in case of fragmented pkts) */
-	unsigned int data_cmprsd_len; /* compressed len */
 	tpp_addr_t src_addr;     /* source host address */
 } tpp_mcast_pkt_hdr_t;
 

--- a/src/lib/Libtpp/tpp_internal.h
+++ b/src/lib/Libtpp/tpp_internal.h
@@ -427,7 +427,7 @@ typedef struct {
 	int conn_type;
 } conn_auth_t;
 
-int tpp_child_terminated; /* whether a forked child called tpp_terminate or not? initialized to 0 */
+int tpp_terminated_in_child; /* whether a forked child called tpp_terminate or not? initialized to 0 */
 
 conn_auth_t *tpp_make_authdata(struct tpp_config *, int, char *, char *);
 int tpp_handle_auth_handshake(int, int, conn_auth_t *, int, void *, size_t);
@@ -446,7 +446,6 @@ char* convert_to_ip_port(char *, int);
 
 int tpp_init_tls_key(void);
 tpp_tls_t *tpp_get_tls(void);
-char *tpp_get_logbuf(void);
 char *mk_hostname(char *, int);
 struct sockaddr_in* tpp_localaddr(int);
 tpp_packet_t *tpp_bld_pkt(tpp_packet_t *, void *, int, int, void **);

--- a/src/lib/Libtpp/tpp_platform.c
+++ b/src/lib/Libtpp/tpp_platform.c
@@ -750,7 +750,7 @@ tpp_sock_resolve_host(char *host, int *count)
 			ips[i].family = (aip->ai_family == AF_INET6)? TPP_ADDR_FAMILY_IPV6 : TPP_ADDR_FAMILY_IPV4;
 			ips[i].port = 0;
 
-			for(j=0; j < i; j++) {
+			for (j=0; j < i; j++) {
 				/* check for duplicate ip addresses dont add if duplicate */
 				if (memcmp(&ips[j].ip, &ips[i].ip, sizeof(ips[j].ip)) == 0) {
 					break;
@@ -814,7 +814,7 @@ tpp_sock_attempt_connection(int fd, char *host, int port)
 		return -1;
 	}
 
-	for(i = 0; i < count; i++) {
+	for (i = 0; i < count; i++) {
 		if (addr[i].family == TPP_ADDR_FAMILY_IPV4)
 			break;
 	}

--- a/src/lib/Libtpp/tpp_platform.c
+++ b/src/lib/Libtpp/tpp_platform.c
@@ -142,9 +142,7 @@ tpp_pipe_err:
 		closesocket(fds[1]);
 
 	errno = tr_2_errno(WSAGetLastError());
-	snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ,
-		"%s failed, winsock errno= %d", op, WSAGetLastError());
-	tpp_log(LOG_CRIT, __func__, tpp_get_logbuf());
+	tpp_log(LOG_CRIT, __func__, "%s failed, winsock errno= %d", op, WSAGetLastError());
 	return -1;
 }
 
@@ -490,8 +488,7 @@ tpp_sock_layer_init()
 {
 	WSADATA	data;
 	if (WSAStartup(MAKEWORD(2, 2), &data)) {
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "winsock_init failed! error=%d\n", WSAGetLastError());
-		tpp_log(LOG_CRIT, NULL, tpp_get_logbuf());
+		tpp_log(LOG_CRIT, NULL, "winsock_init failed! error=%d\n", WSAGetLastError());
 		return -1;
 	}
 	return 0;

--- a/src/lib/Libtpp/tpp_platform.c
+++ b/src/lib/Libtpp/tpp_platform.c
@@ -144,7 +144,7 @@ tpp_pipe_err:
 	errno = tr_2_errno(WSAGetLastError());
 	snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ,
 		"%s failed, winsock errno= %d", op, WSAGetLastError());
-	tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+	tpp_log(LOG_CRIT, __func__, tpp_get_logbuf());
 	return -1;
 }
 
@@ -491,7 +491,7 @@ tpp_sock_layer_init()
 	WSADATA	data;
 	if (WSAStartup(MAKEWORD(2, 2), &data)) {
 		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "winsock_init failed! error=%d\n", WSAGetLastError());
-		tpp_log_func(LOG_CRIT, NULL, tpp_get_logbuf());
+		tpp_log(LOG_CRIT, NULL, tpp_get_logbuf());
 		return -1;
 	}
 	return 0;
@@ -578,12 +578,11 @@ tpp_get_nfiles()
 	struct rlimit rlp;
 
 	if (getrlimit(RLIMIT_NOFILE, &rlp) == -1) {
-		tpp_log_func(LOG_CRIT, __func__, "getrlimit failed");
+		tpp_log(LOG_CRIT, __func__, "getrlimit failed");
 		return -1;
 	}
 
-	snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Max files allowed = %ld", (long) rlp.rlim_cur);
-	tpp_log_func(LOG_INFO, NULL, tpp_get_logbuf());
+	tpp_log(LOG_INFO, NULL, "Max files allowed = %ld", (long) rlp.rlim_cur);
 
 	return (rlp.rlim_cur);
 }
@@ -620,12 +619,12 @@ set_pipe_disposition()
 		if (oact.sa_handler == SIG_DFL) {
 			act.sa_handler = SIG_IGN;
 			if (sigaction(SIGPIPE, &act, &oact) != 0) {
-				tpp_log_func(LOG_CRIT, __func__, "Could not set SIGPIPE to IGN");
+				tpp_log(LOG_CRIT, __func__, "Could not set SIGPIPE to IGN");
 				return -1;
 			}
 		}
 	} else {
-		tpp_log_func(LOG_CRIT, __func__, "Could not query SIGPIPEs disposition");
+		tpp_log(LOG_CRIT, __func__, "Could not query SIGPIPEs disposition");
 		return -1;
 	}
 	return 0;
@@ -674,7 +673,7 @@ tpp_sock_resolve_ip(tpp_addr_t *addr, char *host, int len)
 
 	rc = getnameinfo(sa, salen, host, len, NULL, 0, 0);
 	if (rc != 0) {
-		TPP_DBPRT(("Error: %s", gai_strerror(rc)));
+		TPP_DBPRT("Error: %s", gai_strerror(rc));
 	}
 	return rc;
 }
@@ -715,8 +714,7 @@ tpp_sock_resolve_host(char *host, int *count)
 	hints.ai_protocol = IPPROTO_TCP;
 
 	if ((rc = getaddrinfo(host, NULL, &hints, &pai)) != 0) {
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Error %d resolving %s\n", rc, host);
-		tpp_log_func(LOG_CRIT, NULL, tpp_get_logbuf());
+		tpp_log(LOG_CRIT, NULL, "Error %d resolving %s\n", rc, host);
 		return NULL;
 	}
 
@@ -728,8 +726,7 @@ tpp_sock_resolve_host(char *host, int *count)
 	}
 
 	if (*count == 0) {
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Could not find any usable IP address for host %s", host);
-		tpp_log_func(LOG_CRIT, NULL, tpp_get_logbuf());
+		tpp_log(LOG_CRIT, NULL, "Could not find any usable IP address for host %s", host);
 		return NULL;
 	}
 

--- a/src/lib/Libtpp/tpp_platform.c
+++ b/src/lib/Libtpp/tpp_platform.c
@@ -488,7 +488,7 @@ tpp_sock_layer_init()
 {
 	WSADATA	data;
 	if (WSAStartup(MAKEWORD(2, 2), &data)) {
-		tpp_log(LOG_CRIT, NULL, "winsock_init failed! error=%d\n", WSAGetLastError());
+		tpp_log(LOG_CRIT, NULL, "winsock_init failed! error=%d", WSAGetLastError());
 		return -1;
 	}
 	return 0;
@@ -711,7 +711,7 @@ tpp_sock_resolve_host(char *host, int *count)
 	hints.ai_protocol = IPPROTO_TCP;
 
 	if ((rc = getaddrinfo(host, NULL, &hints, &pai)) != 0) {
-		tpp_log(LOG_CRIT, NULL, "Error %d resolving %s\n", rc, host);
+		tpp_log(LOG_CRIT, NULL, "Error %d resolving %s", rc, host);
 		return NULL;
 	}
 

--- a/src/lib/Libtpp/tpp_router.c
+++ b/src/lib/Libtpp/tpp_router.c
@@ -327,7 +327,7 @@ broadcast_to_my_routers(tpp_chunk_t *chunks, int count, int origin_tfd)
 		int j;
 		tpp_packet_t *pkt = NULL;
 
-		for(j = 0; j < count; j++) {
+		for (j = 0; j < count; j++) {
 			pkt = tpp_bld_pkt(pkt, chunks[j].data, chunks[j].len, 1, NULL);
 			if (!pkt) {
 				tpp_log(LOG_CRIT, __func__, "Failed to build packet");
@@ -422,7 +422,7 @@ broadcast_to_my_leaves(tpp_chunk_t *chunks, int count, int origin_tfd, int type)
 		int j;
 		tpp_packet_t *pkt = NULL;
 
-		for(j = 0; j < count; j++) {
+		for (j = 0; j < count; j++) {
 			pkt = tpp_bld_pkt(pkt, chunks[j].data, chunks[j].len, 1, NULL);
 			if (!pkt) {
 				tpp_log(LOG_CRIT, __func__, "Failed to build packet");
@@ -1782,7 +1782,7 @@ again:
 				tpp_log(LOG_INFO, __func__, "Total target comms=%d", csize);
 
 				/* finish up the MCAST packets for each target comm and send */
-				for(k = 0; k < csize; k++) {
+				for (k = 0; k < csize; k++) {
 					void *t_minfo_buf = NULL;
 					unsigned int t_minfo_len = 0;
 					tpp_mcast_pkt_hdr_t *t_mhdr = NULL;

--- a/src/lib/Libtpp/tpp_router.c
+++ b/src/lib/Libtpp/tpp_router.c
@@ -87,8 +87,8 @@
 
 struct tpp_config *tpp_conf; /* copy of the global tpp_config */
 
-/*pthread_rwlock_t router_lock;*/ /* rw lock for router indexes */
-pthread_mutex_t router_lock; /* for now only a write only lock, since our indexes are not mt-safe */
+pthread_rwlock_t router_lock; /* rw lock for router avl trees, searches over avl should be thread safe now */
+pthread_mutex_t lj_lock;
 
 /* index of routers connected to this router */
 void *routers_idx = NULL;
@@ -103,7 +103,7 @@ time_t router_last_leaf_joined = 0;
 static int router_send_ctl_join(int tfd, void *data, void *c);
 
 /* forward declarations */
-static int router_pkt_presend_handler(int tfd, tpp_packet_t *pkt, void *extra);
+static int router_pkt_presend_handler(int tfd, tpp_packet_t *pkt, void *c, void *extra);
 static int router_pkt_handler(int phy_fd, void *data, int len, void *c, void *extra);
 static int router_close_handler(int phy_con, int error, void *c, void *extra);
 static int send_leaves_to_router(tpp_router_t *parent, tpp_router_t *target);
@@ -129,7 +129,7 @@ alloc_router(char *name, tpp_addr_t *address)
 	/* add self name to tree */
 	r = (tpp_router_t *) calloc(1, sizeof(tpp_router_t));
 	if (!r) {
-		tpp_log_func(LOG_CRIT, __func__, "Out of memory allocating pbs_comm data");
+		tpp_log(LOG_CRIT, __func__, "Out of memory allocating pbs_comm data");
 		return NULL;
 	}
 
@@ -143,8 +143,7 @@ alloc_router(char *name, tpp_addr_t *address)
 		/* do name resolution on the supplied name */
 		addrs = tpp_get_addresses(r->router_name, &count);
 		if (!addrs) {
-			snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Failed to resolve address, pbs_comm=%s", r->router_name);
-			tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+			tpp_log(LOG_CRIT, __func__, "Failed to resolve address, pbs_comm=%s", r->router_name);
 			free_router(r);
 			return NULL;
 		}
@@ -157,22 +156,20 @@ alloc_router(char *name, tpp_addr_t *address)
 	/* initialize the routers leaf tree */
 	r->my_leaves_idx = pbs_idx_create(0, sizeof(tpp_addr_t));
 	if (r->my_leaves_idx == NULL) {
-		tpp_log_func(LOG_CRIT, __func__, "Failed to create index for my leaves");
+		tpp_log(LOG_CRIT, __func__, "Failed to create index for my leaves");
 		free_router(r);
 		return NULL;
 	}
 
 	p_r_addr = &r->router_addr;
 	if (pbs_idx_find(routers_idx, &p_r_addr, &unused, NULL) == PBS_IDX_RET_OK) {
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Duplicate router %s in router list", r->router_name);
-		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+		tpp_log(LOG_CRIT, __func__, "Duplicate router %s in router list", r->router_name);
 		free_router(r);
 		return NULL;
 	}
 
 	if (pbs_idx_insert(routers_idx, &r->router_addr, r) != PBS_IDX_RET_OK) {
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Failed to add router %s in routers index", r->router_name);
-		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+		tpp_log(LOG_CRIT, __func__, "Failed to add router %s in routers index", r->router_name);
 		free_router(r);
 		return NULL;
 	}
@@ -192,8 +189,7 @@ log_noroute(tpp_addr_t *src_host, tpp_addr_t *dest_host, int src_sd, char *msg)
 	strncpy(src, tpp_netaddr(src_host), TPP_MAXADDRLEN);
 	strncpy(dest, tpp_netaddr(dest_host), TPP_MAXADDRLEN);
 
-	snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Pkt from src=%s[%d], noroute to dest=%s, %s", src, src_sd, dest, msg);
-	tpp_log_func(LOG_ERR, NULL, tpp_get_logbuf());
+	tpp_log(LOG_ERR, NULL, "Pkt from src=%s[%d], noroute to dest=%s, %s", src, src_sd, dest, msg);
 }
 
 /**
@@ -219,7 +215,6 @@ static int
 send_leaves_to_router(tpp_router_t *parent, tpp_router_t *target)
 {
 	tpp_leaf_t *l;
-	tpp_chunk_t chunks[2];
 	tpp_que_t ctl_hdr_queue;
 	int index;
 	struct leaf_data {
@@ -230,24 +225,24 @@ send_leaves_to_router(tpp_router_t *parent, tpp_router_t *target)
 
 	TPP_QUE_CLEAR(&ctl_hdr_queue);
 
-	TPP_DBPRT(("Sending leaves to router=%s", target->router_name));
+	TPP_DBPRT("Sending leaves to router=%s", target->router_name);
 
 	/* traverse my leaves tree, there is only one record per leaf */
 	while (pbs_idx_find(parent->my_leaves_idx, NULL, (void **)&l, &idx_ctx) == PBS_IDX_RET_OK) {
 		if ((lf_data = malloc(sizeof(struct leaf_data))) == NULL) {
-			tpp_log_func(LOG_CRIT, __func__, "Out of memory allocating ctl hdr");
+			tpp_log(LOG_CRIT, __func__, "Out of memory allocating ctl hdr");
 			goto err;
 		}
 
 		lf_data->addrs = malloc(sizeof(tpp_addr_t) * l->num_addrs);
 		if (!lf_data->addrs) {
-			tpp_log_func(LOG_CRIT, __func__, "Out of memory allocating ctl hdr");
+			tpp_log(LOG_CRIT, __func__, "Out of memory allocating ctl hdr");
 			goto err;
 		}
 
 		index = leaf_get_router_index(l, this_router);
 		if (index == -1) {
-			tpp_log_func(LOG_CRIT, __func__, "Could not find index of my router in leaf's pbs_comm list");
+			tpp_log(LOG_CRIT, __func__, "Could not find index of my router in leaf's pbs_comm list");
 			goto err;
 		}
 
@@ -260,23 +255,27 @@ send_leaves_to_router(tpp_router_t *parent, tpp_router_t *target)
 		memcpy(lf_data->addrs, l->leaf_addrs, sizeof(tpp_addr_t) * l->num_addrs);
 
 		if (tpp_enque(&ctl_hdr_queue, lf_data) == NULL) {
-			tpp_log_func(LOG_CRIT, __func__, "Out of memory enqueuing to ctl_hdr_queue");
+			tpp_log(LOG_CRIT, __func__, "Out of memory enqueuing to ctl_hdr_queue");
 			goto err;
 		}
 	}
+	tpp_unlock_rwlock(&router_lock);
 
-	tpp_unlock(&router_lock);
-
-	chunks[0].len = sizeof(tpp_join_pkt_hdr_t);
 	while ((lf_data = (struct leaf_data *) tpp_deque(&ctl_hdr_queue))) {
+		tpp_packet_t *pkt = NULL;
+		pkt = tpp_bld_pkt(NULL, &lf_data->hdr, sizeof(tpp_join_pkt_hdr_t), 0, NULL);
+		if (!pkt) {
+			tpp_log(LOG_CRIT, __func__, "Failed to build packet");
+			goto err;
+		}
 
-		chunks[0].data = &lf_data->hdr;
-		chunks[1].data = lf_data->addrs;
-		chunks[1].len = lf_data->hdr.num_addrs * sizeof(tpp_addr_t);
+		if (!tpp_bld_pkt(pkt, lf_data->addrs, lf_data->hdr.num_addrs * sizeof(tpp_addr_t), 0, NULL)) {
+			tpp_log(LOG_CRIT, __func__, "Failed to build packet");
+			goto err;
+		}
 
-		if (tpp_transport_vsend(target->conn_fd, chunks, 2) != 0) {
-			sprintf(tpp_get_logbuf(), "Send leaves to pbs_comm %s failed", target->router_name);
-			tpp_log_func(LOG_ERR, __func__, tpp_get_logbuf());
+		if (tpp_transport_vsend(target->conn_fd, pkt) != 0) {
+			tpp_log(LOG_ERR, __func__, "Send leaves to pbs_comm %s failed", target->router_name);
 			goto err;
 		}
 		free(lf_data->addrs);
@@ -286,9 +285,10 @@ send_leaves_to_router(tpp_router_t *parent, tpp_router_t *target)
 	return 0;
 
 err:
-	tpp_unlock(&router_lock);
+	tpp_unlock_rwlock(&router_lock);
 	if (idx_ctx)
 		pbs_idx_free_ctx(idx_ctx);
+
 	if (lf_data) {
 		if (lf_data->addrs)
 			free(lf_data->addrs);
@@ -334,16 +334,28 @@ broadcast_to_my_routers(tpp_chunk_t *chunks, int count, int origin_tfd)
 		if (r->conn_fd == -1 || r == this_router || r->conn_fd == origin_tfd || r->state != TPP_ROUTER_STATE_CONNECTED) {
 			continue; /* don't send to self, or to originating router */
 		}
-		TPP_DBPRT(("Broadcasting leaf to router %s", r->router_name));
+		TPP_DBPRT("Broadcasting leaf to router %s", r->router_name);
 		list[max_cons++] = r->conn_fd;
 	}
 	pbs_idx_free_ctx(idx_ctx);
 
-	tpp_unlock(&router_lock);
+	tpp_unlock_rwlock(&router_lock);
 
 	for (i = 0; i < max_cons; i++) {
-		if (tpp_transport_vsend(list[i], chunks, count) != 0) {
-			tpp_log_func(LOG_ERR, __func__, "send failed");
+		int j;
+		tpp_packet_t *pkt = NULL;
+
+		for(j = 0; j < count; j++) {
+			pkt = tpp_bld_pkt(pkt, chunks[j].data, chunks[j].len, 1, NULL);
+			if (!pkt) {
+				tpp_log(LOG_CRIT, __func__, "Failed to build packet");
+				return -1;
+			}
+		}
+
+		if (tpp_transport_vsend(list[i], pkt) != 0) {
+			if (errno != ENOTCONN)
+				tpp_log(LOG_ERR, __func__, "send failed");
 		}
 	}
 	return 0;
@@ -395,7 +407,7 @@ broadcast_to_my_leaves(tpp_chunk_t *chunks, int count, int origin_tfd, int type)
 	if (!list)
 		return -1;
 
-	tpp_lock(&router_lock);
+	tpp_read_lock(&router_lock);
 	while (pbs_idx_find(traverse_idx, NULL, (void **)&l, &idx_ctx) == PBS_IDX_RET_OK) {
 		/*
 		 * leaf directly connected to me? and not myself
@@ -411,7 +423,7 @@ broadcast_to_my_leaves(tpp_chunk_t *chunks, int count, int origin_tfd, int type)
 				list_size += RLIST_INC;
 				p = realloc(list, sizeof(int) * list_size);
 				if (!p) {
-					tpp_unlock(&router_lock);
+					tpp_unlock_rwlock(&router_lock);
 					pbs_idx_free_ctx(idx_ctx);
 					free(list);
 					return -1;
@@ -423,12 +435,23 @@ broadcast_to_my_leaves(tpp_chunk_t *chunks, int count, int origin_tfd, int type)
 		}
 	}
 	pbs_idx_free_ctx(idx_ctx);
-	tpp_unlock(&router_lock);
+	tpp_unlock_rwlock(&router_lock);
 
 	for (i = 0; i < max_cons; i++) {
-		if (tpp_transport_vsend(list[i], chunks, count) != 0) {
+		int j;
+		tpp_packet_t *pkt = NULL;
+
+		for(j = 0; j < count; j++) {
+			pkt = tpp_bld_pkt(pkt, chunks[j].data, chunks[j].len, 1, NULL);
+			if (!pkt) {
+				tpp_log(LOG_CRIT, __func__, "Failed to build packet");
+				return -1;
+			}
+		}
+
+		if (tpp_transport_vsend(list[i], pkt) != 0) {
 			if (errno != ENOTCONN)
-				tpp_log_func(LOG_ERR, __func__, "send failed");
+				tpp_log(LOG_ERR, __func__, "send failed");
 		}
 	}
 
@@ -447,32 +470,35 @@ router_send_ctl_join(int tfd, void *data, void *c)
 
 	if (ctx->type == TPP_ROUTER_NODE) {
 		tpp_router_t *r = NULL;
-		tpp_join_pkt_hdr_t hdr = {0};
-		tpp_chunk_t chunks[2] = {{0}};
+		tpp_join_pkt_hdr_t *hdr = NULL;
+		tpp_packet_t *pkt = NULL;
+
 		r = (tpp_router_t *) ctx->ptr;
 
 		/* send a TPP_CTL_JOIN message */
-		hdr.type = TPP_CTL_JOIN;
-		hdr.node_type = TPP_ROUTER_NODE;
-		hdr.hop = 1;
-		hdr.index = 0;
-		hdr.num_addrs = 0;
+		pkt = tpp_bld_pkt(NULL, NULL, sizeof(tpp_join_pkt_hdr_t), 1, (void **) &hdr);
+		if (!pkt) {
+			tpp_log(LOG_CRIT, __func__, "Failed to build packet");
+			return -1;
+		}
 
-		chunks[0].data = &hdr;
-		chunks[0].len = sizeof(tpp_join_pkt_hdr_t);
-		rc = tpp_transport_vsend(r->conn_fd, chunks, 1);
+		hdr->type = TPP_CTL_JOIN;
+		hdr->node_type = TPP_ROUTER_NODE;
+		hdr->hop = 1;
+		hdr->index = 0;
+		hdr->num_addrs = 0;
+
+		rc = tpp_transport_vsend(r->conn_fd, pkt);
 		if (rc == 0) {
-			tpp_lock(&router_lock);
+			tpp_read_lock(&router_lock);
 
 			r->state = TPP_ROUTER_STATE_CONNECTED;
 
-			snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tfd=%d, pbs_comm %s accepted connection", tfd, r->router_name);
-			tpp_log_func(LOG_CRIT, NULL, tpp_get_logbuf());
+			tpp_log(LOG_CRIT, NULL, "tfd=%d, pbs_comm %s accepted connection", tfd, r->router_name);
 
 			rc = send_leaves_to_router(this_router, r);
 		} else {
-			sprintf(tpp_get_logbuf(), "Failed to send JOIN packet/send leaves to pbs_comm %s", this_router->router_name);
-			tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+			tpp_log(LOG_CRIT, __func__, "Failed to send JOIN packet/send leaves to pbs_comm %s", this_router->router_name);
 			tpp_transport_close(r->conn_fd);
 			return 0;
 		}
@@ -622,11 +648,9 @@ router_close_handler_inner(int tfd, int error, void *c, int hop)
 		 * no context available, no join was done, so don't bother
 		 * about disconnection
 		 */
-		TPP_DBPRT(("tfd = %d, No context, leaving", tfd));
+		TPP_DBPRT("tfd = %d, No context, leaving", tfd);
 		return 0;
 	}
-
-	memset(&hdr, 0, sizeof(tpp_leave_pkt_hdr_t)); /* only to satisfy valgrind */
 
 	if (ctx->type == TPP_LEAF_NODE || ctx->type == TPP_LEAF_NODE_LISTEN) {
 
@@ -640,10 +664,10 @@ router_close_handler_inner(int tfd, int error, void *c, int hop)
 		hdr.ecode = error;
 		hdr.num_addrs = l->num_addrs;
 
-		chunks[0].data = &hdr;
+		chunks[0].data = (void *) &hdr;
 		chunks[0].len = sizeof(tpp_leave_pkt_hdr_t);
 
-		chunks[1].data = l->leaf_addrs;
+		chunks[1].data = (void *) l->leaf_addrs;
 		chunks[1].len = l->num_addrs * sizeof(tpp_addr_t);
 
 		if (hop == 1) {
@@ -652,30 +676,24 @@ router_close_handler_inner(int tfd, int error, void *c, int hop)
 			 * broadcast leave pkt to other routers,
 			 * except from where it came from
 			 */
-			tpp_lock(&router_lock); /* below routine expects to be called under lock */
+			tpp_read_lock(&router_lock); /* below routine expects to be called under lock */
 			broadcast_to_my_routers(chunks, 2, tfd); /* this routine unlocks the lock */
 
-			snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tfd=%d, Connection from leaf %s down", tfd, tpp_netaddr(&l->leaf_addrs[0]));
-			tpp_log_func(LOG_CRIT, NULL, tpp_get_logbuf());
+			tpp_log(LOG_CRIT, NULL, "tfd=%d, Connection from leaf %s down", tfd, tpp_netaddr(&l->leaf_addrs[0]));
 		}
 
-		tpp_lock(&router_lock);
+		tpp_write_lock(&router_lock);
 
 		if ((r = del_router_from_leaf(l, tfd)) == NULL) {
-			snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tfd=%d, Failed to clear pbs_comm from leaf %s's list",
-						tfd, tpp_netaddr(&l->leaf_addrs[0]));
-			tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
-			tpp_unlock(&router_lock);
+			tpp_log(LOG_CRIT, __func__, "tfd=%d, Failed to clear pbs_comm from leaf %s's list", tfd, tpp_netaddr(&l->leaf_addrs[0]));
+			tpp_unlock_rwlock(&router_lock);
 			return -1;
 		}
 
 		/* we had only the first address record stored in the my_leaves tree */
 		if (pbs_idx_delete(r->my_leaves_idx, &l->leaf_addrs[0]) != PBS_IDX_RET_OK) {
-			snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ,
-				"tfd=%d, Failed to delete address from my_leaves %s",
-				tfd, tpp_netaddr(&l->leaf_addrs[0]));
-			tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
-			tpp_unlock(&router_lock);
+			tpp_log(LOG_CRIT, __func__, "tfd=%d, Failed to delete address from my_leaves %s", tfd, tpp_netaddr(&l->leaf_addrs[0]));
+			tpp_unlock_rwlock(&router_lock);
 			return -1;
 		}
 
@@ -684,19 +702,18 @@ router_close_handler_inner(int tfd, int error, void *c, int hop)
 		}
 
 		if (l->num_routers > 0) {
-			TPP_DBPRT(("tfd=%d, Other pbs_comms for leaf %s present", tfd, tpp_netaddr(&l->leaf_addrs[0])));
-			tpp_unlock(&router_lock);
+			TPP_DBPRT("tfd=%d, Other pbs_comms for leaf %s present", tfd, tpp_netaddr(&l->leaf_addrs[0]));
+			tpp_unlock_rwlock(&router_lock);
 			return 0;
 		}
 
-		TPP_DBPRT(("No more pbs_comms to leaf %s, deleting leaf", tpp_netaddr(&l->leaf_addrs[0])));
+		TPP_DBPRT("No more pbs_comms to leaf %s, deleting leaf", tpp_netaddr(&l->leaf_addrs[0]));
 
 		/* delete all of this leaf's addresses from the search tree */
 		for (i = 0; i < l->num_addrs; i++) {
 			if (pbs_idx_delete(cluster_leaves_idx, &l->leaf_addrs[i]) != PBS_IDX_RET_OK) {
-				snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tfd=%d, Failed to delete address %s from cluster leaves", tfd, tpp_netaddr(&l->leaf_addrs[i]));
-				tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
-				tpp_unlock(&router_lock);
+				tpp_log(LOG_CRIT, __func__, "tfd=%d, Failed to delete address %s from cluster leaves", tfd, tpp_netaddr(&l->leaf_addrs[i]));
+				tpp_unlock_rwlock(&router_lock);
 				return -1;
 			}
 		}
@@ -709,7 +726,7 @@ router_close_handler_inner(int tfd, int error, void *c, int hop)
 			pbs_idx_delete(my_leaves_notify_idx, &l->leaf_addrs[0]);
 		}
 
-		tpp_unlock(&router_lock);
+		tpp_unlock_rwlock(&router_lock);
 
 		/* broadcast to all self connected leaves */
 		/*
@@ -737,12 +754,9 @@ router_close_handler_inner(int tfd, int error, void *c, int hop)
 			void *idx_ctx = NULL;
 
 			/* do any logging or leaf processing only if it was connected earlier */
+			tpp_log(LOG_CRIT, NULL, "tfd=%d, Connection %s pbs_comm %s down", tfd, (r->initiator == 1) ? "to" : "from", r->router_name);
 
-			snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ,
-				"tfd=%d, Connection %s pbs_comm %s down", tfd, (r->initiator == 1) ? "to" : "from", r->router_name);
-			tpp_log_func(LOG_CRIT, NULL, tpp_get_logbuf());
-
-			tpp_lock(&router_lock);
+			tpp_write_lock(&router_lock);
 			TPP_QUE_CLEAR(&deleted_leaves);
 
 			while (pbs_idx_find(r->my_leaves_idx, NULL, (void **)&l, &idx_ctx) == PBS_IDX_RET_OK) {
@@ -753,11 +767,11 @@ router_close_handler_inner(int tfd, int error, void *c, int hop)
 						 * delete leaf from the leaf tree, since it
 						 * is not connected to any routers now
 						 */
-						TPP_DBPRT(("All routers to leaf %s down, deleting leaf", tpp_netaddr(&l->leaf_addrs[0])));
+						TPP_DBPRT("All routers to leaf %s down, deleting leaf", tpp_netaddr(&l->leaf_addrs[0]));
 
 						if (tpp_enque(&deleted_leaves, l) == NULL) {
-							tpp_unlock(&router_lock);
-							tpp_log_func(LOG_CRIT, __func__, "Out of memory enqueuing deleted leaves");
+							tpp_unlock_rwlock(&router_lock);
+							tpp_log(LOG_CRIT, __func__, "Out of memory enqueuing deleted leaves");
 							return -1;
 						}
 					}
@@ -777,11 +791,8 @@ router_close_handler_inner(int tfd, int error, void *c, int hop)
 
 				for (i = 0; i < l->num_addrs; i++) {
 					if (pbs_idx_delete(cluster_leaves_idx, &l->leaf_addrs[i]) != PBS_IDX_RET_OK) {
-						snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ,
-							"tfd=%d, Failed to delete address %s",
-							tfd, tpp_netaddr(&l->leaf_addrs[i]));
-						tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
-						tpp_unlock(&router_lock);
+						tpp_log(LOG_CRIT, __func__, "tfd=%d, Failed to delete address %s", tfd, tpp_netaddr(&l->leaf_addrs[i]));
+						tpp_unlock_rwlock(&router_lock);
 
 						return -1;
 					}
@@ -798,9 +809,9 @@ router_close_handler_inner(int tfd, int error, void *c, int hop)
 				/* initialize the routers leaf tree */
 				r->my_leaves_idx = pbs_idx_create(0, sizeof(tpp_addr_t));
 				if (r->my_leaves_idx == NULL) {
-					tpp_log_func(LOG_CRIT, __func__, "Failed to create index for my leaves");
+					tpp_log(LOG_CRIT, __func__, "Failed to create index for my leaves");
 					free_router(r);
-					tpp_unlock(&router_lock);
+					tpp_unlock_rwlock(&router_lock);
 					return -1;
 				}
 			}
@@ -813,9 +824,9 @@ router_close_handler_inner(int tfd, int error, void *c, int hop)
 			r->conn_fd = -1;
 			r->state = TPP_ROUTER_STATE_DISCONNECTED;
 
-			tpp_unlock(&router_lock);
+			tpp_unlock_rwlock(&router_lock);
 
-			chunks[0].data = &hdr;
+			chunks[0].data = (void *) &hdr;
 			chunks[0].len = sizeof(tpp_leave_pkt_hdr_t);
 
 			/* broadcast leave msgs of these leaves to my leaves */
@@ -825,7 +836,7 @@ router_close_handler_inner(int tfd, int error, void *c, int hop)
 				hdr.ecode = error;
 				hdr.num_addrs = l->num_addrs;
 
-				chunks[1].data = l->leaf_addrs;
+				chunks[1].data = (void *) l->leaf_addrs;
 				chunks[1].len = l->num_addrs * sizeof(tpp_addr_t);
 
 				/* broadcast to all self connected leaves */
@@ -865,14 +876,12 @@ router_close_handler_inner(int tfd, int error, void *c, int hop)
 			 * to the special connect call, so that the new connection is
 			 * assigned to this same thread instead of new one
 			 */
-			sprintf(tpp_get_logbuf(), "Connecting to pbs_comm %s", r->router_name);
-			tpp_log_func(LOG_INFO, NULL, tpp_get_logbuf());
+			tpp_log(LOG_INFO, NULL, "Connecting to pbs_comm %s", r->router_name);
 
 			thrd = tpp_transport_get_thrd_context(tfd);
 			rc = tpp_transport_connect_spl(r->router_name, r->delay, ctx, &r->conn_fd, thrd);
 			if (rc != 0) {
-				snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tfd=%d, Failed initiating connection to pbs_comm %s", tfd, r->router_name);
-				tpp_log_func(LOG_CRIT, NULL, tpp_get_logbuf());
+				tpp_log(LOG_CRIT, NULL, "tfd=%d, Failed initiating connection to pbs_comm %s", tfd, r->router_name);
 				return -1;
 			}
 
@@ -882,9 +891,9 @@ router_close_handler_inner(int tfd, int error, void *c, int hop)
 			 * remove this router from our list of registered routers
 			 * ie, remove from routers_idx tree
 			 **/
-			tpp_lock(&router_lock);
+			tpp_write_lock(&router_lock);
 			pbs_idx_delete(routers_idx, &r->router_addr);
-			tpp_unlock(&router_lock);
+			tpp_unlock_rwlock(&router_lock);
 
 			/*
 			 * context will be freed and deleted by router_close_handler
@@ -941,8 +950,6 @@ router_close_handler(int tfd, int error, void *c, void *extra)
 			authdata->authdef->destroy_ctx(authdata->authctx);
 		if (authdata->authdef != authdata->encryptdef && authdata->encryptctx && authdata->encryptdef)
 			authdata->encryptdef->destroy_ctx(authdata->encryptctx);
-		if (authdata->cleartext)
-			free(authdata->cleartext);
 		if (authdata->config)
 			free_auth_config(authdata->config);
 		/* DO NOT free authdef here, it will be done in unload_auths() */
@@ -953,7 +960,7 @@ router_close_handler(int tfd, int error, void *c, void *extra)
 	/* set hop to 1 and send to inner */
 	if ((rc = router_close_handler_inner(tfd, error, c, 1)) == 0) {
 		tpp_transport_set_conn_ctx(tfd, NULL);
-		TPP_DBPRT(("Freeing context=%p for tfd=%d", c, tfd));
+		TPP_DBPRT("Freeing context=%p for tfd=%d", c, tfd);
 		free(c);
 	}
 	return rc;
@@ -984,7 +991,7 @@ router_timer_handler(time_t now)
 	int send_update = 0;
 	int ret = -1;
 
-	tpp_lock(&router_lock);
+	tpp_lock(&lj_lock);
 	if (router_last_leaf_joined > 0) {
 		if ((now - router_last_leaf_joined) < 3) {
 			ret = 3; /* time not yet over, retry in the next 3 seconds */
@@ -993,7 +1000,7 @@ router_timer_handler(time_t now)
 			router_last_leaf_joined = 0;
 		}
 	}
-	tpp_unlock(&router_lock);
+	tpp_unlock(&lj_lock);
 
 	if (send_update == 1) {
 		int len;
@@ -1003,7 +1010,7 @@ router_timer_handler(time_t now)
 		hdr.code = TPP_MSG_UPDATE;
 
 		len = sizeof(tpp_ctl_pkt_hdr_t);
-		chunks[0].data = &hdr;
+		chunks[0].data = (void *) &hdr;
 		chunks[0].len = len;
 
 		/* broadcast to self connected leaves asking for notification */
@@ -1034,70 +1041,19 @@ router_timer_handler(time_t now)
  *
  */
 static int
-router_pkt_presend_handler(int tfd, tpp_packet_t *pkt, void *extra)
+router_pkt_presend_handler(int tfd, tpp_packet_t *pkt, void *c, void *extra)
 {
-	tpp_data_pkt_hdr_t *data = (tpp_data_pkt_hdr_t *)(pkt->data + sizeof(int));
-	unsigned char type = data->type;
 	conn_auth_t *authdata = (conn_auth_t *)extra;
-
-	if (type == TPP_AUTH_CTX && ((tpp_auth_pkt_hdr_t *)data)->for_encrypt == FOR_ENCRYPT)
-		return 0;
 
 	/*
 	 * if presend handler is called from handle_disconnect()
 	 * then extra will be NULL and this is just a sending simulation
 	 * so no encryption needed
 	 */
-	if (authdata == NULL)
+	if (authdata == NULL || authdata->encryptdef == NULL)
 		return 0;
 
-	if (authdata->encryptdef) {
-		char *msgbuf = NULL;
-		void *data_out = NULL;
-		size_t len_out = 0;
-		size_t newpktlen = 0;
-		char *pktdata = NULL;
-		size_t npktlen = 0;
-
-		if (authdata->encryptdef->encrypt_data(authdata->encryptctx, (void *)pkt->data, (size_t)pkt->len, &data_out, &len_out) != 0) {
-			return -1;
-		}
-
-		if (pkt->len > 0 && len_out <= 0) {
-			pbs_asprintf(&msgbuf, "invalid encrypted data len: %d, pktlen: %d", len_out, pkt->len);
-			tpp_log_func(LOG_CRIT, __func__, msgbuf);
-			free(msgbuf);
-			return -1;
-		}
-
-		/* + sizeof(int) for npktlen and + 1 for TPP_ENCRYPTED_DATA */
-		newpktlen = len_out + sizeof(int) + 1;
-		pktdata = malloc(newpktlen);
-		if (pktdata != NULL) {
-			free(pkt->data);
-			pkt->data = pktdata;
-		} else {
-			free(data_out);
-			tpp_log_func(LOG_CRIT, __func__, "malloc failure");
-			return -1;
-		}
-
-		pkt->pos = pkt->data;
-
-		npktlen = htonl(len_out + 1);
-		memcpy(pkt->pos, &npktlen, sizeof(int));
-		pkt->pos = pkt->pos + sizeof(int);
-
-		*pkt->pos = (char)TPP_ENCRYPTED_DATA;
-		pkt->pos++;
-		memcpy(pkt->pos, data_out, len_out);
-
-		pkt->pos = pkt->data;
-		pkt->len = newpktlen;
-
-		free(data_out);
-	}
-	return 0;
+	return (tpp_encrypt_pkt(authdata, pkt));
 }
 
 /**
@@ -1123,17 +1079,19 @@ router_pkt_presend_handler(int tfd, tpp_packet_t *pkt, void *extra)
  *
  */
 static int
-router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
+router_pkt_handler(int tfd, void *buf, int len, void *c, void *extra)
 {
 	tpp_context_t *ctx = (tpp_context_t *) c;
+	tpp_data_pkt_hdr_t *dhdr = buf;
 	enum TPP_MSG_TYPES type;
 	tpp_chunk_t chunks[2];
 	tpp_router_t *target_router = NULL;
 	int target_fd = -1;
 	tpp_addr_t connected_host;
+	conn_auth_t *authdata = (conn_auth_t *)extra;
 	tpp_addr_t *addr = tpp_get_connected_host(tfd);
-	void *data_out = NULL;
-	size_t len_out = 0;
+	char msg[TPP_GEN_BUF_SZ];
+	short rc;
 
 	if (!addr)
 		return -1;
@@ -1141,178 +1099,159 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 	memcpy(&connected_host, addr, sizeof(tpp_addr_t));
 	free(addr);
 
-	type = *((unsigned char *) data);
+again:
+	type = dhdr->type;
+	errno = 0;
+
 	if(type >= TPP_LAST_MSG)
 		return -1;
 
-	if (type == TPP_ENCRYPTED_DATA) {
-		char *msgbuf = NULL;
-		conn_auth_t *authdata = (conn_auth_t *)extra;
-
-		if (authdata == NULL) {
-			snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tfd=%d, No auth data found in connection %s", tfd, tpp_netaddr(&connected_host));
-			tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
-			return -1;
-		}
-
-		if (authdata->encryptdef == NULL) {
-			tpp_log_func(LOG_CRIT, __func__, "Connetion doesn't support decryption of data");
-			return -1;
-		}
-
-		if (authdata->encryptdef->decrypt_data(authdata->encryptctx, (void *)((char *)data + 1), (size_t)len - 1, &data_out, &len_out) != 0) {
-			return -1;
-		}
-
-		if ((len - 1) > 0 && len_out <= 0) {
-			pbs_asprintf(&msgbuf, "invalid decrypted data len: %d, pktlen: %d", len_out, len - 1);
-			tpp_log_func(LOG_CRIT, __func__, msgbuf);
-			free(msgbuf);
-			return -1;
-		}
-
-		data = (char *)data_out + sizeof(int);
-		len = len_out - sizeof(int);
-
-		/* re-calculate type as data changed */
-		type = *((unsigned char *) data);
-
-	}
-
-	if (type == TPP_AUTH_CTX) {
-		tpp_auth_pkt_hdr_t ahdr = {0};
-		size_t len_in = 0;
-		void *data_in = NULL;
-		conn_auth_t *authdata = (conn_auth_t *)extra;
-		int rc = 0;
-
-		memcpy(&ahdr, data, sizeof(tpp_auth_pkt_hdr_t));
-
-		if (authdata == NULL) {
-			if (!is_string_in_arr(tpp_conf->supported_auth_methods, ahdr.auth_method)) {
-				snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tfd=%d, Authentication method %s not allowed in connection %s", tfd, ahdr.auth_method, tpp_netaddr(&connected_host));
-				tpp_log_func(LOG_CRIT, NULL, tpp_get_logbuf());
-				tpp_send_ctl_msg(tfd, TPP_MSG_AUTHERR, &connected_host, &this_router->router_addr, -1, 0, tpp_get_logbuf());
-				return 0; /* let connection be alive, so we can send error */
-			}
-			if (strcmp(ahdr.auth_method, AUTH_RESVPORT_NAME) != 0 && get_auth(ahdr.auth_method) == NULL) {
-				snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tfd=%d, Authentication method not supported in connection %s", tfd, tpp_netaddr(&connected_host));
-				tpp_log_func(LOG_CRIT, NULL, tpp_get_logbuf());
-				tpp_send_ctl_msg(tfd, TPP_MSG_AUTHERR, &connected_host, &this_router->router_addr, -1, 0, tpp_get_logbuf());
-				return 0; /* let connection be alive, so we can send error */
-			}
-			if (ahdr.encrypt_method[0] != '\0' && get_auth(ahdr.encrypt_method) == NULL) {
-				snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tfd=%d, Encryption method not supported in connection %s", tfd, tpp_netaddr(&connected_host));
-				tpp_log_func(LOG_CRIT, NULL, tpp_get_logbuf());
-				tpp_send_ctl_msg(tfd, TPP_MSG_AUTHERR, &connected_host, &this_router->router_addr, -1, 0, tpp_get_logbuf());
-				return 0; /* let connection be alive, so we can send error */
-			}
-		}
-
-		len_in = (size_t)len - sizeof(tpp_auth_pkt_hdr_t);
-		data_in = calloc(1, len_in);
-		if (data_in == NULL) {
-			tpp_log_func(LOG_CRIT, __func__, "Out of memory allocating authdata credential");
-			return -1;
-		}
-		memcpy(data_in, (char *)data + sizeof(tpp_auth_pkt_hdr_t), len_in);
-
-		if (authdata == NULL) {
-			authdata = tpp_make_authdata(tpp_conf, AUTH_SERVER, ahdr.auth_method, ahdr.encrypt_method);
+	switch (type) {
+		case TPP_ENCRYPTED_DATA: {
+			int len_out;
+			int sz = sizeof(tpp_encrypt_hdr_t);
 			if (authdata == NULL) {
-				/* tpp_make_authdata already logged error */
-				free(data_in);
+				tpp_log(LOG_CRIT, __func__, "tfd=%d, No auth data found", tfd);
 				return -1;
 			}
-			tpp_transport_set_conn_extra(tfd, authdata);
+
+			if (authdata->encryptdef == NULL) {
+				tpp_log(LOG_CRIT, __func__, "connetion doesn't support decryption of data");
+				return -1;
+			}
+
+			if (authdata->encryptdef->decrypt_data(authdata->encryptctx, (void *)((char *)buf + sz), (size_t)len - sz, (void *) &dhdr, (size_t *) &len_out) != 0) {
+				return -1;
+			}
+
+			if (MAX_INT_LENGTH == 0) {
+				tpp_log(LOG_CRIT, __func__, "invalid decrypted data len: %d, pktlen: %d", len_out, len - 1);
+				return -1;
+			}
+			goto again;
 		}
+		break;
 
-		rc = tpp_handle_auth_handshake(tfd, tfd, authdata, ahdr.for_encrypt, data_in, len_in);
-		if (rc != 1) {
-			free(data_in);
-			return rc;
-		}
+		case TPP_AUTH_CTX: {
+			tpp_auth_pkt_hdr_t ahdr = {0};
+			size_t len_in = 0;
+			void *data_in = NULL;
+			conn_auth_t *authdata = (conn_auth_t *)extra;
 
-		free(data_in);
+			memcpy(&ahdr, buf, sizeof(tpp_auth_pkt_hdr_t));
 
-		if (ahdr.for_encrypt == FOR_ENCRYPT &&
-			strcmp(authdata->config->auth_method, AUTH_RESVPORT_NAME) != 0) {
+			if (authdata == NULL) {
+				msg[0] = '\0';
+				if (!is_string_in_arr(tpp_conf->supported_auth_methods, ahdr.auth_method))
+					snprintf(msg, sizeof(msg), "tfd=%d, Authentication method %s not allowed in connection %s", tfd, ahdr.auth_method, tpp_netaddr(&connected_host));
 
-			if (strcmp(authdata->config->auth_method, authdata->config->encrypt_method) != 0) {
-				if (authdata->conn_initiator) {
-					rc = tpp_handle_auth_handshake(tfd, tfd, authdata, FOR_AUTH, NULL, 0);
-					if (rc != 1) {
-						return rc;
-					}
-				} else
-					return 0;
-			} else {
-				authdata->authctx = authdata->encryptctx;
-				authdata->authdef = authdata->encryptdef;
+				else if (strcmp(ahdr.auth_method, AUTH_RESVPORT_NAME) != 0 && get_auth(ahdr.auth_method) == NULL)
+					snprintf(msg, sizeof(msg), "tfd=%d, Authentication method not supported in connection %s", tfd, tpp_netaddr(&connected_host));
+				
+				else if (ahdr.encrypt_method[0] != '\0' && get_auth(ahdr.encrypt_method) == NULL)
+					snprintf(msg, sizeof(msg), "tfd=%d, Encryption method not supported in connection %s", tfd, tpp_netaddr(&connected_host));
+
+				if (msg[0] != '\0') {
+					/* error message was set, to take action */
+					tpp_log(LOG_CRIT, NULL, msg);
+					tpp_send_ctl_msg(tfd, TPP_MSG_AUTHERR, &connected_host, &this_router->router_addr, -1, 0, msg);
+					return 0; /* let connection be alive, so we can send error */
+				}
+			}
+
+			len_in = (size_t)len - sizeof(tpp_auth_pkt_hdr_t);
+			data_in = calloc(1, len_in);
+			if (data_in == NULL) {
+				tpp_log(LOG_CRIT, __func__, "Out of memory allocating authdata credential");
+				return -1;
+			}
+			memcpy(data_in, (char *)buf + sizeof(tpp_auth_pkt_hdr_t), len_in);
+
+			if (authdata == NULL) {
+				authdata = tpp_make_authdata(tpp_conf, AUTH_SERVER, ahdr.auth_method, ahdr.encrypt_method);
+				if (authdata == NULL) {
+					/* tpp_make_authdata already logged error */
+					free(data_in);
+					return -1;
+				}
 				tpp_transport_set_conn_extra(tfd, authdata);
 			}
-		}
 
-		if (ctx == NULL) {
-			if ((ctx = (tpp_context_t *) malloc(sizeof(tpp_context_t))) == NULL) {
-				tpp_log_func(LOG_CRIT, __func__, "Out of memory allocating tpp context");
-				return -1;
+			rc = tpp_handle_auth_handshake(tfd, tfd, authdata, ahdr.for_encrypt, data_in, len_in);
+			if (rc != 1) {
+				free(data_in);
+				return rc;
 			}
-			ctx->ptr = NULL;
-			ctx->type = TPP_AUTH_NODE; /* denoting that this is an authenticated connection */
+
+			free(data_in);
+
+			if (ahdr.for_encrypt == FOR_ENCRYPT &&
+				strcmp(authdata->config->auth_method, AUTH_RESVPORT_NAME) != 0) {
+
+				if (strcmp(authdata->config->auth_method, authdata->config->encrypt_method) != 0) {
+					if (authdata->conn_initiator) {
+						rc = tpp_handle_auth_handshake(tfd, tfd, authdata, FOR_AUTH, NULL, 0);
+						if (rc != 1) {
+							return rc;
+						}
+					} else
+						return 0;
+				} else {
+					authdata->authctx = authdata->encryptctx;
+					authdata->authdef = authdata->encryptdef;
+					tpp_transport_set_conn_extra(tfd, authdata);
+				}
+			}
+
+			if (ctx == NULL) {
+				if ((ctx = (tpp_context_t *) malloc(sizeof(tpp_context_t))) == NULL) {
+					tpp_log(LOG_CRIT, __func__, "Out of memory allocating tpp context");
+					return -1;
+				}
+				ctx->ptr = NULL;
+				ctx->type = TPP_AUTH_NODE; /* denoting that this is an authenticated connection */
+			}
+
+			/*
+			* associate this router structure (information) with
+			* this physical connection
+			*/
+			tpp_transport_set_conn_ctx(tfd, ctx);
+
+			/* send TPP_CTL_JOIN msg to fellow router */
+			return router_send_ctl_join(tfd, buf, c);
+
 		}
-
-		/*
-		 * associate this router structure (information) with
-		 * this physical connection
-		 */
-		tpp_transport_set_conn_ctx(tfd, ctx);
-
-		/* send TPP_CTL_JOIN msg to fellow router */
-		return router_send_ctl_join(tfd, data, c);
-
-	}
-
-	switch (type) {
+		break;
 
 		case TPP_CTL_JOIN: {
 			unsigned char hop;
 			unsigned char node_type;
-			tpp_join_pkt_hdr_t *hdr = (tpp_join_pkt_hdr_t *) data;
+			tpp_join_pkt_hdr_t *hdr = (tpp_join_pkt_hdr_t *) buf;
 
 			hop = hdr->hop;
 			node_type = hdr->node_type;
 
 			if (ctx == NULL) { /* connection not yet authenticated */
+				msg[0] = '\0';
 				if (extra && strcmp(((conn_auth_t *)extra)->config->auth_method, AUTH_RESVPORT_NAME) != 0) {
 					/*
 					 * In case of external authentication, ctx must already be set
 					 * so error out if ctx is not set.
 					 */
-					snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tfd=%d Unauthenticated connection from %s", tfd, tpp_netaddr(&connected_host));
-					tpp_log_func(LOG_CRIT, NULL, tpp_get_logbuf());
-					tpp_send_ctl_msg(tfd, TPP_MSG_AUTHERR, &connected_host, &this_router->router_addr, -1, 0, tpp_get_logbuf());
-					if (data_out)
-						free(data_out);
-					return 0; /* let connection be alive, so we can send error */
+					snprintf(msg, sizeof(msg), "tfd=%d Unauthenticated connection from %s", tfd, tpp_netaddr(&connected_host));
 				} else {
-					if (!is_string_in_arr(tpp_conf->supported_auth_methods, AUTH_RESVPORT_NAME)) {
-						snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tfd=%d, Authentication method %s not allowed in connection %s", tfd, AUTH_RESVPORT_NAME, tpp_netaddr(&connected_host));
-						tpp_log_func(LOG_CRIT, NULL, tpp_get_logbuf());
-						tpp_send_ctl_msg(tfd, TPP_MSG_AUTHERR, &connected_host, &this_router->router_addr, -1, 0, tpp_get_logbuf());
-						if (data_out)
-							free(data_out);
-						return 0; /* let connection be alive, so we can send error */
-					}
-					/* reserved port based authentication, and is not yet authenticated, so check resv port */
-					if (tpp_transport_isresvport(tfd) != 0) {
-						snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Connection from non-reserved port, rejected");
-						tpp_log_func(LOG_CRIT, NULL, tpp_get_logbuf());
-						tpp_send_ctl_msg(tfd, TPP_MSG_AUTHERR, &connected_host, &this_router->router_addr, -1, 0, tpp_get_logbuf());
-						if (data_out)
-							free(data_out);
-						return 0; /* let connection be alive, so we can send error */
-					}
+					if (!is_string_in_arr(tpp_conf->supported_auth_methods, AUTH_RESVPORT_NAME))
+						snprintf(msg, sizeof(msg), "tfd=%d, Authentication method %s not allowed in connection %s", tfd, AUTH_RESVPORT_NAME, tpp_netaddr(&connected_host));
+					
+					else if (tpp_transport_isresvport(tfd) != 0) /* reserved port based authentication, and is not yet authenticated, so check resv port */
+						snprintf(msg, sizeof(msg), "Connection from non-reserved port, rejected");
+				}
+				if (msg[0] != '\0') {
+					/* error message was set above, take action */
+					tpp_log(LOG_CRIT, NULL, msg);
+					tpp_send_ctl_msg(tfd, TPP_MSG_AUTHERR, &connected_host, &this_router->router_addr, -1, 0, msg);
+					return 0; /* let connection be alive, so we can send error */
 				}
 			}
 
@@ -1321,9 +1260,9 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 				tpp_router_t *r = NULL;
 				void *pconn_host = &connected_host;
 
-				TPP_DBPRT(("Recvd TPP_CTL_JOIN from pbs_comm node %s", tpp_netaddr(&connected_host)));
+				TPP_DBPRT("Recvd TPP_CTL_JOIN from pbs_comm node %s", tpp_netaddr(&connected_host));
 
-				tpp_lock(&router_lock);
+				tpp_write_lock(&router_lock);
 
 				/* find associated router */
 				pbs_idx_find(routers_idx, &pconn_host, (void **)&r, NULL);
@@ -1332,23 +1271,16 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 						/* this router had not yet disconnected,
 						 * so close the existing connection
 						 */
-						snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ,
-							 "tfd=%d, pbs_comm %s is still connected while "
-							 "another connect arrived, dropping existing connection %d",
-							 tfd, r->router_name, r->conn_fd);
-						tpp_log_func(LOG_CRIT, NULL, tpp_get_logbuf());
+						tpp_log(LOG_CRIT, NULL, "tfd=%d, pbs_comm %s is still connected while "
+							 "another connect arrived, dropping existing connection %d", tfd, r->router_name, r->conn_fd);
 						tpp_transport_close(r->conn_fd);
-						tpp_unlock(&router_lock);
-						if (data_out)
-							free(data_out);
+						tpp_unlock_rwlock(&router_lock);
 						return -1;
 					}
 				} else {
 					r = alloc_router(strdup(tpp_netaddr(&connected_host)), &connected_host);
 					if (!r) {
-						tpp_unlock(&router_lock);
-						if (data_out)
-							free(data_out);
+						tpp_unlock_rwlock(&router_lock);
 						return -1;
 					}
 				}
@@ -1356,15 +1288,12 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 				r->initiator = 0;
 				r->state = TPP_ROUTER_STATE_CONNECTED;
 
-				snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tfd=%d, pbs_comm %s connected", tfd, tpp_netaddr(&r->router_addr));
-				tpp_log_func(LOG_CRIT, NULL, tpp_get_logbuf());
+				tpp_log(LOG_CRIT, NULL, "tfd=%d, pbs_comm %s connected", tfd, tpp_netaddr(&r->router_addr));
 
 				if (ctx == NULL) {
 					if ((ctx = (tpp_context_t *) malloc(sizeof(tpp_context_t))) == NULL) {
-						tpp_log_func(LOG_CRIT, __func__, "Out of memory allocating tpp context");
-						tpp_unlock(&router_lock);
-						if (data_out)
-							free(data_out);
+						tpp_log(LOG_CRIT, __func__, "Out of memory allocating tpp context");
+						tpp_unlock_rwlock(&router_lock);
 						return -1;
 					}
 				}
@@ -1379,9 +1308,6 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 
 				/* now send new router info about all leaves I have */
 				send_leaves_to_router(this_router, r); /* this call will unlock the router_lock */
-
-				if (data_out)
-					free(data_out);
 				return 0;
 
 			} else if (node_type == TPP_LEAF_NODE || node_type == TPP_LEAF_NODE_LISTEN) {
@@ -1395,15 +1321,12 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 
 				if (hdr->num_addrs == 0) {
 					/* error, must have atleast one address associated */
-					snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tfd=%d, No address associated with join msg from leaf", tfd);
-					tpp_log_func(LOG_CRIT, NULL, tpp_get_logbuf());
-					if (data_out)
-						free(data_out);
+					tpp_log(LOG_CRIT, NULL, "tfd=%d, No address associated with join msg from leaf", tfd);
 					return -1;
 				}
-				addrs = (tpp_addr_t *) (((char *) data) + sizeof(tpp_join_pkt_hdr_t));
+				addrs = (tpp_addr_t *) (((char *) buf) + sizeof(tpp_join_pkt_hdr_t));
 
-				tpp_lock(&router_lock);
+				tpp_write_lock(&router_lock);
 
 				if (ctx == NULL || ctx->ptr == NULL) {
 					/* router is myself */
@@ -1418,12 +1341,8 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 						char rname[TPP_MAXADDRLEN + 1];
 
 						strcpy(rname, tpp_netaddr(&connected_host));
-						snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tfd=%d, Failed to find pbs_comm %s in join for leaf %s",
-									tfd, rname, tpp_netaddr(&addrs[0]));
-						tpp_log_func(LOG_CRIT, NULL, tpp_get_logbuf());
-						tpp_unlock(&router_lock);
-						if (data_out)
-							free(data_out);
+						tpp_log(LOG_CRIT, NULL, "tfd=%d, Failed to find pbs_comm %s in join for leaf %s", tfd, rname, tpp_netaddr(&addrs[0]));
+						tpp_unlock_rwlock(&router_lock);
 						return -1;
 					}
 				}
@@ -1440,10 +1359,8 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 
 					if (!l || !l->leaf_addrs) {
 						free_leaf(l);
-						tpp_log_func(LOG_CRIT, __func__, "Out of memory allocating leaf");
-						tpp_unlock(&router_lock);
-						if (data_out)
-							free(data_out);
+						tpp_log(LOG_CRIT, __func__, "Out of memory allocating leaf");
+						tpp_unlock_rwlock(&router_lock);
 						return -1;
 					}
 
@@ -1457,23 +1374,18 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 				if (hop == 1) {
 
 					for (i = 0; i < l->num_addrs; i++) {
-						sprintf(tpp_get_logbuf(), "tfd=%d, Leaf registered address %s", tfd, tpp_netaddr(&l->leaf_addrs[i]));
-						tpp_log_func(LOG_CRIT, NULL, tpp_get_logbuf());
+						tpp_log(LOG_CRIT, NULL, "tfd=%d, Leaf registered address %s", tfd, tpp_netaddr(&l->leaf_addrs[i]));
 					}
 
 					if (l->conn_fd != -1) {
 						/* this leaf had not yet disconnected,
 						 * so close the existing connection.
-						 */
-						snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ,
-							 "tfd=%d, Leaf %s still connected while "
+						 */		 
+						tpp_log(LOG_CRIT, NULL, "tfd=%d, Leaf %s still connected while "
 							 "another leaf connect arrived, dropping existing connection %d",
 							 tfd, tpp_netaddr(&l->leaf_addrs[0]), l->conn_fd);
-						tpp_log_func(LOG_CRIT, NULL, tpp_get_logbuf());
 						tpp_transport_close(l->conn_fd);
-						tpp_unlock(&router_lock);
-						if (data_out)
-							free(data_out);
+						tpp_unlock_rwlock(&router_lock);
 						return -1;
 					}
 					l->conn_fd = tfd;
@@ -1486,9 +1398,8 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 					 */
 					if (ctx == NULL) {
 						if ((ctx = (tpp_context_t *) malloc(sizeof(tpp_context_t))) == NULL) {
-							tpp_log_func(LOG_CRIT, __func__, "Out of memory allocating tpp context");
-							if (data_out)
-								free(data_out);
+							tpp_log(LOG_CRIT, __func__, "Out of memory allocating tpp context");
+							tpp_unlock_rwlock(&router_lock);
 							return -1;
 						}
 					}
@@ -1497,7 +1408,7 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 					tpp_transport_set_conn_ctx(tfd, ctx);
 				}
 
-				TPP_DBPRT(("tfd=%d, Router name = %s, address leaf = %p, " "leaf name=%s, index=%d", tfd, r->router_name, (void *) l, tpp_netaddr(&l->leaf_addrs[0]), (int) index));
+				TPP_DBPRT("tfd=%d, Router name = %s, address leaf = %p, " "leaf name=%s, index=%d", tfd, r->router_name, (void *) l, tpp_netaddr(&l->leaf_addrs[0]), (int) index);
 
 				/*
 				 * router is not part of leaf's list
@@ -1505,21 +1416,14 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 				 */
 				i = add_route_to_leaf(l, r, index);
 				if (i == -1) {
-					snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tfd=%d, Leaf %s exists!", tfd, tpp_netaddr(&l->leaf_addrs[0]));
-					tpp_log_func(LOG_CRIT, NULL, tpp_get_logbuf());
-					tpp_unlock(&router_lock);
-					if (data_out)
-						free(data_out);
+					tpp_log(LOG_CRIT, NULL, "tfd=%d, Leaf %s exists!", tfd, tpp_netaddr(&l->leaf_addrs[0]));
+					tpp_unlock_rwlock(&router_lock);
 					return 0;
 				}
 
 				if (pbs_idx_insert(r->my_leaves_idx, &l->leaf_addrs[0], l) != PBS_IDX_RET_OK) {
-					sprintf(tpp_get_logbuf(), "tfd=%d, Failed to add address %s to index of my leaves", tfd,
-							tpp_netaddr(&l->leaf_addrs[0]));
-					tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
-					tpp_unlock(&router_lock);
-					if (data_out)
-						free(data_out);
+					tpp_log(LOG_CRIT, __func__, "tfd=%d, Failed to add address %s to index of my leaves", tfd, tpp_netaddr(&l->leaf_addrs[0]));
+					tpp_unlock_rwlock(&router_lock);
 					return -1;
 				}
 
@@ -1534,9 +1438,8 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 							void *pleaf_addr = &l->leaf_addrs[i];
 							if (pbs_idx_find(cluster_leaves_idx, &pleaf_addr, &unused, NULL) == PBS_IDX_RET_OK) {
 								int k;
-								sprintf(tpp_get_logbuf(), "tfd=%d, Failed to add address %s to cluster-leaves index "
-										"since address already exists, dropping duplicate",
-										tfd, tpp_netaddr(&l->leaf_addrs[i]));
+								tpp_log(LOG_CRIT, __func__, "tfd=%d, Failed to add address %s to cluster-leaves index "
+										"since address already exists, dropping duplicate", tfd, tpp_netaddr(&l->leaf_addrs[i]));
 								/* remove this address from the list of addresses of the leaf */
 								for (k = i; k < (l->num_addrs - 1); k++) {
 									l->leaf_addrs[k] = l->leaf_addrs[k + 1];
@@ -1544,22 +1447,16 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 								l->num_addrs--;
 
 							} else {
-								sprintf(tpp_get_logbuf(), "tfd=%d, Failed to add address %s to cluster-leaves index",
-										tfd, tpp_netaddr(&l->leaf_addrs[i]));
+								tpp_log(LOG_CRIT, __func__, "tfd=%d, Failed to add address %s to cluster-leaves index", tfd, tpp_netaddr(&l->leaf_addrs[i]));
 								fatal++;
 							}
-							tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
 						}
 					}
 
 					if (fatal > 0 || l->num_addrs == 0) {
-						snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ,
-								"tfd=%d, Leaf %s had %s problem adding addresses, rejecting connection",
+						tpp_log(LOG_CRIT, NULL, "tfd=%d, Leaf %s had %s problem adding addresses, rejecting connection",
 								 tfd, tpp_netaddr(&l->leaf_addrs[0]), (fatal > 0)? "fatal" : "all duplicates");
-						tpp_log_func(LOG_CRIT, NULL, tpp_get_logbuf());
-						tpp_unlock(&router_lock);
-						if (data_out)
-							free(data_out);
+						tpp_unlock_rwlock(&router_lock);
 						return -1;
 					}
 				}
@@ -1567,12 +1464,8 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 				if (r == this_router) {
 					if (l->leaf_type == TPP_LEAF_NODE_LISTEN) {
 						if (pbs_idx_insert(my_leaves_notify_idx, &l->leaf_addrs[0], l) != PBS_IDX_RET_OK) {
-							sprintf(tpp_get_logbuf(), "tfd=%d, Failed to add address %s to notify-leaves index",
-									tfd, tpp_netaddr(&l->leaf_addrs[0]));
-							tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
-							tpp_unlock(&router_lock);
-							if (data_out)
-								free(data_out);
+							tpp_log(LOG_CRIT, __func__, "tfd=%d, Failed to add address %s to notify-leaves index", tfd, tpp_netaddr(&l->leaf_addrs[0]));
+							tpp_unlock_rwlock(&router_lock);
 							return -1;
 						}
 					}
@@ -1584,7 +1477,9 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 					 * for each leaf; rather set a timer, postponing it each time
 					 * we get an update by 2 seconds
 					 */
+					tpp_lock(&lj_lock);
 					router_last_leaf_joined = time(0);
+					tpp_unlock(&lj_lock);
 				}
 
 				if (hop == 1) {
@@ -1597,7 +1492,7 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 					hop++; /* increment hop */
 					hdr->hop = hop;
 
-					chunks[0].data = data;
+					chunks[0].data = buf;
 					chunks[0].len = len;
 
 					/*
@@ -1606,40 +1501,29 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 					 */
 					broadcast_to_my_routers(chunks, 1, tfd); /* this call will unlock the router_lock */
 				} else {
-					tpp_unlock(&router_lock); /* unlock router_lock explicitly */
+					tpp_unlock_rwlock(&router_lock); /* unlock router_lock explicitly */
 				}
-				if (data_out)
-					free(data_out);
 				return 0;
 			}
-			if (data_out)
-				free(data_out);
 			return 0;
 		}
 		break; /* TPP_CTL_JOIN */
 
 		case TPP_CTL_LEAVE: {
 			unsigned char hop;
-			tpp_leave_pkt_hdr_t *hdr = (tpp_leave_pkt_hdr_t *) data;
+			tpp_leave_pkt_hdr_t *hdr = (tpp_leave_pkt_hdr_t *) buf;
 
 			hop = hdr->hop;
 
 			if (ctx == NULL) {
-				TPP_DBPRT(("tfd=%d, No context, leaving", tfd));
-				if (data_out)
-					free(data_out);
+				TPP_DBPRT("tfd=%d, No context, leaving", tfd);
 				return 0;
 			}
 
-			TPP_DBPRT(("Recvd TPP_CTL_LEAVE message tfd=%d from src=%s, hop=%d, type=%d", tfd, tpp_netaddr(&connected_host), hop, ctx->type));
+			TPP_DBPRT("Recvd TPP_CTL_LEAVE message tfd=%d from src=%s, hop=%d, type=%d", tfd, tpp_netaddr(&connected_host), hop, ctx->type);
 
-			if (ctx->type == TPP_LEAF_NODE || ctx->type == TPP_LEAF_NODE_LISTEN) {
-
-				sprintf(tpp_get_logbuf(),
-						"tfd=%d, Internal error! TPP_CTL_LEAVE arrived with a leaf context", tfd);
-				tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
-				if (data_out)
-					free(data_out);
+			if (ctx->type == TPP_LEAF_NODE || ctx->type == TPP_LEAF_NODE_LISTEN) {						
+				tpp_log(LOG_CRIT, __func__, "tfd=%d, Internal error! TPP_CTL_LEAVE arrived with a leaf context", tfd);
 				return -1;
 
 			} else if (ctx->type == TPP_ROUTER_NODE) {
@@ -1648,26 +1532,22 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 				 * from a leaf, but fd is routers context
 				 */
 				tpp_leaf_t *l = NULL;
-				tpp_addr_t *src_addr = (tpp_addr_t *) (((char *) data) + sizeof(tpp_leave_pkt_hdr_t));
+				tpp_addr_t *src_addr = (tpp_addr_t *) (((char *) buf) + sizeof(tpp_leave_pkt_hdr_t));
 
-				tpp_lock(&router_lock);
+				tpp_write_lock(&router_lock);
 
 				/* find the leaf context to pass to close handler */
 				pbs_idx_find(cluster_leaves_idx, (void **)&src_addr, (void **)&l, NULL);
 				if (!l) {
-					TPP_DBPRT(("No leaf %s found", tpp_netaddr(src_addr)));
-					tpp_unlock(&router_lock);
-					if (data_out)
-						free(data_out);
+					TPP_DBPRT("No leaf %s found", tpp_netaddr(src_addr));
+					tpp_unlock_rwlock(&router_lock);
 					return 0;
 				}
 
-				tpp_unlock(&router_lock);
+				tpp_unlock_rwlock(&router_lock);
 
 				if ((ctx = (tpp_context_t *) malloc(sizeof(tpp_context_t))) == NULL) {
-					tpp_log_func(LOG_CRIT, __func__, "Out of memory allocating tpp context");
-					if (data_out)
-						free(data_out);
+					tpp_log(LOG_CRIT, __func__, "Out of memory allocating tpp context");
 					return -1;
 				}
 				ctx->ptr = l;
@@ -1678,8 +1558,6 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 				/* we created the fake context here, so delete it here */
 				free(ctx);
 			}
-			if (data_out)
-				free(data_out);
 			return 0;
 		}
 		break; /* TPP_CTL_LEAVE */
@@ -1699,15 +1577,13 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 			int rsize = 0;
 			int csize = 0;
 			void *tmp;
-			tpp_chunk_t mchunks[3]; /* mcast packet has 3 chunks */
 
 			/* find the fd to forward to via the associated router */
-			tpp_mcast_pkt_hdr_t *mhdr = (tpp_mcast_pkt_hdr_t *) data;
+			tpp_mcast_pkt_hdr_t *mhdr = (tpp_mcast_pkt_hdr_t *) buf;
 			unsigned char orig_hop;
 			tpp_mcast_pkt_info_t *minfo;
 			void *minfo_base = NULL;
-			void *info_start = (char *) data + sizeof(tpp_mcast_pkt_hdr_t);
-			tpp_data_pkt_hdr_t shdr;
+			void *info_start = (char *) buf + sizeof(tpp_mcast_pkt_hdr_t);
 			unsigned int payload_len;
 			void *payload;
 			unsigned int cmprsd_len = ntohl(mhdr->info_cmprsd_len);
@@ -1726,30 +1602,14 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 			src_host = &mhdr->src_addr;
 			orig_hop = mhdr->hop;
 
-			snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ,
-				"tfd=%d, MCAST packet from %s, %u member streams, cmprsd_len=%d, info_len=%d, len=%d",
+			tpp_log(LOG_INFO, NULL, "tfd=%d, MCAST packet from %s, %u member streams, cmprsd_len=%d, info_len=%d, len=%d",
 				tfd, tpp_netaddr(src_host), num_streams, cmprsd_len, info_len, payload_len);
-			tpp_log_func(LOG_INFO, NULL, tpp_get_logbuf());
-
-			/* set common things here */
-			memset(&shdr, 0, sizeof(tpp_data_pkt_hdr_t)); /* only to satisfy valgrind */
-			shdr.type = TPP_DATA;
-			shdr.ack_seq = htonl(UNINITIALIZED_INT);
-			shdr.dup = 0;
-
-			chunks[0].data = &shdr;
-			chunks[0].len = sizeof(tpp_data_pkt_hdr_t);
-
-			chunks[1].data = payload;
-			chunks[1].len = payload_len;
 
 #ifdef PBS_COMPRESSION_ENABLED
 			if (cmprsd_len > 0) {
 				minfo_base = tpp_inflate(info_start, cmprsd_len, info_len);
 				if (minfo_base == NULL) {
-					tpp_log_func(LOG_CRIT, __func__, "Decompression of mcast hdr failed");
-					if (data_out)
-						free(data_out);
+					tpp_log(LOG_CRIT, __func__, "Decompression of mcast hdr failed");
 					return -1;
 				}
 			}
@@ -1757,8 +1617,7 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 
 			mhdr->hop = 1; /* set hop=1 to forward, use orig_hop for checking */
 
-			snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Total mcast member streams=%d", num_streams);
-			tpp_log_func(LOG_INFO, __func__, tpp_get_logbuf());
+			tpp_log(LOG_INFO, __func__, "Total mcast member streams=%d", num_streams);
 
 			/*
 			 * go backwards in an attempt to distribute mcast packet
@@ -1768,20 +1627,19 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 				tpp_addr_t *dest_host;
 				unsigned int src_sd;
 				tpp_leaf_t *l = NULL;
-
+				
 				minfo = (tpp_mcast_pkt_info_t *)(((char *) minfo_base) + k * sizeof(tpp_mcast_pkt_info_t));
 
 				dest_host = &minfo->dest_addr;
 				src_sd = ntohl(minfo->src_sd);
 
-				TPP_DBPRT(("MCAST data on fd=%u", src_sd));
+				TPP_DBPRT("MCAST data on fd=%u", src_sd);
 
-				tpp_lock(&router_lock);
+				tpp_read_lock(&router_lock);
 				pbs_idx_find(cluster_leaves_idx, (void **)&dest_host, (void **)&l, NULL);
 				if (l == NULL) {
-					char msg[TPP_LOGBUF_SZ];
-					tpp_unlock(&router_lock);
-					snprintf(msg, TPP_LOGBUF_SZ, "pbs_comm:%s: Dest not found at pbs_comm", tpp_netaddr(&this_router->router_addr));
+					tpp_unlock_rwlock(&router_lock);
+					snprintf(msg, sizeof(msg), "pbs_comm:%s: Dest not found at pbs_comm", tpp_netaddr(&this_router->router_addr));
 					log_noroute(src_host, dest_host, src_sd, msg);
 					tpp_send_ctl_msg(tfd, TPP_MSG_NOROUTE, src_host, dest_host, src_sd, 0, msg);
 					continue;
@@ -1789,38 +1647,44 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 
 				/* find a router that is still connected */
 				target_router = get_preferred_router(l, this_router, &target_fd);
-				tpp_unlock(&router_lock);
+				tpp_unlock_rwlock(&router_lock);
 
 				if (target_router == NULL) {
-					char msg[TPP_LOGBUF_SZ];
-					snprintf(msg, TPP_LOGBUF_SZ, "pbs_comm:%s: No target pbs_comm found", tpp_netaddr(&this_router->router_addr));
+					snprintf(msg, sizeof(msg), "pbs_comm:%s: No target pbs_comm found", tpp_netaddr(&this_router->router_addr));
 					log_noroute(src_host, dest_host, src_sd, msg);
 					tpp_send_ctl_msg(tfd, TPP_MSG_NOROUTE, src_host, dest_host, src_sd, 0, msg);
 					continue;
 				}
 
 				if (target_router == this_router) {
-					shdr.src_sd = minfo->src_sd;
-					shdr.src_magic = minfo->src_magic;
-					shdr.dest_sd = minfo->dest_sd;
-					shdr.seq_no = minfo->seq_no;
-					shdr.cmprsd_len = mhdr->data_cmprsd_len;
-					shdr.totlen = mhdr->totlen;
-					memcpy(&shdr.src_addr, &mhdr->src_addr, sizeof(tpp_addr_t));
-					memcpy(&shdr.dest_addr, &minfo->dest_addr, sizeof(tpp_addr_t));
+					tpp_packet_t *pkt = NULL;
+					tpp_data_pkt_hdr_t *shdr = NULL;
 
-					TPP_DBPRT(("Send mcast indiv packet to %s", tpp_netaddr(&shdr.dest_addr)));
+					pkt = tpp_bld_pkt(NULL, NULL, sizeof(tpp_data_pkt_hdr_t), 1, (void **) &shdr);
+					if (!pkt) {
+						tpp_log(LOG_CRIT, __func__, "Failed to build packet");
+						goto mcast_err;
+					}
 
-					if (tpp_transport_vsend(target_fd, chunks, 2) != 0) {
-						tpp_log_func(LOG_ERR, __func__, "Failed to send mcast indiv pkt");
+					shdr->type = TPP_DATA;
+					shdr->src_sd = minfo->src_sd;
+					shdr->src_magic = minfo->src_magic;
+					shdr->dest_sd = minfo->dest_sd;
+					shdr->totlen = mhdr->totlen;
+					memcpy(&shdr->src_addr, &mhdr->src_addr, sizeof(tpp_addr_t));
+					memcpy(&shdr->dest_addr, &minfo->dest_addr, sizeof(tpp_addr_t));
+					
+					if (!tpp_bld_pkt(pkt, payload, payload_len, 1, NULL)) {
+						tpp_log(LOG_CRIT, __func__, "Failed to build packet");
+						goto mcast_err;
+					}
+
+					TPP_DBPRT("Send mcast indiv packet to %s", tpp_netaddr(&shdr->dest_addr));
+
+					if (tpp_transport_vsend(target_fd, pkt) != 0) {
+						tpp_log(LOG_ERR, __func__, "Failed to send mcast indiv pkt");
 						tpp_transport_close(target_fd);
-						if (rlist)
-							free(rlist);
-						if (cmprsd_len > 0)
-							free(minfo_base);
-						if (data_out)
-							free(data_out);
-						return 0;
+						goto mcast_err;
 					}
 				} else if (orig_hop == 0) {
 					/* add this to list of routers to whom we need to send */
@@ -1845,9 +1709,7 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 							/* got to add, but no space */
 							tmp = realloc(rlist, sizeof(target_comm_struct_t) * (rsize + RLIST_INC));
 							if (!tmp) {
-								snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ,
-									"Out of memory resizing pbs_comm list to %lu bytes", (unsigned long)(sizeof(int) * rsize));
-								tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+								tpp_log(LOG_CRIT, __func__, "Out of memory resizing pbs_comm list to %lu bytes", (unsigned long)(sizeof(int) * rsize));
 								goto mcast_err;
 							}
 							rsize += RLIST_INC;
@@ -1867,8 +1729,7 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 						} else {
 							rlist[found].minfo_buf = malloc(c_minfo_len);
 							if (!rlist[found].minfo_buf) {
-								snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Out of memory allocating mcast buffer of %d bytes", c_minfo_len);
-								tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+								tpp_log(LOG_CRIT, __func__, "Out of memory allocating mcast buffer of %d bytes", c_minfo_len);
 								goto mcast_err;
 							}
 						}
@@ -1890,29 +1751,24 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 			} /* for k streams */
 
 			if (csize > 0) {
-				tpp_mcast_pkt_hdr_t t_mhdr;
-				/* header data */
-				memcpy(&t_mhdr, mhdr, sizeof(tpp_mcast_pkt_hdr_t)); /* only to satisfy valgrind */
-				t_mhdr.hop = 1;
-
-				/* set the header chunk and data chunk one time for all target comms */
-				mchunks[0].data = &t_mhdr;
-				mchunks[0].len = sizeof(tpp_mcast_pkt_hdr_t);
-
-				mchunks[2].data = payload;
-				mchunks[2].len = payload_len;
-
-				snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Total target comms=%d", csize);
-				tpp_log_func(LOG_INFO, __func__, tpp_get_logbuf());
+				tpp_log(LOG_INFO, __func__, "Total target comms=%d", csize);
 
 				/* finish up the MCAST packets for each target comm and send */
 				for(k = 0; k < csize; k++) {
 					void *t_minfo_buf = NULL;
 					unsigned int t_minfo_len = 0;
+					tpp_mcast_pkt_hdr_t *t_mhdr = NULL;
+					tpp_packet_t *pkt = NULL;
 
-					t_mhdr.num_streams = htonl(rlist[k].num_streams);
+					pkt = tpp_bld_pkt(NULL, mhdr, sizeof(tpp_mcast_pkt_hdr_t), 1, (void **) &t_mhdr);
+					if (!pkt) {
+						tpp_log(LOG_CRIT, __func__, "Failed to build packet");
+						goto mcast_err;
+					}
+
+					t_mhdr->num_streams = htonl(rlist[k].num_streams);
 					t_minfo_len = rlist[k].num_streams * sizeof(tpp_mcast_pkt_info_t);
-					t_mhdr.info_len = htonl(t_minfo_len);
+					t_mhdr->info_len = htonl(t_minfo_len);
 
 					/* the router information has been collected in rlist[k] */
 					if (rlist[k].cmpr_ctx != NULL) {
@@ -1921,22 +1777,26 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 						t_minfo_buf = tpp_multi_deflate_done(rlist[k].cmpr_ctx, &t_minfo_len);
 						if (t_minfo_buf == NULL)
 							goto mcast_err;
-						t_mhdr.info_cmprsd_len = htonl(t_minfo_len);
+						t_mhdr->info_cmprsd_len = htonl(t_minfo_len);
 						rlist[k].cmpr_ctx = NULL; /* done with compression */
 					} else {
 						t_minfo_buf = rlist[k].minfo_buf;
-						t_mhdr.info_cmprsd_len = 0;
+						t_mhdr->info_cmprsd_len = 0;
+					}
+					
+					if (!tpp_bld_pkt(pkt, t_minfo_buf, t_minfo_len, 0, NULL)) {
+						tpp_log(LOG_CRIT, __func__, "Failed to build packet");
+						goto mcast_err;
 					}
 
-					mchunks[1].data = t_minfo_buf;
-					mchunks[1].len = t_minfo_len;
-
-					snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Sending MCAST packet to %s, num_streams=%d", rlist[k].router_name, rlist[k].num_streams);
-					tpp_log_func(LOG_INFO, __func__, tpp_get_logbuf());
-					if (tpp_transport_vsend(rlist[k].target_fd, mchunks, 3) != 0) {
-						snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "send failed: errno = %d", errno);
-						tpp_log_func(LOG_ERR, __func__, tpp_get_logbuf());
+					if (!tpp_bld_pkt(pkt, payload, payload_len, 1, NULL)) {
+						tpp_log(LOG_CRIT, __func__, "Failed to build packet");
+						goto mcast_err;
 					}
+
+					tpp_log(LOG_INFO, __func__, "Sending MCAST packet to %s, num_streams=%d", rlist[k].router_name, rlist[k].num_streams);
+					if (tpp_transport_vsend(rlist[k].target_fd, pkt) != 0)
+						tpp_log(LOG_ERR, __func__, "send failed: errno = %d", errno);
 				}
 			}
 mcast_err:
@@ -1949,10 +1809,7 @@ mcast_err:
 				free(rlist);
 			}
 
-			tpp_log_func(LOG_INFO, NULL, "mcast done");
-
-			if (data_out)
-				free(data_out);
+			tpp_log(LOG_INFO, NULL, "mcast done");
 
 			return 0;
 		}
@@ -1962,118 +1819,93 @@ mcast_err:
 		case TPP_CLOSE_STRM: {
 			tpp_leaf_t *l = NULL;
 			tpp_addr_t *src_host, *dest_host;
+			tpp_packet_t *pkt = NULL;
 			unsigned int src_sd;
-			tpp_data_pkt_hdr_t *dhdr = (tpp_data_pkt_hdr_t *) data;
+			tpp_data_pkt_hdr_t *dhdr = (tpp_data_pkt_hdr_t *) buf;
 
 			src_host = &dhdr->src_addr;
 			dest_host = &dhdr->dest_addr;
 			src_sd = ntohl(dhdr->src_sd);
 
-			tpp_lock(&router_lock);
+			tpp_read_lock(&router_lock);
 
 			pbs_idx_find(cluster_leaves_idx, (void **)&dest_host, (void **)&l, NULL);
 			if (l == NULL) {
-				char msg[TPP_LOGBUF_SZ];
-				tpp_unlock(&router_lock);
-
-				snprintf(msg, TPP_LOGBUF_SZ, "tfd=%d, pbs_comm:%s: Dest not found", tfd, tpp_netaddr(&this_router->router_addr));
+				tpp_unlock_rwlock(&router_lock);
+				snprintf(msg, sizeof(msg), "tfd=%d, pbs_comm:%s: Dest not found", tfd, tpp_netaddr(&this_router->router_addr));
 				log_noroute(src_host, dest_host, src_sd, msg);
 				tpp_send_ctl_msg(tfd, TPP_MSG_NOROUTE, src_host, dest_host, src_sd, 0, msg);
-				if (data_out)
-					free(data_out);
 				return 0;
 			}
 
 			/* find a router that is still connected */
 			target_router = get_preferred_router(l, this_router, &target_fd);
+			tpp_unlock_rwlock(&router_lock);
 
-			tpp_unlock(&router_lock);
 			if (target_router == NULL) {
-				char msg[TPP_LOGBUF_SZ];
-				snprintf(msg, TPP_LOGBUF_SZ, "tfd=%d, pbs_comm:%s: No target pbs_comm found", tfd, tpp_netaddr(&this_router->router_addr));
+				snprintf(msg, sizeof(msg), "tfd=%d, pbs_comm:%s: No target pbs_comm found", tfd, tpp_netaddr(&this_router->router_addr));
 				log_noroute(src_host, dest_host, src_sd, msg);
 				tpp_send_ctl_msg(tfd, TPP_MSG_NOROUTE, src_host, dest_host, src_sd, 0, msg);
-				if (data_out)
-					free(data_out);
 				return 0;
 			}
 
+			pkt = tpp_bld_pkt(NULL, buf, len, 1, NULL);
+			if (!pkt) {
+				tpp_log(LOG_CRIT, __func__, "Failed to build packet");
+				return 0;
+			}
 
-			chunks[0].data = data;
-			chunks[0].len = len;
-
-			if (tpp_transport_vsend(target_fd, chunks, 1) != 0) {
-				tpp_log_func(LOG_ERR, __func__, "Failed to send TPP_DATA/TPP_CLOSE_STRM");
-
-				/*
-				 * basically out of memory while sending data out
-				 * current logic is to close the connection to the dest
-				 * Drop this target connection
-				 */
-				snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tfd=%d, send failed - errno = %d", tfd, errno);
-				tpp_log_func(LOG_ERR, __func__, tpp_get_logbuf());
-
+			rc = tpp_transport_vsend(target_fd, pkt);
+			if (rc == -1)  {
+				tpp_log(LOG_ERR, __func__, "Failed to send TPP_DATA/TPP_CLOSE_STRM");
 				tpp_transport_close(target_fd);
-				if (data_out)
-					free(data_out);
-				return 0;
 			}
-			if (data_out)
-				free(data_out);
-			return 0;
+
+			return rc; /* 0 - success, -1 failed, -2 app mbox full */
 		}
 		break; /* TPP_DATA, TPP_CLOSE_STRM */
 
 		case TPP_CTL_MSG: {
-			tpp_ctl_pkt_hdr_t *ehdr = (tpp_ctl_pkt_hdr_t *) data;
+			tpp_ctl_pkt_hdr_t *ehdr = (tpp_ctl_pkt_hdr_t *) buf;
 			tpp_leaf_t *l = NULL;
 			int subtype = ehdr->code;
 
 			if (subtype == TPP_MSG_NOROUTE) {
 				char lbuf[TPP_MAXADDRLEN + 1];
+				tpp_packet_t *pkt = NULL;
 				tpp_addr_t *dest_host = &ehdr->dest_addr;
 				char *msg = ((char *) ehdr) + sizeof(tpp_ctl_pkt_hdr_t);
 
-				strcpy(lbuf, tpp_netaddr(&ehdr->dest_addr));
-				snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tfd=%d, Recvd TPP_CTL_NOROUTE for message, %s(sd=%d) -> %s: %s",
+				strcpy(lbuf, tpp_netaddr(&ehdr->dest_addr)); 
+				tpp_log(LOG_WARNING, __func__, "tfd=%d, Recvd TPP_CTL_NOROUTE for message, %s(sd=%d) -> %s: %s",
 							tfd, lbuf, ntohl(ehdr->src_sd), tpp_netaddr(&ehdr->src_addr), msg);
-				tpp_log_func(LOG_WARNING, __func__, tpp_get_logbuf());
 
 				/* find the fd to forward to via the associated router */
-				tpp_lock(&router_lock);
+				tpp_read_lock(&router_lock);
 
 				pbs_idx_find(cluster_leaves_idx, (void **)&dest_host, (void **)&l, NULL);
 				if (l == NULL) {
-					tpp_unlock(&router_lock);
-					if (data_out)
-						free(data_out);
+					tpp_unlock_rwlock(&router_lock);
 					return 0;
 				}
 				/* find a router that is still connected */
 				target_router = get_preferred_router(l, this_router, &target_fd);
 
-				tpp_unlock(&router_lock);
+				tpp_unlock_rwlock(&router_lock);
 				if (target_router == NULL) {
-					snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tfd=%d, No connections to send TPP_CTL_NOROUTE", tfd);
-					tpp_log_func(LOG_WARNING, NULL, tpp_get_logbuf());
-					if (data_out)
-						free(data_out);
+					tpp_log(LOG_WARNING, NULL, "tfd=%d, No connections to send TPP_CTL_NOROUTE", tfd);
 					return 0;
 				}
 
-				chunks[0].data = data;
-				chunks[0].len = len;
-
-				if (tpp_transport_vsend(target_fd, chunks, 1) != 0) {
-					snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tfd=%d, Failed to send pkt type TPP_CTL_NOROUTE", tfd);
-					tpp_log_func(LOG_ERR, NULL, tpp_get_logbuf());
+				pkt = tpp_bld_pkt(NULL, buf, len, 1, NULL);
+				if (!pkt) {
+					tpp_log(LOG_CRIT, __func__, "Failed to build packet");
+					return 0;
+				}
+				if (tpp_transport_vsend(target_fd, pkt) != 0) {
+					tpp_log(LOG_ERR, NULL, "tfd=%d, Failed to send pkt type TPP_CTL_NOROUTE", tfd);
 					tpp_transport_close(target_fd);
-					if (data_out)
-						free(data_out);
-					return 0;
 				}
-				if (data_out)
-					free(data_out);
 				return 0;
 			}
 		}
@@ -2081,12 +1913,9 @@ mcast_err:
 
 		default:
 			/* no known message type, log and close connection by returning error code */
-			snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tfd=%d, Unknown message type = %d", tfd, type);
-			tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+			tpp_log(LOG_CRIT, __func__, "tfd=%d, Unknown message type = %d", tfd, type);
 	} /* switch */
 
-	if (data_out)
-		free(data_out);
 	return -1;
 }
 
@@ -2173,13 +2002,13 @@ del_router_from_leaf(tpp_leaf_t *l, int tfd)
 		if (l->r[i] && /* router exists in this slot */
 			((l->r[i]->conn_fd == tfd) || /* router fd matches tfd */
 			(l->conn_fd == tfd && l->r[i]->conn_fd == -1))) {
-			TPP_DBPRT(("Removing pbs_comm %s from leaf %s", l->r[i]->router_name, tpp_netaddr(&l->leaf_addrs[0])));
+			TPP_DBPRT("Removing pbs_comm %s from leaf %s", l->r[i]->router_name, tpp_netaddr(&l->leaf_addrs[0]));
 			r = l->r[i];
 			l->r[i] = NULL;
 			l->num_routers--;
 			if (l->num_routers == 0)
 				free(l->r);
-			TPP_DBPRT(("pbs_comm count for leaf=%s is %d", tpp_netaddr(&l->leaf_addrs[0]), l->num_routers));
+			TPP_DBPRT("pbs_comm count for leaf=%s is %d", tpp_netaddr(&l->leaf_addrs[0]), l->num_routers);
 			return r;
 		}
 	}
@@ -2318,23 +2147,24 @@ tpp_init_router(struct tpp_config *cnf)
 		return -1;
 	}
 
-	tpp_init_lock(&router_lock);
+	tpp_init_lock(&lj_lock);
+	tpp_init_rwlock(&router_lock);
 
 	routers_idx = pbs_idx_create(0, sizeof(tpp_addr_t));
 	if (routers_idx == NULL) {
-		tpp_log_func(LOG_CRIT, __func__, "Failed to create index for pbs comms");
+		tpp_log(LOG_CRIT, __func__, "Failed to create index for pbs comms");
 		return -1;
 	}
 
 	cluster_leaves_idx = pbs_idx_create(0, sizeof(tpp_addr_t));
 	if (cluster_leaves_idx == NULL) {
-		tpp_log_func(LOG_CRIT, __func__, "Failed to create index for cluster leaves");
+		tpp_log(LOG_CRIT, __func__, "Failed to create index for cluster leaves");
 		return -1;
 	}
 
 	my_leaves_notify_idx = pbs_idx_create(0, sizeof(tpp_addr_t));
 	if (my_leaves_notify_idx == NULL) {
-		tpp_log_func(LOG_CRIT, __func__, "Failed to create index for leaves requiring notification");
+		tpp_log(LOG_CRIT, __func__, "Failed to create index for leaves requiring notification");
 		return -1;
 	}
 
@@ -2345,44 +2175,43 @@ tpp_init_router(struct tpp_config *cnf)
 	this_router = r; /* mark this one as this router */
 
 	/* first set the transport handlers */
-	tpp_transport_set_handlers(router_pkt_presend_handler, NULL, router_pkt_handler, router_close_handler, router_post_connect_handler, router_timer_handler);
+	tpp_transport_set_handlers(router_pkt_presend_handler, router_pkt_handler, router_close_handler, router_post_connect_handler, router_timer_handler);
 
 	if ((tpp_transport_init(tpp_conf)) == -1)
 		return -1;
 
 	/* initiate connections to sister routers */
 	j = 0;
-	tpp_lock(&router_lock);
+	tpp_write_lock(&router_lock);
 	while (tpp_conf->routers && tpp_conf->routers[j]) {
 		/* add to connection table */
 
 		r = alloc_router(tpp_conf->routers[j], NULL);
 		if (!r) {
-			tpp_unlock(&router_lock);
+			tpp_unlock_rwlock(&router_lock);
 			return -1; /* error already logged */
 		}
 		r->initiator = 1;
 
 		/* since we connected we should add a context */
 		if ((ctx = (tpp_context_t *) malloc(sizeof(tpp_context_t))) == NULL) {
-			tpp_unlock(&router_lock);
-			tpp_log_func(LOG_CRIT, __func__, "Out of memory allocating tpp context");
+			tpp_unlock_rwlock(&router_lock);
+			tpp_log(LOG_CRIT, __func__, "Out of memory allocating tpp context");
 			return -1;
 		}
 		ctx->ptr = r;
 		ctx->type = TPP_ROUTER_NODE;
 
-		sprintf(tpp_get_logbuf(), "Connecting to pbs_comm %s", tpp_conf->routers[j]);
-		tpp_log_func(LOG_INFO, NULL, tpp_get_logbuf());
+		tpp_log(LOG_INFO, NULL, "Connecting to pbs_comm %s", tpp_conf->routers[j]);
 
 		if (tpp_transport_connect(tpp_conf->routers[j], 0, ctx, &r->conn_fd) == -1) {
-			tpp_unlock(&router_lock);
+			tpp_unlock_rwlock(&router_lock);
 			return -1;
 		}
 
 		j++;
 	}
-	tpp_unlock(&router_lock);
+	tpp_unlock_rwlock(&router_lock);
 
 	sleep(1);
 	return 0;
@@ -2406,7 +2235,7 @@ tpp_router_shutdown()
 {
 	tpp_going_down = 1;
 
-	TPP_DBPRT(("from pid = %d", getpid()));
+	TPP_DBPRT("from pid = %d", getpid());
 	tpp_transport_shutdown();
 }
 

--- a/src/lib/Libtpp/tpp_router.c
+++ b/src/lib/Libtpp/tpp_router.c
@@ -318,6 +318,7 @@ broadcast_to_my_routers(tpp_chunk_t *chunks, int count, int origin_tfd)
 		}
 		if (tpp_enque(&router_list, r) == NULL) {
 			tpp_log(LOG_CRIT, __func__, "Out of memory enqueuing to router_list");
+			pbs_idx_free_ctx(idx_ctx);
 			tpp_unlock_rwlock(&router_lock);
 			goto err;
 		}
@@ -350,11 +351,7 @@ broadcast_to_my_routers(tpp_chunk_t *chunks, int count, int origin_tfd)
 
 err:
 	tpp_log(LOG_CRIT, __func__, "Error broadcasting to my routers");
-	if (idx_ctx)
-		pbs_idx_free_ctx(idx_ctx);
-
 	while (tpp_deque(&router_list)); /* drain the list, dont free packets, transport will free */
-
 	return -1;
 }
 
@@ -412,6 +409,7 @@ broadcast_to_my_leaves(tpp_chunk_t *chunks, int count, int origin_tfd, int type)
 
 			if (tpp_enque(&leaf_list, l) == NULL) {
 				tpp_log(LOG_CRIT, __func__, "Out of memory enqueuing to leaf_list");
+				pbs_idx_free_ctx(idx_ctx);
 				tpp_unlock_rwlock(&router_lock);
 				goto err;
 			}
@@ -444,11 +442,7 @@ broadcast_to_my_leaves(tpp_chunk_t *chunks, int count, int origin_tfd, int type)
 
 err:
 	tpp_log(LOG_CRIT, __func__, "Error broadcasting to my leaves");
-	if (idx_ctx)
-		pbs_idx_free_ctx(idx_ctx);
-
 	while (tpp_deque(&leaf_list)); /* drain the list, dont free pacets, transport will free */
-
 	return -1;
 }
 

--- a/src/lib/Libtpp/tpp_transport.c
+++ b/src/lib/Libtpp/tpp_transport.c
@@ -1973,7 +1973,6 @@ send_data(phy_conn_t *conn)
 		if (!pkt) {
 			/* get the next packet from send_mbox */
 			if (tpp_mbox_read(&conn->send_mbox, NULL, NULL, (void **) &conn->curr_send_pkt) != 0) {
-				TPP_DBPRT("No data to send");
 				if (!(errno == EAGAIN || errno == EWOULDBLOCK))
 					tpp_log(LOG_ERR, __func__, "tpp_mbox_read failed");				
 				return;

--- a/src/lib/Libtpp/tpp_transport.c
+++ b/src/lib/Libtpp/tpp_transport.c
@@ -90,6 +90,7 @@ int tpp_going_down = 0;
 #define TPP_CONN_CONNECT_DELAY 1
 typedef struct {
 	int tfd;       /* on which physical connection */
+	char cmdval; 	/* cmd type */
 	time_t conn_time; /* time at which to connect */
 } conn_event_t;
 
@@ -143,8 +144,7 @@ typedef struct {
 	double nas_lrg_send_sum_kb_C;
 #endif /* localmod 149 */
 	void *em_context;         /* the em context */
-	tpp_que_t lazy_conn_que;  /* The delayed connection queue on this thread */
-	tpp_que_t close_conn_que;  /* The closed connection queue on this thread */
+	tpp_que_t def_act_que;  /* The deferred action queue on this thread */
 	tpp_mbox_t mbox;     /* message box for this thread */
 	tpp_tls_t *tpp_tls;	/* tls data related to tpp work */
 } thrd_data_t;
@@ -180,18 +180,18 @@ typedef struct {
 	int sock_fd;             /* socket fd (TCP) for this physical connection*/
 	int lasterr;             /* last error that was captured on this socket */
 	short net_state;         /* network status of this connection, up, down etc */
-	int can_send;            /* can we send data in this fd now, or would it block? */
+	int ev_mask;			 /* event mask in effect so far */
 
 	conn_param_t *conn_params; /* the connection params */
 
-	unsigned long send_queue_size;  /* total bytes waiting on send queue */
-	tpp_que_t send_queue;      /* queue of pkts to send */
-	tpp_packet_t scratch;      /* scratch to work on incoming data */
-	thrd_data_t *td;                  /* connections controller thread */
+	tpp_mbox_t send_mbox;     /* mbox of pkts to send */
+	tpp_chunk_t scratch;      /* scratch to work on incoming data */
+	tpp_packet_t *curr_send_pkt; /* current packet dequed from send_mbox to be sent out  */
+	thrd_data_t *td;          /* connections controller thread */
 
-	tpp_context_t *ctx;        /* upper layers context information */
+	tpp_context_t *ctx;       /* upper layers context information */
 
-	void *extra;               /* extra data structure */
+	void *extra;              /* extra data structure */
 } phy_conn_t;
 
 /* structure for holding an array of physical connection structures */
@@ -202,7 +202,7 @@ typedef struct {
 
 conns_array_type_t *conns_array = NULL; /* array of physical connections */
 int conns_array_size = 0;                    /* the size of physical connection array */
-pthread_mutex_t cons_array_lock;             /* mutex used to synchronize array ops */
+pthread_rwlock_t cons_array_lock;            /* rwlock used to synchronize array ops */
 pthread_mutex_t thrd_array_lock;             /* mutex used to synchronize thrd assignment */
 
 /* function forward declarations */
@@ -213,15 +213,15 @@ static void handle_incoming_data(phy_conn_t *conn);
 static void send_data(phy_conn_t *conn);
 static void free_phy_conn(phy_conn_t *conn);
 static void handle_cmd(thrd_data_t *td, int tfd, int cmd, void *data);
-static int add_pkts(phy_conn_t *conn);
+static short add_pkt(phy_conn_t *conn);
 static phy_conn_t *get_transport_atomic(int tfd, int *slot_state);
 
 /**
  * @brief
- *	Enqueue an delayed connect
+ *	Enqueue an deferred action
  *
  * @par Functionality
- *	Used for initiating a connection after a delay.
+ *	Used for initiating a connection after a delay, or deferred close / reads
  *
  * @param[in] td    - The thread data for the controlling thread
  * @param[in] tfd   - The descriptor of the physical connection
@@ -234,7 +234,7 @@ static phy_conn_t *get_transport_atomic(int tfd, int *slot_state);
  *
  */
 static void
-enque_lazy_connect(thrd_data_t *td, int tfd, int delay)
+enque_deferred_event(thrd_data_t *td, int tfd, int cmd, int delay)
 {
 	conn_event_t *conn_ev;
 	tpp_que_elem_t *n;
@@ -242,14 +242,15 @@ enque_lazy_connect(thrd_data_t *td, int tfd, int delay)
 
 	conn_ev = malloc(sizeof(conn_event_t));
 	if (!conn_ev) {
-		tpp_log_func(LOG_CRIT, __func__, "Out of memory queueing a lazy connect");
+		tpp_log(LOG_CRIT, __func__, "Out of memory queueing a lazy connect");
 		return;
 	}
 	conn_ev->tfd = tfd;
+	conn_ev->cmdval = cmd;
 	conn_ev->conn_time = time(0) + delay;
 
 	n = NULL;
-	while ((n = TPP_QUE_NEXT(&td->lazy_conn_que, n))) {
+	while ((n = TPP_QUE_NEXT(&td->def_act_que, n))) {
 		conn_event_t *p;
 
 		p = TPP_QUE_DATA(n);
@@ -260,24 +261,24 @@ enque_lazy_connect(thrd_data_t *td, int tfd, int delay)
 	}
 	/* insert before this position */
 	if (n)
-		ret = tpp_que_ins_elem(&td->lazy_conn_que, n, conn_ev, 1);
+		ret = tpp_que_ins_elem(&td->def_act_que, n, conn_ev, 1);
 	else
-		ret = tpp_enque(&td->lazy_conn_que, conn_ev);
+		ret = tpp_enque(&td->def_act_que, conn_ev);
 
 	if (ret == NULL) {
-		tpp_log_func(LOG_CRIT, __func__, "Out of memory queueing a lazy connect");
+		tpp_log(LOG_CRIT, __func__, "Out of memory queueing a lazy connect");
 		free(conn_ev);
 	}
 }
 
 /**
  * @brief
- *	Trigger connects for those whose connect time has been reached
+ *	Trigger deferred action for those whose time has been reached
  *
  * @param[in] td   - The thread data for the controlling thread
  * @param[in] now  - Current time to check events with
  *
- * @return Wait time for the next connection event
+ * @return Wait time for the next deferred event
  *
  * @par Side Effects:
  *	None
@@ -286,23 +287,23 @@ enque_lazy_connect(thrd_data_t *td, int tfd, int delay)
  *
  */
 static int
-trigger_lazy_connects(thrd_data_t *td, time_t now)
+trigger_deferred_events(thrd_data_t *td, time_t now)
 {
 	conn_event_t *q;
 	tpp_que_elem_t *n = NULL;
 	int slot_state;
 	time_t wait_time = -1;
 
-	while ((n = TPP_QUE_NEXT(&td->lazy_conn_que, n))) {
+	while ((n = TPP_QUE_NEXT(&td->def_act_que, n))) {
 		q = TPP_QUE_DATA(n);
 		if (q == NULL)
 			continue;
 		if (now >= q->conn_time) {
 			(void) get_transport_atomic(q->tfd, &slot_state);
 			if (slot_state == TPP_SLOT_BUSY)
-				handle_cmd(td, q->tfd, TPP_CMD_ASSIGN, NULL);
+				handle_cmd(td, q->tfd, q->cmdval, NULL);
 
-			n = tpp_que_del_elem(&td->lazy_conn_que, n);
+			n = tpp_que_del_elem(&td->def_act_que, n);
 			free(q);
 		} else {
 			wait_time = q->conn_time - now;
@@ -334,14 +335,14 @@ tpp_transport_get_thrd_context(int tfd)
 {
 	thrd_data_t *td = NULL;
 
-	if (tpp_lock(&cons_array_lock)) {
+	if (tpp_read_lock(&cons_array_lock))
 		return NULL;
-	}
+
 	if (tfd >= 0 && tfd < conns_array_size) {
 		if (conns_array[tfd].conn && conns_array[tfd].slot_state == TPP_SLOT_BUSY)
 			td = conns_array[tfd].conn->td;
 	}
-	tpp_unlock(&cons_array_lock);
+	tpp_unlock_rwlock(&cons_array_lock);
 
 	return td;
 }
@@ -424,33 +425,29 @@ tpp_cr_server_socket(int port)
 	memset(&(serveraddr.sin_zero), '\0', sizeof(serveraddr.sin_zero));
 
 	if ((sd = tpp_sock_socket(AF_INET, SOCK_STREAM, 0)) == -1) {
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tpp_sock_socket() error, errno=%d", errno);
-		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+		tpp_log(LOG_CRIT, __func__, "tpp_sock_socket() error, errno=%d", errno);
 		return -1;
 	}
 	if (tpp_sock_setsockopt(sd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(int)) == -1) {
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tpp_sock_setsockopt() error, errno=%d", errno);
-		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+		tpp_log(LOG_CRIT, __func__, "tpp_sock_setsockopt() error, errno=%d", errno);
 		return -1;
 	}
 	if (tpp_sock_bind(sd, (struct sockaddr *) &serveraddr, sizeof(serveraddr)) == -1) {
 		char *msgbuf;
 #ifdef HAVE_STRERROR_R
-		char buf[TPP_LOGBUF_SZ + 1];
+		char buf[TPP_GEN_BUF_SZ];
 
 		if (strerror_r(errno, buf, sizeof(buf)) == 0)
 			pbs_asprintf(&msgbuf, "%s while binding to port %d", buf, port);
 		else
 #endif
 			pbs_asprintf(&msgbuf, "Error %d while binding to port %d", errno, port);
-		tpp_log_func(LOG_CRIT, NULL, msgbuf);
-		fprintf(stderr, "%s", msgbuf);
+		tpp_log(LOG_CRIT, NULL, msgbuf);
 		free(msgbuf);
 		return -1;
 	}
 	if (tpp_sock_listen(sd, 1000) == -1) {
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tpp_sock_listen() error, errno=%d", errno);
-		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+		tpp_log(LOG_CRIT, __func__, "tpp_sock_listen() error, errno=%d", errno);
 		return -1;
 	}
 	return sd;
@@ -484,37 +481,38 @@ int
 tpp_transport_init(struct tpp_config *conf)
 {
 	int i;
+	char mbox_name[TPP_MBOX_NAME_SZ];
 
 	if (conf->node_type == TPP_LEAF_NODE || conf->node_type == TPP_LEAF_NODE_LISTEN) {
 		if (conf->numthreads != 1) {
-			tpp_log_func(LOG_CRIT, NULL, "Leaves should start exactly one thread");
+			tpp_log(LOG_CRIT, NULL, "Leaves should start exactly one thread");
 			return -1;
 		}
 	} else {
 		if (conf->numthreads < 2) {
-			tpp_log_func(LOG_CRIT, NULL, "pbs_comms should have at least 2 threads");
+			tpp_log(LOG_CRIT, NULL, "pbs_comms should have at least 2 threads");
 			return -1;
 		}
 		if (conf->numthreads > 100) {
-			tpp_log_func(LOG_CRIT, NULL, "pbs_comms should have <= 100 threads");
+			tpp_log(LOG_CRIT, NULL, "pbs_comms should have <= 100 threads");
 			return -1;
 		}
 	}
 
-	tpp_log_func(LOG_INFO, NULL, "Initializing TPP transport Layer");
-	if (tpp_init_lock(&thrd_array_lock)) {
+	tpp_log(LOG_INFO, NULL, "Initializing TPP transport Layer");
+	if (tpp_init_lock(&thrd_array_lock))
 		return -1;
-	}
-	if (tpp_init_lock(&cons_array_lock)) {
+
+	if (tpp_init_rwlock(&cons_array_lock))
 		return -1;
-	}
+
 	tpp_sock_layer_init();
 
 	max_con = tpp_get_nfiles();
 	if (max_con < TPP_MAXOPENFD) {
-		tpp_log_func(LOG_WARNING, NULL, "Max files too low - you may want to increase it.");
+		tpp_log(LOG_WARNING, NULL, "Max files too low - you may want to increase it.");
 		if (max_con < 100) {
-			tpp_log_func(LOG_CRIT, NULL, "Max files < 100, cannot continue");
+			tpp_log(LOG_CRIT, NULL, "Max files < 100, cannot continue");
 			return -1;
 		}
 	}
@@ -530,20 +528,20 @@ tpp_transport_init(struct tpp_config *conf)
 	max_con--;
 
 	if (set_pipe_disposition() != 0) {
-		tpp_log_func(LOG_CRIT, __func__, "Could not query SIGPIPEs disposition");
+		tpp_log(LOG_CRIT, __func__, "Could not query SIGPIPEs disposition");
 		return -1;
 	}
 
 	/* create num_threads worker threads */
 	if ((thrd_pool = calloc(conf->numthreads, sizeof(thrd_data_t *))) == NULL) {
-		tpp_log_func(LOG_CRIT, __func__, "Out of memory allocating threads");
+		tpp_log(LOG_CRIT, __func__, "Out of memory allocating threads");
 		return -1;
 	}
 
 	for (i = 0; i < conf->numthreads; i++) {
 		thrd_pool[i] = calloc(1, sizeof(thrd_data_t));
 		if (thrd_pool[i] == NULL) {
-			tpp_log_func(LOG_CRIT, __func__, "Out of memory creating threadpool");
+			tpp_log(LOG_CRIT, __func__, "Out of memory creating threadpool");
 			return -1;
 		}
 		tpp_invalidate_thrd_handle(&(thrd_pool[i]->worker_thrd_id));
@@ -576,24 +574,21 @@ tpp_transport_init(struct tpp_config *conf)
 #endif /* localmod 149 */
 
 		thrd_pool[i]->listen_fd = -1;
-		TPP_QUE_CLEAR(&thrd_pool[i]->lazy_conn_que);
-		TPP_QUE_CLEAR(&thrd_pool[i]->close_conn_que);
+		TPP_QUE_CLEAR(&thrd_pool[i]->def_act_que);
 
 		if ((thrd_pool[i]->em_context = tpp_em_init(max_con)) == NULL) {
-			snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "em_init() error, errno=%d", errno);
-			tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+			tpp_log(LOG_CRIT, __func__, "em_init() error, errno=%d", errno);
 			return -1;
 		}
 
-		if (tpp_mbox_init(&thrd_pool[i]->mbox) != 0) {
-			snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tpp_mbox_init() error, errno=%d", errno);
-			tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+		snprintf(mbox_name, sizeof(mbox_name), "Th_%d", (char) i);
+		if (tpp_mbox_init(&thrd_pool[i]->mbox, mbox_name, -1) != 0) {
+			tpp_log(LOG_CRIT, __func__, "tpp_mbox_init() error, errno=%d", errno);
 			return -1;
 		}
 
 		if (tpp_mbox_monitor(thrd_pool[i]->em_context, &thrd_pool[i]->mbox) != 0) {
-			snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "em_mbox_enable_monitoing() error, errno=%d", errno);
-			tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+			tpp_log(LOG_CRIT, __func__, "em_mbox_enable_monitoing() error, errno=%d", errno);
 			return -1;
 		}
 
@@ -605,18 +600,18 @@ tpp_transport_init(struct tpp_config *conf)
 		int port;
 
 		if ((host = tpp_parse_hostname(conf->node_name, &port)) == NULL) {
-			tpp_log_func(LOG_CRIT, __func__, "Out of memory parsing pbs_comm name");
+			tpp_log(LOG_CRIT, __func__, "Out of memory parsing pbs_comm name");
 			return -1;
 		}
 		free(host);
 
 		if ((thrd_pool[0]->listen_fd = tpp_cr_server_socket(port)) == -1) {
-			tpp_log_func(LOG_CRIT, __func__, "pbs_comm socket creation failed");
+			tpp_log(LOG_CRIT, __func__, "pbs_comm socket creation failed");
 			return -1;
 		}
 
 		if (tpp_em_add_fd(thrd_pool[0]->em_context, thrd_pool[0]->listen_fd, EM_IN) == -1) {
-			tpp_log_func(LOG_CRIT, __func__, "Multiplexing failed");
+			tpp_log(LOG_CRIT, __func__, "Multiplexing failed");
 			return -1;
 		}
 	}
@@ -627,11 +622,11 @@ tpp_transport_init(struct tpp_config *conf)
 	for (i = 0; i < conf->numthreads; i++) {
 		/* leave the write side of the command pipe to block */
 		if (tpp_cr_thrd(work, &(thrd_pool[i]->worker_thrd_id), thrd_pool[i]) != 0) {
-			tpp_log_func(LOG_CRIT, __func__, "Failed to create thread");
+			tpp_log(LOG_CRIT, __func__, "Failed to create thread");
 			return -1;
 		}
 	}
-	tpp_log_func(LOG_INFO, NULL, "TPP initialization done");
+	tpp_log(LOG_INFO, NULL, "TPP initialization done");
 
 	return 0;
 }
@@ -646,10 +641,7 @@ int (*the_close_handler)(int tfd, int error, void *ctx, void *extra) = NULL;
 int (*the_post_connect_handler)(int tfd, void *data, void *ctx, void *extra) = NULL;
 
 /* the function pointer to the upper layer pre packet send handler */
-int (*the_pkt_presend_handler)(int tfd, tpp_packet_t *pkt, void *extra) = NULL;
-
-/* the function pointer to the upper layer post packet send handler */
-int (*the_pkt_postsend_handler)(int tfd, tpp_packet_t *pkt, void *extra) = NULL;
+int (*the_pkt_presend_handler)(int tfd, tpp_packet_t *pkt, void *ctx, void *extra) = NULL;
 
 /* upper layer timer handler */
 int (*the_timer_handler)(time_t now) = NULL;
@@ -659,7 +651,6 @@ int (*the_timer_handler)(time_t now) = NULL;
  *	Function to register the upper layer handler functions
  *
  * @param[in] pkt_presend_handler  - function ptr to presend handler
- * @param[in] pkt_postsend_handler - function ptr to postsend handler
  * @param[in] pkt_handler          - function ptr to pkt recvd handler
  * @param[in] close_handler        - function ptr to net close handler
  * @param[in] post_connect_handler - function ptr to post_connect_handler
@@ -672,17 +663,16 @@ int (*the_timer_handler)(time_t now) = NULL;
  *
  */
 void
-tpp_transport_set_handlers(int (*pkt_presend_handler)(int phy_con, tpp_packet_t *pkt, void *extra),
-	int (*pkt_postsend_handler)(int phy_con, tpp_packet_t *pkt, void *extra),
-	int (*pkt_handler)(int, void *data, int len, void *, void *extra),
-	int (*close_handler)(int, int, void *, void *extra),
-	int (*post_connect_handler)(int sd, void *data, void *ctx, void *extra),
+tpp_transport_set_handlers(
+	int (*pkt_presend_handler)(int tfd, tpp_packet_t *pkt, void *ctx, void *extra),
+	int (*pkt_handler)(int tfd, void *data, int len, void *ctx, void *extra),
+	int (*close_handler)(int tfd, int error, void *ctx, void *extra),
+	int (*post_connect_handler)(int tfd, void *data, void *ctx, void *extra),
 	int (*timer_handler)(time_t now))
 {
 	the_pkt_handler = pkt_handler;
 	the_close_handler = close_handler;
 	the_post_connect_handler = post_connect_handler;
-	the_pkt_postsend_handler = pkt_postsend_handler;
 	the_pkt_presend_handler = pkt_presend_handler;
 	the_timer_handler = timer_handler;
 }
@@ -711,20 +701,26 @@ static phy_conn_t*
 alloc_conn(int tfd)
 {
 	phy_conn_t *conn;
+	char mbox_name[TPP_MBOX_NAME_SZ];
 
 	conn = calloc(1, sizeof(phy_conn_t));
 	if (!conn) {
-		tpp_log_func(LOG_CRIT, __func__, "Out of memory allocating physical connection");
+		tpp_log(LOG_CRIT, __func__, "Out of memory allocating physical connection");
 		return NULL;
 	}
 	conn->sock_fd = tfd;
-	conn->send_queue_size = 0;
 	conn->extra = NULL;
-	TPP_QUE_CLEAR(&conn->send_queue);
+
+	snprintf(mbox_name, sizeof(mbox_name), "Conn_%d", conn->sock_fd);
+	if (tpp_mbox_init(&conn->send_mbox, mbox_name, TPP_MAX_MBOX_SIZE) != 0) {
+		free(conn);
+		tpp_log(LOG_CRIT, __func__, "tpp_mbox_init() error, errno=%d", errno);
+		return NULL;
+	}
 	/* initialize the send queue to empty */
 
 	/* set to stream array */
-	if (tpp_lock(&cons_array_lock)) {
+	if (tpp_write_lock(&cons_array_lock)) {
 		free(conn);
 		return NULL;
 	}
@@ -737,8 +733,8 @@ alloc_conn(int tfd)
 		p = realloc(conns_array, sizeof(conns_array_type_t) * newsize);
 		if (!p) {
 			free(conn);
-			tpp_unlock(&cons_array_lock);
-			tpp_log_func(LOG_CRIT, __func__, "Out of memory expanding connection array");
+			tpp_unlock_rwlock(&cons_array_lock);
+			tpp_log(LOG_CRIT, __func__, "Out of memory expanding connection array");
 			return NULL;
 		}
 		conns_array = (conns_array_type_t *) p;
@@ -751,9 +747,9 @@ alloc_conn(int tfd)
 		conns_array_size = newsize;
 	}
 	if (conns_array[tfd].slot_state != TPP_SLOT_FREE) {
-		tpp_log_func(LOG_ERR, __func__, "Internal error - slot not free");
+		tpp_log(LOG_ERR, __func__, "Internal error - slot not free");
 		free(conn);
-		tpp_unlock(&cons_array_lock);
+		tpp_unlock_rwlock(&cons_array_lock);
 		return NULL;
 	}
 
@@ -762,14 +758,14 @@ alloc_conn(int tfd)
 
 	if (tpp_set_keep_alive(conn->sock_fd, tpp_conf) == -1) {
 		free(conn);
-		tpp_unlock(&cons_array_lock);
+		tpp_unlock_rwlock(&cons_array_lock);
 		return NULL;
 	}
 
 	conns_array[tfd].slot_state = TPP_SLOT_BUSY;
 	conns_array[tfd].conn = conn;
 
-	tpp_unlock(&cons_array_lock);
+	tpp_unlock_rwlock(&cons_array_lock);
 
 	return conn;
 }
@@ -804,15 +800,14 @@ tpp_transport_connect_spl(char *hostname, int delay, void *ctx, int *ret_tfd, vo
 	int port;
 
 	if ((host = tpp_parse_hostname(hostname, &port)) == NULL) {
-		tpp_log_func(LOG_CRIT, __func__, "Out of memory while parsing hostname");
+		tpp_log(LOG_CRIT, __func__, "Out of memory while parsing hostname");
 		free(host);
 		return -1;
 	}
 
 	fd = tpp_sock_socket(AF_INET, SOCK_STREAM, 0);
 	if (fd < 0) {
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "socket() error, errno=%d", errno);
-		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+		tpp_log(LOG_CRIT, __func__, "socket() error, errno=%d", errno);
 		free(host);
 		return -1;
 	}
@@ -907,14 +902,14 @@ get_transport_atomic(int tfd, int *slot_state)
 	phy_conn_t *conn = NULL;
 	*slot_state = TPP_SLOT_FREE;
 
-	if (tpp_lock(&cons_array_lock)) {
+	if (tpp_read_lock(&cons_array_lock))
 		return NULL;
-	}
+
 	if (tfd >= 0 && tfd < conns_array_size) {
 		conn = conns_array[tfd].conn;
 		*slot_state = conns_array[tfd].slot_state;
 	}
-	tpp_unlock(&cons_array_lock);
+	tpp_unlock_rwlock(&cons_array_lock);
 
 	return conn;
 }
@@ -941,103 +936,45 @@ get_transport_atomic(int tfd, int *slot_state)
  *
  */
 static int
-tpp_post_cmd(int tfd, int cmd, tpp_packet_t *pkt)
+tpp_post_cmd(int tfd, char cmd, tpp_packet_t *pkt)
 {
+	int rc;
+	phy_conn_t *conn = NULL;
 	thrd_data_t *td = NULL;
 
 	errno = 0;
 
-	if (tpp_lock(&cons_array_lock)) {
+	if (tpp_read_lock(&cons_array_lock))
 		return -1;
-	}
 
 	if (tfd >= 0 && tfd < conns_array_size) {
-		if (conns_array[tfd].conn && conns_array[tfd].slot_state == TPP_SLOT_BUSY)
-			td = conns_array[tfd].conn->td;
+		if (conns_array[tfd].conn && conns_array[tfd].slot_state == TPP_SLOT_BUSY) {
+			conn = conns_array[tfd].conn;
+			td = conn->td;
+		}
 	}
 
-	if (!td) {
-		tpp_unlock(&cons_array_lock);
+	if (!td || !conn) {
+		tpp_unlock_rwlock(&cons_array_lock);
 		errno = EBADF;
 		return -1;
 	}
 
-	/* write to worker threads send pipe */
-	if (tpp_mbox_post(&td->mbox, tfd, cmd, (void*) pkt) != 0) {
-		tpp_unlock(&cons_array_lock);
-		return -1;
+	if (cmd == TPP_CMD_SEND) {
+		/* data associated that needs to be sent out, put directly into target mbox */
+		/* write to worker threads send pipe */
+		rc = tpp_mbox_post(&conn->send_mbox, tfd, cmd, (void*) pkt, pkt->totlen);
+		if (rc == -2) {
+			tpp_unlock_rwlock(&cons_array_lock);
+			return rc;
+		}
 	}
 
-	tpp_unlock(&cons_array_lock);
-	return 0;
-}
+	/* write to worker threads send pipe, to wakeup thread */
+	rc = tpp_mbox_post(&td->mbox, tfd, cmd, NULL, 0);
+	tpp_unlock_rwlock(&cons_array_lock);
 
-/**
- * @brief
- *	Queue a raw (without adding header) packet to the IO thread
- *
- * @param[in] tfd - The file descriptor of the connection
- * @param[in] pkt - The raw packet (possibly one that already has a header)
- *		    (mostly used for retransmitting already formatted packets)
- *
- * @return  Error code
- * @retval  -1  - Failure
- * @retval   0  - Success
- *
- * @par Side Effects:
- *	None
- *
- * @par MT-safe: No
- *
- */
-int
-tpp_transport_send_raw(int tfd, tpp_packet_t *pkt)
-{
-	/* write to worker threads send pipe */
-	if (tpp_post_cmd(tfd, TPP_CMD_SEND, (void*) pkt) != 0) {
-		return -1;
-	}
-	return 0;
-}
-
-/**
- * @brief
- *	Queue data to be sent out by the IO thread
- *
- * @param[in] tfd  - The file descriptor of the connection
- * @param[in] data - The ptr to the data buffer to be sent
- * @param[in] len  - The length of the data buffer
- *
- * @return  Error code
- * @retval  -1 - Failure
- * @retval   0 - Success
- *
- * @par Side Effects:
- *	None
- *
- * @par MT-safe: No
- *
- */
-int
-tpp_transport_send(int tfd, void *data, int len)
-{
-	tpp_packet_t *pkt;
-	int nlen;
-
-	pkt = tpp_cr_pkt(NULL, len + sizeof(int), 1);
-	if (!pkt)
-		return -1;
-
-	nlen = htonl(len);
-	memcpy(pkt->data, &nlen, sizeof(int));
-	memcpy(pkt->data + sizeof(int), data, len);
-
-	/* write to worker threads send pipe */
-	if (tpp_post_cmd(tfd, TPP_CMD_SEND, (void*) pkt) != 0) {
-		tpp_free_pkt(pkt);
-		return -1;
-	}
-	return 0;
+	return rc;
 }
 
 /**
@@ -1061,6 +998,9 @@ tpp_transport_send(int tfd, void *data, int len)
 int
 tpp_transport_wakeup_thrd(int tfd)
 {
+	if (tfd < 0)
+		return -1;
+
 	if (tpp_post_cmd(tfd, TPP_CMD_WAKEUP, NULL) != 0) {
 		return -1;
 	}
@@ -1104,6 +1044,7 @@ check_buffer_limits(phy_conn_t *conn)
  *
  * @return  Error code
  * @retval  -1 - Failure
+ * @retval  -2 - transport buffers full
  * @retval   0 - Success
  *
  * @par Side Effects:
@@ -1113,66 +1054,31 @@ check_buffer_limits(phy_conn_t *conn)
  *
  */
 int
-tpp_transport_vsend_extra(int tfd, tpp_chunk_t *chunk, int count, void *extra)
+tpp_transport_vsend(int tfd, tpp_packet_t *pkt)
 {
-	tpp_packet_t *pkt;
-	int i;
-	int ntotlen;
-	int totlen = 0;
+	/* compute the length in network byte order for the whole packet */
+	tpp_chunk_t *first_chunk = GET_NEXT(pkt->chunks);
+	void *p = (void *) (first_chunk->data);
+	int wire_len = htonl(pkt->totlen);
+	int rc;
 
-	errno = 0;
-
-	for (i = 0; i < count; i++)
-		totlen += chunk[i].len;
-
-	pkt = tpp_cr_pkt(NULL, totlen + sizeof(int), 1);
-	if (!pkt)
+	if (tfd < 0) 
 		return -1;
 
-	ntotlen = htonl(totlen);
-	memcpy(pkt->pos, &ntotlen, sizeof(int));
-	pkt->pos = pkt->pos + sizeof(int);
+	TPP_DBPRT("sending total length = %d", pkt->totlen);
 
-	for (i = 0; i < count; i++) {
-		memcpy(pkt->pos, chunk[i].data, chunk[i].len);
-		pkt->pos = pkt->pos + chunk[i].len;
-	}
-	pkt->len = totlen + sizeof(int);
-	pkt->pos = pkt->data;
-	pkt->extra_data = extra;
+	memcpy(p, &wire_len, sizeof(int));
 
 	/* write to worker threads send pipe */
-	if (tpp_post_cmd(tfd, TPP_CMD_SEND, (void *) pkt) != 0) {
+	rc = tpp_post_cmd(tfd, TPP_CMD_SEND, (void *) pkt);
+	if (rc != 0) {
+		if (rc == -1)
+			tpp_log(LOG_CRIT, __func__, "Error writing to thread cmd mbox");
+		else if (rc == -2)
+			tpp_log(LOG_CRIT, __func__, "thread cmd mbox is full");
 		tpp_free_pkt(pkt);
-		return -1;
 	}
-	return 0;
-}
-
-/**
- * @brief
- *	Wrapper over tpp_transport_vsend_extra, calls tpp_transport_vsend_extra
- *	with a NULL set for the parameter extra.
- *
- * @param[in] tfd   - The file descriptor of the connection
- * @param[in] chunk - Array of chunks that describes each data buffer
- * @param[in] count - Number of chunks in the array of chunks
- * @param[in] totlen  - total length of data to be sent out
- *
- * @return  Error code
- * @retval  -1 - Failure
- * @retval   0 - Success
- *
- * @par Side Effects:
- *	None
- *
- * @par MT-safe: No
- *
- */
-int
-tpp_transport_vsend(int tfd, tpp_chunk_t *chunk, int count)
-{
-	return (tpp_transport_vsend_extra(tfd, chunk, count, NULL));
+	return rc;
 }
 
 /**
@@ -1238,10 +1144,8 @@ assign_to_worker(int tfd, int delay, thrd_data_t *td)
 	if (conn == NULL || slot_state != TPP_SLOT_BUSY)
 		return 1;
 
-	if (conn->td != NULL) {
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "ERROR! tfd=%d conn_td=%p, conn_td_index=%d, thrd_td=%p, thrd_td_index=%d", tfd, conn->td, conn->td->thrd_index, td, td ? td->thrd_index: -1);
-		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
-	}
+	if (conn->td != NULL)
+		tpp_log(LOG_CRIT, __func__, "ERROR! tfd=%d conn_td=%p, conn_td_index=%d, thrd_td=%p, thrd_td_index=%d", tfd, conn->td, conn->td->thrd_index, td, td ? td->thrd_index: -1);
 
 	if (td == NULL) {
 		int iters = 0;
@@ -1262,10 +1166,9 @@ assign_to_worker(int tfd, int delay, thrd_data_t *td)
 	} else
 		conn->td = td;
 
-	if (tpp_mbox_post(&conn->td->mbox, tfd, TPP_CMD_ASSIGN, (void *)(long) delay) != 0) {
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tfd=%d, Error writing to mbox", tfd);
-		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
-	}
+	if (tpp_mbox_post(&conn->td->mbox, tfd, TPP_CMD_ASSIGN, (void *)(long) delay, 0) != 0)
+		tpp_log(LOG_CRIT, __func__, "tfd=%d, Error writing to mbox", tfd);
+
 	return 0;
 }
 
@@ -1325,66 +1228,63 @@ add_transport_conn(phy_conn_t *conn)
 					break;
 			}
 			if (rc == -1) {
-				tpp_log_func(LOG_WARNING, NULL, "No reserved ports available");
+				tpp_log(LOG_WARNING, NULL, "No reserved ports available");
 				return (-1);
 			}
 		}
 
 		conn->net_state = TPP_CONN_CONNECTING;
-		if (tpp_em_add_fd(conn->td->em_context, conn->sock_fd,
-			EM_OUT | EM_ERR | EM_HUP) == -1) {
-			tpp_log_func(LOG_ERR, __func__, "Multiplexing failed");
+
+		conn->ev_mask = EM_OUT | EM_ERR | EM_HUP;
+		TPP_DBPRT("New socket, Added EM_OUT to ev_mask, now=%x", conn->ev_mask);
+		if (tpp_em_add_fd(conn->td->em_context, conn->sock_fd, conn->ev_mask) == -1) {
+			tpp_log(LOG_ERR, __func__, "Multiplexing failed");
 			return -1;
 		}
-
-		conn->can_send = 0;
 
 		if (tpp_sock_attempt_connection(conn->sock_fd, conn->conn_params->hostname, conn->conn_params->port) == -1) {
 			if (errno != EINPROGRESS && errno != EWOULDBLOCK && errno != EAGAIN) {
 				char *msgbuf;
 #ifdef HAVE_STRERROR_R
-				char buf[TPP_LOGBUF_SZ + 1];
+				char buf[TPP_GEN_BUF_SZ];
 
 				if (strerror_r(errno, buf, sizeof(buf)) == 0)
-					pbs_asprintf(&msgbuf,
-						"%s while connecting to %s:%d", buf,
-						conn->conn_params->hostname,
-						conn->conn_params->port);
+					pbs_asprintf(&msgbuf, "%s while connecting to %s:%d", buf, conn->conn_params->hostname, conn->conn_params->port);
 				else
 #endif
-					pbs_asprintf(&msgbuf,
-						"Error %d while connecting to %s:%d", errno,
-						conn->conn_params->hostname,
-						conn->conn_params->port);
-				tpp_log_func(LOG_ERR, NULL, msgbuf);
+					pbs_asprintf(&msgbuf, "Error %d while connecting to %s:%d", errno, conn->conn_params->hostname, conn->conn_params->port);
+				tpp_log(LOG_ERR, NULL, msgbuf);
 				free(msgbuf);
 				return -1;
 			}
 		} else {
-			TPP_DBPRT(("phy_con %d connected", fd));
+			TPP_DBPRT("phy_con %d connected", fd);
 			conn->net_state = TPP_CONN_CONNECTED;
 
-			/* since we connected, remove EMOUT from the list */
-			if (tpp_em_mod_fd(conn->td->em_context, conn->sock_fd, EM_IN | EM_ERR | EM_HUP) == -1) {
-				tpp_log_func(LOG_CRIT, __func__, "Multiplexing failed");
+			/* since we connected, remove EM_OUT from the list and add EM_IN */
+			conn->ev_mask = EM_IN | EM_ERR | EM_HUP;
+			TPP_DBPRT("Connected, Removed EM_OUT and added EM_IN to ev_mask, now=%x", conn->ev_mask);
+			if (tpp_em_mod_fd(conn->td->em_context, conn->sock_fd, conn->ev_mask) == -1) {
+				tpp_log(LOG_CRIT, __func__, "Multiplexing failed");
 				return -1;
 			}
-			conn->can_send = 1;
 			if (the_post_connect_handler)
 				the_post_connect_handler(fd, NULL, conn->ctx, conn->extra);
 		}
 	} else if (conn->net_state == TPP_CONN_CONNECTED) {/* accepted socket */
-
+		/* since we connected, remove EM_OUT from the list and add EM_IN */
+		conn->ev_mask = EM_IN | EM_ERR | EM_HUP;
+		TPP_DBPRT("Connected, Removed EM_OUT and added EM_IN to ev_mask, now=%x", conn->ev_mask);
+		
 		/* add it to my own monitored list */
-		if (tpp_em_add_fd(conn->td->em_context, conn->sock_fd, EM_IN | EM_ERR | EM_HUP) == -1) {
-			tpp_log_func(LOG_ERR, __func__, "Multiplexing failed");
+		if (tpp_em_add_fd(conn->td->em_context, conn->sock_fd, conn->ev_mask) == -1) {
+			tpp_log(LOG_ERR, __func__, "Multiplexing failed");
 			return -1;
 		}
-		conn->can_send = 1;
 
-		TPP_DBPRT(("Phy Con %d accepted", conn->sock_fd));
+		TPP_DBPRT("Phy Con %d accepted", conn->sock_fd);
 	} else {
-		tpp_log_func(LOG_CRIT, __func__, "Bad net state - internal error");
+		tpp_log(LOG_CRIT, __func__, "Bad net state - internal error");
 		return -1;
 	}
 	return 0;
@@ -1425,13 +1325,21 @@ handle_cmd(thrd_data_t *td, int tfd, int cmd, void *data)
 
 	conn = get_transport_atomic(tfd, &slot_state);
 
-	if(conn && (conn->td != td)) {
-		sprintf(tpp_get_logbuf(), "ERROR! tfd=%d conn_td=%p, conn_td_index=%d, thrd_td=%p, thrd_td_index=%d, cmd=%d", tfd, conn->td, conn->td->thrd_index, td, td->thrd_index, cmd);
-		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
-	}
+	if(conn && (conn->td != td))
+		tpp_log(LOG_CRIT, __func__, "ERROR! tfd=%d conn_td=%p, conn_td_index=%d, thrd_td=%p, thrd_td_index=%d, cmd=%d", tfd, conn->td, conn->td->thrd_index, td, td->thrd_index, cmd);
 
 	if (cmd == TPP_CMD_CLOSE) {
 		handle_disconnect(conn);
+
+	} else if (cmd == TPP_CMD_FREECONN) {
+		/* now actually delete and close fd's that got the close
+		 * we do this at the end of the event loop so that we
+		 * do not advertently free things but a later event in the
+		 * array triggers another close, possibly closing another fd
+		 */
+		tpp_sock_close(conn->sock_fd);
+		free_phy_conn(conn);
+
 	} else if (cmd == TPP_CMD_EXIT) {
 		int i;
 
@@ -1444,60 +1352,53 @@ handle_cmd(thrd_data_t *td, int tfd, int cmd, void *data)
 			}
 		}
 
-		tpp_mbox_destroy(&td->mbox, 1);
-		tpp_em_destroy(td->em_context);
+		tpp_mbox_destroy(&td->mbox);
 		if (td->listen_fd > -1)
 			tpp_sock_close(td->listen_fd);
 
 		/* clean up the lazy conn queue */
-		while ((conn_ev = tpp_deque(&td->lazy_conn_que))) {
+		while ((conn_ev = tpp_deque(&td->def_act_que))) {
+			if (conn_ev->cmdval == TPP_CMD_FREECONN) {
+				tpp_sock_close(conn_ev->tfd);
+				free_phy_conn(conn);
+			}
 			free(conn_ev);
 		}
 
-		/* clean up the close queue and piled up send data */
-		while ((conn = tpp_deque(&td->close_conn_que))) {
-			tpp_sock_close(conn->sock_fd);
-			free_phy_conn(conn);
-		}
-
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Thrd exiting, had %d connections", num_cons);
-		tpp_log_func(LOG_INFO, NULL, tpp_get_logbuf());
+		tpp_log(LOG_INFO, NULL, "Thrd exiting, had %d connections", num_cons);
 
 		pthread_exit(NULL);
 		/* no execution after this */
 
-	} else if (cmd == TPP_CMD_ASSIGN) {
+	} else if ((cmd == TPP_CMD_ASSIGN) || (cmd == TPP_CMD_CONNECT)) {
 		int delay = (int)(long) data;
 
 		if (conn == NULL || slot_state != TPP_SLOT_BUSY) {
-			snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Phy Con %d (cmd = %d) already deleted/closing", tfd, cmd);
-			tpp_log_func(LOG_WARNING, __func__, tpp_get_logbuf());
+			tpp_log(LOG_WARNING, __func__, "Phy Con %d (cmd = %d) already deleted/closing", tfd, cmd);
 			return;
 		}
-		if (delay == 0) {
+		if ((delay == 0) || (cmd == TPP_CMD_CONNECT)) {
 			if (add_transport_conn(conn) != 0) {
 				handle_disconnect(conn);
 			}
 		} else {
-			enque_lazy_connect(td, tfd, delay);
+			enque_deferred_event(td, tfd, TPP_CMD_CONNECT, delay);
 		}
+
 	} else if (cmd == TPP_CMD_SEND) {
 		tpp_packet_t *pkt = (tpp_packet_t *) data;
 
 		if (conn == NULL || slot_state != TPP_SLOT_BUSY) {
-			snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Phy Con %d (cmd = %d) already deleted/closing", tfd, cmd);
-			tpp_log_func(LOG_WARNING, __func__, tpp_get_logbuf());
+			tpp_log(LOG_WARNING, __func__, "Phy Con %d (cmd = %d) already deleted/closing", tfd, cmd);
 			tpp_free_pkt(pkt);
 			return;
 		}
-		if (tpp_enque(&conn->send_queue, pkt) == NULL) {
-			tpp_log_func(LOG_CRIT, __func__, "Out of memory enqueing to send queue");
-			return;
-		}
-		conn->send_queue_size += pkt->len;
 
 		/* handle socket add calls */
 		send_data(conn);
+
+	} else if (cmd == TPP_CMD_READ) {
+		add_pkt(conn);
 	}
 }
 
@@ -1611,12 +1512,11 @@ work(void *v)
 	sigaddset(&blksigs, SIGTERM);
 
 	if ((rc = pthread_sigmask(SIG_BLOCK, &blksigs, NULL)) != 0) {
-		sprintf(tpp_get_logbuf(), "Failed in pthread_sigmask, errno=%d", rc);
-		tpp_log_func(LOG_CRIT, NULL, "Failed in pthread_sigmask");
+		tpp_log(LOG_CRIT, NULL, "Failed in pthread_sigmask, errno=%d", rc);
 		return NULL;
 	}
 #endif
-	tpp_log_func(LOG_CRIT, NULL, "Thread ready");
+	tpp_log(LOG_CRIT, NULL, "Thread ready");
 
 	/* start processing loop */
 	for (;;) {
@@ -1626,7 +1526,7 @@ work(void *v)
 			now = time(0);
 
 			/* trigger all delayed connects, and return the wait time till the next one to trigger */
-			timeout = trigger_lazy_connects(td, now);
+			timeout = trigger_deferred_events(td, now);
 			if (the_timer_handler) {
 				timeout2 = the_timer_handler(now);
 			} else {
@@ -1646,8 +1546,7 @@ work(void *v)
 			nfds = tpp_em_wait(td->em_context, &events, timeout);
 			if (nfds <= 0) {
 				if (!(errno == EINTR || errno == EINPROGRESS || errno == EAGAIN || errno == 0)) {
-					snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "em_wait() error, errno=%d", errno);
-					tpp_log_func(LOG_ERR, __func__, tpp_get_logbuf());
+					tpp_log(LOG_ERR, __func__, "em_wait() error, errno=%d", errno);
 				}
 				continue;
 			} else
@@ -1697,7 +1596,6 @@ work(void *v)
 					}
 
 					if (em_ev & EM_OUT) {
-						/* set can_send_now flag on stream */
 
 						if (conn->net_state == TPP_CONN_CONNECTING) {
 							/* check to see if the connection really completed */
@@ -1705,7 +1603,7 @@ work(void *v)
 							pbs_socklen_t result_len = sizeof(result);
 
 							if (tpp_sock_getsockopt(conn->sock_fd, SOL_SOCKET, SO_ERROR, &result, &result_len) != 0) {
-								TPP_DBPRT(("phy_con %d getsockopt failed", conn->sock_fd));
+								TPP_DBPRT("phy_con %d getsockopt failed", conn->sock_fd);
 								handle_disconnect(conn);
 								continue;
 							}
@@ -1714,7 +1612,7 @@ work(void *v)
 								continue;
 							} else if (result != 0) {
 								/* non-recoverable error occurred, eg, ECONNRESET, so disconnect */
-								TPP_DBPRT(("phy_con %d disconnected", conn->sock_fd));
+								TPP_DBPRT("phy_con %d disconnected", conn->sock_fd);
 								handle_disconnect(conn);
 								continue;
 							}
@@ -1724,19 +1622,16 @@ work(void *v)
 
 							if (the_post_connect_handler)
 								the_post_connect_handler(conn->sock_fd, NULL, conn->ctx, conn->extra);
-							TPP_DBPRT(("phy_con %d connected", conn->sock_fd));
+							TPP_DBPRT("phy_con %d connected", conn->sock_fd);
 						}
 
-						/**
-						 * since we can write data now remove
-						 * POLLOUT from list of events, else we will
-						 * have a infinite loop from em_wait
-						 **/
-						if (tpp_em_mod_fd(conn->td->em_context, conn->sock_fd, EM_IN | EM_HUP | EM_ERR) == -1) {
-							tpp_log_func(LOG_ERR, __func__, "Multiplexing failed");
+						/* since we connected, remove EM_OUT from the list and add EM_IN */
+						conn->ev_mask = EM_IN | EM_ERR | EM_HUP;
+						TPP_DBPRT("Connected, Removed EM_OUT and added EM_IN to ev_mask, now=%x", conn->ev_mask);
+						if (tpp_em_mod_fd(conn->td->em_context, conn->sock_fd, conn->ev_mask) == -1) {
+							tpp_log(LOG_ERR, __func__, "Multiplexing failed");
 							return NULL;
 						}
-						conn->can_send = 1;
 						send_data(conn);
 					}
 				}
@@ -1746,8 +1641,7 @@ work(void *v)
 		if (new_connection == 1) {
 			pbs_socklen_t addrlen = sizeof(clientaddr);
 			if ((newfd = tpp_sock_accept(td->listen_fd, (struct sockaddr *) &clientaddr, &addrlen)) == -1) {
-				snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tpp_sock_accept() error, errno=%d", errno);
-				tpp_log_func(LOG_ERR, NULL, tpp_get_logbuf());
+				tpp_log(LOG_ERR, NULL, "tpp_sock_accept() error, errno=%d", errno);
 				if (errno == EMFILE) {
 					/* out of files, sleep couple of seconds to avoid error coming in loop */
 					sleep(2);
@@ -1765,7 +1659,7 @@ work(void *v)
 
 			conn->conn_params = calloc(1, sizeof(conn_param_t));
 			if (!conn->conn_params) {
-				tpp_log_func(LOG_CRIT, __func__, "Out of memory allocating connection params");
+				tpp_log(LOG_CRIT, __func__, "Out of memory allocating connection params");
 				free(conn);
 				tpp_sock_close(newfd);
 				return NULL;
@@ -1779,17 +1673,6 @@ work(void *v)
 			 * thread, and write to that thread control pipe
 			 **/
 			assign_to_worker(newfd, 0, NULL); /* time 0 means no delay */
-		}
-
-		/* now actually delete and close fd's that got the close
-		 * we do this at the end of the event loop so that we
-		 * do not advertently free things but a later event in the
-		 * array triggers another close, possibly closing another
-		 * fd
-		 */
-		while ((conn = tpp_deque(&td->close_conn_que))) {
-			tpp_sock_close(conn->sock_fd);
-			free_phy_conn(conn);
 		}
 	}
 	return NULL;
@@ -1840,7 +1723,7 @@ static int
 handle_disconnect(phy_conn_t *conn)
 {
 	int error;
-	int cmd;
+	short cmd;
 	void *data;
 	pbs_socklen_t len = sizeof(error);
 	tpp_que_elem_t *n;
@@ -1850,7 +1733,7 @@ handle_disconnect(phy_conn_t *conn)
 
 	if (conn->net_state == TPP_CONN_CONNECTING || conn->net_state == TPP_CONN_CONNECTED) {
 		if (tpp_em_del_fd(conn->td->em_context, conn->sock_fd) == -1) {
-			tpp_log_func(LOG_ERR, __func__, "Multiplexing failed");
+			tpp_log(LOG_ERR, __func__, "Multiplexing failed");
 			return 1;
 		}
 	}
@@ -1858,58 +1741,47 @@ handle_disconnect(phy_conn_t *conn)
 
 	conn->net_state = TPP_CONN_DISCONNECTED;
 	conn->lasterr = error;
-	conn->can_send = 0;
 
 	if (the_close_handler)
 		the_close_handler(conn->sock_fd, error, conn->ctx, conn->extra);
 
 	conn->extra = NULL;
 
-	if (tpp_lock(&cons_array_lock)) {
+	if (tpp_write_lock(&cons_array_lock))
 		return 1;
-	}
 
 	/*
 	 * Since we are freeing the socket connection we must
 	 * empty any pending commands that were in this thread's
 	 * mbox (since this thread is the connection's manager.
-	 * Some of these pending commands are "send" data, and
-	 * this is the only copy we have since packet gets shelved
-	 * only in the_pkt_postsend_handler.
+	 *
 	 * Simulate a successful data-send by allowing the packets to
 	 * flow through the_call back functions the_pkt_presend_handler
-	 * and the_pkt_postsend_handler. This is similar to us having
-	 * just sent out the packets but they failed in transit.
+	 * This is similar to us having just sent out the packets
+	 * but they failed in transit.
 	 */
 	n = NULL;
 	while (tpp_mbox_clear(&conn->td->mbox, &n, conn->sock_fd, &cmd, &data) == 0) {
 		if (cmd == TPP_CMD_SEND) {
-			int freed = 0;
-			if (the_pkt_presend_handler) {
-				if (the_pkt_presend_handler(conn->sock_fd, data, conn->extra) == 0) {
-					if (the_pkt_postsend_handler) {
-						the_pkt_postsend_handler(conn->sock_fd, data, conn->extra);
-						freed = 1;
-					}
-				} else
-					freed = 1;
-			}
-			if (!freed)
-				tpp_free_pkt(data);
+			tpp_packet_t *pkt = data;
+
+			if (the_pkt_presend_handler)
+				the_pkt_presend_handler(conn->sock_fd, pkt, conn->ctx, conn->extra);
+
+			tpp_free_pkt(pkt);
 		}
 	}
 
 	conns_array[conn->sock_fd].slot_state = TPP_SLOT_FREE;
 	conns_array[conn->sock_fd].conn = NULL;
 
-	tpp_unlock(&cons_array_lock);
+	tpp_unlock_rwlock(&cons_array_lock);
 
 	/* now enque the connection structure to a queue to be
 	 * actually deleted at the end of the event loop for
 	 * this thread (fd will also be closed there)
 	 */
-	if (tpp_enque(&conn->td->close_conn_que, conn) == NULL)
-		tpp_log_func(LOG_CRIT, __func__, "Out of memory queueing close connection");
+	enque_deferred_event(conn->td, -1, TPP_CMD_FREECONN, 0);
 
 	return 0;
 }
@@ -1934,15 +1806,15 @@ handle_disconnect(phy_conn_t *conn)
 static void
 handle_incoming_data(phy_conn_t *conn)
 {
-	int rc;
 	int torecv = 0;
+	int space_left;
+	int offset;
+	int closed;
+	int pkt_len;
+	char *p;
+	short rc;
 
 	while (1) {
-		int space_left;
-		int offset;
-		int closed;
-		int amt;
-
 		offset = conn->scratch.pos - conn->scratch.data;
 		space_left = conn->scratch.len - offset; /* remaining space */
 		if (space_left == 0) {
@@ -1950,33 +1822,37 @@ handle_incoming_data(phy_conn_t *conn)
 			if (conn->scratch.len == 0)
 				conn->scratch.len = TPP_SCRATCHSIZE;
 			else {
-				conn->scratch.len += TPP_SCRATCHSIZE;
-				snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ,
-						"Increased scratch size for tfd=%d to %d", conn->sock_fd, conn->scratch.len);
-				tpp_log_func(LOG_INFO, __func__, tpp_get_logbuf());
+				conn->scratch.len += TPP_SCRATCHSIZE;						
+				tpp_log(LOG_INFO, __func__, "Increased scratch size for tfd=%d to %d", conn->sock_fd, conn->scratch.len);
 			}
-			conn->scratch.data = realloc(conn->scratch.data, conn->scratch.len);
-			if (conn->scratch.data == NULL) {
-				tpp_log_func(LOG_CRIT, __func__, "Out of memory resizing scratch data");
+			p = realloc(conn->scratch.data, conn->scratch.len);
+			if (!p) {
+				tpp_log(LOG_CRIT, __func__, "Out of memory resizing scratch data");
 				return;
 			}
+			conn->scratch.data = p;
 			conn->scratch.pos = conn->scratch.data + offset;
-			torecv = conn->scratch.len - (conn->scratch.pos - conn->scratch.data);
-		} else
-			torecv = space_left;
+			space_left = conn->scratch.len - offset;
+		}
 
-		/*
-		 * do not receive any more than TPP_SCRATCHSIZE data
-		 * because that can cause add_pkts to do a lot of
-		 * memmove() unnecessarily. If there is more data
-		 * we will circle right back from epoll() anyway
-		 */
-		if (torecv > TPP_SCRATCHSIZE)
-			torecv = TPP_SCRATCHSIZE;
+		if (offset > sizeof(int)) {
+			pkt_len = ntohl(*((int *) conn->scratch.data));
+			torecv = pkt_len - offset; /* offset amount of data already received */
+			if (torecv > space_left)
+				torecv = space_left;
+		} else {
+			/* 
+			 * we are starting to read a new packet now
+			 * so we try to read the length part only first
+			 * so we know how much more to read this is to 
+			 * avoid reading more than one packet, to eliminate memmoves 
+			 */
+			torecv = sizeof(int) + sizeof(char) - offset; /* also read the type character */
+			pkt_len = 0;
+		}
 
 		/* receive as much as we can */
 		closed = 0;
-		amt = 0;
 		while (torecv > 0) {
 			rc = tpp_sock_recv(conn->sock_fd, conn->scratch.pos, torecv, 0);
 			if (rc == 0) {
@@ -1991,13 +1867,7 @@ handle_incoming_data(phy_conn_t *conn)
 				break;
 			}
 			torecv -= rc;
-			amt += rc;
 			conn->scratch.pos += rc;
-		}
-		rc = add_pkts(conn);
-		if (rc == -1) {
-			/* a disconnect had happened in the flow, quit this routine */
-			return;
 		}
 
 		if (closed == 1) {
@@ -2006,19 +1876,18 @@ handle_incoming_data(phy_conn_t *conn)
 		}
 		if (torecv > 0) /* did not receive full data, do not try any more */
 			break;
+
+		if (add_pkt(conn) != 0)
+			return;
 	}
 }
 
 /**
  * @brief
- *	Carve packets out of the data received and send any complete packet to
- *	the application by calling the upper layers "the_pkt_handler".
+ *	Add a packet to the receivers buffer or if buffer if full
+ *  add a defered action, so that it can be checked later
  *
  * @param[in] conn - The physical connection
- *
- * @retval Error code
- * @return -1 - Error
- * @return  0 - Success
  *
  * @par Side Effects:
  *	None
@@ -2026,59 +1895,53 @@ handle_incoming_data(phy_conn_t *conn)
  * @par MT-safe: No
  *
  */
-static int
-add_pkts(phy_conn_t *conn)
+static short
+add_pkt(phy_conn_t *conn)
 {
-	char *pkt_start;
-	int avail_len;
-	int rc = 0;
-	int tfd = conn->sock_fd;
-	int slot_state;
-	int count = 0;
+	short rc = 0;
+	short mod_rc = 0;
+	int avl_len;
+	int pkt_len;
 
-	int recv_len = conn->scratch.pos - conn->scratch.data;
-	pkt_start = conn->scratch.data;
-	avail_len = recv_len;
-
-	while (avail_len >= (sizeof(int) + sizeof(char))) {
-		int pkt_len;
-		int data_len;
-		char *data;
-
-		/*  We have enough data now to validate the header */
-		if (tpp_validate_hdr(tfd, pkt_start) != 0) {
-			handle_disconnect(conn);
-			return -1;
-		}
-
-		data_len = ntohl(*((int *) pkt_start));
-		pkt_len = data_len + sizeof(int);
-		if (avail_len < pkt_len)
-			break;
-
-		data = pkt_start + sizeof(int);
-		if (the_pkt_handler) {
-			if ((rc = the_pkt_handler(conn->sock_fd, data, data_len, conn->ctx, conn->extra)) != 0) {
-				/* upper layer rejected data, disconnect */
-				handle_disconnect(conn);
-				return -1;
+	avl_len = conn->scratch.pos - conn->scratch.data;
+	if (avl_len >= sizeof(int)) {
+		pkt_len = ntohl(*((int *) conn->scratch.data));
+		if (avl_len == pkt_len) {
+			/* we got a full packet */
+			if (the_pkt_handler) {
+				rc = the_pkt_handler(conn->sock_fd, conn->scratch.data, pkt_len, conn->ctx, conn->extra);
+				if (rc != 0) {
+					if (rc == -1) {
+						/* upper layer rejected data, disconnect */
+						handle_disconnect(conn);
+					} else if (rc == -2) {
+						conn->ev_mask &= ~EM_IN; /* reciever buffer full, must wait, remove EM_IN */
+						TPP_DBPRT("Buffer full, removed EM_IN from ev_mask, now=%x", conn->ev_mask);
+						enque_deferred_event(conn->td, -1, TPP_CMD_READ, 0);
+						mod_rc = tpp_em_mod_fd(conn->td->em_context, conn->sock_fd, conn->ev_mask);
+					}
+				} else {
+					if ((conn->ev_mask & EM_IN) == 0) {
+						/* packet added successfully, add EM_IN back */
+						conn->ev_mask |= EM_IN;
+						TPP_DBPRT("Buffer ok again, added EM_IN to ev_mask, now=%x", conn->ev_mask);
+						mod_rc = tpp_em_mod_fd(conn->td->em_context, conn->sock_fd, conn->ev_mask);
+					}
+				}
+				if (mod_rc != 0) {
+					tpp_log(LOG_ERR, __func__, "Multiplexing failed");
+					rc = mod_rc;
+				}
 			}
 
-			conn = get_transport_atomic(tfd, &slot_state);
-			if (slot_state != TPP_SLOT_BUSY)
-				return -1;
+			if (rc == 0) {
+			   /* 
+				* no need to memmove or coalesce the data, since we would have read 
+				* just enough for a packet, so, just reset pointers
+				*/
+				conn->scratch.pos = conn->scratch.data;
+			}
 		}
-
-		count++;
-		/* coalesce before next packet to maintain alignment */
-		avail_len = avail_len - pkt_len;
-		memmove(conn->scratch.data, conn->scratch.data + pkt_len, (size_t)avail_len); /* area OVERLAP - use memmove */
-		conn->scratch.pos = conn->scratch.data + avail_len;
-	}
-
-	if (count > 50) {
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Received many small packets(%d)", count);
-		tpp_log_func(LOG_INFO, __func__, tpp_get_logbuf());
 	}
 	return rc;
 }
@@ -2099,238 +1962,85 @@ add_pkts(phy_conn_t *conn)
 static void
 send_data(phy_conn_t *conn)
 {
-	tpp_packet_t *p = NULL;
+	tpp_chunk_t *p = NULL;
+	tpp_packet_t *pkt = NULL;
 	int rc;
-	int can_send_more;
-	tpp_que_elem_t *n;
-#ifdef NAS /* localmod 149 */
-	time_t curr;
-	int rc_iflag;
-#endif /* localmod 149 */
-
+	int curr_pkt_done = 0;
+	int tosend;
 
 	/*
 	 * if a socket is still connecting, we will wait to send out data,
 	 * even if app called close - so check this first
 	 */
-	if (conn->net_state == TPP_CONN_CONNECTING || conn->net_state == TPP_CONN_INITIATING)
+	if ((conn->net_state == TPP_CONN_CONNECTING) || (conn->net_state == TPP_CONN_INITIATING))
 		return;
 
-	n = TPP_QUE_HEAD(&conn->send_queue);
-	p = TPP_QUE_DATA(n);
+	TPP_DBPRT("send_data, EM_OUT=%d, ev_mask now=%x", (conn->ev_mask & EM_OUT), conn->ev_mask);
+	while ((conn->ev_mask & EM_OUT) == 0) {
+		rc = 0;
+		curr_pkt_done = 0;
 
-	if (conn->can_send == 0)
-		return;
+		pkt = conn->curr_send_pkt;
+		if (!pkt) {
+			/* get the next packet from send_mbox */
+			if (tpp_mbox_read(&conn->send_mbox, NULL, NULL, (void **) &conn->curr_send_pkt) != 0) {
+				TPP_DBPRT("No data to send");
+				if (!(errno == EAGAIN || errno == EWOULDBLOCK))
+					tpp_log(LOG_ERR, __func__, "tpp_mbox_read failed");				
+				return;
+			}
+			pkt = conn->curr_send_pkt;
+		}
+		p = pkt->curr_chunk;
 
-	can_send_more = 1;
-
-	while (p && can_send_more) {
-		int tosend;
-
-		tosend = p->len - (p->pos - p->data);
-		if (p->pos == p->data) {
-			if (the_pkt_presend_handler) {
-				if (the_pkt_presend_handler(conn->sock_fd, p, conn->extra) != 0) {
-					/* handler asked not to send data, skip packet */
-					conn->send_queue_size -= tosend;
-					(void) tpp_que_del_elem(&conn->send_queue, n);
-					n = TPP_QUE_HEAD(&conn->send_queue);
-					p = TPP_QUE_DATA(n);
-					continue;
-				}
-				/* the_pkt_presend_handler could change the pkt size*/
-				tosend = p->len;
+		/* data available, first byte, and presend handler presend, call handler */
+		if ((p == GET_NEXT(pkt->chunks)) && (p->pos == p->data) && the_pkt_presend_handler) {
+			if ((rc = the_pkt_presend_handler(conn->sock_fd, pkt, conn->ctx, conn->extra)) == 0) {
+				p = pkt->curr_chunk; /* presend handler could change pkt contents */
 			}
 		}
 
-		while (tosend > 0) {
-			rc = tpp_sock_send(conn->sock_fd, p->pos, tosend, 0);
-#ifdef NAS /* localmod 149 */
-			if (rc > 0) {
-				curr = time(0);
-
-				conn->td->nas_kb_sent_A += ((double) rc) / 1024.0;
-				conn->td->nas_kb_sent_B += ((double) rc) / 1024.0;
-				conn->td->nas_kb_sent_C += ((double) rc) / 1024.0;
-
-				if (tosend > TPP_SCRATCHSIZE) {
-					conn->td->nas_num_lrg_sends_A++;
-					conn->td->nas_lrg_send_sum_kb_A += ((double) tosend) / 1024.0;
-
-					if (rc != tosend) {
-						conn->td->nas_num_qual_lrg_sends_A++;
-					}
-
-					if (tosend > conn->td->nas_max_bytes_lrg_send_A) {
-						conn->td->nas_max_bytes_lrg_send_A = tosend;
-					}
-
-					if (tosend < conn->td->nas_min_bytes_lrg_send_A) {
-						conn->td->nas_min_bytes_lrg_send_A = tosend;
-					}
-
-
-
-					conn->td->nas_num_lrg_sends_B++;
-					conn->td->nas_lrg_send_sum_kb_B += ((double) tosend) / 1024.0;
-
-					if (rc != tosend) {
-						conn->td->nas_num_qual_lrg_sends_B++;
-					}
-
-					if (tosend > conn->td->nas_max_bytes_lrg_send_B) {
-						conn->td->nas_max_bytes_lrg_send_B = tosend;
-					}
-
-					if (tosend < conn->td->nas_min_bytes_lrg_send_B) {
-						conn->td->nas_min_bytes_lrg_send_B = tosend;
-					}
-
-
-
-					conn->td->nas_num_lrg_sends_C++;
-					conn->td->nas_lrg_send_sum_kb_C += ((double) tosend) / 1024.0;
-
-					if (rc != tosend) {
-						conn->td->nas_num_qual_lrg_sends_C++;
-					}
-
-					if (tosend > conn->td->nas_max_bytes_lrg_send_C) {
-						conn->td->nas_max_bytes_lrg_send_C = tosend;
-					}
-
-					if (tosend < conn->td->nas_min_bytes_lrg_send_C) {
-						conn->td->nas_min_bytes_lrg_send_C = tosend;
-					}
-				}
-
-				if (curr > (conn->td->nas_last_time_A + conn->td->NAS_TPP_LOG_PERIOD_A)) {
-					rc_iflag = access(tpp_instr_flag_file, F_OK);
-					if (rc_iflag != 0) {
-						conn->td->nas_tpp_log_enabled = 0;
+		if (p && (rc == 0)) {
+			tosend = p->len - (p->pos - p->data);
+			while (tosend > 0) {
+				rc = tpp_sock_send(conn->sock_fd, p->pos, tosend, 0);
+				if (rc < 0) {
+					if (errno == EWOULDBLOCK || errno == EAGAIN) {
+						/* set this socket in POLLOUT */
+						conn->ev_mask |= EM_OUT;
+						TPP_DBPRT("EWOULDBLOCK, added EM_OUT to ev_mask, now=%x", conn->ev_mask);
+						if (tpp_em_mod_fd(conn->td->em_context, conn->sock_fd, conn->ev_mask)	== -1) {
+							tpp_log(LOG_ERR, __func__, "Multiplexing failed");
+							return;
+						}
 					} else {
-						conn->td->nas_tpp_log_enabled = 1;
-					}
-
-					if (conn->td->nas_tpp_log_enabled) {
-						snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ,
-							 "tpp_instr period_A %d last %d secs (mb=%.3f, mb/min=%.3f) lrg send over %d (sends=%d, qualified=%d, minbytes=%d, maxbytes=%d, avgkb=%.1f)",
-							 conn->td->NAS_TPP_LOG_PERIOD_A,
-							 (int) (curr - conn->td->nas_last_time_A),
-							 conn->td->nas_kb_sent_A / 1024.0,
-							 (conn->td->nas_kb_sent_A / 1024.0) / (((double) (curr - conn->td->nas_last_time_A)) / 60.0),
-							 TPP_SCRATCHSIZE,
-							 conn->td->nas_num_lrg_sends_A,
-							 conn->td->nas_num_qual_lrg_sends_A,
-							 conn->td->nas_num_lrg_sends_A > 0 ? conn->td->nas_min_bytes_lrg_send_A : 0,
-							 conn->td->nas_max_bytes_lrg_send_A,
-							 conn->td->nas_num_lrg_sends_A > 0 ? conn->td->nas_lrg_send_sum_kb_A / ((double) conn->td->nas_num_lrg_sends_A) : 0.0);
-						tpp_log_func(LOG_ERR, __func__, tpp_get_logbuf());
-					}
-
-					conn->td->nas_last_time_A = curr;
-					conn->td->nas_kb_sent_A = 0.0;
-					conn->td->nas_num_lrg_sends_A = 0;
-					conn->td->nas_num_qual_lrg_sends_A = 0;
-					conn->td->nas_max_bytes_lrg_send_A = 0;
-					conn->td->nas_min_bytes_lrg_send_A = INT_MAX - 1;
-					conn->td->nas_lrg_send_sum_kb_A = 0.0;
-				}
-
-				if (curr > (conn->td->nas_last_time_B + conn->td->NAS_TPP_LOG_PERIOD_B)) {
-					if (conn->td->nas_tpp_log_enabled) {
-						snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ,
-							 "tpp_instr period_B %d last %d secs (mb=%.3f, mb/min=%.3f) lrg send over %d (sends=%d, qualified=%d, minbytes=%d, maxbytes=%d, avgkb=%.1f)",
-							 conn->td->NAS_TPP_LOG_PERIOD_B,
-							 (int) (curr - conn->td->nas_last_time_B),
-							 conn->td->nas_kb_sent_B / 1024.0,
-							 (conn->td->nas_kb_sent_B / 1024.0) / (((double) (curr - conn->td->nas_last_time_B)) / 60.0),
-							 TPP_SCRATCHSIZE,
-							 conn->td->nas_num_lrg_sends_B,
-							 conn->td->nas_num_qual_lrg_sends_B,
-							 conn->td->nas_num_lrg_sends_B > 0 ? conn->td->nas_min_bytes_lrg_send_B : 0,
-							 conn->td->nas_max_bytes_lrg_send_B,
-							 conn->td->nas_num_lrg_sends_B > 0 ? conn->td->nas_lrg_send_sum_kb_B / ((double) conn->td->nas_num_lrg_sends_B) : 0.0);
-						tpp_log_func(LOG_ERR, __func__, tpp_get_logbuf());
-					}
-
-					conn->td->nas_last_time_B = curr;
-					conn->td->nas_kb_sent_B = 0.0;
-					conn->td->nas_num_lrg_sends_B = 0;
-					conn->td->nas_num_qual_lrg_sends_B = 0;
-					conn->td->nas_max_bytes_lrg_send_B = 0;
-					conn->td->nas_min_bytes_lrg_send_B = INT_MAX - 1;
-					conn->td->nas_lrg_send_sum_kb_B = 0.0;
-				}
-
-				if (curr > (conn->td->nas_last_time_C + conn->td->NAS_TPP_LOG_PERIOD_C)) {
-					if (conn->td->nas_tpp_log_enabled) {
-						snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ,
-							 "tpp_instr period_C %d last %d secs (mb=%.3f, mb/min=%.3f) lrg send over %d (sends=%d, qualified=%d, minbytes=%d, maxbytes=%d, avgkb=%.1f)",
-							conn->td->NAS_TPP_LOG_PERIOD_C,
-							(int) (curr - conn->td->nas_last_time_C),
-							conn->td->nas_kb_sent_C / 1024.0,
-							(conn->td->nas_kb_sent_C / 1024.0) / (((double) (
-							curr - conn->td->nas_last_time_C)) / 60.0),
-							TPP_SCRATCHSIZE,
-							conn->td->nas_num_lrg_sends_C,
-							conn->td->nas_num_qual_lrg_sends_C,
-							conn->td->nas_num_lrg_sends_C > 0 ? conn->td->nas_min_bytes_lrg_send_C : 0,
-							conn->td->nas_max_bytes_lrg_send_C,
-							conn->td->nas_num_lrg_sends_C > 0 ? conn->td->nas_lrg_send_sum_kb_C / ((double) conn->td->nas_num_lrg_sends_C) : 0.0);
-						tpp_log_func(LOG_ERR, __func__, tpp_get_logbuf());
-					}
-
-					conn->td->nas_last_time_C = curr;
-					conn->td->nas_kb_sent_C = 0.0;
-					conn->td->nas_num_lrg_sends_C = 0;
-					conn->td->nas_num_qual_lrg_sends_C = 0;
-					conn->td->nas_max_bytes_lrg_send_C = 0;
-					conn->td->nas_min_bytes_lrg_send_C = INT_MAX - 1;
-					conn->td->nas_lrg_send_sum_kb_C = 0.0;
-				}
-			}
-#endif /* localmod 149 */
-
-			if (rc < 0) {
-				if (errno == EWOULDBLOCK || errno == EAGAIN) {
-					/* set this socket in POLLOUT */
-					if (tpp_em_mod_fd(conn->td->em_context, conn->sock_fd,
-						EM_IN | EM_OUT | EM_HUP | EM_ERR)	== -1) {
-						tpp_log_func(LOG_ERR, __func__, "Multiplexing failed");
+						handle_disconnect(conn);
 						return;
 					}
-
-					/* set to cannot send data any more */
-					conn->can_send = 0;
-				} else {
-					handle_disconnect(conn);
-					return;
+					break;
 				}
-				can_send_more = 0;
-				break;
-			}
-			TPP_DBPRT(("tfd=%d, sending out %d bytes", conn->sock_fd, rc));
-			p->pos += rc;
-			tosend -= rc;
-		}
-
-		if (tosend == 0) {
-			conn->send_queue_size -= p->len;
-
-			if (the_pkt_postsend_handler)
-				the_pkt_postsend_handler(conn->sock_fd, p, conn->extra);
-			else {
-				tpp_free_pkt(p);
+				TPP_DBPRT("tfd=%d, sending out %d bytes", conn->sock_fd, rc);
+				p->pos += rc;
+				tosend -= rc;
 			}
 
+			if (tosend == 0) {
+				p = GET_NEXT(p->chunk_link);
+				if (p)
+					pkt->curr_chunk = p;
+				else
+					curr_pkt_done = 1;
+			}
+		} else
+			curr_pkt_done = 1;
+
+		if (pkt && curr_pkt_done) {
 			/*
-			 * all data in this packet has been sent or done with.
-			 * delete this node and get next node in queue
-			 */
-			(void)tpp_que_del_elem(&conn->send_queue, n);
-			n = TPP_QUE_HEAD(&conn->send_queue);
-			p = TPP_QUE_DATA(n);
+			* all data in this packet has been sent or done with.
+			* delete this node and get next node in queue
+			*/
+			tpp_free_pkt(pkt);
+			conn->curr_send_pkt = NULL;
 		}
 	}
 }
@@ -2350,7 +2060,9 @@ send_data(phy_conn_t *conn)
 static void
 free_phy_conn(phy_conn_t *conn)
 {
-	tpp_packet_t *p = NULL;
+	tpp_que_elem_t *n;
+	tpp_packet_t *pkt;
+	short cmd;
 
 	if (!conn)
 		return;
@@ -2361,20 +2073,20 @@ free_phy_conn(phy_conn_t *conn)
 		free(conn->conn_params);
 	}
 
-	while ((p = tpp_deque(&conn->send_queue))) {
-		tpp_free_pkt(p);
+	while (tpp_mbox_clear(&conn->send_mbox, &n, conn->sock_fd, &cmd, (void **) &pkt) == 0) {
+		if (cmd == TPP_CMD_SEND)
+			tpp_free_pkt(pkt);
 	}
 
 	free(conn->ctx);
 	free(conn->scratch.data);
-	free(conn->scratch.extra_data);
 	free(conn);
 }
 
 /*
  * Dummy log function used when terminate is called
  * We cannot log anything after fork even if tpp_dummy_logfunc
- * is called accidentally, so set tpp_log_func to this
+ * is called accidentally, so set tpp_log to this
  * dummy function
  */
 void
@@ -2402,10 +2114,10 @@ tpp_transport_shutdown()
 	int i;
 	void *ret;
 
-	tpp_log_func(LOG_INFO, NULL, "Shutting down TPP transport Layer");
+	tpp_log(LOG_INFO, NULL, "Shutting down TPP transport Layer");
 
 	for (i = 0; i < num_threads; i++) {
-		tpp_mbox_post(&thrd_pool[i]->mbox, 0, TPP_CMD_EXIT, NULL);
+		tpp_mbox_post(&thrd_pool[i]->mbox, 0, TPP_CMD_EXIT, NULL, 0);
 	}
 
 	for (i = 0; i < num_threads; i++) {
@@ -2424,9 +2136,9 @@ tpp_transport_shutdown()
 
 	/* free the array */
 	free(conns_array);
-	if (tpp_destroy_lock(&cons_array_lock)) {
+	if (tpp_destroy_rwlock(&cons_array_lock))
 		return 1;
-	}
+
 	return 0;
 }
 
@@ -2447,9 +2159,7 @@ tpp_transport_terminate()
 
 	/* Warning: Do not attempt to destroy any lock
 	 * This is not required since our library is effectively
-	 * not used after a fork. The function tpp_mbox_destroy
-	 * calls pthread_mutex_destroy, so don't call them.
-	 * Also never log anything from a terminate handler
+	 * not used after a fork.
 	 *
 	 * Don't bother to free any TPP data as well, as the forked
 	 * process is usually short lived and no point spending time
@@ -2463,7 +2173,6 @@ tpp_transport_terminate()
 	 * main process.
 	 *
 	 */
-	tpp_log_func = tpp_dummy_logfunc;
 
 	for (i = 0; i < num_threads; i++) {
 		if (thrd_pool[i]->listen_fd > -1)

--- a/src/lib/Libtpp/tpp_transport.c
+++ b/src/lib/Libtpp/tpp_transport.c
@@ -1009,30 +1009,6 @@ tpp_transport_wakeup_thrd(int tfd)
 
 /**
  * @brief
- *	Check the amount of data queued on a outgoing connection. If the buffered
- *	(and unsent) data is greater than some limit specified per connection,
- *	then that connection is closed.
- *
- * @param[in] conn   - The connection that has to be checked
- *
- * @return  Error code
- * @retval  -1 - buffered data exceeds specified limits
- * @retval   0 - buffered data within limits
- *
- * @par Side Effects:
- *	None
- *
- * @par MT-safe: No
- *
- */
-int
-check_buffer_limits(phy_conn_t *conn)
-{
-	return 0;
-}
-
-/**
- * @brief
  *	Queue data to be sent out by the IO thread. This function can take a
  *	set of data buffers and sends them out after concatenating
  *
@@ -1525,7 +1501,7 @@ work(void *v)
 		while (1) {
 			now = time(0);
 
-			/* trigger all delayed connects, and return the wait time till the next one to trigger */
+			/* trigger all delayed events, and return the wait time till the next one to trigger */
 			timeout = trigger_deferred_events(td, now);
 			if (the_timer_handler) {
 				timeout2 = the_timer_handler(now);
@@ -1993,7 +1969,7 @@ send_data(phy_conn_t *conn)
 		}
 		p = pkt->curr_chunk;
 
-		/* data available, first byte, and presend handler presend, call handler */
+		/* data available, first byte, presend handler present, call handler */
 		if ((p == GET_NEXT(pkt->chunks)) && (p->pos == p->data) && the_pkt_presend_handler) {
 			if ((rc = the_pkt_presend_handler(conn->sock_fd, pkt, conn->ctx, conn->extra)) == 0) {
 				p = pkt->curr_chunk; /* presend handler could change pkt contents */
@@ -2081,17 +2057,6 @@ free_phy_conn(phy_conn_t *conn)
 	free(conn->ctx);
 	free(conn->scratch.data);
 	free(conn);
-}
-
-/*
- * Dummy log function used when terminate is called
- * We cannot log anything after fork even if tpp_dummy_logfunc
- * is called accidentally, so set tpp_log to this
- * dummy function
- */
-void
-tpp_dummy_logfunc(int level, const char *id, char *mess)
-{
 }
 
 /**

--- a/src/lib/Libtpp/tpp_util.c
+++ b/src/lib/Libtpp/tpp_util.c
@@ -181,7 +181,7 @@ tpp_log(int level, const char *routine, const char *fmt, ...)
 
 	func[0] = '\0';
 	if (routine)
-		snprintf(func, sizeof(func), ",%s,", routine);
+		snprintf(func, sizeof(func), ";%s", routine);
 
 	thrd_index = tpp_get_thrd_index();
 	if (thrd_index == -1)
@@ -665,10 +665,13 @@ tpp_bld_pkt(tpp_packet_t *pkt, void *data, int len, int dup, void **dup_data)
 	tpp_chunk_t *chunk;
 	void *d = data;
 
+	/* first create the requested chunk for the packet */
 	if ((chunk = malloc(sizeof(tpp_chunk_t))) == NULL) {
-		tpp_log(LOG_CRIT, __func__, "Failed to build packet");
+		tpp_log(LOG_CRIT, __func__, "Failed to build chunk");
+		tpp_free_pkt(pkt);
 		return NULL;
 	}
+	/* dup flag was provided, so allocate space */
 	if (dup) {
 		d = malloc(len);
 		if (!d) {
@@ -687,6 +690,8 @@ tpp_bld_pkt(tpp_packet_t *pkt, void *data, int len, int dup, void **dup_data)
 	chunk->len = len;
 	CLEAR_LINK(chunk->chunk_link);
 
+	/* add chunk to packet */
+	/* if packet NULL, create packet now and add chunk */
 	if (pkt == NULL) {
 		if ((pkt = malloc(sizeof(tpp_packet_t))) == NULL) {
 			if (d != data) 

--- a/src/lib/Libtpp/tpp_util.c
+++ b/src/lib/Libtpp/tpp_util.c
@@ -65,6 +65,7 @@
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <arpa/inet.h>
+#include <stdarg.h>
 #include "pbs_idx.h"
 #include "pbs_error.h"
 #include "tpp_internal.h"
@@ -73,18 +74,18 @@
 #include <zlib.h>
 #endif
 
+#define BACKTRACE_SIZE 100
+#include <execinfo.h>
+
 /*
  *	Global Variables
  */
-int tpp_dbprt = 1; /* controls debug printing */
 
 /* TLS data for each TPP thread */
 static pthread_key_t tpp_key_tls;
 static pthread_once_t tpp_once_ctrl = PTHREAD_ONCE_INIT; /* once ctrl to initialize tls key */
 
 long tpp_log_event_mask = 0;
-
-void (*tpp_log_func)(int level, const char *id, char *mess) = NULL;
 
 /* default keepalive values */
 #define DEFAULT_TCP_KEEPALIVE_TIME 30
@@ -100,8 +101,7 @@ static pbs_tcp_chan_t * tppdis_get_user_data(int sd);
 void
 tpp_auth_logger(int type, int objclass, int severity, const char *objname, const char *text)
 {
-	if (tpp_log_func)
-		tpp_log_func(severity, objname, (char *)text);
+	tpp_log(severity, objname, (char *)text);
 }
 
 /**
@@ -167,21 +167,43 @@ DIS_tpp_funcs()
  * @param[in]	mess    - The log message
  *
  */
-static void
-log_tppmsg(int level, const char *objname, char *mess)
+void
+tpp_log(int level, const char *routine, const char *fmt, ...)
 {
 	char id[2 * PBS_MAXHOSTNAME];
 	int thrd_index;
 	int etype = log_level_2_etype(level);
+	int len;
+	char logbuf[LOG_BUF_SIZE];
+	char *buf;
+	va_list args;
+
+	va_start(args, fmt);
 
 	thrd_index = tpp_get_thrd_index();
 	if (thrd_index == -1)
-		snprintf(id, sizeof(id), "%s(Main Thread)", (objname != NULL) ? objname : msg_daemonname);
+		snprintf(id, sizeof(id), "%s(Main Thread)", msg_daemonname ? msg_daemonname : "");
 	else
-		snprintf(id, sizeof(id), "%s(Thread %d)", (objname != NULL) ? objname : msg_daemonname, thrd_index);
+		snprintf(id, sizeof(id), "%s(Thread %d)", msg_daemonname ? msg_daemonname : "", thrd_index);
 
-	log_event(etype, PBS_EVENTCLASS_TPP, level, id, mess);
-	DBPRT(("%s\n", mess));
+	len = vsnprintf(logbuf, sizeof(logbuf), fmt, args);
+
+	if (len >= sizeof(logbuf)) {
+		buf = pbs_asprintf_format(len, fmt, args);
+		if (buf == NULL) {
+			va_end(args);
+			return;
+		}
+	} else
+		buf = logbuf;
+
+	log_event(etype, PBS_EVENTCLASS_TPP, level, id, buf);
+
+	if (len >= sizeof(logbuf))
+		free(buf);
+	va_end(args);
+
+	DBPRT(("%s %s\n", id, buf));
 }
 
 /**
@@ -210,7 +232,7 @@ log_tppmsg(int level, const char *objname, char *mess)
  *
  */
 int
-set_tpp_config(void (*log_fn)(int, const char *, char *), struct pbs_config *pbs_conf, struct tpp_config *tpp_conf, char *nodenames, int port, char *r)
+set_tpp_config(struct pbs_config *pbs_conf, struct tpp_config *tpp_conf, char *nodenames, int port, char *r)
 {
 	int i;
 	int num_routers = 0;
@@ -220,11 +242,6 @@ set_tpp_config(void (*log_fn)(int, const char *, char *), struct pbs_config *pbs
 	int len, hlen;
 	char *token, *saveptr, *tmp;
 	char *formatted_names = NULL;
-
-	if (log_fn)
-		tpp_log_func = log_fn;
-	else
-		tpp_log_func = log_tppmsg;
 
 	/* before doing anything else, initialize the key to the tls
 	 * its okay to call this function multiple times since it
@@ -239,17 +256,13 @@ set_tpp_config(void (*log_fn)(int, const char *, char *), struct pbs_config *pbs
 	if (r) {
 		routers = strdup(r);
 		if (!routers) {
-			snprintf(log_buffer, TPP_LOGBUF_SZ, "Out of memory allocating routers");
-			fprintf(stderr, "%s\n", log_buffer);
-			tpp_log_func(LOG_CRIT, __func__, log_buffer);
+			tpp_log(LOG_CRIT, __func__, "Out of memory allocating routers");
 			return -1;
 		}
 	}
 
 	if (!nodenames) {
-		snprintf(log_buffer, TPP_LOGBUF_SZ, "TPP node name not set");
-		fprintf(stderr, "%s\n", log_buffer);
-		tpp_log_func(LOG_CRIT, NULL, log_buffer);
+		tpp_log(LOG_CRIT, NULL, "TPP node name not set");
 		return -1;
 	}
 
@@ -260,9 +273,7 @@ set_tpp_config(void (*log_fn)(int, const char *, char *), struct pbs_config *pbs
 		tpp_addr_t *addr;
 
 		if ((sd = tpp_sock_socket(AF_INET, SOCK_STREAM, 0)) == -1) {
-			snprintf(log_buffer, TPP_LOGBUF_SZ, "tpp_sock_socket() error, errno=%d", errno);
-			fprintf(stderr, "%s\n", log_buffer);
-			tpp_log_func(LOG_ERR, __func__, log_buffer);
+			tpp_log(LOG_ERR, __func__, "tpp_sock_socket() error, errno=%d", errno);
 			return -1;
 		}
 
@@ -272,9 +283,7 @@ set_tpp_config(void (*log_fn)(int, const char *, char *), struct pbs_config *pbs
 		in.sin_port = 0;
 		memset(&(in.sin_zero), '\0', sizeof(in.sin_zero));
 		if ((rc = tpp_sock_bind(sd, (struct sockaddr *) &in, sizeof(in))) == -1) {
-			snprintf(log_buffer, TPP_LOGBUF_SZ, "tpp_sock_bind() error, errno=%d", errno);
-			fprintf(stderr, "%s\n", log_buffer);
-			tpp_log_func(LOG_ERR, __func__, log_buffer);
+			tpp_log(LOG_ERR, __func__, "tpp_sock_bind() error, errno=%d", errno);
 			tpp_sock_close(sd);
 			return -1;
 		}
@@ -286,9 +295,7 @@ set_tpp_config(void (*log_fn)(int, const char *, char *), struct pbs_config *pbs
 		}
 
 		if (port == -1) {
-			snprintf(log_buffer, TPP_LOGBUF_SZ, "TPP client could not detect port to use");
-			fprintf(stderr, "%s\n", log_buffer);
-			tpp_log_func(LOG_ERR, __func__, log_buffer);
+			tpp_log(LOG_ERR, __func__, "TPP client could not detect port to use");
 			tpp_sock_close(sd);
 			return -1;
 		}
@@ -302,17 +309,13 @@ set_tpp_config(void (*log_fn)(int, const char *, char *), struct pbs_config *pbs
 	while (token) {
 		nm = mk_hostname(token, port);
 		if (!nm) {
-			snprintf(log_buffer, TPP_LOGBUF_SZ, "Failed to make node name");
-			fprintf(stderr, "%s\n", log_buffer);
-			tpp_log_func(LOG_CRIT, NULL, log_buffer);
+			tpp_log(LOG_CRIT, NULL, "Failed to make node name");
 			return -1;
 		}
 
 		hlen = strlen(nm);
 		if ((tmp = realloc(formatted_names, len + hlen + 2)) == NULL) { /* 2 for command and null char */
-			snprintf(log_buffer, TPP_LOGBUF_SZ, "Failed to make formatted node name");
-			fprintf(stderr, "%s\n", log_buffer);
-			tpp_log_func(LOG_CRIT, NULL, log_buffer);
+			tpp_log(LOG_CRIT, NULL, "Failed to make formatted node name");
 			return -1;
 		}
 
@@ -341,19 +344,17 @@ set_tpp_config(void (*log_fn)(int, const char *, char *), struct pbs_config *pbs
 							pbs_conf->pbs_home_path,
 							(void *)tpp_auth_logger);
 	if (tpp_conf->auth_config == NULL) {
-		tpp_log_func(LOG_CRIT, __func__, "Out of memory allocating auth config");
+		tpp_log(LOG_CRIT, __func__, "Out of memory allocating auth config");
 		return -1;
 	}
 
-	snprintf(log_buffer, TPP_LOGBUF_SZ, "TPP authentication method = %s", tpp_conf->auth_config->auth_method);
-	tpp_log_func(LOG_INFO, NULL, log_buffer);
-	if (tpp_conf->auth_config->encrypt_method[0] != '\0') {
-		snprintf(log_buffer, TPP_LOGBUF_SZ, "TPP encryption method = %s", tpp_conf->auth_config->encrypt_method);
-		tpp_log_func(LOG_INFO, NULL, log_buffer);
-	}
+	tpp_log(LOG_INFO, NULL, "TPP authentication method = %s", tpp_conf->auth_config->auth_method);
+	if (tpp_conf->auth_config->encrypt_method[0] != '\0') 
+		tpp_log(LOG_INFO, NULL, "TPP encryption method = %s", tpp_conf->auth_config->encrypt_method);
+
 
 	if ((tpp_conf->supported_auth_methods = dup_string_arr(pbs_conf->supported_auth_methods)) == NULL) {
-		tpp_log_func(LOG_CRIT, __func__, "Out of memory while making copy of supported auth methods");
+		tpp_log(LOG_CRIT, __func__, "Out of memory while making copy of supported auth methods");
 		return -1;
 	}
 
@@ -405,22 +406,16 @@ set_tpp_config(void (*log_fn)(int, const char *, char *), struct pbs_config *pbs
 				}
 
 				/* emit a log depicting what we are going to use as keepalive */
-				snprintf(log_buffer, TPP_LOGBUF_SZ,
+				tpp_log(LOG_CRIT, NULL, 
 						"Using tcp_keepalive_time=%d, tcp_keepalive_intvl=%d, tcp_keepalive_probes=%d, tcp_user_timeout=%d",
 						tpp_conf->tcp_keep_idle, tpp_conf->tcp_keep_intvl, tpp_conf->tcp_keep_probes, tpp_conf->tcp_user_timeout);
 			} else {
-				snprintf(log_buffer, TPP_LOGBUF_SZ, "tcp keepalive disabled");
+				tpp_log(LOG_CRIT, NULL, "tcp keepalive disabled");
 			}
 		}
-		tpp_log_func(LOG_CRIT, NULL, log_buffer);
 	}
 
 	tpp_conf->buf_limit_per_conn = 5000; /* size in KB, TODO: load from pbs.conf */
-
-	if (pbs_conf->pbs_use_ft == 1)
-		tpp_conf->force_fault_tolerance = 1;
-	else
-		tpp_conf->force_fault_tolerance = 0;
 
 	if (routers && routers[0] != '\0') {
 		char *p = routers;
@@ -436,7 +431,7 @@ set_tpp_config(void (*log_fn)(int, const char *, char *), struct pbs_config *pbs
 
 		tpp_conf->routers = malloc(sizeof(char *) * (num_routers + 1));
 		if (!tpp_conf->routers) {
-			tpp_log_func(LOG_CRIT, __func__, "Out of memory allocating routers array");
+			tpp_log(LOG_CRIT, __func__, "Out of memory allocating routers array");
 			return -1;
 		}
 
@@ -464,9 +459,7 @@ set_tpp_config(void (*log_fn)(int, const char *, char *), struct pbs_config *pbs
 
 		nm = mk_hostname(q, TPP_DEF_ROUTER_PORT);
 		if (!nm) {
-			snprintf(log_buffer, TPP_LOGBUF_SZ, "Failed to make router name");
-			fprintf(stderr, "%s\n", log_buffer);
-			tpp_log_func(LOG_CRIT, NULL, log_buffer);
+			tpp_log(LOG_CRIT, NULL, "Failed to make router name");
 			return -1;
 		}
 		tpp_conf->routers[i++] = nm;
@@ -478,10 +471,7 @@ set_tpp_config(void (*log_fn)(int, const char *, char *), struct pbs_config *pbs
 
 	for (i = 0; i < num_routers; i++) {
 		if (tpp_conf->routers[i] == NULL || strcmp(tpp_conf->routers[i], tpp_conf->node_name) == 0) {
-			snprintf(log_buffer, TPP_LOGBUF_SZ, "Router name NULL or points to same node endpoint %s",
-				(tpp_conf->routers[i]) ?(tpp_conf->routers[i]) : "");
-			fprintf(stderr, "%s\n", log_buffer);
-			tpp_log_func(LOG_CRIT, NULL, log_buffer);
+			tpp_log(LOG_CRIT, NULL, "Router name NULL or points to same node endpoint %s", (tpp_conf->routers[i]) ?(tpp_conf->routers[i]) : "");
 			return -1;
 		}
 	}
@@ -510,7 +500,7 @@ tpp_make_authdata(struct tpp_config *tpp_conf, int conn_type, char *auth_method,
 	conn_auth_t *authdata = NULL;
 
 	if ((authdata = (conn_auth_t *)calloc(1, sizeof(conn_auth_t))) == NULL) {
-		tpp_log_func(LOG_CRIT, __func__, "Out of memory");
+		tpp_log(LOG_CRIT, __func__, "Out of memory");
 		return NULL;
 	}
 	authdata->conn_type = conn_type;
@@ -520,7 +510,7 @@ tpp_make_authdata(struct tpp_config *tpp_conf, int conn_type, char *auth_method,
 						tpp_conf->auth_config->pbs_home_path,
 						tpp_conf->auth_config->logfunc);
 	if (authdata->config == NULL) {
-		tpp_log_func(LOG_CRIT, __func__, "Out of memory");
+		tpp_log(LOG_CRIT, __func__, "Out of memory");
 		return NULL;
 	}
 
@@ -552,8 +542,7 @@ tpp_handle_auth_handshake(int tfd, int conn_fd, conn_auth_t *authdata, int for_e
 	auth_def_t *authdef = NULL;
 
 	if (authdata == NULL) {
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tfd=%d, No auth data found", tfd);
-		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+		tpp_log(LOG_CRIT, __func__, "tfd=%d, No auth data found", tfd);
 		return -1;
 	}
 
@@ -561,13 +550,13 @@ tpp_handle_auth_handshake(int tfd, int conn_fd, conn_auth_t *authdata, int for_e
 		if (authdata->authdef == NULL) {
 			authdef = get_auth(authdata->config->auth_method);
 			if (authdef == NULL) {
-				tpp_log_func(LOG_CRIT, __func__, "Failed to find authdef");
+				tpp_log(LOG_CRIT, __func__, "Failed to find authdef");
 				return -1;
 			}
 			authdata->authdef = authdef;
 			authdef->set_config((const pbs_auth_config_t *)(authdata->config));
 			if (authdef->create_ctx(&(authdata->authctx), authdata->conn_type, AUTH_SERVICE_CONN, tpp_transport_get_conn_hostname(tfd))) {
-				tpp_log_func(LOG_CRIT, __func__, "Failed to create auth context");
+				tpp_log(LOG_CRIT, __func__, "Failed to create auth context");
 				return -1;
 			}
 
@@ -578,13 +567,13 @@ tpp_handle_auth_handshake(int tfd, int conn_fd, conn_auth_t *authdata, int for_e
 		if (authdata->encryptdef == NULL) {
 			authdef = get_auth(authdata->config->encrypt_method);
 			if (authdef == NULL) {
-				tpp_log_func(LOG_CRIT, __func__, "Failed to find authdef");
+				tpp_log(LOG_CRIT, __func__, "Failed to find authdef");
 				return -1;
 			}
 			authdata->encryptdef = authdef;
 			authdef->set_config((const pbs_auth_config_t *)(authdata->config));
 			if (authdef->create_ctx(&(authdata->encryptctx), authdata->conn_type, AUTH_SERVICE_CONN, tpp_transport_get_conn_hostname(tfd))) {
-				tpp_log_func(LOG_CRIT, __func__, "Failed to create encrypt context");
+				tpp_log(LOG_CRIT, __func__, "Failed to create encrypt context");
 				return -1;
 			}
 
@@ -596,30 +585,35 @@ tpp_handle_auth_handshake(int tfd, int conn_fd, conn_auth_t *authdata, int for_e
 
 	if (authdef->process_handshake_data(authctx, data_in, len_in, &data_out, &len_out, &is_handshake_done) != 0) {
 		if (len_out > 0) {
-			tpp_log_func(LOG_CRIT, __func__, (char *)data_out);
+			tpp_log(LOG_CRIT, __func__, (char *)data_out);
 			free(data_out);
 		}
 		return -1;
 	}
 
 	if (len_out > 0) {
-		tpp_auth_pkt_hdr_t ahdr = {0};
-		tpp_chunk_t chunks[2] = {{0}};
+		tpp_auth_pkt_hdr_t *ahdr = NULL;
+		tpp_packet_t *pkt = NULL;
 
-		ahdr.type = TPP_AUTH_CTX;
-		ahdr.for_encrypt = for_encrypt;
-		strcpy(ahdr.auth_method, authdata->config->auth_method);
-		strcpy(ahdr.encrypt_method, authdata->config->encrypt_method);
+		pkt = tpp_bld_pkt(NULL, NULL, sizeof(tpp_auth_pkt_hdr_t), 1, (void **) &ahdr);
+		if (!pkt) {
+			tpp_log(LOG_CRIT, __func__, "Failed to build packet");
+			free(data_out);
+			return -1;
+		}
+		ahdr->type = TPP_AUTH_CTX;
+		ahdr->for_encrypt = for_encrypt;
+		strcpy(ahdr->auth_method, authdata->config->auth_method);
+		strcpy(ahdr->encrypt_method, authdata->config->encrypt_method);
 
-		chunks[0].data = &ahdr;
-		chunks[0].len = sizeof(tpp_auth_pkt_hdr_t);
+		if (!tpp_bld_pkt(pkt, data_out, len_out, 0, NULL)) {
+			tpp_log(LOG_CRIT, __func__, "Failed to build packet");
+			free(data_out);
+			return -1;
+		}
 
-		chunks[1].data = data_out;
-		chunks[1].len = len_out;
-
-		if (tpp_transport_vsend(conn_fd, chunks, 2) != 0) {
-			snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tpp_transport_vsend failed, err=%d", errno);
-			tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+		if (tpp_transport_vsend(conn_fd, pkt) != 0) {
+			tpp_log(LOG_CRIT, __func__, "tpp_transport_vsend failed, err=%d", errno);
 			free(data_out);
 			return -1;
 		}
@@ -632,7 +626,7 @@ tpp_handle_auth_handshake(int tfd, int conn_fd, conn_auth_t *authdata, int for_e
 	 * or handshake should be completed
 	 */
 	if (is_handshake_done == 0 && len_out == 0) {
-		tpp_log_func(LOG_CRIT, __func__, "Auth handshake failed");
+		tpp_log(LOG_CRIT, __func__, "Auth handshake failed");
 		return -1;
 	}
 
@@ -645,10 +639,11 @@ tpp_handle_auth_handshake(int tfd, int conn_fd, conn_auth_t *authdata, int for_e
  * @brief
  *	Create a packet structure from the inputs provided
  *
- *
+ * @param[in] - pkt  - Pointer to packet to add chunk, or create new packet if NULL
  * @param[in] - data - pointer to data buffer (if NULL provided, no copy happens)
  * @param[in] - len  - Lentgh of data buffer
- * @param[in] - mk_data - Make a copy of the data provided?
+ * @param[in] - dup  - Make a copy of the data provided?
+ * @param[in] - dup_data  - Ptr to copy of data created, if dup is true
  *
  * @return Newly allocated packet structure
  * @retval NULL - Failure (Out of memory)
@@ -661,39 +656,61 @@ tpp_handle_auth_handshake(int tfd, int conn_fd, conn_auth_t *authdata, int for_e
  *
  */
 tpp_packet_t *
-tpp_cr_pkt(void *data, int len, int mk_data)
+tpp_bld_pkt(tpp_packet_t *pkt, void *data, int len, int dup, void **dup_data)
 {
-	tpp_packet_t *pkt;
+	tpp_chunk_t *chunk;
+	void *d = data;
 
-	if ((pkt = malloc(sizeof(tpp_packet_t))) == NULL) {
-		tpp_log_func(LOG_CRIT, __func__, "Out of memory allocating packet");
+	if ((chunk = malloc(sizeof(tpp_chunk_t))) == NULL) {
+		tpp_log(LOG_CRIT, __func__, "Failed to build packet");
 		return NULL;
 	}
-	if (mk_data == 0)
-		pkt->data = data;
-	else {
-#ifdef DEBUG
-		/* use calloc() to satisfy valgrind in debug mode */
-		pkt->data = calloc(len, 1);
-#else
-		/* use malloc() in non-debug mode for performance */
-		pkt->data = malloc(len);
-#endif
-		if (!pkt->data) {
-			free(pkt);
-			snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Out of memory allocating packet data of %d bytes", len);
-			tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+	if (dup) {
+		d = malloc(len);
+		if (!d) {
+			tpp_log(LOG_CRIT, __func__, "Out of memory allocating packet duplicate data for chunk");
+			free(chunk);
+			tpp_free_pkt(pkt);
 			return NULL;
 		}
 		if (data)
-			memcpy(pkt->data, data, len);
+			memcpy(d, data, len);
+		if (dup_data)
+			*dup_data = d; /* return allocated data ptr */
 	}
-	pkt->pos = pkt->data;
-	pkt->extra_data = NULL;
-	pkt->len = len;
-	pkt->ref_count = 1;
+	chunk->data = d;
+	chunk->pos = chunk->data;
+	chunk->len = len;
+	CLEAR_LINK(chunk->chunk_link);
+
+	if (pkt == NULL) {
+		if ((pkt = malloc(sizeof(tpp_packet_t))) == NULL) {
+			if (d != data) 
+				free(d);
+			tpp_free_pkt(pkt);
+			tpp_log(LOG_CRIT, __func__, "Out of memory allocating packet");
+			return NULL;
+		}
+		CLEAR_HEAD(pkt->chunks);
+		pkt->ref_count = 1;
+		pkt->totlen = 0;
+		pkt->curr_chunk = chunk;
+	}
+
+	pkt->totlen += len;
+	append_link(&pkt->chunks, &chunk->chunk_link, chunk);
 
 	return pkt;
+}
+
+void
+tpp_free_chunk(tpp_chunk_t *chunk)
+{
+	if (chunk) {
+		delete_link(&chunk->chunk_link);
+		free(chunk->data);
+		free(chunk);
+	}
 }
 
 /**
@@ -715,10 +732,9 @@ tpp_free_pkt(tpp_packet_t *pkt)
 		pkt->ref_count--;
 
 		if (pkt->ref_count <= 0) {
-			if (pkt->data)
-				free(pkt->data);
-			if (pkt->extra_data)
-				free(pkt->extra_data);
+			tpp_chunk_t *chunk;
+			while((chunk = GET_NEXT(pkt->chunks)))
+				tpp_free_chunk(chunk);
 			free(pkt);
 		}
 	}
@@ -819,8 +835,7 @@ tpp_set_keep_alive(int fd, struct tpp_config *cnf)
 #ifdef SO_KEEPALIVE
 	optval = cnf->tcp_keepalive;
 	if (tpp_sock_setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &optval, optlen) < 0) {
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "setsockopt(SO_KEEPALIVE) errno=%d", errno);
-		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+		tpp_log(LOG_CRIT, __func__, "setsockopt(SO_KEEPALIVE) errno=%d", errno);
 		return -1;
 	}
 #endif
@@ -829,8 +844,7 @@ tpp_set_keep_alive(int fd, struct tpp_config *cnf)
 #ifdef TCP_KEEPIDLE
 	optval = cnf->tcp_keep_idle;
 	if (tpp_sock_setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, &optval, optlen) < 0) {
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "setsockopt(TCP_KEEPIDLE) errno=%d", errno);
-		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+		tpp_log(LOG_CRIT, __func__, "setsockopt(TCP_KEEPIDLE) errno=%d", errno);
 		return -1;
 	}
 #endif
@@ -838,8 +852,7 @@ tpp_set_keep_alive(int fd, struct tpp_config *cnf)
 #ifdef TCP_KEEPINTVL
 	optval = cnf->tcp_keep_intvl;
 	if (tpp_sock_setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, &optval, optlen) < 0) {
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "setsockopt(TCP_KEEPINTVL) errno=%d", errno);
-		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+		tpp_log(LOG_CRIT, __func__, "setsockopt(TCP_KEEPINTVL) errno=%d", errno);
 		return -1;
 	}
 #endif
@@ -847,8 +860,7 @@ tpp_set_keep_alive(int fd, struct tpp_config *cnf)
 #ifdef TCP_KEEPCNT
 	optval = cnf->tcp_keep_probes;
 	if (tpp_sock_setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, &optval, optlen) < 0) {
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "setsockopt(TCP_KEEPCNT) errno=%d", errno);
-		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+		tpp_log(LOG_CRIT, __func__, "setsockopt(TCP_KEEPCNT) errno=%d", errno);
 		return -1;
 	}
 #endif
@@ -887,21 +899,21 @@ tpp_cr_thrd(void *(*start_routine)(void*), pthread_t *id, void *data)
 
 	attr = &setattr;
 	if (pthread_attr_init(attr) != 0) {
-		tpp_log_func(LOG_CRIT, __func__, "Failed to initialize attribute");
+		tpp_log(LOG_CRIT, __func__, "Failed to initialize attribute");
 		return -1;
 	}
 	if (pthread_attr_getstacksize(attr, &stack_size) != 0) {
-		tpp_log_func(LOG_CRIT, __func__, "Failed to get stack size of thread");
+		tpp_log(LOG_CRIT, __func__, "Failed to get stack size of thread");
 		return -1;
 	} else	{
 		if (stack_size < MIN_STACK_LIMIT) {
 			if (pthread_attr_setstacksize(attr, MIN_STACK_LIMIT) != 0) {
-				tpp_log_func(LOG_CRIT, __func__, "Failed to set stack size for thread");
+				tpp_log(LOG_CRIT, __func__, "Failed to set stack size for thread");
 				return -1;
 			}
 		} else {
 			if (pthread_attr_setstacksize(attr, stack_size) != 0) {
-				tpp_log_func(LOG_CRIT, __func__, "Failed to set stack size for thread");
+				tpp_log(LOG_CRIT, __func__, "Failed to set stack size for thread");
 				return -1;
 			}
 		}
@@ -912,11 +924,30 @@ tpp_cr_thrd(void *(*start_routine)(void*), pthread_t *id, void *data)
 
 #ifndef WIN32
 	if (pthread_attr_destroy(attr) != 0) {
-		tpp_log_func(LOG_CRIT, __func__, "Failed to destroy attribute");
+		tpp_log(LOG_CRIT, __func__, "Failed to destroy attribute");
 		return -1;
 	}
 #endif
 	return rc;
+}
+
+void
+print_bt()
+{
+	int i, frames;
+	void *bt_buf[BACKTRACE_SIZE];
+	char **bt_strings;
+
+	frames = backtrace(bt_buf, BACKTRACE_SIZE);
+	bt_strings = backtrace_symbols(bt_buf, frames);
+	if (bt_strings == NULL) {
+		tpp_log(LOG_CRIT, __func__, "No backtrace symbols present!");
+	} else {
+		for (i=0; i < frames; i++) {
+			tpp_log(LOG_CRIT, __func__, "%s", bt_strings[i]);
+		}
+		free(bt_strings);
+	}
 }
 
 /**
@@ -941,7 +972,7 @@ tpp_init_lock(pthread_mutex_t *lock)
 	int type;
 
 	if (pthread_mutexattr_init(&attr) != 0) {
-		tpp_log_func(LOG_CRIT, __func__, "Failed to initialize mutex attr");
+		tpp_log(LOG_CRIT, __func__, "Failed to initialize mutex attr");
 		return 1;
 	}
 #if defined (linux)
@@ -950,12 +981,12 @@ tpp_init_lock(pthread_mutex_t *lock)
 	type = PTHREAD_MUTEX_RECURSIVE;
 #endif
 	if (pthread_mutexattr_settype(&attr, type)) {
-		tpp_log_func(LOG_CRIT, __func__, "Failed to set mutex type");
+		tpp_log(LOG_CRIT, __func__, "Failed to set mutex type");
 		return 1;
 	}
 
 	if (pthread_mutex_init(lock, &attr) != 0) {
-		tpp_log_func(LOG_CRIT, __func__, "Failed to initialize mutex");
+		tpp_log(LOG_CRIT, __func__, "Failed to initialize mutex");
 		return 1;
 	}
 
@@ -981,7 +1012,7 @@ int
 tpp_destroy_lock(pthread_mutex_t *lock)
 {
 	if (pthread_mutex_destroy(lock) != 0) {
-		tpp_log_func(LOG_CRIT, __func__, "Failed to destroy mutex");
+		tpp_log(LOG_CRIT, __func__, "Failed to destroy mutex");
 		return 1;
 	}
 	return 0;
@@ -1006,7 +1037,7 @@ int
 tpp_lock(pthread_mutex_t *lock)
 {
 	if (pthread_mutex_lock(lock) != 0) {
-		tpp_log_func(LOG_CRIT, __func__, "Failed to lock mutex");
+		tpp_log(LOG_CRIT, __func__, "Failed to lock mutex");
 		return 1;
 	}
 	return 0;
@@ -1031,7 +1062,7 @@ int
 tpp_unlock(pthread_mutex_t *lock)
 {
 	if (pthread_mutex_unlock(lock) != 0) {
-		tpp_log_func(LOG_CRIT, __func__, "Failed to unlock mutex");
+		tpp_log(LOG_CRIT, __func__, "Failed to unlock mutex");
 		return 1;
 	}
 	return 0;
@@ -1056,7 +1087,7 @@ int
 tpp_init_rwlock(void *lock)
 {
 	if (pthread_rwlock_init(lock, NULL) != 0) {
-		tpp_log_func(LOG_CRIT, __func__, "Failed to initialize rw lock");
+		tpp_log(LOG_CRIT, __func__, "Failed to initialize rw lock");
 		return 1;
 	}
 	return 0;
@@ -1078,10 +1109,10 @@ tpp_init_rwlock(void *lock)
  * @retval	0	success
  */
 int
-tpp_rdlock_rwlock(void *lock)
+tpp_read_lock(void *lock)
 {
 	if (pthread_rwlock_rdlock(lock) != 0) {
-		tpp_log_func(LOG_CRIT, __func__, "Failed in rdlock");
+		tpp_log(LOG_CRIT, __func__, "Failed in rdlock");
 		return 1;
 	}
 	return 0;
@@ -1100,10 +1131,10 @@ tpp_rdlock_rwlock(void *lock)
  *
  */
 int
-tpp_wrlock_rwlock(void *lock)
+tpp_write_lock(void *lock)
 {
 	if (pthread_rwlock_wrlock(lock) != 0) {
-		tpp_log_func(LOG_CRIT, __func__, "Failed to wrlock");
+		tpp_log(LOG_CRIT, __func__, "Failed to wrlock");
 		return 1;
 	}
 	return 0;
@@ -1128,7 +1159,7 @@ int
 tpp_unlock_rwlock(void *lock)
 {
 	if (pthread_rwlock_unlock(lock) != 0) {
-		tpp_log_func(LOG_CRIT, __func__, "Failed to unlock rw lock");
+		tpp_log(LOG_CRIT, __func__, "Failed to unlock rw lock");
 		return 1;
 	}
 	return 0;
@@ -1153,7 +1184,7 @@ int
 tpp_destroy_rwlock(void *lock)
 {
 	if (pthread_rwlock_destroy(lock) != 0) {
-		tpp_log_func(LOG_CRIT, __func__, "Failed to destroy rw lock");
+		tpp_log(LOG_CRIT, __func__, "Failed to destroy rw lock");
 		return 1;
 	}
 	return 0;
@@ -1424,34 +1455,36 @@ tpp_que_ins_elem(tpp_que_t *l, tpp_que_elem_t *n, void *data, int before)
 int
 tpp_send_ctl_msg(int fd, int code, tpp_addr_t *src, tpp_addr_t *dest, unsigned int src_sd, char err_num, char *msg)
 {
-	tpp_ctl_pkt_hdr_t lhdr;
-	tpp_chunk_t chunks[2];
+	tpp_ctl_pkt_hdr_t *lhdr = NULL;
+	tpp_packet_t *pkt = NULL;
 
 	/* send a packet back to where the original packet came from
 	 * basically reverse src and dest
 	 */
-	memset(&lhdr, 0, sizeof(tpp_ctl_pkt_hdr_t)); /* only to satisfy valgrind */
-	lhdr.type = TPP_CTL_MSG;
-	lhdr.code = code;
-	lhdr.src_sd = htonl(src_sd);
-	lhdr.error_num = err_num;
+	pkt = tpp_bld_pkt(NULL,  NULL, sizeof(tpp_ctl_pkt_hdr_t), 1, (void **) &lhdr);
+	if (!pkt) {
+		tpp_log(LOG_CRIT, __func__, "Failed to build packet");
+		return -1;
+	}
+	lhdr->type = TPP_CTL_MSG;
+	lhdr->code = code;
+	lhdr->src_sd = htonl(src_sd);
+	lhdr->error_num = err_num;
 	if (src)
-		memcpy(&lhdr.dest_addr, src, sizeof(tpp_addr_t));
-
+		memcpy(&lhdr->dest_addr, src, sizeof(tpp_addr_t));
 	if (dest)
-		memcpy(&lhdr.src_addr, dest, sizeof(tpp_addr_t));
-
+		memcpy(&lhdr->src_addr, dest, sizeof(tpp_addr_t));
 	if (msg == NULL)
 		msg = "";
+	
+	if (!tpp_bld_pkt(pkt, msg, strlen(msg) + 1, 1, NULL)) {
+		tpp_log(LOG_CRIT, __func__, "Failed to build packet");
+		return -1;
+	}
 
-	chunks[0].data = &lhdr;
-	chunks[0].len = sizeof(tpp_ctl_pkt_hdr_t);
-	chunks[1].data = msg;
-	chunks[1].len = strlen(msg) + 1;
-
-	TPP_DBPRT(("Sending CTL PKT: sd=%d, msg=%s", src_sd, msg));
-	if (tpp_transport_vsend(fd, chunks, 2) != 0) {
-		tpp_log_func(LOG_CRIT, __func__, "tpp_transport_vsend failed");
+	TPP_DBPRT("Sending CTL PKT: sd=%d, msg=%s", src_sd, msg);
+	if (tpp_transport_vsend(fd, pkt) != 0) {
+		tpp_log(LOG_CRIT, __func__, "tpp_transport_vsend failed");
 		return -1;
 	}
 	return 0;
@@ -1575,7 +1608,7 @@ tpp_get_tls()
  *
  */
 char *
-tpp_get_logbuf()
+tpp_get_staticbuf()
 {
 	tpp_tls_t *ptr;
 
@@ -1585,7 +1618,7 @@ tpp_get_logbuf()
 		return NULL;
 	}
 
-	return ptr->tpplogbuf;
+	return ptr->tppstaticbuf;
 }
 
 #ifdef PBS_COMPRESSION_ENABLED
@@ -1621,16 +1654,13 @@ tpp_multi_deflate_init(int initial_len)
 	int ret;
 	struct def_ctx *ctx = malloc(sizeof(struct def_ctx));
 	if (!ctx) {
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Out of memory allocating context buffer %lu bytes",
-			sizeof(struct def_ctx));
-		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+		tpp_log(LOG_CRIT, __func__, "Out of memory allocating context buffer %lu bytes", sizeof(struct def_ctx));
 		return NULL;
 	}
 
 	if ((ctx->cmpr_buf = malloc(initial_len)) == NULL) {
 		free(ctx);
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Out of memory allocating deflate buffer %d bytes", initial_len);
-		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+		tpp_log(LOG_CRIT, __func__, "Out of memory allocating deflate buffer %d bytes", initial_len);
 		return NULL;
 	}
 
@@ -1642,7 +1672,7 @@ tpp_multi_deflate_init(int initial_len)
 	if (ret != Z_OK) {
 		free(ctx->cmpr_buf);
 		free(ctx);
-		tpp_log_func(LOG_CRIT, __func__, "Multi compression init failed");
+		tpp_log(LOG_CRIT, __func__, "Multi compression init failed");
 		return NULL;
 	}
 
@@ -1692,8 +1722,7 @@ tpp_multi_deflate_do(void *c, int fini, void *inbuf, unsigned int inlen)
 			ctx->len = ctx->len * 2;
 			p = realloc(ctx->cmpr_buf, ctx->len);
 			if (!p) {
-				snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Out of memory allocating deflate buffer %d bytes", ctx->len);
-				tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+				tpp_log(LOG_CRIT, __func__, "Out of memory allocating deflate buffer %d bytes", ctx->len);
 				deflateEnd(&ctx->cmpr_strm);
 				free(ctx->cmpr_buf);
 				free(ctx);
@@ -1709,7 +1738,7 @@ tpp_multi_deflate_do(void *c, int fini, void *inbuf, unsigned int inlen)
 		deflateEnd(&ctx->cmpr_strm);
 		free(ctx->cmpr_buf);
 		free(ctx);
-		tpp_log_func(LOG_CRIT, __func__, "Multi compression step failed");
+		tpp_log(LOG_CRIT, __func__, "Multi compression step failed");
 		return -1;
 	}
 	return 0;
@@ -1745,7 +1774,7 @@ tpp_multi_deflate_done(void *c, unsigned int *cmpr_len)
 	free(ctx);
 	if (ret != Z_OK) {
 		free(data);
-		tpp_log_func(LOG_CRIT, __func__, "Compression cleanup failed");
+		tpp_log(LOG_CRIT, __func__, "Compression cleanup failed");
 		return NULL;
 	}
 	return data;
@@ -1782,7 +1811,7 @@ tpp_deflate(void *inbuf, unsigned int inlen, unsigned int *outlen)
 	strm.opaque = Z_NULL;
 	ret = deflateInit(&strm, Z_DEFAULT_COMPRESSION);
 	if (ret != Z_OK) {
-		tpp_log_func(LOG_CRIT, __func__, "Compression failed");
+		tpp_log(LOG_CRIT, __func__, "Compression failed");
 		return NULL;
 	}
 
@@ -1795,8 +1824,7 @@ tpp_deflate(void *inbuf, unsigned int inlen, unsigned int *outlen)
 	data = malloc(len);
 	if (!data) {
 		deflateEnd(&strm);
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Out of memory allocating deflate buffer %d bytes", len);
-		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+		tpp_log(LOG_CRIT, __func__, "Out of memory allocating deflate buffer %d bytes", len);
 		return NULL;
 	}
 
@@ -1816,8 +1844,7 @@ tpp_deflate(void *inbuf, unsigned int inlen, unsigned int *outlen)
 			if (!p) {
 				deflateEnd(&strm);
 				free(data);
-				snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Out of memory allocating deflate buffer %d bytes", len);
-				tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+				tpp_log(LOG_CRIT, __func__, "Out of memory allocating deflate buffer %d bytes", len);
 				return NULL;
 			}
 			data = p;
@@ -1829,7 +1856,7 @@ tpp_deflate(void *inbuf, unsigned int inlen, unsigned int *outlen)
 	deflateEnd(&strm); /* clean up */
 	if (ret != Z_STREAM_END) {
 		free(data);
-		tpp_log_func(LOG_CRIT, __func__, "Compression failed");
+		tpp_log(LOG_CRIT, __func__, "Compression failed");
 		return NULL;
 	}
 	filled = (char *) strm.next_out - (char *) data;
@@ -1839,8 +1866,7 @@ tpp_deflate(void *inbuf, unsigned int inlen, unsigned int *outlen)
 		p = realloc(data, filled);
 		if (!p) {
 			free(data);
-			snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Out of memory allocating deflate buffer %d bytes", filled);
-			tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+			tpp_log(LOG_CRIT, __func__, "Out of memory allocating deflate buffer %d bytes", filled);
 			return NULL;
 		}
 		data = p;
@@ -1876,8 +1902,7 @@ tpp_inflate(void *inbuf, unsigned int inlen, unsigned int totlen)
 	 */
 	outbuf = malloc(totlen > inlen ? totlen:inlen);
 	if (!outbuf) {
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Out of memory allocating inflate buffer %d bytes", totlen);
-		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+		tpp_log(LOG_CRIT, __func__, "Out of memory allocating inflate buffer %d bytes", totlen);
 		return NULL;
 	}
 
@@ -1890,8 +1915,7 @@ tpp_inflate(void *inbuf, unsigned int inlen, unsigned int totlen)
 	ret = inflateInit(&strm);
 	if (ret != Z_OK) {
 		free(outbuf);
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Decompression Init (inflateInit) failed, ret = %d", ret);
-		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+		tpp_log(LOG_CRIT, __func__, "Decompression Init (inflateInit) failed, ret = %d", ret);
 		return NULL;
 	}
 
@@ -1906,8 +1930,7 @@ tpp_inflate(void *inbuf, unsigned int inlen, unsigned int totlen)
 	inflateEnd(&strm);
 	if (ret != Z_STREAM_END) {
 		free(outbuf);
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Decompression (inflate) failed, ret = %d", ret);
-		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+		tpp_log(LOG_CRIT, __func__, "Decompression (inflate) failed, ret = %d", ret);
 		return NULL;
 	}
 	return outbuf;
@@ -1916,35 +1939,35 @@ tpp_inflate(void *inbuf, unsigned int inlen, unsigned int totlen)
 void *
 tpp_multi_deflate_init(int initial_len)
 {
-	tpp_log_func(LOG_CRIT, __func__, "TPP compression disabled");
+	tpp_log(LOG_CRIT, __func__, "TPP compression disabled");
 	return NULL;
 }
 
 int
 tpp_multi_deflate_do(void *c, int fini, void *inbuf, unsigned int inlen)
 {
-	tpp_log_func(LOG_CRIT, __func__, "TPP compression disabled");
+	tpp_log(LOG_CRIT, __func__, "TPP compression disabled");
 	return -1;
 }
 
 void *
 tpp_multi_deflate_done(void *c, unsigned int *cmpr_len)
 {
-	tpp_log_func(LOG_CRIT, __func__, "TPP compression disabled");
+	tpp_log(LOG_CRIT, __func__, "TPP compression disabled");
 	return NULL;
 }
 
 void *
 tpp_deflate(void *inbuf, unsigned int inlen, unsigned int *outlen)
 {
-	tpp_log_func(LOG_CRIT, __func__, "TPP compression disabled");
+	tpp_log(LOG_CRIT, __func__, "TPP compression disabled");
 	return NULL;
 }
 
 void *
 tpp_inflate(void *inbuf, unsigned int inlen, unsigned int totlen)
 {
-	tpp_log_func(LOG_CRIT, __func__, "TPP compression disabled");
+	tpp_log(LOG_CRIT, __func__, "TPP compression disabled");
 	return NULL;
 }
 #endif
@@ -1979,9 +2002,7 @@ tpp_validate_hdr(int tfd, char *pkt_start)
 			type != TPP_MCAST_DATA &&
 			type != TPP_ENCRYPTED_DATA &&
 			type != TPP_AUTH_CTX)) {
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ,
-				 "tfd=%d, Received invalid packet type with type=%d? data_len=%d", tfd, type, data_len);
-		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+		tpp_log(LOG_CRIT, __func__, "tfd=%d, Received invalid packet type with type=%d? data_len=%d", tfd, type, data_len);
 		return -1;
 	}
 	return 0;
@@ -2016,7 +2037,7 @@ tpp_get_addresses(char *names, int *count)
 
 	*count = 0;
 	if ((node_names = strdup(names)) == NULL) {
-		tpp_log_func(LOG_CRIT, __func__, "Out of memory allocating address block");
+		tpp_log(LOG_CRIT, __func__, "Out of memory allocating address block");
 		return NULL;
 	}
 
@@ -2038,7 +2059,7 @@ tpp_get_addresses(char *names, int *count)
 			if ((tmp = realloc(addrs, (tot_count + tmp_count) * sizeof(tpp_addr_t))) == NULL) {
 				free(addrs);
 				free(node_names);
-				tpp_log_func(LOG_CRIT, __func__, "Out of memory allocating address block");
+				tpp_log(LOG_CRIT, __func__, "Out of memory allocating address block");
 				return NULL;
 			}
 			addrs = tmp;
@@ -2089,19 +2110,17 @@ tpp_get_local_host(int sock)
 	socklen_t len = sizeof(struct sockaddr);
 
 	if (getsockname(sock, addr, &len) == -1) {
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Could not get name of peer for sock %d, errno=%d", sock, errno);
-		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+		tpp_log(LOG_CRIT, __func__, "Could not get name of peer for sock %d, errno=%d", sock, errno);
 		return NULL;
 	}
 	if (addr->sa_family != AF_INET && addr->sa_family != AF_INET6) {
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Bad address family for sock %d", sock);
-		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+		tpp_log(LOG_CRIT, __func__, "Bad address family for sock %d", sock);
 		return NULL;
 	}
 
 	taddr = calloc(1, sizeof(tpp_addr_t));
 	if (!taddr) {
-		tpp_log_func(LOG_CRIT, __func__, "Out of memory allocating address");
+		tpp_log(LOG_CRIT, __func__, "Out of memory allocating address");
 		return NULL;
 	}
 
@@ -2143,22 +2162,20 @@ tpp_get_connected_host(int sock)
 
 	if (getpeername(sock, addr, &len) == -1) {
 		if (errno == ENOTCONN)
-			snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Peer disconnected sock %d", sock);
+			tpp_log(LOG_CRIT, __func__, "Peer disconnected sock %d", sock);
 		else
-			snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Could not get name of peer for sock %d, errno=%d", sock, errno);
+			tpp_log(LOG_CRIT, __func__, "Could not get name of peer for sock %d, errno=%d", sock, errno);
 
-		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
 		return NULL;
 	}
 	if (addr->sa_family != AF_INET && addr->sa_family != AF_INET6) {
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Bad address family for sock %d", sock);
-		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+		tpp_log(LOG_CRIT, __func__, "Bad address family for sock %d", sock);
 		return NULL;
 	}
 
 	taddr = calloc(1, sizeof(tpp_addr_t));
 	if (!taddr) {
-		tpp_log_func(LOG_CRIT, __func__, "Out of memory allocating address");
+		tpp_log(LOG_CRIT, __func__, "Out of memory allocating address");
 		return NULL;
 	}
 
@@ -2269,10 +2286,7 @@ tpp_netaddr(tpp_addr_t *ap)
 char *
 tpp_netaddr_sa(struct sockaddr *sa)
 {
-	tpp_tls_t *ptr;
-	int len = TPP_LOGBUF_SZ;
-
-	ptr = tpp_get_tls();
+	tpp_tls_t *ptr = tpp_get_tls();
 	if (!ptr) {
 		fprintf(stderr, "Out of memory\n");
 		return NULL;
@@ -2280,12 +2294,12 @@ tpp_netaddr_sa(struct sockaddr *sa)
 	ptr->tppstaticbuf[0] = '\0';
 
 #ifdef WIN32
-	WSAAddressToString((LPSOCKADDR)&sa, sizeof(struct sockaddr), NULL, (LPSTR)&ptr->tppstaticbuf, &len);
+	WSAAddressToString((LPSOCKADDR)&sa, sizeof(struct sockaddr), NULL, (LPSTR)&ptr->tppstaticbuf, sizeof(ptr->tppstaticbuf));
 #else
 	if (sa->sa_family == AF_INET)
-		inet_ntop(sa->sa_family, &(((struct sockaddr_in *) sa)->sin_addr), ptr->tppstaticbuf, len);
+		inet_ntop(sa->sa_family, &(((struct sockaddr_in *) sa)->sin_addr), ptr->tppstaticbuf, sizeof(ptr->tppstaticbuf));
 	else
-		inet_ntop(sa->sa_family, &(((struct sockaddr_in6 *) sa)->sin6_addr), ptr->tppstaticbuf, len);
+		inet_ntop(sa->sa_family, &(((struct sockaddr_in6 *) sa)->sin6_addr), ptr->tppstaticbuf, sizeof(ptr->tppstaticbuf));
 #endif
 
 	return ptr->tppstaticbuf;
@@ -2333,6 +2347,74 @@ tpp_set_logmask(long logmask)
 	tpp_log_event_mask = logmask;
 }
 
+
+/**
+ * @brief encrypt the pkt  with the authdata provided
+ *
+ * @param[in] authdata - encryption information
+ * @param[in] pkt - packet of data
+ *
+ * @par MT-safe: No
+ **/
+int
+tpp_encrypt_pkt(conn_auth_t *authdata, tpp_packet_t *pkt)
+{
+	void *data_out = NULL;
+	size_t len_out = 0;
+	tpp_encrypt_hdr_t ehdr;
+	int totlen;
+	tpp_chunk_t *chunk;
+	tpp_chunk_t *first_chunk;
+
+	pkt->totlen = 0;
+	for (chunk = GET_NEXT(pkt->chunks); chunk; chunk = GET_NEXT(chunk->chunk_link)) {
+		if (authdata->encryptdef->encrypt_data(authdata->encryptctx, (void *) chunk->data, (size_t) chunk->len, &data_out, &len_out) != 0) {
+			return -1;
+		}
+
+		if (chunk->len > 0 && len_out <= 0) {
+			tpp_log(LOG_CRIT, __func__, "invalid encrypted data len: %d, pktlen: %d", (int) len_out, chunk->len);
+			return -1;
+		}
+
+		/* now replace the data with encrypted buffer */
+		free(chunk->data);
+		chunk->data = data_out;
+		chunk->len = len_out;
+		chunk->pos = chunk->data;
+
+		pkt->totlen += len_out;
+	}
+
+	/* now prepend with an unencrypted chunk about the encrypted data */
+	chunk = NULL;
+	chunk = malloc(sizeof(tpp_chunk_t));
+	if (chunk)
+		chunk->data = malloc(sizeof(int));
+	if (!chunk || !chunk->data) {
+		free(chunk);
+		tpp_log(LOG_CRIT, __func__, "Out of memory adding length chunk");
+		return -1;
+	}
+	chunk->pos = chunk->data;
+	CLEAR_LINK(chunk->chunk_link);
+	pkt->totlen += sizeof(tpp_encrypt_hdr_t); 
+	
+	totlen = htonl(pkt->totlen);
+	ehdr.ntotlen = totlen;
+	ehdr.type = TPP_ENCRYPTED_DATA;
+
+	memcpy(chunk->data, &ehdr, sizeof(tpp_encrypt_hdr_t));
+
+	first_chunk = GET_NEXT(pkt->chunks);
+
+	/* now prepend this chunk before other chunks */
+	insert_link(&first_chunk->chunk_link, &chunk->chunk_link, chunk, LINK_INSET_BEFORE);
+	pkt->curr_chunk = chunk;
+
+	return 0;
+}
+
 #ifdef DEBUG
 /*
  * Convenience function to print the packet header
@@ -2351,51 +2433,25 @@ print_packet_hdr(const char *fnc, void *data, int len)
 	char str_types[][20] = { "TPP_CTL_JOIN", "TPP_CTL_LEAVE", "TPP_DATA", "TPP_CTL_MSG", "TPP_CLOSE_STRM", "TPP_MCAST_DATA" };
 	unsigned char type = hdr->type;
 
-	if (!tpp_dbprt)
-		return;
-
-	printf("%ld:%x:%s: ", time(0), (int) pthread_self(), fnc);
 	if (type == TPP_CTL_JOIN) {
 		tpp_addr_t *addrs = (tpp_addr_t *) (((char *) data) + sizeof(tpp_join_pkt_hdr_t));
-		printf("%s message arrived from src_host = %s\n", str_types[type - 1], tpp_netaddr(addrs));
+		tpp_log(LOG_CRIT, __func__, "%s message arrived from src_host = %s\n", str_types[type - 1], tpp_netaddr(addrs));
 	} else if (type == TPP_CTL_LEAVE) {
 		tpp_addr_t *addrs = (tpp_addr_t *) (((char *) data) + sizeof(tpp_leave_pkt_hdr_t));
-		printf("%s message arrived from src_host = %s\n", str_types[type - 1], tpp_netaddr(addrs));
+		tpp_log(LOG_CRIT, __func__, "%s message arrived from src_host = %s\n", str_types[type - 1], tpp_netaddr(addrs));
 	} else if (type == TPP_MCAST_DATA) {
 		tpp_mcast_pkt_hdr_t *mhdr = (tpp_mcast_pkt_hdr_t *) data;
-		printf("%s message arrived from src_host = %s\n", str_types[type - 1], tpp_netaddr(&mhdr->src_addr));
+		tpp_log(LOG_CRIT, __func__,  "%s message arrived from src_host = %s\n", str_types[type - 1], tpp_netaddr(&mhdr->src_addr));
 	} else if ((type == TPP_DATA) || (type == TPP_CLOSE_STRM)) {
-		int seq_no_recvd, seq_no_acked;
-		unsigned char dup;
 		char buff[PATH_MAX+1];
 		tpp_data_pkt_hdr_t *dhdr = (tpp_data_pkt_hdr_t *) data;
 
-		seq_no_recvd = ntohl(dhdr->seq_no);
-		seq_no_acked = ntohl(dhdr->ack_seq);
-		dup = dhdr->dup;
-
 		strncpy(buff, tpp_netaddr(&dhdr->src_addr), sizeof(buff));
-		printf("%s: src_host=%s, dest_host=%s, len=%d, src_sd=%d", str_types[type - 1], buff, tpp_netaddr(&dhdr->dest_addr), len,
-			ntohl(dhdr->src_sd));
-
-		if (ntohl(dhdr->dest_sd) == UNINITIALIZED_INT)
-			printf(", dest_sd=NONE");
-		else
-			printf(", dest_sd=%d", ntohl(dhdr->dest_sd));
-
-		printf(", seq_no=%d", seq_no_recvd);
-		printf(", src_magic=%d", ntohl(dhdr->src_magic));
-
-		if (seq_no_acked == UNINITIALIZED_INT)
-			printf(", seq_no_acked=NONE");
-		else
-			printf(", seq_no_acked=%d", seq_no_acked);
-
-		printf(", dup=%d\n", dup);
+		tpp_log(LOG_CRIT, __func__, "%s: src_host=%s, dest_host=%s, len=%d, src_sd=%d, dest_sd=%d, src_magic=%d", str_types[type - 1], buff, tpp_netaddr(&dhdr->dest_addr), len,
+			ntohl(dhdr->src_sd), (ntohl(dhdr->dest_sd) == UNINITIALIZED_INT) ? -1 : ntohl(dhdr->dest_sd), ntohl(dhdr->src_magic));
 
 	} else {
-		printf("%s message arrived from src_host = %s\n", str_types[type - 1], tpp_netaddr(&hdr->src_addr));
+		tpp_log(LOG_CRIT, __func__, "%s message arrived from src_host = %s\n", str_types[type - 1], tpp_netaddr(&hdr->src_addr));
 	}
-	fflush(stdout);
 }
 #endif

--- a/src/lib/Libtpp/tpp_util.c
+++ b/src/lib/Libtpp/tpp_util.c
@@ -2221,13 +2221,13 @@ tpp_netaddr(tpp_addr_t *ap)
 		memcpy(&in.sin_addr, ap->ip, sizeof(in.sin_addr));
 		in.sin_family = AF_INET;
 		in.sin_port = 0;
-		len = TPP_LOGBUF_SZ;
+		len = LOG_BUF_SIZE;
 		WSAAddressToString((LPSOCKADDR) &in, sizeof(in), NULL, (LPSTR) &ptr->tppstaticbuf, &len);
 	} else if (ap->family == TPP_ADDR_FAMILY_IPV6) {
 		memcpy(&in6.sin6_addr, ap->ip, sizeof(in6.sin6_addr));
 		in6.sin6_family = AF_INET6;
 		in6.sin6_port = 0;
-		len = TPP_LOGBUF_SZ;
+		len = LOG_BUF_SIZE;
 		WSAAddressToString((LPSOCKADDR) &in6, sizeof(in6), NULL, (LPSTR) &ptr->tppstaticbuf, &len);
 	}
 #else

--- a/src/lib/Libutil/avltree.c
+++ b/src/lib/Libutil/avltree.c
@@ -126,7 +126,7 @@ typedef struct {
 
 static pthread_once_t avl_init_once = PTHREAD_ONCE_INIT;
 static pthread_key_t avl_tls_key;
-pthread_mutex_t tind_lock = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t tind_lock;
 
 #define MAX_AVLKEY_LEN 100
 
@@ -152,10 +152,15 @@ avl_set_maxthreads(int n)
  *
  */
 void
-avl_init_tls(void)
+avl_init_func(void)
 {
 	if (pthread_key_create(&avl_tls_key, NULL) != 0) {
 		fprintf(stderr, "avl tls key creation failed\n");
+	}
+
+	if (pthread_mutex_init(&tind_lock, NULL) != 0) {
+		fprintf(stderr, "avl mutex init failed\n");
+		return;
 	}
 }
 
@@ -189,7 +194,7 @@ get_avl_tls(void)
 {
 	avl_tls_t *p_avl_tls = NULL;
 
-	pthread_once(&avl_init_once, avl_init_tls);
+	pthread_once(&avl_init_once, avl_init_func);
 
 	if ((p_avl_tls = (avl_tls_t *) pthread_getspecific(avl_tls_key)) == NULL) {
 		p_avl_tls = (avl_tls_t *) calloc(1, sizeof(avl_tls_t));

--- a/src/lib/Libutil/avltree.c
+++ b/src/lib/Libutil/avltree.c
@@ -169,7 +169,7 @@ avl_init_func(void)
  *	return an unique thread index for each new thread
  *
  */
-short
+static short
 get_thread_index(void)
 {
 	static short tind = -1;

--- a/src/lib/Libutil/avltree.c
+++ b/src/lib/Libutil/avltree.c
@@ -94,7 +94,7 @@ typedef char way3; /* -1, 0, 1 */
 
 typedef struct _node {
 	struct _node *ptr[2]; /* left, right */
-	way3 balance, trace;
+	way3 balance, *trace;
 	rectype data;
 } node;
 
@@ -112,6 +112,7 @@ typedef struct _node {
 #define avltree_init(x) (*(x) = NULL)
 
 typedef struct {
+	short __tind; /* index of this thread */
 	int __ix_keylength;
 	int __ix_flags;    /* set from AVL_IX_DESC */
 	int __rec_keylength; /* set from actual key */
@@ -125,8 +126,25 @@ typedef struct {
 
 static pthread_once_t avl_init_once = PTHREAD_ONCE_INIT;
 static pthread_key_t avl_tls_key;
+pthread_mutex_t tind_lock = PTHREAD_MUTEX_INITIALIZER;
 
 #define MAX_AVLKEY_LEN 100
+
+/**
+ * Set max_threads to 2 by default since mom, server etc have basically 2 threads
+ * If caller has > 2 threads, e.g. pbs_comm, it must first call avl_set_maxthreads()
+ */
+static int max_threads = 2; 
+
+/**
+ * @brief set the max threads that the application uses, before any calls to avltree
+ * 
+ */
+void 
+avl_set_maxthreads(int n)
+{
+	max_threads = n;
+}
 
 /**
  * @brief
@@ -139,6 +157,23 @@ avl_init_tls(void)
 	if (pthread_key_create(&avl_tls_key, NULL) != 0) {
 		fprintf(stderr, "avl tls key creation failed\n");
 	}
+}
+
+/**
+ * @brief
+ *	return an unique thread index for each new thread
+ *
+ */
+short
+get_thread_index(void)
+{
+	static short tind = -1;
+	short retval;
+	
+	pthread_mutex_lock(&tind_lock);
+	retval = ++tind;
+	pthread_mutex_unlock(&tind_lock);
+	return retval;
 }
 
 /**
@@ -162,12 +197,14 @@ get_avl_tls(void)
 			fprintf(stderr, "Out of memory creating avl_tls\n");
 			return NULL;
 		}
+		p_avl_tls->__tind = get_thread_index();
 		p_avl_tls->__node_overhead = sizeof(node) - AVL_DEFAULTKEYLEN;
 		pthread_setspecific(avl_tls_key, (void *) p_avl_tls);
 	}
 	return p_avl_tls;
 }
 
+#define tind             (((avl_tls_t *) get_avl_tls())->__tind)
 #define ix_keylength  (((avl_tls_t *) get_avl_tls())->__ix_keylength)
 #define ix_flags   (((avl_tls_t *) get_avl_tls())->__ix_flags)
 #define rec_keylength (((avl_tls_t *) get_avl_tls())->__rec_keylength)
@@ -201,6 +238,8 @@ way3opp2(way3 x, way3 y)
 static void
 freenode(node *n)
 {
+	if (n)
+		free(n->trace);
 	free(n);
 }
 
@@ -273,6 +312,12 @@ allocnode()
 	}
 	if (ix_flags & AVL_DUP_KEYS_OK)
 		n->data.count = 1;
+
+	n->trace = calloc(max_threads, sizeof(way3));
+	if (n->trace == NULL) {
+		fprintf(stderr, "avltrees: out of memory\n");
+		return NULL;
+	}
 	return n;
 }
 
@@ -369,24 +414,24 @@ avltree_search(node **tt, rectype *key, unsigned short searchflags)
 	wayopp = way3opp(waydir);
 	p = q = NULL;
 	while ((pp = *tt) != NULL) {
-		aa = searchflags & SRF_FROMMARK ? pp->trace : makeway3(compkey(key, &(pp->data)));
+		aa = searchflags & SRF_FROMMARK ? pp->trace[tind] : makeway3(compkey(key, &(pp->data)));
 		if (searchflags & SRF_SETMARK)
-			pp->trace = aa;
+			pp->trace[tind] = aa;
 		if (aa == way3stop) {
 			if (searchflags & SRF_FINDEQUAL)
 				return &(pp->data);
 			if ((q = stepway(pp, waydir)) == NULL)
 				break;
 			if (searchflags & SRF_SETMARK)
-				pp->trace = waydir;
+				pp->trace[tind] = waydir;
 			while (1) {
 				if ((pp = stepway(q, wayopp)) == NULL) {
 					if (searchflags & SRF_SETMARK)
-						q->trace = way3stop;
+						q->trace[tind] = way3stop;
 					return &(q->data);
 				}
 				if (searchflags & SRF_SETMARK)
-					q->trace = wayopp;
+					q->trace[tind] = wayopp;
 				q = pp;
 			}
 		}
@@ -398,7 +443,7 @@ avltree_search(node **tt, rectype *key, unsigned short searchflags)
 	if (p == NULL || !(searchflags & (SRF_FINDLESS | SRF_FINDGREAT)))
 		return NULL;
 	if (searchflags & SRF_SETMARK)
-		p->trace = way3stop;
+		p->trace[tind] = way3stop;
 	return &(p->data);
 }
 
@@ -415,7 +460,7 @@ avltree_first(node **tt)
 {
 	node *pp;
 	while ((pp = *tt) != NULL) {
-		pp->trace = way3left;
+		pp->trace[tind] = way3left;
 		tt = &stepway(pp, way3left);
 	}
 }
@@ -447,21 +492,21 @@ avltree_insert(node **tt, rectype *key)
 		}
 		if (pp->balance != way3stop)
 			avl_t = tt; /* t-> the last disbalanced node */
-		pp->trace = aa;
+		pp->trace[tind] = aa;
 		tt = &stepway(pp, aa);
 	}
 	*tt = q = allocnode();
-	q->balance = q->trace = way3stop;
+	q->balance = q->trace[tind] = way3stop;
 	stepway(q, way3left) = stepway(q, way3right) = NULL;
 	key->count = 1;
 	copydata(&(q->data), key);
 	/* balancing */
 	avl_s = *avl_t;
-	avl_wayhand = avl_s->trace;
+	avl_wayhand = avl_s->trace[tind];
 	if (avl_wayhand != way3stop) {
 		avl_r = stepway(avl_s, avl_wayhand);
 		for (p = avl_r; p != NULL; p = stepway(p, b))
-			b = p->balance = p->trace;
+			b = p->balance = p->trace[tind];
 		b = avl_s->balance;
 		if (b != avl_wayhand)
 			avl_s->balance = way3sum(avl_wayhand, b);
@@ -496,7 +541,7 @@ avltree_delete(node **tt, rectype *key, unsigned short searchflags)
 	aaa = way3stop;
 
 	while ((pp = *tt) != NULL) {
-		aa = aaa != way3stop ? aaa : searchflags & SRF_FROMMARK ? pp->trace : makeway3(compkey(key, &(pp->data)));
+		aa = aaa != way3stop ? aaa : searchflags & SRF_FROMMARK ? pp->trace[tind] : makeway3(compkey(key, &(pp->data)));
 		b = pp->balance;
 		if (aa == way3stop) {
 			qq1 = tt;
@@ -510,23 +555,23 @@ avltree_delete(node **tt, rectype *key, unsigned short searchflags)
 			t1 = tt;
 		tt1 = tt;
 		tt = &stepway(pp, aa);
-		pp->trace = aa;
+		pp->trace[tind] = aa;
 	}
 	if (aaa == way3stop)
 		return NULL;
 	copydata(key, &(q->data));
 	p = *tt1;
-	*tt1 = p1 = stepopp(p, p->trace);
+	*tt1 = p1 = stepopp(p, p->trace[tind]);
 	if (p != q) {
 		*qq1 = p;
 		memcpy(p->ptr, q->ptr, sizeof(p->ptr));
 		p->balance = q->balance;
-		avl_wayhand = p->trace = q->trace;
+		avl_wayhand = p->trace[tind] = q->trace[tind];
 		if (avl_t == &stepway(q, avl_wayhand))
 			avl_t = &stepway(p, avl_wayhand);
 	}
 	while ((avl_s = *avl_t) != p1) {
-		avl_wayhand = way3opp(avl_s->trace);
+		avl_wayhand = way3opp(avl_s->trace[tind]);
 		b = avl_s->balance;
 		if (b != avl_wayhand) {
 			avl_s->balance = way3sum(avl_wayhand, b);
@@ -543,7 +588,7 @@ avltree_delete(node **tt, rectype *key, unsigned short searchflags)
 	while ((p = *rr) != NULL) {
 		/* adjusting trace */
 		aa = makeway3(compkey(&(q->data), &(p->data)));
-		p->trace = aa;
+		p->trace[tind] = aa;
 		rr = &stepway(p, aa);
 	}
 	freenode(q);

--- a/src/resmom/catch_child.c
+++ b/src/resmom/catch_child.c
@@ -874,6 +874,10 @@ send_hellosvr(int stream)
 	int		rc = 0;
 	char		*svr = NULL;
 	unsigned int	port = default_server_port;
+	extern int     mom_net_up;
+
+	if (mom_net_up == 0)
+		return;
 
 	if (stream < 0) {
 		if ((svr = get_servername_random(&port)) == NULL) {

--- a/src/resmom/catch_child.c
+++ b/src/resmom/catch_child.c
@@ -903,7 +903,7 @@ send_hellosvr(int stream)
 	server_stream = stream;
 
 	if (svr)
-		sprintf(log_buffer, "HELLO sent to server at %s:%d", svr, port);
+		sprintf(log_buffer, "HELLO sent to server at %s:%d, stream:%d", svr, port, stream);
 	else
 		sprintf(log_buffer, "HELLO sent to server at stream:%d", stream);
 	log_event(PBSEVENT_SYSTEM, PBS_EVENTCLASS_SERVER, LOG_NOTICE,

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -8197,7 +8197,7 @@ main(int argc, char *argv[])
 #ifndef	WIN32
 	initialize();		/* init RM code */
 #endif
-	/* set tpp config */
+
 	rc = set_tpp_config(&pbs_conf, &tpp_conf, nodename, pbs_rm_port, pbs_conf.pbs_leaf_routers);
 	free(nodename);
 

--- a/src/server/mom_info.c
+++ b/src/server/mom_info.c
@@ -91,7 +91,7 @@ static char merr[] = "malloc failed";
 
 mominfo_t **mominfo_array = NULL;
 int         mominfo_array_size = 0;     /* num entries in the array */
-mominfo_time_t  mominfo_time = {0, 0};	/* time stamp of mominfo update */
+mominfo_time_t  mominfo_time = {0};	/* time stamp of mominfo update */
 int	    svr_num_moms = 0;
 vnpool_mom_t    *vnode_pool_mom_list = NULL;
 

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -271,38 +271,6 @@ tinsert2(const u_long key1, const u_long key2, mominfo_t *momp, struct tree **ro
 }
 
 /**
- * @brief In case of TPP multicast mode, this function flushes IS_NULL data to be sent out
- * 	to all the moms
- *
- * @param[in] mtfd - The TPP multicast channel to flush
- * @param[in] combine_msg - message will be combined in the caller.
- *
- */
-static int
-send_rpp_values(int mtfd, int combine_msg)
-{
-	int	ret;
-
-	DBPRT(("%s: entered\n", __func__))
-
-	if (mtfd < 0)
-		return -1;
-
-	if (!combine_msg)
-		if ((ret = is_compose(mtfd, IS_NULL)) != DIS_SUCCESS)
-			return ret;
-
-	if ((ret = diswsi(mtfd, rpp_retry)) != DIS_SUCCESS)
-		return ret;
-	if ((ret = diswsi(mtfd, rpp_highwater)) != DIS_SUCCESS)
-		return ret;
-
-	if (!combine_msg)
-		return dis_flush(mtfd);
-	return 0;
-}
-
-/**
  * @brief Send the IS_CLUSTER_ADDRS message to Mom so she has the
  *      latest list of IP addresses of the all the Moms in the complex.
  *
@@ -378,8 +346,6 @@ reply_hellosvr(int stream, int need_inv)
 		return ret;
 
 	if ((ret = diswsi(stream, need_inv)) != DIS_SUCCESS)
-		return ret;
-	if ((ret = send_rpp_values(stream, 1)) != DIS_SUCCESS)
 		return ret;
 
 	if (msvr_mode()) {
@@ -3157,18 +3123,6 @@ mcast_moms(struct work_task *ptask)
 
 	switch (cmd)
 	{
-		case IS_NULL:
-			for (i = 0; i < mominfo_array_size; i++) {
-				if (mominfo_array[i])
-					add_mom_mcast(mominfo_array[i], &mtfd);
-			}
-
-			if ((ret = send_rpp_values(mtfd, 0)) != DIS_SUCCESS)
-				close_streams(mtfd, ret);
-
-			tpp_mcast_close(mtfd);
-			break;
-
 		case IS_CLUSTER_ADDRS:
 			for (i = 0; i < mominfo_array_size; i++) {
 

--- a/src/server/pbs_db_func.c
+++ b/src/server/pbs_db_func.c
@@ -449,7 +449,9 @@ connect_to_db(int background) {
 	int db_stop_counts = 0;
 	int db_stop_email_sent = 0;
 	int conn_state;
+#ifndef DEBUG
 	pid_t sid = -1;
+#endif
 	int db_delay = 0;
 try_db_again:
 	fprintf(stdout, "Connecting to PBS dataservice.");

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -208,8 +208,7 @@ int tpp_network_up = 0;
 void
 net_restore_handler(void *data)
 {
-	if (tpp_log_func)
-		tpp_log_func(LOG_INFO, NULL, "net restore handler called");
+	log_event(PBSEVENT_ERROR | PBSEVENT_FORCE, PBS_EVENTCLASS_SERVER, LOG_ALERT,  __func__, "net restore handler called");
 	tpp_network_up = 1;
 }
 
@@ -228,8 +227,7 @@ net_down_handler(void *data)
 	if (tpp_network_up == 1) {
 		tpp_network_up = 0;
 		/* now loop and set all nodes to down */
-		if (tpp_log_func)
-			tpp_log_func(LOG_CRIT, NULL, "marking all nodes unknown");
+		log_event(PBSEVENT_ERROR | PBSEVENT_FORCE, PBS_EVENTCLASS_SERVER, LOG_ALERT, __func__, "marking all nodes unknown");
 		mark_nodes_unknown(1);
 	}
 }
@@ -1196,7 +1194,7 @@ main(int argc, char **argv)
 	}
 
 	/* set tpp config */
-	rc = set_tpp_config(NULL, &pbs_conf, &tpp_conf, nodename, pbs_server_port_dis, pbs_conf.pbs_leaf_routers);
+	rc = set_tpp_config(&pbs_conf, &tpp_conf, nodename, pbs_server_port_dis, pbs_conf.pbs_leaf_routers);
 	free(nodename);
 	if (rc == -1) {
 		(void) sprintf(log_buffer, "Error setting TPP config");

--- a/src/server/svr_func.c
+++ b/src/server/svr_func.c
@@ -622,9 +622,10 @@ action_reserve_retry_init(attribute *pattr, void *pobj, int actmode)
 	return PBSE_NONE;
 }
 
+
 /**
  * @brief
- * 		set_rpp_retry - action routine for the server's "rpp_retry" attribute.
+ * 		dummy action function for rpp_retry
  *
  * @param[in]	pattr	-	pointer to attribute structure
  * @param[in]	pobj	-	not used
@@ -637,38 +638,13 @@ action_reserve_retry_init(attribute *pattr, void *pobj, int actmode)
 int
 set_rpp_retry(attribute *pattr, void *pobj, int actmode)
 {
-	int old_rpp_retry = rpp_retry;
-
-	if (actmode == ATR_ACTION_ALTER ||
-		actmode == ATR_ACTION_RECOV) {
-		/*
-		 ** rpp_retry can be zero, i.e. no retries.
-		 */
-		if (pattr->at_val.at_long < 0)
-			return PBSE_BADATVAL;
-
-		rpp_retry = (int)pattr->at_val.at_long;
-		if (rpp_retry < 10) {
-			sprintf(log_buffer,
-				"warning: low value for rpp_retry: %d",
-				rpp_retry);
-			log_event(PBSEVENT_ADMIN, PBS_EVENTCLASS_SERVER,
-				LOG_DEBUG, msg_daemonname, log_buffer);
-		}
-	}
-
-	if (actmode == ATR_ACTION_ALTER && old_rpp_retry != rpp_retry) {
-		struct work_task *ptask = set_task(WORK_Immed, 0, mcast_moms, NULL);
-		ptask->wt_aux = IS_NULL;
-	}
-
+	log_err(-1, __func__, "rpp_retry is deprecated. This functionality is now automatic without needing this attribute");
 	return PBSE_NONE;
 }
 
 /**
  * @brief
- * 		set_rpp_highwater - action routine for the server's "rpp_highwater"
- * 		attribute.
+ * 		dummy action function for rpp_highwater
  *
  * @param[in]	pattr	-	pointer to attribute structure
  * @param[in]	pobj	-	not used
@@ -681,29 +657,9 @@ set_rpp_retry(attribute *pattr, void *pobj, int actmode)
 int
 set_rpp_highwater(attribute *pattr, void *pobj, int actmode)
 {
-	int old_rpp_highwater = rpp_highwater;
-
-	if (actmode == ATR_ACTION_ALTER ||
-		actmode == ATR_ACTION_RECOV) {
-		/*
-		 ** rpp_highwater must be greater than zero.
-		 ** It is the number of packets allowed to be "on the wire"
-		 ** at any given time.
-		 */
-		if (pattr->at_val.at_long <= 0)
-			return PBSE_BADATVAL;
-
-		rpp_highwater = (int)pattr->at_val.at_long;
-	}
-
-	if (actmode == ATR_ACTION_ALTER && old_rpp_highwater != rpp_highwater) {
-		struct work_task *ptask = set_task(WORK_Immed, 0, mcast_moms, NULL);
-		ptask->wt_aux = IS_NULL;
-	}
-
+	log_err(-1, __func__, "rpp_highwater is deprecated. This functionality is now automatic without needing this attribute");
 	return PBSE_NONE;
 }
-
 
 /**
  * @brief

--- a/src/tools/pbsTclInit.c
+++ b/src/tools/pbsTclInit.c
@@ -72,14 +72,6 @@ extern	int	quiet;
 extern	void	add_cmds(Tcl_Interp *interp);
 
 #define SHOW_NONE 0xff
-int log_mask;
-
-void
-log_tppmsg(int level, const char *objname, char *mess)
-{
-	if ((level | log_mask) <= LOG_ERR)
-		fprintf(stderr, "tpp error: %s\n", mess);
-}
 
 /**
  * @brief
@@ -166,13 +158,8 @@ main(int argc, char *argv[])
 		}
 	}
 
-	/* We don't want to show logs related to connecting pbs_comm on console
-		* this set this flag to ignore it
-		*/
-	log_mask = SHOW_NONE;
-
 	/* call tpp_init */
-	rc = set_tpp_config(log_tppmsg, &pbs_conf, &tpp_conf, pbs_conf.pbs_leaf_name, -1, pbs_conf.pbs_leaf_routers);
+	rc = set_tpp_config(&pbs_conf, &tpp_conf, pbs_conf.pbs_leaf_name, -1, pbs_conf.pbs_leaf_routers);
 	if (rc == -1) {
 		fprintf(stderr, "Error setting TPP config\n");
 		return -1;
@@ -194,8 +181,6 @@ main(int argc, char *argv[])
 
 	tpp_poll(); /* to clear off the read notification */
 
-	/* Once the connection is established we can unset log_mask */
-	log_mask &= ~SHOW_NONE;
 	Tcl_Main(argc, argv, pbsTcl_Init);
 	return 0;
 }

--- a/src/unsupported/pbs_rmget.c
+++ b/src/unsupported/pbs_rmget.c
@@ -50,14 +50,6 @@
 #include "log.h"
 
 #define SHOW_NONE 0xff
-int log_mask;
-
-static void
-log_tppmsg(int level, const char *objname, char *mess)
-{
-	if ((level | log_mask) <= LOG_ERR)
-		fprintf(stderr, "tpp error: %s\n", mess);
-}
 
 int
 main(int argc, char *argv[])
@@ -126,13 +118,8 @@ main(int argc, char *argv[])
 		}
 	}
 
-	/* We don't want to show logs related to connecting pbs_comm on console
-		* this set this flag to ignore it
-		*/
-	log_mask = SHOW_NONE;
-
 	/* call tpp_init */
-	rc = set_tpp_config(log_tppmsg, &pbs_conf, &tpp_conf, pbs_conf.pbs_leaf_name, -1, pbs_conf.pbs_leaf_routers);
+	rc = set_tpp_config(&pbs_conf, &tpp_conf, pbs_conf.pbs_leaf_name, -1, pbs_conf.pbs_leaf_routers);
 	if (rc == -1) {
 		fprintf(stderr, "Error setting TPP config\n");
 		return -1;
@@ -153,9 +140,6 @@ main(int argc, char *argv[])
 	select(FD_SETSIZE, &selset, NULL, NULL, &tv);
 
 	tpp_poll(); /* to clear off the read notification */
-
-	/* Once the connection is established we can unset log_mask */
-	log_mask &= ~SHOW_NONE;
 
 	/* get the FQDN of the mom */
 	c = get_fullhostname(mom_name, mom_name, (sizeof(mom_name) - 1));


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
TPP networking layer had a lot of difficult to maintain and complicated code to support seamless backup transmission circuits. This functionality of a backup circuit is necessary for failover and resilience, but the way it is implemented in TPP currently is an overkill. TPP attempts to continue transmitting and receiving data for a stream seamlessly over multiple circuits. After the addition of features in PBS mom where jobs are no longer killed if network is temporarily down, such sophistication and complication is not required. When a connection breaks, TPP can close streams over those connections (unlike before) and the the users (mom, server etc) can re-open the required streams over the backup circuits (in lieu of never seeing the stream going down before)


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
The TPP framework had a lot of code to handle data for the same stream being transmitted over multiple circuits, and hence needed to sequence packets, keep packets at source for retransmission, and send and receive acks for packets. This was duplicate function on top of the similar functionality provided by TCP (which TPP uses underneath anyway) and was required only because the design goal was to never close the stream if an alternate circuit was available. However, since there is no practical impact/harm of closing the stream and allowing the application layer (mom, server) to re-open those same streams as and when required, we can remove the code related to packet acks retries etc.

Since the layer will now directly only use the TCP functionality, rpp_retry and rpp_highwater has no effect on the TPP streams. These values, if set, will be silently ignored (qmgr will not error if admin attempts to set these values - however a log warning that these switches are deprecated will be printed in the server logs)

Another significant change done is to the way the pbs_comm router works. Eariler we had only a mutex to go over the shared avltree tables that mapped destination IPs to comm routers. This synchronization mechanism is now changed to use pthread rwlocks where multiple readers can simultaneously traverse the avltrees, without needing to wait for each other. Minor changes were done to the avltree implementation to support the same as well.

While we are simplifying things, the logging related mutexes and fork handlers were simplified as well. The atfork() handlers do not need to do all that it was doing - primarily because, we know that only the APP thread (the pbs daemons thread) call fork, ever. The TPP thread would never called fork. When fork() is called, only the calling thread is duplicated in the child process, but the entire heap is copied over. This means locks, if held by the TPP thread would be copied over to the child process in "locked" state and can never be unlocked (because the TPP thread is dead, and nobody else can unlock a lock that is acquired by a different thread). The atfork handlers exist were there to allow the APP thread to acquire the mutex, so that the child can actually safely unlock it in the APP thread. However, no TPP functionality is called after a fork in the child, so only the logging needs to be handled. Thus only the pbs_log.c will have atfork handlers.

The tpp_log() function is also simplified to no longer need a TLS based buffer, now using only a stack based buffer. This also means that there is no need to register a logger function with the tpp layer.  


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Description: Tests from given sources on platforms SUSE15, CENTOS8
Platforms: SUSE15,CENTOS8
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|5306|1927|1|1|0|0|1925|



Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, WIN2K16
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|5310|3842|5|0|0|0|3837|


The failures are known test/product issues for which bugs have been raised earlier.


### Hellgrind thread race detection tests
PBS_CONF_FILE=$conf_file valgrind --tool=helgrind --log-file=/tmp/mom_hellgrind.txt $i ${PBS_EXEC}/sbin/pbs_mom -N > /tmp/mom$i.out 2>&1 &
[mom_hellgrind.txt](https://github.com/openpbs/openpbs/files/5693693/mom_hellgrind.txt)

/usr/bin/valgrind.bin --tool=helgrind --log-file=./comm_hellgrind.txt pbs_comm -t 20
[comm_hellgrind.txt](https://github.com/openpbs/openpbs/files/5693724/comm_hellgrind.txt)

 valgrind --tool=helgrind --log-file=./server_hellgrind.txt pbs_server.bin
[server_hellgrind.txt](https://github.com/openpbs/openpbs/files/5693729/server_hellgrind.txt)

### Valgring memory error detection run results
[val_comm_74873.txt](https://github.com/openpbs/openpbs/files/5719336/val_comm_74873.txt)
[val_mom_79435.txt](https://github.com/openpbs/openpbs/files/5719337/val_mom_79435.txt)
[val_svr_79453.txt](https://github.com/openpbs/openpbs/files/5719338/val_svr_79453.txt)


### Failover tests output
Steps:
1. Configure a failover setup with a primary pbs server host/container, a secondary pbs server host/container and a separate mom container. The primary and the secondary hosts/containers share the PBS_HOME over a shared FS
2. Submit a long running job that starts running on the mom
3. Kill only the primary server process. Observe, that job is not killed, mom reconnects to secondary pbs server, but via the primary comm (primary comm keeps logging)
4. Reverse the test: Bring back primary server and kill only the primary comm. Observe that job is not killed, mom drops connection for a moment but reconnects to server via the secondary comm and continues normally
5. Kill the secondary comm as well. Notice that mom loses connections to server, but does not kill job.
6. Bring up primary/secondary comm (any one): Notice that mom reconnects back and works normally
[server.log](https://github.com/openpbs/openpbs/files/5693942/server.log)
[comm.log](https://github.com/openpbs/openpbs/files/5693943/comm.log)
[mom.log](https://github.com/openpbs/openpbs/files/5693946/mom.log)


### TPP regression automation tests output

[Execution_logs_TestTPP_2moms_2comms.txt](https://github.com/openpbs/openpbs/files/5719134/Execution_logs_TestTPP_2moms_2comms.txt)
[iso_pool2.txt](https://github.com/openpbs/openpbs/files/5719135/iso_pool2.txt)
[TestTPP_2moms.txt](https://github.com/openpbs/openpbs/files/5719137/TestTPP_2moms.txt)
[TestTPP_3moms_3comms.txt](https://github.com/openpbs/openpbs/files/5719138/TestTPP_3moms_3comms.txt)
[TestTPP_3rdfromlast.txt](https://github.com/openpbs/openpbs/files/5719139/TestTPP_3rdfromlast.txt)
[TestTPP_5comms.txt](https://github.com/openpbs/openpbs/files/5719140/TestTPP_5comms.txt)
[TestTPP_client_only.txt](https://github.com/openpbs/openpbs/files/5719407/TestTPP_client_only.txt)
[TestTPP_mom_nonserver_2.txt](https://github.com/openpbs/openpbs/files/5719408/TestTPP_mom_nonserver_2.txt)
[TestTPP_nonserver1.txt](https://github.com/openpbs/openpbs/files/5719409/TestTPP_nonserver1.txt)
[comm_with_vnode_insertion.txt](https://github.com/openpbs/openpbs/files/5719411/comm_with_vnode_insertion.txt)





<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
