### PR TITLE
Multi-server: adding server local placement in sched

### DIFF
--- a/src/include/attribute.h
+++ b/src/include/attribute.h
@@ -602,8 +602,8 @@ extern int decode_attr_db(void *parent, pbs_db_attr_list_t *db_attr_list,
 
 extern int is_attr(int, char *, int);
 
-extern int set_attr(struct attrl **attrib, char *attrib_name, char *attrib_value);
-extern int set_attr_resc(struct attrl **attrib, char *attrib_name, char *attrib_resc, char *attrib_value);
+extern int set_attr(struct attrl **attrib, const char *attrib_name, const char *attrib_value);
+extern int set_attr_resc(struct attrl **attrib, const char *attrib_name, const char *attrib_resc, const char *attrib_value);
 
 extern svrattrl *make_attr(char *attr_name, char *attr_resc, char *attr_value, int attr_flags);
 extern void *cr_attrdef_idx(struct attribute_def *adef, int limit);

--- a/src/include/libpbs.h
+++ b/src/include/libpbs.h
@@ -401,7 +401,7 @@ char *PBSD_modify_resv(int, char *, struct attropl *, char *);
 int PBSD_cred(int, char *, char *, int, char *, long, int, char **);
 int PBSD_server_ready(int);
 int tcp_send_auth_req(int, unsigned int, char *, char *, char *);
-void *get_conn_svr_instances(int);
+svr_conn_t **get_conn_svr_instances(int);
 int pbs_register_sched(const char *sched_id, int primary_conn_id, int secondary_conn_id);
 int get_svr_inst_fd(int vfd, char *svr_inst_id);
 int random_srv_conn(svr_conn_t **);

--- a/src/include/log.h
+++ b/src/include/log.h
@@ -103,7 +103,7 @@ extern char *msg_daemonname;
 extern long *log_event_mask;
 
 extern void set_logfile(FILE *fp);
-extern int set_msgdaemonname(char *ch);
+extern int set_msgdaemonname(const char *ch);
 void set_log_conf(char *leafname, char *nodename,
 		  unsigned int islocallog, unsigned int sl_fac, unsigned int sl_svr,
 		  unsigned int log_highres);

--- a/src/include/pbs_ecl.h
+++ b/src/include/pbs_ecl.h
@@ -138,7 +138,7 @@ int verify_value_state(int, int, int, struct attropl *, char **);
 int verify_value_tolerate_node_failures(int, int, int, struct attropl *, char **);
 
 /* verify object name function */
-int pbs_verify_object_name(int, char *);
+int pbs_verify_object_name(int, const char *);
 
 #ifdef	__cplusplus
 }

--- a/src/include/pbs_ifl.h
+++ b/src/include/pbs_ifl.h
@@ -529,10 +529,10 @@ struct attropl {
 };
 
 struct batch_status {
-	struct batch_status	*next;
-	char			*name;
-	struct attrl		*attribs;
-	char			*text;
+	struct batch_status *next;
+	char *name;
+	struct attrl *attribs;
+	char *text;
 };
 
 struct batch_deljob_status {

--- a/src/include/pbs_internal.h
+++ b/src/include/pbs_internal.h
@@ -467,7 +467,7 @@ DECLDIR int      parse_depend_list(char *, char **, int);
 DECLDIR int      parse_stage_list(char *);
 DECLDIR int      prepare_path(char *, char*);
 DECLDIR void     prt_job_err(char *, int, char *);
-DECLDIR int		 set_attr(struct attrl **, char *, char *);
+DECLDIR int		 set_attr(struct attrl **, const char *, const char *);
 DECLDIR int      set_attr_resc(struct attrl **, char *, char *, char *);
 DECLDIR int      set_resources(struct attrl **, char *, int, char **);
 DECLDIR int      cnt2server(char *);
@@ -548,11 +548,11 @@ extern int      parse_destination_id(char *, char **, char **);
 extern int      parse_stage_list(char *);
 extern int      prepare_path(char *, char*);
 extern void     prt_job_err(char *, int, char *);
-extern int     set_attr(struct attrl **, char *, char *);
+extern int     set_attr(struct attrl **, const char *, const char *);
 #ifndef pbs_get_dataservice_usr
 extern char*    pbs_get_dataservice_usr(char *, int);
 #endif
-extern char*	get_attr(struct attrl *, char *, char *);
+extern char*	get_attr(struct attrl *, const char *, const char *);
 extern int      set_resources(struct attrl **, char *, int, char **);
 extern int      cnt2server(char *server);
 extern int      cnt2server_extend(char *server, char *);

--- a/src/include/resource.h
+++ b/src/include/resource.h
@@ -141,7 +141,7 @@ extern int alloc_svrleaf(char *resc_name, svr_entlim_leaf_t **pplf);
 extern int parse_resc_type(char *val, int *resc_type_p);
 extern int  parse_resc_flags(char *val, int *flag_ir_p, int *resc_flag_p);
 extern int verify_resc_name(char *name);
-extern int verify_resc_type_and_flags(int resc_type, int *pflag_ir, int *presc_flag, char *rescname, char *buf, int buflen, int autocorrect);
+extern int verify_resc_type_and_flags(int resc_type, int *pflag_ir, int *presc_flag, const char *rescname, char *buf, int buflen, int autocorrect);
 extern void update_resc_sum(void);
 
 /* Defines for entity limit tracking */

--- a/src/lib/Libattr/attr_resc_func.c
+++ b/src/lib/Libattr/attr_resc_func.c
@@ -297,7 +297,7 @@ verify_resc_name(char *name)
  * @retval -2 when errors that got autocorrected
  */
 int
-verify_resc_type_and_flags(int resc_type, int *pflag_ir, int *presc_flag, char *rescname, char *buf, int buflen, int autocorrect)
+verify_resc_type_and_flags(int resc_type, int *pflag_ir, int *presc_flag, const char *rescname, char *buf, int buflen, int autocorrect)
 {
 	char fchar;
 	int correction = 0;

--- a/src/lib/Libattr/master_resc_def_all.xml
+++ b/src/lib/Libattr/master_resc_def_all.xml
@@ -951,6 +951,20 @@
       <member_at_entlim>PBS_ENTLIM_NOLIMIT</member_at_entlim>
       <member_at_struct>NULL</member_at_struct>
    </attributes>
+   <attributes>
+      <member_index>RESC_MSVR_ND_GROUP</member_index>
+      <member_name>"msvr_node_group"</member_name>
+      <member_at_decode>decode_arst</member_at_decode>
+      <member_at_encode>encode_arst</member_at_encode>
+      <member_at_set>set_arst</member_at_set>
+      <member_at_comp>comp_arst</member_at_comp>
+      <member_at_free>free_arst</member_at_free>
+      <member_at_action>NULL_FUNC_RESC</member_at_action>
+      <member_at_flags>ATR_DFLAG_SvRD | ATR_DFLAG_SvWR</member_at_flags>
+      <member_at_type>ATR_TYPE_ARST</member_at_type>
+      <member_at_entlim>PBS_ENTLIM_NOLIMIT</member_at_entlim>
+      <member_at_struct>NULL</member_at_struct>
+   </attributes>
    <attributes flag="SVR">
       <member_name>"|unknown|"</member_name>
       <member_at_decode>decode_unkn</member_at_decode>

--- a/src/lib/Libcmds/get_attr.c
+++ b/src/lib/Libcmds/get_attr.c
@@ -62,7 +62,7 @@
  */
 
 char *
-get_attr(struct attrl *pattrl, char *name, char *resc)
+get_attr(struct attrl *pattrl, const char *name, const char *resc)
 {
 	while (pattrl) {
 		if (strcmp(name, pattrl->name) == 0) {

--- a/src/lib/Libcmds/set_attr.c
+++ b/src/lib/Libcmds/set_attr.c
@@ -70,7 +70,7 @@ static struct attrl* new_attr;
  */
 
 int
-set_attr(struct attrl **attrib, char *attrib_name, char *attrib_value)
+set_attr(struct attrl **attrib, const char *attrib_name, const char *attrib_value)
 {
 	struct attrl *attr, *ap;
 
@@ -125,7 +125,7 @@ set_attr(struct attrl **attrib, char *attrib_name, char *attrib_value)
  */
 
 int
-set_attr_resc(struct attrl **attrib, char *attrib_name, char *attrib_resc, char *attrib_value)
+set_attr_resc(struct attrl **attrib, const char *attrib_name, const char *attrib_resc, const char *attrib_value)
 {
 	if (set_attr(attrib, attrib_name, attrib_value))
 		return 1;

--- a/src/lib/Libecl/ecl_verify_object_name.c
+++ b/src/lib/Libecl/ecl_verify_object_name.c
@@ -82,9 +82,9 @@
  *
  */
 int
-pbs_verify_object_name(int type, char *name)
+pbs_verify_object_name(int type, const char *name)
 {
-	char *ptr;
+	const char *ptr;
 
 	if ((type < 0) || (type >= MGR_OBJ_LAST)) {
 		pbs_errno = PBSE_IVAL_OBJ_NAME;

--- a/src/lib/Libifl/pbsD_connect.c
+++ b/src/lib/Libifl/pbsD_connect.c
@@ -417,7 +417,7 @@ err:
  *
  * @par MT-safe: Yes
  */
-void *
+svr_conn_t **
 get_conn_svr_instances(int parentfd)
 {
 	svr_conns_list_t *iter_conns = NULL;
@@ -1199,7 +1199,7 @@ send_register_sched(int sock, const char *sched_id)
 rerr:
 	pbs_disconnect(sock);
 	PBSD_FreeReply(reply);
-	return 0;	
+	return 0;
 }
 
 /**
@@ -1232,9 +1232,11 @@ pbs_register_sched(const char *sched_id, int primary_conn_id, int secondary_conn
 		return 0;
 
 	for (i = 0; i < get_num_servers(); i++) {
-		if (send_register_sched(svr_conns_primary[i]->sd, sched_id) == 0)
+		if (svr_conns_primary[i]->sd < 0 ||
+			send_register_sched(svr_conns_primary[i]->sd, sched_id) == 0)
 			return 0;
-		if (send_register_sched(svr_conns_secondary[i]->sd, sched_id) == 0)
+		if (svr_conns_secondary[i]->sd < 0 ||
+			send_register_sched(svr_conns_secondary[i]->sd, sched_id) == 0)
 			return 0;
 	}
 

--- a/src/lib/Liblog/pbs_log.c
+++ b/src/lib/Liblog/pbs_log.c
@@ -216,7 +216,7 @@ gettimeofday(struct timeval *tp, struct timezone *tzp)
  */
 
 int
-set_msgdaemonname(char *ch)
+set_msgdaemonname(const char *ch)
 {
 	if(!(msg_daemonname = strdup(ch))) {
 		return 1;

--- a/src/scheduler/Makefile.am
+++ b/src/scheduler/Makefile.am
@@ -116,6 +116,7 @@ libpbs_sched_a_SOURCES = \
 	resource_resv.h \
 	resv_info.cpp \
 	resv_info.h \
+	sched_ifl_wrappers.cpp \
 	server_info.cpp \
 	server_info.h \
 	simulate.cpp \

--- a/src/scheduler/buckets.cpp
+++ b/src/scheduler/buckets.cpp
@@ -523,7 +523,7 @@ new_chunk_map() {
 		return NULL;
 	}
 
-	cmap->chunk = NULL;
+	cmap->chk = NULL;
 	cmap->bkt_cnts = NULL;
 	cmap->node_bits = pbs_bitmap_alloc(NULL, 1);
 	if (cmap->node_bits == NULL) {
@@ -576,7 +576,7 @@ log_chunk_map_array(resource_resv *resresv, chunk_map **cmap) {
 	for (i = 0; cmap[i] != NULL; i++) {
 		int total_chunks = 0;
 
-		log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_JOB, LOG_DEBUG, resresv->name, "Chunk: %s", cmap[i]->chunk->str_chunk);
+		log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_JOB, LOG_DEBUG, resresv->name, "Chunk: %s", cmap[i]->chk->str_chunk);
 
 		for (j = 0; cmap[i]->bkt_cnts[j] != NULL; j++) {
 			int chunk_count;
@@ -585,9 +585,9 @@ log_chunk_map_array(resource_resv *resresv, chunk_map **cmap) {
 			log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_JOB, LOG_DEBUG, resresv->name, "Bucket %s can fit %d chunks", nbc->bkt->name, chunk_count);
 			total_chunks += chunk_count;
 		}
-		if (total_chunks < cmap[i]->chunk->num_chunks)
+		if (total_chunks < cmap[i]->chk->num_chunks)
 			log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_JOB, LOG_DEBUG, resresv->name,
-				"Found %d out of %d chunks needed", total_chunks, cmap[i]->chunk->num_chunks);
+				"Found %d out of %d chunks needed", total_chunks, cmap[i]->chk->num_chunks);
 	}
 }
 
@@ -652,7 +652,7 @@ bucket_match(chunk_map **cmap, resource_resv *resresv, schd_error *err)
 	}
 
 	for (i = 0; cmap[i] != NULL; i++) {
-		int num_chunks_needed = cmap[i]->chunk->num_chunks;
+		int num_chunks_needed = cmap[i]->chk->num_chunks;
 
 		if (cmap[i]->bkt_cnts == NULL)
 			break;
@@ -832,7 +832,7 @@ bucket_to_nspecs(status *policy, chunk_map **cb_map, resource_resv *resresv)
 	}
 
 	for (i = 0; cb_map[i] != NULL; i++) {
-		int chunks_needed = cb_map[i]->chunk->num_chunks;
+		int chunks_needed = cb_map[i]->chk->num_chunks;
 		for (j = pbs_bitmap_first_on_bit(cb_map[i]->node_bits); j >= 0;
 		     j = pbs_bitmap_next_on_bit(cb_map[i]->node_bits, j)) {
 			/* Find the bucket the node is in */
@@ -852,7 +852,7 @@ bucket_to_nspecs(status *policy, chunk_map **cb_map, resource_resv *resresv)
 			 * For the final chunk, we might allocate less.
 			 */
 			for( ; cnt > 0 && chunks_needed > 0; cnt--, chunks_needed--, n++) {
-				ns_arr[n] = chunk_to_nspec(policy, cb_map[i]->chunk, sinfo->unordered_nodes[j], resresv->aoename);
+				ns_arr[n] = chunk_to_nspec(policy, cb_map[i]->chk, sinfo->unordered_nodes[j], resresv->aoename);
 				if (ns_arr[n] == NULL) {
 					free_nspecs(ns_arr);
 					return NULL;
@@ -979,7 +979,7 @@ find_correct_buckets(status *policy, node_bucket **buckets, resource_resv *resre
 			free_chunk_map_array(cb_map);
 			return NULL;
 		}
-		cb_map[i]->chunk = resresv->select->chunks[i];
+		cb_map[i]->chk = resresv->select->chunks[i];
 		cb_map[i]->bkt_cnts = static_cast<node_bucket_count **>(calloc(bucket_ct + 1, sizeof(node_bucket_count *)));
 		if (cb_map[i]->bkt_cnts == NULL) {
 			log_err(errno, __func__, MEM_ERR_MSG);
@@ -1021,7 +1021,7 @@ find_correct_buckets(status *policy, node_bucket **buckets, resource_resv *resre
 		}
 
 		/* No buckets match or not enough nodes in the buckets: the job can't run */
-		if(b == 0 || total < cb_map[i]->chunk->num_chunks)
+		if(b == 0 || total < cb_map[i]->chk->num_chunks)
 			can_run = 0;
 	}
 	cb_map[i] = NULL;
@@ -1132,11 +1132,21 @@ check_node_buckets(status *policy, server_info *sinfo, queue_info *qinfo, resour
 			 * use that error code
 			 */
 			move_schd_error(err, failerr);
-	}
-	else
-		return map_buckets(policy, sinfo->buckets, resresv, err);
+	} else if (!(sinfo->svr_to_psets.empty())) {
+		/* Find buckets associated with nodes of the server which owns the job */
+		for (auto &spset: sinfo->svr_to_psets) {
+			if (spset.svr_inst_id == resresv->job->svr_inst_id) {
+				nspec **nspecs;
 
-	return NULL;
+				nspecs = map_buckets(policy, spset.np->bkts, resresv, err);
+				if (nspecs != NULL)
+					return nspecs;
+				break;
+			}
+		}
+	}
+
+	return map_buckets(policy, sinfo->buckets, resresv, err);
 }
 
 /*

--- a/src/scheduler/buckets.h
+++ b/src/scheduler/buckets.h
@@ -38,9 +38,6 @@
  */
 
 
-#ifdef	__cplusplus
-extern "C" {
-#endif
 #ifndef _BUCKETS_H
 #define _BUCKETS_H
 
@@ -103,7 +100,4 @@ nspec **map_buckets(status *policy, node_bucket **bkts, resource_resv *resresv, 
 /* map job to buckets that can satisfy */
 chunk_map **find_correct_buckets(status *policy, node_bucket **buckets, resource_resv *resresv, schd_error *err);
 
-#ifdef	__cplusplus
-}
-#endif
 #endif	/* _BUCKETS_H */

--- a/src/scheduler/check.cpp
+++ b/src/scheduler/check.cpp
@@ -1502,15 +1502,19 @@ check_nodes(status *policy, server_info *sinfo, queue_info *qinfo, resource_resv
 nspec **
 check_normal_node_path(status *policy, server_info *sinfo, queue_info *qinfo, resource_resv *resresv, unsigned int flags, schd_error *err)
 {
-	nspec			**nspec_arr = NULL;
-	selspec			*spec = NULL;
-	place			*pl = NULL;
-	int			rc = 0;
-	char			*grouparr[2] = {0};
-	np_cache		*npc = NULL;
-	int			error = 0;
-	node_partition		**nodepart = NULL;
-	node_info		**ninfo_arr = NULL;
+	nspec **nspec_arr = NULL;
+	selspec *spec = NULL;
+	place *pl = NULL;
+	int rc = 0;
+	char *grouparr[2] = {0};
+	np_cache *npc = NULL;
+	int error = 0;
+	node_partition **nodepart = NULL;
+	node_info **ninfo_arr = NULL;
+	node_partition *msvr_pset[3];
+
+	if (!sc_attrs.do_not_span_psets)
+		flags |= SPAN_PSETS;
 
 	if (sinfo == NULL || resresv == NULL || err == NULL) {
 		if (err != NULL)
@@ -1529,6 +1533,8 @@ check_normal_node_path(status *policy, server_info *sinfo, queue_info *qinfo, re
 			return NULL;
 	}
 
+	get_resresv_spec(resresv, &spec, &pl);
+
 	/* Sets of nodes:
 	   * 1. job is in a reservation - use reservation nodes
 	   * 2. job or reservation has nodes -- use them
@@ -1538,20 +1544,18 @@ check_normal_node_path(status *policy, server_info *sinfo, queue_info *qinfo, re
 	   * node partition, therefore it falls in here
 	   */
 
-	/* if we're in a reservation, only check nodes assigned to the resv
-	 * and not worry about node grouping since the nodes for the reservation
-	 * are already in a group
-	 */
 	if (resresv->is_job && resresv->job->resv != NULL) {
+		/* if we're in a reservation, only check nodes assigned to the resv
+		 * and not worry about node grouping since the nodes for the reservation
+		 * are already in a group
+		 */
 		ninfo_arr = resresv->job->resv->resv->resv_nodes;
 		nodepart = NULL;
-	}
-
-	/* if we have nodes, use them
-	 * don't care about node grouping because nodes are already assigned
-	 * to the job.  We won't need to search for them.
-	 */
-	else if (resresv->ninfo_arr != NULL) {
+	} else if (resresv->ninfo_arr != NULL) {
+		/* if we have nodes, use them
+		 * don't care about node grouping because nodes are already assigned
+		 * to the job.  We won't need to search for them.
+		 */
 		ninfo_arr = resresv->ninfo_arr;
 		nodepart = NULL;
 	} else {
@@ -1566,12 +1570,33 @@ check_normal_node_path(status *policy, server_info *sinfo, queue_info *qinfo, re
 			/* if there are nodes assigned to the queue, then check those */
 			if (qinfo->has_nodes)
 				ninfo_arr = qinfo->nodes;
-			else
-				ninfo_arr = sinfo->unassoc_nodes;
-		} else
-			/* last up we're not in a queue with nodes -- use the unassociated nodes */
-			ninfo_arr = sinfo->unassoc_nodes;
+			else if (!(sinfo->svr_to_psets.empty())) {	/* Multi-server psets */
+				/* Find the pset of the server which owns the job */
+				for (auto &spset: sinfo->svr_to_psets) {
+					if (spset.svr_inst_id == resresv->job->svr_inst_id) {
+						msvr_pset[0] = spset.np;
+						if (!resresv->job->is_array && spec->total_chunks == 1) {
+							/* Allow job to be placed on nodes of other servers as well
+							 * For now, restricting job arrays and multi-chunk jobs
+							 * to nodes of just the local server
+							 */
+							msvr_pset[1] = sinfo->allpart;
+							msvr_pset[2] = NULL;
+						} else {
+							/* This prevents eval_selspec from considering all unassociated nodes */
+							flags &= ~SPAN_PSETS;
+							msvr_pset[1] = NULL;
+						}
+						nodepart = msvr_pset;
+						break;
+					}
+				}
+			}
+		}
 	}
+
+	if (ninfo_arr == NULL)
+		ninfo_arr = sinfo->unassoc_nodes;
 
 	if (resresv->node_set_str != NULL) {
 		/* Note that jobs inside reservations have their node_set
@@ -1604,11 +1629,8 @@ check_normal_node_path(status *policy, server_info *sinfo, queue_info *qinfo, re
 	if (ninfo_arr == NULL || error)
 		return NULL;
 
-	get_resresv_spec(resresv, &spec, &pl);
-
 	err->status_code = NOT_RUN;
-	rc = eval_selspec(policy, spec, pl, ninfo_arr, nodepart, resresv,
-		flags, &nspec_arr, err);
+	rc = eval_selspec(policy, spec, pl, ninfo_arr, nodepart, resresv, flags, &nspec_arr, err);
 
 	/* We can run, yippie! */
 	if (rc > 0)

--- a/src/scheduler/check.h
+++ b/src/scheduler/check.h
@@ -40,9 +40,6 @@
 
 #ifndef	_CHECK_H
 #define	_CHECK_H
-#ifdef	__cplusplus
-extern "C" {
-#endif
 
 #include "server_info.h"
 #include "queue_info.h"
@@ -240,7 +237,4 @@ schd_resource *unset_str_res(void);
  *	returns void
  */
 void get_resresv_spec(resource_resv *resresv, selspec **spec, place **pl);
-#ifdef	__cplusplus
-}
-#endif
 #endif	/* _CHECK_H */

--- a/src/scheduler/constant.h
+++ b/src/scheduler/constant.h
@@ -39,9 +39,6 @@
 
 #ifndef	_CONSTANT_H
 #define	_CONSTANT_H
-#ifdef	__cplusplus
-extern "C" {
-#endif
 
 #include <math.h>
 
@@ -594,8 +591,9 @@ enum check_flags {
 	ONLY_COMP_CONS = 128,
 	IGNORE_EQUIV_CLASS = 256,
 	USE_BUCKETS = 512,
-	NO_ALLPART = 1024
-	/* next flag 2048 */
+	NO_ALLPART = 1024,
+	SPAN_PSETS = 2048
+	/* next flag 4096 */
 };
 
 enum schd_error_args {
@@ -636,7 +634,4 @@ enum nscr_vals {
 	NSCR_INELIGIBLE = 4
 };
 
-#ifdef	__cplusplus
-}
-#endif
 #endif	/* _CONSTANT_H */

--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -52,9 +52,6 @@
 #ifndef	_DATA_TYPES_H
 #define	_DATA_TYPES_H
 
-#ifdef	__cplusplus
-extern "C" {
-#endif
 
 #include <time.h>
 #include <pbs_ifl.h>
@@ -67,6 +64,9 @@ extern "C" {
 #ifdef NAS
 #include "site_queue.h"
 #endif
+
+#include <vector>
+#include <string>
 
 struct server_info;
 struct state_count;
@@ -145,6 +145,7 @@ typedef struct th_data_free_ninfo th_data_free_ninfo;
 typedef struct th_data_dup_resresv th_data_dup_resresv;
 typedef struct th_data_query_jinfo th_data_query_jinfo;
 typedef struct th_data_free_resresv th_data_free_resresv;
+typedef struct server_psets server_psets;
 
 
 #ifdef NAS
@@ -476,6 +477,7 @@ struct server_info
 	resresv_set **equiv_classes;
 	node_bucket **buckets;		/* node bucket array */
 	node_info **unordered_nodes;
+	std::vector<server_psets> svr_to_psets;
 #ifdef NAS
 	/* localmod 034 */
 	share_head *share_head;	/* root of share info */
@@ -637,6 +639,11 @@ struct node_scratch
 	unsigned int to_be_sorted:1;	/* used for sorting of the nodes while
 					 * altering a reservation.
 					 */
+};
+
+struct server_psets {
+	std::string svr_inst_id;	/* server_instance_id (<hostname>:<port>) */
+	node_partition *np;	/* placement set of all nodes owned by this server */
 };
 
 struct node_info
@@ -1252,7 +1259,7 @@ struct node_bucket_count {
 };
 
 struct chunk_map {
-	chunk *chunk;
+	chunk *chk;
 	node_bucket_count **bkt_cnts;	/* buckets job can run in and chunk counts */
 	pbs_bitmap *node_bits;		/* assignment of nodes from buckets */
 };
@@ -1261,7 +1268,4 @@ struct resresv_filter {
 	resource_resv *job;
 	schd_error *err;		/* reason why set can not run*/
 };
-#ifdef	__cplusplus
-}
-#endif
 #endif	/* _DATA_TYPES_H */

--- a/src/scheduler/dedtime.h
+++ b/src/scheduler/dedtime.h
@@ -39,9 +39,6 @@
 
 #ifndef	_DEDTIME_H
 #define	_DEDTIME_H
-#ifdef	__cplusplus
-extern "C" {
-#endif
 
 #include <time.h>
 
@@ -76,7 +73,4 @@ int is_ded_time(time_t t);
  */
 struct timegap find_next_dedtime(time_t t);
 
-#ifdef	__cplusplus
-}
-#endif
 #endif	/* _DEDTIME_H */

--- a/src/scheduler/fairshare.h
+++ b/src/scheduler/fairshare.h
@@ -39,9 +39,6 @@
 
 #ifndef	_FAIRSHARE_H
 #define	_FAIRSHARE_H
-#ifdef	__cplusplus
-extern "C" {
-#endif
 
 #include "data_types.h"
 /*
@@ -267,7 +264,4 @@ void calc_usage_factor(fairshare_head *tree);
 
 
 
-#ifdef	__cplusplus
-}
-#endif
 #endif	/* _FAIRSHARE_H */

--- a/src/scheduler/fifo.h
+++ b/src/scheduler/fifo.h
@@ -39,9 +39,6 @@
 
 #ifndef	_FIFO_H
 #define	_FIFO_H
-#ifdef	__cplusplus
-extern "C" {
-#endif
 
 #include  <limits.h>
 #include "data_types.h"
@@ -203,7 +200,8 @@ int add_job_to_calendar(int pbs_sd, status *policy, server_info *sinfo, resource
  *	       first move it to the local server and then run it.
  *	       if it's a local job, just run it.
  */
-int run_job(int pbs_sd, resource_resv *rjob, char *execvnode, int had_runjob_hook, char *node_owner, schd_error *err);
+int run_job(int pbs_sd, resource_resv *rjob, char *execvnode, int had_runjob_hook,
+	    schd_error *err, char *svr_id_node);
 
 /*
  *	should_backfill_with_job - should we call add_job_to_calendar() with job
@@ -258,9 +256,7 @@ int validate_running_user(char *exename);
 
 void clear_last_running();
 
-int send_run_job(int pbs_sd, int has_runjob_hook, char *jobid, char *execvnode, char *node_owner);
+int send_run_job(int virtual_sd, int has_runjob_hook, char *jobid, char *execvnode,
+		 char *svr_id_node, char *svr_id_job);
 
-#ifdef	__cplusplus
-}
-#endif
 #endif	/* _FIFO_H */

--- a/src/scheduler/globals.h
+++ b/src/scheduler/globals.h
@@ -39,9 +39,6 @@
 
 #ifndef	_GLOBALS_H
 #define	_GLOBALS_H
-#ifdef	__cplusplus
-extern "C" {
-#endif
 #include <pthread.h>
 #include <limits.h>
 
@@ -128,7 +125,4 @@ extern int clust_secondary_sock;
  */
 extern char *cmp_aoename;
 
-#ifdef	__cplusplus
-}
-#endif
 #endif	/* _GLOBALS_H */

--- a/src/scheduler/job_info.h
+++ b/src/scheduler/job_info.h
@@ -39,9 +39,6 @@
 
 #ifndef	_JOB_INFO_H
 #define	_JOB_INFO_H
-#ifdef	__cplusplus
-extern "C" {
-#endif
 
 #include <pbs_ifl.h>
 #include "data_types.h"
@@ -90,7 +87,9 @@ update_job_attr(int pbs_sd, resource_resv *resresv, const char *attr_name,
 int send_job_updates(int pbs_sd, resource_resv *job);
 
 /* send delayed attributes to the server for a job */
-int send_attr_updates(int pbs_sd, char *job_name, struct attrl *pattr);
+int send_attr_updates(int job_owner_sd, char *job_name, struct attrl *pattr);
+
+preempt_job_info *send_preempt_jobs(int virtual_sd, char **preempt_jobs_list);
 
 
 /*
@@ -415,7 +414,4 @@ void associate_dependent_jobs(server_info *sinfo);
 /* This function associated the job passed in to its parent job */
 int associate_array_parent(resource_resv *pjob, server_info *sinfo);
 
-#ifdef	__cplusplus
-}
-#endif
 #endif	/* _JOB_INFO_H */

--- a/src/scheduler/misc.cpp
+++ b/src/scheduler/misc.cpp
@@ -56,6 +56,7 @@
 #include <log.h>
 #include <pbs_share.h>
 #include <libutil.h>
+#include <libpbs.h>
 #include "config.h"
 #include "constant.h"
 #include "misc.h"
@@ -1595,3 +1596,4 @@ free_ptr_array(void *inp)
 		free(arr[i]);
 	free(arr);
 }
+

--- a/src/scheduler/misc.h
+++ b/src/scheduler/misc.h
@@ -40,9 +40,6 @@
 #ifndef	_MISC_H
 #define	_MISC_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include "data_types.h"
 #include "server_info.h"
@@ -297,9 +294,6 @@ add_str_to_unique_array(char ***str_arr, char *str);
  */
 void free_ptr_array (void *inp);
 
-#ifdef __cplusplus
-}
-#endif
 
 
 #endif	/* _MISC_H */

--- a/src/scheduler/multi_threading.h
+++ b/src/scheduler/multi_threading.h
@@ -41,9 +41,6 @@
 #ifndef SRC_SCHEDULER_MULTI_THREADING_H_
 #define SRC_SCHEDULER_MULTI_THREADING_H_
 
-#ifdef	__cplusplus
-extern "C" {
-#endif
 #include "data_types.h"
 
 #define MT_CHUNK_SIZE_MIN 1024
@@ -54,7 +51,4 @@ void kill_threads(void);
 void *worker(void *);
 void queue_work_for_threads(th_task_info *task);
 
-#ifdef	__cplusplus
-}
-#endif
 #endif /* SRC_SCHEDULER_MULTI_THREADING_H_ */

--- a/src/scheduler/node_info.cpp
+++ b/src/scheduler/node_info.cpp
@@ -468,7 +468,7 @@ query_node_info(struct batch_status *node, server_info *sinfo)
 		/* Node State... i.e. offline down free etc */
 		if (!strcmp(attrp->name, ATTR_NODE_state))
 			set_node_info_state(ninfo, attrp->value);
-		
+
 		else if (!strcmp(attrp->name, ATTR_server_inst_id)) {
 			ninfo->svr_inst_id = string_dup(attrp->value);
 			if (ninfo->svr_inst_id == NULL) {
@@ -2478,7 +2478,7 @@ eval_selspec(status *policy, selspec *spec, place *placespec,
 	}
 
 	if (!can_fit) {
-		if (!sc_attrs.do_not_span_psets) {
+		if (flags & SPAN_PSETS) {
 			log_event(PBSEVENT_DEBUG3, PBS_EVENTCLASS_JOB, LOG_DEBUG, resresv->name,
 				"Request won't fit into any placement sets, will use all nodes");
 			resresv->can_not_fit = 1;

--- a/src/scheduler/node_info.h
+++ b/src/scheduler/node_info.h
@@ -39,9 +39,6 @@
 
 #ifndef	_NODE_INFO_H
 #define	_NODE_INFO_H
-#ifdef	__cplusplus
-extern "C" {
-#endif
 
 #include "data_types.h"
 #include <pbs_ifl.h>
@@ -640,7 +637,4 @@ int add_node_events(timed_event *te, void *arg1, void *arg2);
  * Find a node by its hostname
  */
 node_info *find_node_by_host(node_info **ninfo_arr, char *host);
-#ifdef	__cplusplus
-}
-#endif
 #endif	/* _NODE_INFO_H */

--- a/src/scheduler/node_partition.cpp
+++ b/src/scheduler/node_partition.cpp
@@ -76,6 +76,8 @@
 #include <log.h>
 #include <pbs_ifl.h>
 #include <pbs_internal.h>
+#include <libpbs.h>
+
 #include "config.h"
 #include "constant.h"
 #include "data_types.h"
@@ -91,6 +93,7 @@
 #include "sort.h"
 #include "buckets.h"
 
+#include <vector>
 
 /**
  * @brief

--- a/src/scheduler/node_partition.h
+++ b/src/scheduler/node_partition.h
@@ -39,9 +39,6 @@
 
 #ifndef	_NODE_PARTITION_H
 #define _NODE_PARTITION_H
-#ifdef	__cplusplus
-extern "C" {
-#endif
 
 #include "data_types.h"
 #include <pbs_ifl.h>
@@ -238,7 +235,4 @@ void update_buckets_for_node(node_bucket **bkts, node_info *ninfo);
  */
 void update_buckets_for_node_array(node_bucket **bkts, node_info **ninfo_arr);
 
-#ifdef	__cplusplus
-}
-#endif
 #endif	/* _NODE_PARTITION_H */

--- a/src/scheduler/parse.h
+++ b/src/scheduler/parse.h
@@ -39,9 +39,6 @@
 
 #ifndef	_PARSE_H
 #define	_PARSE_H
-#ifdef	__cplusplus
-extern "C" {
-#endif
 
 #include "data_types.h"
 #include "globals.h"
@@ -99,7 +96,4 @@ int is_speccase_sort(char *sort_res, int sort_type);
 
 void free_sort_info(enum sort_info_type si_type);
 
-#ifdef	__cplusplus
-}
-#endif
 #endif	/* _PARSE_H */

--- a/src/scheduler/pbs_bitmap.h
+++ b/src/scheduler/pbs_bitmap.h
@@ -40,9 +40,6 @@
 
 #ifndef _PBS_BITMASK_H
 #define _PBS_BITMASK_H
-#ifdef	__cplusplus
-extern "C" {
-#endif
 
 
 struct pbs_bitmap {
@@ -80,7 +77,4 @@ int pbs_bitmap_assign(pbs_bitmap *L, pbs_bitmap *R);
 /* pbs_bitmap's version of L == R */
 int pbs_bitmap_is_equal(pbs_bitmap *L, pbs_bitmap *R);
 
-#ifdef	__cplusplus
-}
-#endif
 #endif	/* _PBS_BITMASK_H */

--- a/src/scheduler/pbs_sched_bare.cpp
+++ b/src/scheduler/pbs_sched_bare.cpp
@@ -55,6 +55,7 @@
 #include "data_types.h"
 #include "fifo.h"
 #include "globals.h"
+#include "libpbs.h"
 #include "log.h"
 #include "resource.h"
 #include "server_info.h"
@@ -111,7 +112,8 @@ main_sched_loop_bare(int sd, server_info *sinfo)
 			snprintf(execvnode, sizeof(execvnode), "(%s:ncpus=1)", node->name);
 
 			/* Send the run request */
-			send_run_job(sd, 0, jobs[ij]->name, execvnode, node->svr_inst_id);
+			send_run_job(sd, 0, jobs[ij]->name, execvnode, node->svr_inst_id,
+					     jobs[ij]->job->svr_inst_id);
 
 			break;
 		}

--- a/src/scheduler/pbs_sched_utils.cpp
+++ b/src/scheduler/pbs_sched_utils.cpp
@@ -564,9 +564,8 @@ connect_svrpool()
 			continue;
 		}
 
-		svr_conns_primary = static_cast<svr_conn_t **>(get_conn_svr_instances(clust_primary_sock));
-		svr_conns_secondary = static_cast<svr_conn_t **>(get_conn_svr_instances(clust_secondary_sock));
-
+		svr_conns_primary = get_conn_svr_instances(clust_primary_sock);
+		svr_conns_secondary = get_conn_svr_instances(clust_secondary_sock);
 		if (svr_conns_primary == NULL || svr_conns_secondary == NULL) {
 			/* wait for 2s for not to burn too much CPU, and then retry connection */
 			sleep(2);
@@ -757,8 +756,8 @@ send_cycle_end()
 	svr_conn_t **svr_conns;
 	int i;
 	static int cycle_end_marker = 0;
-	svr_conns = static_cast<svr_conn_t **>(get_conn_svr_instances(clust_secondary_sock));
-	
+
+	svr_conns = get_conn_svr_instances(clust_secondary_sock);
 	if (svr_conns == NULL)
 		goto err;
 

--- a/src/scheduler/prev_job_info.h
+++ b/src/scheduler/prev_job_info.h
@@ -39,9 +39,6 @@
 
 #ifndef	_PREV_JOB_INFO_H
 #define	_PREV_JOB_INFO_H
-#ifdef	__cplusplus
-extern "C" {
-#endif
 
 #include "data_types.h"
 
@@ -60,7 +57,4 @@ void free_prev_job_info(prev_job_info *pjinfo);
  *      free_pjobs - free a list of prev_job_info structs
  */
 void free_pjobs(prev_job_info *pjinfo_arr, int size);
-#ifdef	__cplusplus
-}
-#endif
 #endif	/* _PREV_JOB_INFO_H */

--- a/src/scheduler/prime.h
+++ b/src/scheduler/prime.h
@@ -39,9 +39,6 @@
 
 #ifndef	_PRIME_H
 #define	_PRIME_H
-#ifdef	__cplusplus
-extern "C" {
-#endif
 
 #include "time.h"
 
@@ -110,7 +107,4 @@ int init_non_prime_time(struct status *, char *);
 time_t end_prime_status(time_t date);
 
 
-#ifdef	__cplusplus
-}
-#endif
 #endif	/* _PRIME_H */

--- a/src/scheduler/queue.h
+++ b/src/scheduler/queue.h
@@ -40,9 +40,6 @@
 #ifndef SRC_SCHEDULER_QUEUE_H_
 #define SRC_SCHEDULER_QUEUE_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 
 
@@ -64,8 +61,5 @@ int ds_enqueue(ds_queue *queue, void *obj);
 void *ds_dequeue(ds_queue *queue);
 int ds_queue_is_empty(ds_queue *queue);
 
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* SRC_SCHEDULER_QUEUE_H_ */

--- a/src/scheduler/queue_info.h
+++ b/src/scheduler/queue_info.h
@@ -40,9 +40,6 @@
 
 #ifndef _QUEUE_INFO_H
 #define _QUEUE_INFO_H
-#ifdef	__cplusplus
-extern "C" {
-#endif
 #include <pbs_ifl.h>
 #include "data_types.h"
 
@@ -113,7 +110,4 @@ update_queue_on_end(queue_info *qinfo, resource_resv *resresv,
 int queue_in_partition(queue_info *qinfo, char *partition);
 
 
-#ifdef	__cplusplus
-}
-#endif
 #endif /* _QUEUE_INFO_H */

--- a/src/scheduler/resource.h
+++ b/src/scheduler/resource.h
@@ -41,9 +41,6 @@
 #ifndef _RESOURCE_H
 #define _RESOURCE_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 /*
  *	query_resources - query a pbs server for the resources it knows about
@@ -139,7 +136,4 @@ resdef **copy_resdef_array(resdef **deflist);
 /* update the def member in sort_info structures in conf */
 void update_sorting_defs(int op);
 
-#ifdef __cplusplus
-}
-#endif
 #endif /* _RESOURCE_H */

--- a/src/scheduler/resource_resv.h
+++ b/src/scheduler/resource_resv.h
@@ -39,9 +39,6 @@
 
 #ifndef	_RESOURCE_RESV_H
 #define	_RESOURCE_RESV_H
-#ifdef	__cplusplus
-extern "C" {
-#endif
 
 #include "data_types.h"
 
@@ -386,7 +383,4 @@ char *create_select_from_nspec(nspec **nspec_array);
 /* function returns true if job/resv is in a state which it can be run */
 int in_runnable_state(resource_resv *resresv);
 
-#ifdef	__cplusplus
-}
-#endif
 #endif /* _RESOURCE_RESV_H */

--- a/src/scheduler/resv_info.h
+++ b/src/scheduler/resv_info.h
@@ -39,9 +39,6 @@
 
 #ifndef	_RESV_INFO_H
 #define	_RESV_INFO_H
-#ifdef	__cplusplus
-extern "C" {
-#endif
 
 #include <pbs_config.h>
 #include "data_types.h"
@@ -121,7 +118,4 @@ int ralter_reduce_chunks(resource_resv *resv);
 /* Will we try and confirm this reservation in this cycle */
 int will_confirm(resource_resv *resv, time_t server_time);
 
-#ifdef	__cplusplus
-}
-#endif
 #endif /* _RESV_INFO_H */

--- a/src/scheduler/sched_ifl_wrappers.cpp
+++ b/src/scheduler/sched_ifl_wrappers.cpp
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 1994-2020 Altair Engineering, Inc.
+ * For more information, contact Altair at www.altair.com.
+ *
+ * This file is part of both the OpenPBS software ("OpenPBS")
+ * and the PBS Professional ("PBS Pro") software.
+ *
+ * Open Source License Information:
+ *
+ * OpenPBS is free software. You can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * OpenPBS is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Commercial License Information:
+ *
+ * PBS Pro is commercially licensed software that shares a common core with
+ * the OpenPBS software.  For a copy of the commercial license terms and
+ * conditions, go to: (http://www.pbspro.com/agreement.html) or contact the
+ * Altair Legal Department.
+ *
+ * Altair's dual-license business model allows companies, individuals, and
+ * organizations to create proprietary derivative works of OpenPBS and
+ * distribute them - whether embedded or bundled with other software -
+ * under a commercial license agreement.
+ *
+ * Use of Altair's trademarks, including but not limited to "PBS™",
+ * "OpenPBS®", "PBS Professional®", and "PBS Pro™" and Altair's logos is
+ * subject to Altair's trademark licensing policies.
+ */
+
+#include <pbs_config.h>
+
+#include <stdlib.h>
+#include <pbs_ifl.h>
+#include <libpbs.h>
+#include "data_types.h"
+#include "fifo.h"
+#include "globals.h"
+#include "job_info.h"
+#include "log.h"
+
+
+/**
+ * @brief	Send the relevant runjob request to server
+ *
+ * @param[in]	virtual_sd	-	virtual sd for the cluster
+ * @param[in]	has_runjob_hook	- does server have a runjob hook?
+ * @param[in]	jobid	-	id of the job to run
+ * @param[in]	execvnode	-	the execvnode to run the job on
+ * @param[in]	svr_id_node	-	server id of the first node in execvnode
+ * @param[in]	svr_id_job -	server id of the job
+ *
+ * @return	int
+ * @retval	return value of the runjob call
+ */
+int
+send_run_job(int virtual_sd, int has_runjob_hook, char *jobid, char *execvnode,
+ 	     char *svr_id_node, char *svr_id_job)
+{
+	char extend[PBS_MAXHOSTNAME + 6];
+ 	int job_owner_sd;
+
+	if (jobid == NULL || execvnode == NULL || svr_id_node == NULL || svr_id_job == NULL)
+		return 1;
+
+  	job_owner_sd = get_svr_inst_fd(virtual_sd, svr_id_job);
+
+  	extend[0] = '\0';
+ 	if (svr_id_node && svr_id_job && strcmp(svr_id_node, svr_id_job) != 0)
+ 		snprintf(extend, sizeof(extend), "%s=%s", SERVER_IDENTIFIER, svr_id_node);
+
+	if (sc_attrs.runjob_mode == RJ_EXECJOB_HOOK)
+		return pbs_runjob(job_owner_sd, jobid, execvnode, extend);
+	else if (((sc_attrs.runjob_mode == RJ_RUNJOB_HOOK) && has_runjob_hook))
+		return pbs_asyrunjob_ack(job_owner_sd, jobid, execvnode, extend);
+	else
+		return pbs_asyrunjob(job_owner_sd, jobid, execvnode, extend);
+}
+
+/**
+ * @brief
+ * 		send delayed attributes to the server for a job
+ *
+ * @param[in]	job_owner_sd	-	server connection descriptor of the job owner
+ * @param[in]	job_name	-	name of job for pbs_asyalterjob()
+ * @param[in]	pattr	-	attrl list to update on the server
+ *
+ * @return	int
+ * @retval	1	success
+ * @retval	0	failure to update
+ */
+int
+send_attr_updates(int job_owner_sd, char *job_name, struct attrl *pattr)
+{
+	const char *errbuf;
+	int one_attr = 0;
+
+	if (job_name == NULL || pattr == NULL)
+		return 0;
+
+	if (job_owner_sd == SIMULATE_SD)
+		return 1; /* simulation always successful */
+
+	if (pattr->next == NULL)
+		one_attr = 1;
+
+	if (pbs_asyalterjob(job_owner_sd, job_name, pattr, NULL) == 0) {
+		last_attr_updates = time(NULL);
+		return 1;
+	}
+
+	if (is_finished_job(pbs_errno) == 1) {
+		if (one_attr)
+			log_eventf(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_INFO, job_name,
+				   "Failed to update attr \'%s\' = %s, Job already finished",
+				   pattr->name, pattr->value);
+		else
+			log_event(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_INFO, job_name,
+				"Failed to update job attributes, Job already finished");
+		return 0;
+	}
+
+	errbuf = pbs_geterrmsg(job_owner_sd);
+	if (errbuf == NULL)
+		errbuf = "";
+	if (one_attr)
+		log_eventf(PBSEVENT_SCHED, PBS_EVENTCLASS_SCHED, LOG_WARNING, job_name,
+			   "Failed to update attr \'%s\' = %s: %s (%d)",
+			   pattr->name, pattr->value, errbuf, pbs_errno);
+	else
+		log_eventf(PBSEVENT_SCHED, PBS_EVENTCLASS_SCHED, LOG_WARNING, job_name,
+			"Failed to update job attributes: %s (%d)",
+			errbuf, pbs_errno);
+
+	return 0;
+}
+
+/**
+ * @brief	Wrapper for pbs_preempt_jobs
+ *
+ * @param[in]	virtual_sd - virtual sd for the cluster
+ * @param[in]	preempt_jobs_list - list of jobs to preempt
+ *
+ * @return	preempt_job_info *
+ * @retval	return value of pbs_preempt_jobs
+ */
+preempt_job_info *
+send_preempt_jobs(int virtual_sd, char **preempt_jobs_list)
+{
+    return pbs_preempt_jobs(virtual_sd, preempt_jobs_list);
+}

--- a/src/scheduler/server_info.h
+++ b/src/scheduler/server_info.h
@@ -39,9 +39,6 @@
 
 #ifndef	_SERVER_INFO_H
 #define	_SERVER_INFO_H
-#ifdef	__cplusplus
-extern "C" {
-#endif
 
 #include <pbs_ifl.h>
 #include "state_count.h"
@@ -486,7 +483,4 @@ int compare_resource_avail(schd_resource *r1, schd_resource *r2);
 
 node_info **dup_unordered_nodes(node_info **old_unordered_nodes, node_info **nnodes);
 
-#ifdef	__cplusplus
-}
-#endif
 #endif	/* _SERVER_INFO_H */

--- a/src/scheduler/simulate.h
+++ b/src/scheduler/simulate.h
@@ -39,9 +39,6 @@
 
 #ifndef	_SIMULATE_H
 #define	_SIMULATE_H
-#ifdef	__cplusplus
-extern "C" {
-#endif
 
 #include "data_types.h"
 #include "constant.h"
@@ -458,7 +455,4 @@ int add_te_list(te_list **tel, timed_event *te);
 int remove_te_list(te_list **tel, timed_event *e);
 
 
-#ifdef	__cplusplus
-}
-#endif
 #endif /* _SIMULATE_H */

--- a/src/scheduler/sort.h
+++ b/src/scheduler/sort.h
@@ -39,9 +39,6 @@
 
 #ifndef	_SORT_H
 #define	_SORT_H
-#ifdef	__cplusplus
-extern "C" {
-#endif
 
 /*
  *	compare two new numerical resource numbers
@@ -200,7 +197,4 @@ int cmp_resv_state(const void *r1, const void *r2);
  */
 void sort_jobs(status *policy, server_info *sinfo);
 
-#ifdef	__cplusplus
-}
-#endif
 #endif	/* _SORT_H */

--- a/src/scheduler/state_count.h
+++ b/src/scheduler/state_count.h
@@ -39,9 +39,6 @@
 
 #ifndef	_STATE_COUNT_H
 #define	_STATE_COUNT_H
-#ifdef	__cplusplus
-extern "C" {
-#endif
 
 #include "data_types.h"
 
@@ -66,7 +63,4 @@ void total_states(state_count *sc1, state_count *sc2);
  *                        it increment, pass in 1, to decrement pass in -1
  */
 void state_count_add(state_count *sc, const char *job_state, int amount);
-#ifdef	__cplusplus
-}
-#endif
 #endif	/* _STATE_COUNT_H */

--- a/src/server/node_func.c
+++ b/src/server/node_func.c
@@ -93,6 +93,7 @@ extern int h_errno;
 
 /* Global Data */
 
+extern char *pbs_server_name;
 extern int	 svr_quehasnodes;
 extern int	 svr_totnodes;
 extern pbs_list_head svr_queues;
@@ -367,6 +368,20 @@ initialize_pbsnode(struct pbsnode *pnode, char *pname, int ntype)
 
 	prd  = &svr_resc_def[RESC_NCPUS];
 	(void)add_resource_entry(pat1, prd);
+
+	if (get_num_servers() > 1) {
+		resource *svr_nd_grp = NULL;
+
+		/* Set the value of msvr_node_group to "server_id" where
+		 * server_id is the id of the server for the node */
+		prd = &svr_resc_def[RESC_MSVR_ND_GROUP];
+		if ((svr_nd_grp = add_resource_entry(pat1, prd)) != NULL) {
+			char buf[PBS_MAXHOSTNAME];
+
+			snprintf(buf, sizeof(buf), "%s", pbs_server_name);
+			decode_arst(&svr_nd_grp->rs_value, NULL, NULL, buf);
+		}
+	}
 
 	/* add to resources_assigned any resource with ATR_DFLAG_FNASSN */
 	/* or  ATR_DFLAG_ANASSN set in the resource definition          */


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
In a multi-server setup, there can be a single scheduler for all server instances. Each node and each job is owned by a particular server. The scheduler gets a view of all nodes and all jobs and can potentially run a job anywhere. Running a job on nodes which don't belong to the same server incurs the cost of moving the job from one server to another. To avoid this, it's desirable to enhance scheduler to consider nodes of the server which owns a job before considering other nodes in the cluster, in the hope to minimize job moves between servers. This PR aims to do just that.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
- Added a new resource called 'msvr_node_group' which is set by each server to the server id on all of its nodes
- In the absence of admin configured node grouping, for a multi-server setup, scheduler groups nodes by this msvr_node_group, which creates placement sets of nodes of each server, and caches it.
- When considering the nodes to use for a job, the scheduler looks up the cache of placement sets of nodes for each server and creates a pset array with that pset as the first element. If the job is not an array, and is single chunk, it also adds the allpart as the second element of this array, and then passes it to eval_selspec, which means that the pset of the local server gets picked first before sched tries non local nodes.
- Right now, we are going to restrict job arrays and multi-chunk jobs to not span across servers

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
the following test shows how jobs are first scheduled on their owner's nodes and are only placed on nodes of another server in the absence of resources on the owner server
```
[ravi@pbsc8 ~]$ pbsnodes -av
pbsc8
     Mom = pbsc8
     ntype = PBS
     state = free
     pcpus = 4
     resources_available.arch = linux
     resources_available.host = pbsc8
     resources_available.mem = 2035188kb
     resources_available.msvr_node_group = pbsc8
     resources_available.ncpus = 4
     resources_available.vnode = pbsc8
     resources_assigned.accelerator_memory = 0kb
     resources_assigned.hbmem = 0kb
     resources_assigned.mem = 0kb
     resources_assigned.naccelerators = 0
     resources_assigned.ncpus = 0
     resources_assigned.vmem = 0kb
     resv_enable = True
     sharing = default_shared
     license = l
     last_state_change_time = Thu Dec 10 00:22:05 2020
     last_used_time = Thu Dec 10 00:22:11 2020

pbsc8-2
     Mom = pbsc8
     ntype = PBS
     state = free
     pcpus = 4
     jobs = 4.pbsc8-2/0, 5.pbsc8-2/1
     resources_available.arch = linux
     resources_available.host = pbsc8
     resources_available.mem = 2035188kb
     resources_available.msvr_node_group = pbsc8-2
     resources_available.ncpus = 4
     resources_available.vnode = pbsc8-2
     resources_assigned.accelerator_memory = 0kb
     resources_assigned.hbmem = 0kb
     resources_assigned.mem = 0kb
     resources_assigned.naccelerators = 0
     resources_assigned.ncpus = 2
     resources_assigned.vmem = 0kb
     resv_enable = True
     sharing = default_shared
     license = l
     last_state_change_time = Thu Dec 10 00:22:05 2020
     last_used_time = Thu Dec 10 00:22:05 2020

[ravi@pbsc8 ~]$ qsub -- /bin/sleep 100
6.pbsc8-2
[ravi@pbsc8 ~]$ qsub -- /bin/sleep 100
7.pbsc8-2
[ravi@pbsc8 ~]$ qstat
Job id            Name             User              Time Use S Queue
----------------  ---------------- ----------------  -------- - -----
4.pbsc8-2         STDIN            ravi              00:00:00 R workq           
5.pbsc8-2         STDIN            ravi              00:00:00 R workq           
6.pbsc8-2         STDIN            ravi              00:00:00 R workq           
7.pbsc8-2         STDIN            ravi              00:00:00 R workq           
[ravi@pbsc8 ~]$ pbsnodes -av
pbsc8
     Mom = pbsc8
     ntype = PBS
     state = free
     pcpus = 4
     resources_available.arch = linux
     resources_available.host = pbsc8
     resources_available.mem = 2035188kb
     resources_available.msvr_node_group = pbsc8
     resources_available.ncpus = 4
     resources_available.vnode = pbsc8
     resources_assigned.accelerator_memory = 0kb
     resources_assigned.hbmem = 0kb
     resources_assigned.mem = 0kb
     resources_assigned.naccelerators = 0
     resources_assigned.ncpus = 0
     resources_assigned.vmem = 0kb
     resv_enable = True
     sharing = default_shared
     license = l
     last_state_change_time = Thu Dec 10 00:22:05 2020
     last_used_time = Thu Dec 10 00:22:11 2020

pbsc8-2
     Mom = pbsc8
     ntype = PBS
     state = job-busy
     pcpus = 4
     jobs = 4.pbsc8-2/0, 5.pbsc8-2/1, 6.pbsc8-2/2, 7.pbsc8-2/3
     resources_available.arch = linux
     resources_available.host = pbsc8
     resources_available.mem = 2035188kb
     resources_available.msvr_node_group = pbsc8-2
     resources_available.ncpus = 4
     resources_available.vnode = pbsc8-2
     resources_assigned.accelerator_memory = 0kb
     resources_assigned.hbmem = 0kb
     resources_assigned.mem = 0kb
     resources_assigned.naccelerators = 0
     resources_assigned.ncpus = 4
     resources_assigned.vmem = 0kb
     resv_enable = True
     sharing = default_shared
     license = l
     last_state_change_time = Thu Dec 10 00:22:57 2020
     last_used_time = Thu Dec 10 00:22:05 2020

[ravi@pbsc8 ~]$ qsub -- /bin/sleep 100
8.pbsc8-2
[ravi@pbsc8 ~]$ qsub -- /bin/sleep 100
9.pbsc8-2
[ravi@pbsc8 ~]$ pbsnodes -av
pbsc8
     Mom = pbsc8
     ntype = PBS
     state = free
     pcpus = 4
     jobs = 8.pbsc8-2/0, 9.pbsc8-2/1
     resources_available.arch = linux
     resources_available.host = pbsc8
     resources_available.mem = 2035188kb
     resources_available.msvr_node_group = pbsc8
     resources_available.ncpus = 4
     resources_available.vnode = pbsc8
     resources_assigned.accelerator_memory = 0kb
     resources_assigned.hbmem = 0kb
     resources_assigned.mem = 0kb
     resources_assigned.naccelerators = 0
     resources_assigned.ncpus = 2
     resources_assigned.vmem = 0kb
     resv_enable = True
     sharing = default_shared
     license = l
     last_state_change_time = Thu Dec 10 00:22:05 2020
     last_used_time = Thu Dec 10 00:22:11 2020

pbsc8-2
     Mom = pbsc8
     ntype = PBS
     state = job-busy
     pcpus = 4
     jobs = 4.pbsc8-2/0, 5.pbsc8-2/1, 6.pbsc8-2/2, 7.pbsc8-2/3
     resources_available.arch = linux
     resources_available.host = pbsc8
     resources_available.mem = 2035188kb
     resources_available.msvr_node_group = pbsc8-2
     resources_available.ncpus = 4
     resources_available.vnode = pbsc8-2
     resources_assigned.accelerator_memory = 0kb
     resources_assigned.hbmem = 0kb
     resources_assigned.mem = 0kb
     resources_assigned.naccelerators = 0
     resources_assigned.ncpus = 4
     resources_assigned.vmem = 0kb
     resv_enable = True
     sharing = default_shared
     license = l
     last_state_change_time = Thu Dec 10 00:22:57 2020
     last_used_time = Thu Dec 10 00:22:05 2020
```


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
