### PR TITLE
Bump up PBS_BATCH_PROT_VER

### DIFF
--- a/src/include/libpbs.h
+++ b/src/include/libpbs.h
@@ -61,7 +61,8 @@ extern "C" {
 #define PROT_TPP 1 /* For TPP based connection */
 
 #define PBS_BATCH_PROT_TYPE 2
-#define PBS_BATCH_PROT_VER  1
+#define PBS_BATCH_PROT_VER_OLD  1
+#define PBS_BATCH_PROT_VER  2
 #define SCRIPT_CHUNK_Z (65536)
 #ifndef TRUE
 #define TRUE  1
@@ -217,9 +218,9 @@ struct batch_reply
 		struct batch_status *brp_statc; /* status (cmd) replies) */
 		struct {
 			int tot_jobs;
-			int tot_rpys; 
+			int tot_rpys;
 			int tot_arr_jobs;
-			struct batch_deljob_status *brp_delstatc;	
+			struct batch_deljob_status *brp_delstatc;
 		} brp_deletejoblist;
 		struct {
 			int brp_txtlen;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
As part of #1953, we changed batch protocol to support part reply send in status call, but missed to bump up PBS_BATCH_PROT_VER, which lead to hang new client when connection to old server.

Fixes #2158 

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Bumped PBS_BATCH_PROT_VER

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
* None

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
```
root@node2:~# qstat --version (Release 20.0.1)
pbs_version = 20.0.1

root@node3:~# qstat --version (After fix)
pbs_version = 22.0.1

root@node1:~# qstat --version (Before fix)
pbs_version = 22.0.0

root@node1:~# PBS_SERVER=node2 qstat (This hangs forever)
^C

root@node3:~# PBS_SERVER=node2 qstat
Communication failure.
qstat: cannot connect to server node2 (errno=15031)

node2's Server log:
12/10/2020 05:17:51;0100;Server@node2;Req;;Type 0 request received from root@node1.dev.local, sock=15
12/10/2020 05:18:11;0080;Server@node2;Req;req_reject;Reject reply code=15056, aux=0, type=0, from root@node3.dev.local

```

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
