### PR TITLE
pbs_disconnect is not freeing memory allocated for connections

### DIFF
--- a/src/lib/Libifl/pbsD_connect.c
+++ b/src/lib/Libifl/pbsD_connect.c
@@ -787,9 +787,8 @@ __pbs_disconnect(int connect)
 			svr_conns[i]->state = SVR_CONN_STATE_DOWN;
 		}
 	} else {
-		/* fd doesn't belong to a multi-server setup, just disconnect and exit */
+		/* fd doesn't belong to a multi-server setup */
 		disconnect_from_server(connect);
-		return 0;
 	}
 
 	/* Destroy the connection cache associated with this set of connections */

--- a/src/lib/Libutil/pbs_array_list.c
+++ b/src/lib/Libutil/pbs_array_list.c
@@ -99,7 +99,7 @@ create_pbs_iplist(void)
 	pntPBS_IP_LIST list= (pntPBS_IP_LIST)calloc(1, sizeof(PBS_IP_LIST));
 	if (list) {
 		list->li_range = create_pbs_range();
-		if (! list->li_range) {
+		if (!list->li_range) {
 			free(list);
 			return NULL;
 		}

--- a/src/server/svr_movejob.c
+++ b/src/server/svr_movejob.c
@@ -465,11 +465,13 @@ post_movejob(struct work_task *pwt)
 		* for history purpose without purging. No need to check
 		* for sub-jobs as sub jobs can't be moved.
 		*/
-		if (jobp && ((move_type == MOVE_TYPE_Move_Run) || !svr_chk_history_conf())) {
-			job_purge(jobp);
-			jobp = NULL;
-		} else if (svr_chk_history_conf()) {
-			svr_setjob_histinfo(jobp, T_MOV_JOB);
+		if (jobp) {
+			if ((move_type == MOVE_TYPE_Move_Run) || !svr_chk_history_conf()) {
+				job_purge(jobp);
+				jobp = NULL;
+			} else if (svr_chk_history_conf()) {
+				svr_setjob_histinfo(jobp, T_MOV_JOB);
+			}
 		}
 
 		if (move_type != MOVE_TYPE_Move_Run || force_ack)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
* pbs_disconnect is not freeing memory allocated for connections


#### Describe Your Change
* Freeing memory irrespective of multi-server or single server
* Adding NULL check in post_moverun



#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
