### PR TITLE
 Making legacy failover to work properly

### DIFF
--- a/src/include/pbs_internal.h
+++ b/src/include/pbs_internal.h
@@ -223,7 +223,6 @@ struct pbs_config
 	char *pbs_home_path;			/* path to the pbs home dir */
 	char *pbs_exec_path;			/* path to the pbs exec dir */
 	char *pbs_server_name;		/* name of PBS Server, usually hostname of host on which PBS server is executing */
-	char *pbs_server_id;                  /* name of the database PBS server id associated with the server hostname, pbs_server_name */
 	unsigned int pbs_num_servers;	/* currently configured number of instances */
 	psi_t *psi;						/* array of pbs server instances loaded from comma separated host:port[,host:port] */
 	char *cp_path;			/* path to local copy function */

--- a/src/include/portability.h
+++ b/src/include/portability.h
@@ -55,6 +55,9 @@
 #define get_uncpath(char)  
 #define critical_section() 
 
+/* check for the file in failover mode*/
+#define CHECK_FILE 1
+
 #ifdef PBS_MOM
 #define TRAILING_CHAR '/'
 #define verify_dir(dir_val, isdir, sticky, disallow, fullpath) tmp_file_sec(dir_val, isdir, sticky, disallow, fullpath)

--- a/src/include/portability.h
+++ b/src/include/portability.h
@@ -55,7 +55,7 @@
 #define get_uncpath(char)  
 #define critical_section() 
 
-/* check for the file in failover mode*/
+/* check for the file in failover mode for optimizaton*/
 #define CHECK_FILE 1
 
 #ifdef PBS_MOM

--- a/src/include/portability.h
+++ b/src/include/portability.h
@@ -55,8 +55,6 @@
 #define get_uncpath(char)  
 #define critical_section() 
 
-/* check for the file in failover mode for optimizaton*/
-#define CHECK_FILE 1
 
 #ifdef PBS_MOM
 #define TRAILING_CHAR '/'

--- a/src/lib/Libifl/pbsD_connect.c
+++ b/src/lib/Libifl/pbsD_connect.c
@@ -658,16 +658,17 @@ __pbs_connect_extend(char *server, char *extend_data)
 		/* failover configuered ...   */	
 		if (is_same_host(server, pbs_conf.pbs_primary)) {	
 			have_alt = 1;	
+			
+			altservers[0] = pbs_conf.pbs_primary;	
+			altservers[1] = pbs_conf.pbs_secondary;	
+			
+#ifdef CHECK_FILE	
 			/* We want to try the one last seen as "up" first to not   */	
 			/* have connection delays.   If the primary was up, there  */	
 			/* is no .pbsrc.NAME file.  If the last command connected  */	
 			/* to the Secondary, then it created the .pbsrc.USER file. */	
 
-			/* see if already seen Primary down */	
-#ifndef CHECK_FILE	
-			altservers[0] = pbs_conf.pbs_primary;	
-			altservers[1] = pbs_conf.pbs_secondary;	
-#else	
+			/* see if already seen Primary down */		
 			snprintf(pbsrc, _POSIX_PATH_MAX, "%s/.pbsrc.%s", pbs_conf.pbs_tmpdir, pbs_current_user);
 			if (stat(pbsrc, &sb) == -1) {	
 				/* try primary first */	

--- a/src/lib/Libifl/pbsD_connect.c
+++ b/src/lib/Libifl/pbsD_connect.c
@@ -632,12 +632,10 @@ __pbs_connect_extend(char *server, char *extend_data)
 	int	sock = -1;
 	int	i;
 	int	f;
-	
-#ifdef CHECK_FILE	
+		
 	char   pbsrc[_POSIX_PATH_MAX];	
 	struct stat sb;	
 	int    using_secondary = 0;	
-#endif
 	
 	/* initialize the thread context data, if not already initialized */
 	if (pbs_client_thread_init_thread_context() != 0)
@@ -661,8 +659,7 @@ __pbs_connect_extend(char *server, char *extend_data)
 			
 			altservers[0] = pbs_conf.pbs_primary;	
 			altservers[1] = pbs_conf.pbs_secondary;	
-			
-#ifdef CHECK_FILE	
+				
 			/* We want to try the one last seen as "up" first to not   */	
 			/* have connection delays.   If the primary was up, there  */	
 			/* is no .pbsrc.NAME file.  If the last command connected  */	
@@ -675,8 +672,7 @@ __pbs_connect_extend(char *server, char *extend_data)
 				altservers[0] = pbs_conf.pbs_secondary;		
 				altservers[1] = pbs_conf.pbs_primary;
 				using_secondary = 1;	
-			} 	
-#endif	
+			} 		
 		}	
 	}
 
@@ -700,7 +696,6 @@ __pbs_connect_extend(char *server, char *extend_data)
 		return -1; 		/* cannot connect */
 	}
 	
-#ifdef CHECK_FILE
 	if (have_alt && (i == 1)) {
 		/* had to use the second listed server ... */
 		if (using_secondary == 1) {
@@ -713,7 +708,6 @@ __pbs_connect_extend(char *server, char *extend_data)
 				close(f);
 		}
 	}
-#endif
 	
 	return sock;
 }

--- a/src/lib/Libifl/pbsD_connect.c
+++ b/src/lib/Libifl/pbsD_connect.c
@@ -706,7 +706,7 @@ __pbs_connect_extend(char *server, char *extend_data)
 			altservers[0] = pbs_conf.pbs_primary;	
 			altservers[1] = pbs_conf.pbs_secondary;	
 #else	
-			(void)snprintf(pbsrc, _POSIX_PATH_MAX, "%s/.pbsrc.%s", pbs_conf.pbs_tmpdir, pbs_current_user);	
+			snprintf(pbsrc, _POSIX_PATH_MAX, "%s/.pbsrc.%s", pbs_conf.pbs_tmpdir, pbs_current_user);
 			if (stat(pbsrc, &sb) == -1) {	
 				/* try primary first */	
 				altservers[0] = pbs_conf.pbs_primary;	
@@ -728,7 +728,7 @@ __pbs_connect_extend(char *server, char *extend_data)
 	 *   if attempting to connect to Primary,  try the Secondary	
 	 *   if attempting to connect to Secondary, try the Primary	
 	 */	
-	for (i=0; i<(have_alt+1); ++i) {
+	for (i = 0; i<(have_alt+1); ++i) {
 		if (have_alt) 
 			pbs_strncpy(server_name, altservers[i], PBS_MAXSERVERNAME);
 		if ((sock = connect_to_servers(server_name, server_port, extend_data)) != -1)

--- a/src/lib/Libifl/pbsD_connect.c
+++ b/src/lib/Libifl/pbsD_connect.c
@@ -690,7 +690,7 @@ __pbs_connect_extend(char *server, char *extend_data)
 	 *   if attempting to connect to Primary,  try the Secondary	
 	 *   if attempting to connect to Secondary, try the Primary	
 	 */	
-	for (i = 0; i<(have_alt+1); ++i) {
+	for (i = 0; i < (have_alt + 1); ++i) {
 		if (have_alt) 
 			pbs_strncpy(server_name, altservers[i], PBS_MAXSERVERNAME);
 		if ((sock = connect_to_servers(server_name, server_port, extend_data)) != -1)
@@ -714,7 +714,7 @@ __pbs_connect_extend(char *server, char *extend_data)
 			/* create file that causes trying the Primary first   */
 			f = open(pbsrc, O_WRONLY|O_CREAT, 0200);
 			if (f != -1)
-				(void)close(f);
+				close(f);
 		}
 	}
 #endif

--- a/src/lib/Libifl/pbsD_connect.c
+++ b/src/lib/Libifl/pbsD_connect.c
@@ -670,17 +670,12 @@ __pbs_connect_extend(char *server, char *extend_data)
 
 			/* see if already seen Primary down */		
 			snprintf(pbsrc, _POSIX_PATH_MAX, "%s/.pbsrc.%s", pbs_conf.pbs_tmpdir, pbs_current_user);
-			if (stat(pbsrc, &sb) == -1) {	
-				/* try primary first */	
-				altservers[0] = pbs_conf.pbs_primary;	
-				altservers[1] = pbs_conf.pbs_secondary;	
-				using_secondary = 0;	
-			} else {	
+			if (stat(pbsrc, &sb) != -1) {	
 				/* try secondary first */	
-				altservers[0] = pbs_conf.pbs_secondary;	
-				altservers[1] = pbs_conf.pbs_primary;	
+				altservers[0] = pbs_conf.pbs_secondary;		
+				altservers[1] = pbs_conf.pbs_primary;
 				using_secondary = 1;	
-			}	
+			} 	
 #endif	
 		}	
 	}

--- a/src/lib/Libifl/pbs_loadconf.c
+++ b/src/lib/Libifl/pbs_loadconf.c
@@ -98,7 +98,6 @@ struct pbs_config pbs_conf = {
 	NULL,					/* pbs_home_path */
 	NULL,					/* pbs_exec_path */
 	NULL,					/* pbs_server_name */
-	NULL,					/* PBS server id */
 	0,					/* single pbs server instance by default */
 	NULL,					/* pbs_server_instances */
 	NULL,					/* cp_path */

--- a/src/server/process_request.c
+++ b/src/server/process_request.c
@@ -293,10 +293,23 @@ req_register_sched(conn_t *conn, struct batch_request *preq)
 		rc = PBSE_UNKSCHED;
 		goto rerr;
 	}
+
 	if (sched->sc_conn_addr != conn->cn_addr) {
-		rc = PBSE_BADHOST;
-		goto rerr;
+		if (pbs_conf.pbs_primary != NULL && pbs_conf.pbs_secondary != NULL) {
+			pbs_net_t addr = get_hostaddr(pbs_conf.pbs_primary);
+			if (addr != conn->cn_addr) {
+				addr = get_hostaddr(pbs_conf.pbs_secondary);
+				if (addr != conn->cn_addr) {
+					rc = PBSE_BADHOST;
+					goto rerr;
+				}
+			}
+		} else {
+			rc = PBSE_BADHOST;
+			goto rerr;
+		}
 	}
+	
 	if (sched->sc_primary_conn != -1 && sched->sc_secondary_conn != -1) {
 		rc = PBSE_SCHEDCONNECTED;
 		goto rerr;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
In a failover setup after the primary server is down, the front end clients do not automatically talk to the secondary anymore. The refactoring work on pbs_connet() causes the failure in pbs_server failover. In this PR, I am fixing the broken changes and making the failover to work properly. 

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* The failover code which recognizes the pbs_conf switches are added back and refactored to work with multi-server. 
* Fixed the bug in scheduler registering logic. Added the code to check both the primary and secondary hosts for connection validation.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
N/A

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

[Failover_test_logs.txt](https://github.com/openpbs/openpbs/files/5691017/Failover_test_logs.txt)

Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, WIN2K16
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|5316|3842|5|0|0|0|3837|

Description: Rerun Only Failed Tests From #5316
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|5317|5|3|0|0|0|2|

These 3 test failures are seen in the mainline branch as well. 

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
