### PR TITLE
Fixing a sched crash for multi-server setup

### DIFF
--- a/src/lib/Libifl/pbsD_connect.c
+++ b/src/lib/Libifl/pbsD_connect.c
@@ -420,6 +420,9 @@ get_conn_svr_instances(int parentfd)
 {
 	svr_conns_list_t *iter_conns = NULL;
 
+	if (parentfd < 0)
+		return NULL;
+
 	/* Find the set of connections associated with the parent fd */
 	for (iter_conns = conn_list; iter_conns; iter_conns = iter_conns->next) {
 		if (iter_conns->cfd == parentfd)

--- a/src/lib/Libifl/pbsD_connect.c
+++ b/src/lib/Libifl/pbsD_connect.c
@@ -1146,7 +1146,7 @@ pbs_register_sched(const char *sched_id, int primary_conn_id, int secondary_conn
 	svr_conn_t **svr_conns_primary = NULL;
 	svr_conn_t **svr_conns_secondary = NULL;
 
-	if (sched_id == NULL)
+	if (sched_id == NULL || primary_conn_id < 0 || secondary_conn_id < 0)
 		return 0;
 
 	svr_conns_primary =  get_conn_svr_instances(primary_conn_id);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Segfault in pbs_sched_register when there are multiple servers, and either one or more of them are not up yet. Trace:

Core was generated by `/opt/pbs/sbin/pbs_sched'.

Program terminated with signal SIGABRT, Aborted.

#0  0x000014fea68777ff in raise () from /usr/lib64/libc.so.6

[Current thread is 1 (Thread 0x14fea8754740 (LWP 57975))]

Missing separate debuginfos, use: yum debuginfo-install glibc-2.28-127.el8.x86_64 libgcc-8.3.1-5.1.el8.x86_64 libical-3.0.3-3.el8.x86_64 libicu-60.3-2.el8_1.x86_64 libstdc++-8.3.1-5.1.el8.x86_64 libxcrypt-4.1.1-4.el8.x86_64 openssl-libs-1.1.1g-11.el8.x86_64 python3-libs-3.6.8-31.el8.x86_64 zlib-1.2.11-16.el8_2.x86_64

(gdb) bt

#0  0x000014fea68777ff in raise () from /usr/lib64/libc.so.6

#1  0x000014fea6861c35 in abort () from /usr/lib64/libc.so.6

#2  0x000014fea6861b09 in __assert_fail_base.cold.0 () from /usr/lib64/libc.so.6

#3  0x000014fea686fde6 in __assert_fail () from /usr/lib64/libc.so.6

#4  0x0000000000493c82 in diswul (stream=-1, value=2) at ../../../../src/lib/Libpbs/../Libdis/diswul.c:95

#5  0x0000000000486768 in encode_DIS_ReqHdr (sock=-1, reqt=98, user=0x6da450 <pbs_conf+528> "root") at ../../../../src/lib/Libpbs/../Libifl/enc_ReqHdr.c:77

#6  0x000000000048ce42 in send_register_sched (sock=-1, sched_id=0x4bb115 "default") at ../../../../src/lib/Libpbs/../Libifl/pbsD_connect.c:1102

#7  0x000000000048cfaa in pbs_register_sched (sched_id=0x4bb115 "default", primary_conn_id=-1, secondary_conn_id=-1) at ../../../../src/lib/Libpbs/../Libifl/pbsD_connect.c:1161

#8  0x00000000004717c4 in connect_svrpool () at ../../../src/scheduler/pbs_sched_utils.cpp:594

#9  0x0000000000472950 in sched_main (argc=1, argv=0x7ffd5dd51ec8, sched_ptr=0x41e2f6 <schedule(int, sched_cmd const*)>) at ../../../src/scheduler/pbs_sched_utils.cpp:1116

#10 0x000000000041d3c3 in main (argc=1, argv=0x7ffd5dd51ec8) at ../../../src/scheduler/pbs_sched.cpp:61

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
