### PR TITLE
pbs_compare_results changes for multiple run average measurements

### DIFF
--- a/test/fw/bin/pbs_compare_results
+++ b/test/fw/bin/pbs_compare_results
@@ -167,20 +167,25 @@ if __name__ == '__main__':
     TDR = '      <td rowspan=%d>%s</td>\n'
 
     data = []
-    for k, v in sorted(oldv['testsuites'].items()):
-        assert k in newv['testsuites'], k
-        _ntcs = newv['testsuites'][k]['testcases']
+    for k, v in sorted(oldv['avg_measurements']['testsuites'].items()):
+        assert k in newv['avg_measurements']['testsuites'], k
+        _ntcs = newv['avg_measurements']['testsuites'][k]['testcases']
         _otcs = v['testcases']
         for _k, _v in sorted(v['testcases'].items()):
             _tcn = k + '.' + _k
             assert _k in _ntcs, _tcn
-            _om = _v['results']['measurements']
+            _om = _v
             _om = [x for x in _om if 'test_measure' in x]
             _om = sorted(_om, key=lambda x: x['test_measure'])
-            _nm = _ntcs[_k]['results']['measurements']
+            _nm = _ntcs[_k]
             _nm = [x for x in _nm if 'test_measure' in x]
             _nm = sorted(_nm, key=lambda x: x['test_measure'])
             _nm_ms = [x['test_measure'] for x in _nm]
+            for key, val in sorted(oldv['testsuites'].items()):
+                assert key in newv['testsuites'], key
+                for tc, doc in sorted(val['testcases'].items()):
+                    if _k == tc:
+                        _docs = doc['docstring']
             for i, _m in enumerate(_om):
                 _mn = _m['test_measure']
                 _msg = 'test measure %s missing' % _mn
@@ -188,7 +193,7 @@ if __name__ == '__main__':
                 assert _mn in _nm_ms, _msg
                 _o = _m['test_data']['mean']
                 _n = _nm[i]['test_data']['mean']
-                _row = [_v['docstring'].split(' Test Params')[0], _tcn, _mn]
+                _row = [_docs, _tcn, _mn]
                 _row += [str(_o), str(_n), percent_change(_n, _o, _m['unit']),
                          _m['unit']]
                 data.append(_row)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
pbs_compare_results changes for multiple run average measurements


#### Describe Your Change 
New changes to PTL to run PTL tests with --repeat-count allows tests to run multiple times and json report collects the data and does list the average results out of all runs. So use it to create a comparision report.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

Attached json reports csv and html report in a zip file


[performace comparision reports.zip](https://github.com/openpbs/openpbs/files/5755081/performace.comparision.reports.zip)
[single_run_reports.zip](https://github.com/openpbs/openpbs/files/5765454/single_run_reports.zip)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
