### PR TITLE
Fix for server crash in multi-svr

### DIFF
--- a/src/cmds/qrun.c
+++ b/src/cmds/qrun.c
@@ -198,7 +198,7 @@ cnt:
 					prt_job_err("qrun", ct, job);
 				}
 			} else {
-				fprintf(stderr, "qrun : Server returned error %d for job ", pbs_errno);
+				fprintf(stderr, "qrun : Server returned error %d for job\n", pbs_errno);
 			}
 			exitstatus = 2;
 		} else if (err && (pbs_errno == PBSE_UNKJOBID) && !located) {

--- a/src/include/batch_request.h
+++ b/src/include/batch_request.h
@@ -154,6 +154,7 @@ struct rq_move {
 	char rq_destin[(PBS_MAXSVRRESVID > PBS_MAXDEST ? PBS_MAXSVRRESVID : PBS_MAXDEST) + 1];
 	char *run_exec_vnode;
 	int orig_rq_type;
+	void *ptask_runjob;
 };
 
 /* Resource Query/Reserve/Free */

--- a/src/include/svrfunc.h
+++ b/src/include/svrfunc.h
@@ -78,7 +78,7 @@ extern char *get_hostPart(char *);
 extern int is_compose(int, int);
 extern int is_compose_cmd(int, int, char **);
 extern char *get_servername(unsigned int *);
-extern char *get_svr_inst_id(void);
+extern char *gen_svr_inst_id(void);
 extern void process_Areply(int);
 extern void process_Dreply(int);
 extern void process_DreplyTPP(int);

--- a/src/lib/Libifl/dec_MoveJob.c
+++ b/src/lib/Libifl/dec_MoveJob.c
@@ -100,6 +100,7 @@ decode_DIS_MoveJob(int sock, struct batch_request *preq)
 
 	preq->rq_ind.rq_move.run_exec_vnode = NULL;
 	preq->rq_ind.rq_move.orig_rq_type = PBS_BATCH_MoveJob;
+	preq->rq_ind.rq_move.ptask_runjob = NULL;
 
 	return rc;
 }

--- a/src/resmom/catch_child.c
+++ b/src/resmom/catch_child.c
@@ -848,7 +848,7 @@ get_servername_failover(unsigned int *port)
 	if (!pbs_conf.pbs_secondary)
 		return get_servername(port);
 	else {
-		whom_to_connect = (whom_to_connect + 1) % 2;
+		whom_to_connect = !whom_to_connect;
 
 		if (whom_to_connect)
 			return get_servername(port);

--- a/src/scheduler/pbs_sched_utils.cpp
+++ b/src/scheduler/pbs_sched_utils.cpp
@@ -758,6 +758,9 @@ send_cycle_end()
 	int i;
 	static int cycle_end_marker = 0;
 	svr_conns = static_cast<svr_conn_t **>(get_conn_svr_instances(clust_secondary_sock));
+	
+	if (svr_conns == NULL)
+		goto err;
 
 	for (i = 0; svr_conns[i] != NULL; i++) {
 		if (svr_conns[i]->state == SVR_CONN_STATE_DOWN)

--- a/src/server/job_func.c
+++ b/src/server/job_func.c
@@ -385,7 +385,7 @@ job_alloc(void)
 	set_jattr_l_slim(pj, JOB_ATR_sample_starttime, time_now, SET);
 	set_jattr_l_slim(pj, JOB_ATR_eligible_time, 0, SET);
 
-	if ((svr_inst_id = get_svr_inst_id()) == NULL) {
+	if ((svr_inst_id = gen_svr_inst_id()) == NULL) {
 		log_err(errno, __func__, "unable to get server_instance_id");
 		return NULL;
 	}

--- a/src/server/multi_svr.c
+++ b/src/server/multi_svr.c
@@ -282,14 +282,14 @@ init_msi()
 
 /**
  * @brief
- * 	Used to get serverer_instance_id which is of the form server_instance_name:server_instance_port
+ * 	Used to Create serverer_instance_id which is of the form server_instance_name:server_instance_port
  * 
  * @return char *
  * @return NULL - failure
  * @retval !NULL - pointer to server_instance_id
  */
 char *
-get_svr_inst_id(void)
+gen_svr_inst_id(void)
 {
 	char svr_inst_name[PBS_MAXHOSTNAME + 1];
 	unsigned int svr_inst_port;

--- a/src/server/multi_svr.c
+++ b/src/server/multi_svr.c
@@ -279,3 +279,30 @@ init_msi()
 
 	return 0;
 }
+
+/**
+ * @brief
+ * 	Used to get serverer_instance_id which is of the form server_instance_name:server_instance_port
+ * 
+ * @return char *
+ * @return NULL - failure
+ * @retval !NULL - pointer to server_instance_id
+ */
+char *
+get_svr_inst_id(void)
+{
+	char svr_inst_name[PBS_MAXHOSTNAME + 1];
+	unsigned int svr_inst_port;
+	char *svr_inst_id = NULL;
+
+
+	if (gethostname(svr_inst_name, PBS_MAXHOSTNAME) == 0)
+        	get_fullhostname(svr_inst_name, svr_inst_name, PBS_MAXHOSTNAME);
+
+	svr_inst_port = pbs_conf.batch_service_port;
+
+	pbs_asprintf(&svr_inst_id, "%s:%d", svr_inst_name, svr_inst_port);
+
+	return svr_inst_id;
+
+}

--- a/src/server/node_func.c
+++ b/src/server/node_func.c
@@ -328,7 +328,7 @@ initialize_pbsnode(struct pbsnode *pnode, char *pname, int ntype)
 	pnode->nd_attr[(int)ND_ATR_state].at_val.at_long = pnode->nd_state;
 	pnode->nd_attr[(int)ND_ATR_state].at_flags = ATR_VFLAG_SET;
 
-	if ((svr_inst_id = get_svr_inst_id()) == NULL) {
+	if ((svr_inst_id = gen_svr_inst_id()) == NULL) {
 		log_err(errno, __func__, "unable to get server_instance_id");
 		return (PBSE_SYSTEM);
 	}

--- a/src/server/process_request.c
+++ b/src/server/process_request.c
@@ -1781,33 +1781,3 @@ get_servername(unsigned int *port)
 
 	return name;
 }
-
-/**
- * @brief
- * 	Used to get serverer_instance_id which is of the form server_instance_name:server_instance_port
- * 
- * @return char *
- * @return NULL - failure
- * @retval !NULL - pointer to server_instance_id
- */
-char *
-get_svr_inst_id(void)
-{
-	char svr_inst_name[PBS_MAXHOSTNAME + 1];
-	unsigned int svr_inst_port;
-	char *svr_inst_id = NULL;
-
-
-	if (gethostname(svr_inst_name, PBS_MAXHOSTNAME) == 0)
-        	get_fullhostname(svr_inst_name, svr_inst_name, PBS_MAXHOSTNAME);
-
-	if (pbs_conf.batch_service_port)
-		svr_inst_port = pbs_conf.batch_service_port;
-	else
-		svr_inst_port = PBS_BATCH_SERVICE_PORT;
-
-	pbs_asprintf(&svr_inst_id, "%s:%d", svr_inst_name, svr_inst_port);
-
-	return svr_inst_id;
-
-}

--- a/src/server/sched_func.c
+++ b/src/server/sched_func.c
@@ -424,7 +424,6 @@ sched_alloc(char *sched_name)
 	psched->sc_secondary_conn = -1;
 	psched->newobj = 1;
 	append_link(&svr_allscheds, &psched->sc_link, psched);
-	psched->sc_conn_addr = get_hostaddr(psched->sc_name);
 
 	/* set the working attributes to "unspecified" */
 

--- a/src/server/svr_movejob.c
+++ b/src/server/svr_movejob.c
@@ -393,6 +393,7 @@ post_movejob(struct work_task *pwt)
 	struct work_task *ptask;
 	int move_type = -1;
 	int force_ack = 0;
+	int replied = 0;
 
 	req = (struct batch_request *) pwt->wt_parm1;
 	pbs_errno = PBSE_NONE;
@@ -468,14 +469,15 @@ post_movejob(struct work_task *pwt)
 		if (jobp) {
 			if ((move_type == MOVE_TYPE_Move_Run) || !svr_chk_history_conf()) {
 				job_purge(jobp);
-				jobp = NULL;
 			} else if (svr_chk_history_conf()) {
 				svr_setjob_histinfo(jobp, T_MOV_JOB);
 			}
 		}
 
-		if (move_type != MOVE_TYPE_Move_Run || force_ack)
+		if (move_type != MOVE_TYPE_Move_Run || force_ack) {
 			reply_ack(req);
+			replied = 1;
+		}
 		break;
 
 	case PBSE_SYSTEM:
@@ -494,6 +496,16 @@ post_movejob(struct work_task *pwt)
 		if (move_type == MOVE_TYPE_Move_Run)
 			r = wstat;
 		req_reject(r, 0, req);
+		replied = 1;
+	}
+
+	/* If already replied, delete any pending tasks associated with this request */
+	ptask = req->rq_ind.rq_move.ptask_runjob;
+	if (replied && ptask && ptask != pwt) {
+		free(ptask->wt_event2);
+		delete_link(&ptask->wt_linkobj2);
+		delete_task(ptask);
+		req->rq_ind.rq_move.ptask_runjob = NULL;
 	}
 
 	return;
@@ -676,6 +688,7 @@ done:
 			pbs_errno = PBSE_SYSTEM;
 			goto send_err;
 		}
+		rq_move->ptask_runjob = ptask_runjob;
 	}
 	free(dup_msgid); /* free this as it is not part of any work task */
 	resc_access_perm = save_resc_access_perm; /* reset back to it's old value */


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
* Job owning server crashes when move+run job fails due to an error while submitting the job.
* Mom choosing between primary and secondary servers randomly could result in skewed results.


#### Describe Your Change
* Move and run sends two requests to the destination server - submit and run. When the submit fails due to an error, it sends the error back and the source server sends it back to the client. When it receives the error corresponding to the run request, the request is invalid as it has been already processed.
The fix is to delete any existing task corresponding to the request after replying.
* Mom will choose between primary and secondary in an interleaved way than random



#### Attach Test and Valgrind Logs/Output

[move_run_fix.log](https://github.com/openpbs/openpbs/files/5703167/move_run_fix.log)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
