### PR TITLE
Added a check for valid recurrence frequency

### DIFF
--- a/src/lib/Libutil/pbs_ical.c
+++ b/src/lib/Libutil/pbs_ical.c
@@ -322,6 +322,11 @@ check_rrule(char *rrule, time_t dtstart, time_t dtend, char *tz, int *err_code)
 		}
 	}
 
+        /* Check if frequency was correctly set */
+	if (rt.freq == ICAL_NO_RECURRENCE) {
+		*err_code = PBSE_BAD_RRULE_SYNTAX;
+		return 0;
+	}
 	/* Check if the rest of the by_* rules are defined
 	 * and valid.
 	 * currently no support for

--- a/src/lib/Libutil/pbs_ical.c
+++ b/src/lib/Libutil/pbs_ical.c
@@ -321,8 +321,8 @@ check_rrule(char *rrule, time_t dtstart, time_t dtend, char *tz, int *err_code)
 			return 0;
 		}
 	}
-
-        /* Check if frequency was correctly set */
+	
+	/* Check if frequency was correctly set */
 	if (rt.freq == ICAL_NO_RECURRENCE) {
 		*err_code = PBSE_BAD_RRULE_SYNTAX;
 		return 0;

--- a/src/lib/Libutil/pbs_ical.c
+++ b/src/lib/Libutil/pbs_ical.c
@@ -321,7 +321,7 @@ check_rrule(char *rrule, time_t dtstart, time_t dtend, char *tz, int *err_code)
 			return 0;
 		}
 	}
-	
+
 	/* Check if frequency was correctly set */
 	if (rt.freq == ICAL_NO_RECURRENCE) {
 		*err_code = PBSE_BAD_RRULE_SYNTAX;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
When someone gives invalid frequency in standing reservation's recurrence rule, it throws out a wrong error stating COUNT and UNTIL cannot be used together - 
"[root@Nile /tmp]# PBS_TZID=America/Los_Angeles /opt/pbs/bin/pbs_rsub -r 'FREQ=ABCD;COUNT=2' -R 2200 -D 1200
pbs_rsub: Undefined iCalendar syntax. A valid COUNT or UNTIL is required"


#### Describe Your Change
Added a check to verify freq and throw the right error.


#### Link to Design Doc
NA
#### Attach Test and Valgrind Logs/Output
Before:
[root@Nile /tmp]# PBS_TZID=America/Los_Angeles /opt/pbs/bin/pbs_rsub -r 'FREQ=ABCD;COUNT=2' -R 2200 -D 1200
pbs_rsub: Undefined iCalendar syntax. A valid COUNT or UNTIL is required
After:
[root@Nile /tmp]# PBS_TZID=America/Los_Angeles /opt/pbs/bin/pbs_rsub -r 'FREQ=ABCD;COUNT=2' -R 2200 -D 1200
pbs_rsub: Undefined iCalendar syntax



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
