### PR TITLE
Fixing test_fairshare_usage from multisched suite

### DIFF
--- a/test/tests/functional/pbs_multi_sched.py
+++ b/test/tests/functional/pbs_multi_sched.py
@@ -769,7 +769,7 @@ class TestMultipleSchedulers(TestFunctional):
         # submit jobs to multisched 'sc1'
         sc1_attr = {ATTR_queue: 'wq1',
                     'Resource_List.select': '1:ncpus=1',
-                    'Resource_List.walltime': 10}
+                    'Resource_List.walltime': 100}
         sc1_J1 = Job(TEST_USER1, attrs=sc1_attr)
         sc1_jid1 = self.server.submit(sc1_J1)
         sc1_J2 = Job(TEST_USER2, attrs=sc1_attr)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
This test fails because the qdel is trying to delete a job that has already exited. The job's walltime was set to 10s, so by the time the qdel is called the job had ended.
Here I am increasing the walltime of the job to 100s


#### Attach Test and Valgrind Logs/Output
[test_fairshare_usage.txt](https://github.com/openpbs/openpbs/files/5706199/test_fairshare_usage.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
