### PR TITLE
Added a null check while confirming degraded resv

### DIFF
--- a/src/scheduler/resv_info.cpp
+++ b/src/scheduler/resv_info.cpp
@@ -1798,7 +1798,8 @@ check_down_running(resource_resv *resv, int chunk_ind)
 	int i, j, k;
 	int ret = 0;
 
-	if (resv == NULL || chunk_ind < 0 || !resv->is_resv)
+	if (resv == NULL || chunk_ind < 0 || !resv->is_resv ||
+	    resv->resv == NULL || resv->resv->resv_queue == NULL)
 		return -3;
 
 	for (i = chunk_ind; resv->resv->orig_nspec_arr[i] != NULL && ret != -2; i++) {


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
It has been found in valgrind reports that in some case while trying to reconfirm a degraded reservation scheduler may try to access some invalid memory.

#### Describe Your Change
The issue is very rarely seen and is not reproducible. This change, for now, makes sure that the variables are set before accessing them.


#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
[log.txt](https://github.com/openpbs/openpbs/files/5706492/log.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
