### PR TITLE
Tests of TestGenNodefileOnSisterMom are getting skipped

### DIFF
--- a/test/tests/functional/pbs_gen_nodefile_on_sister_mom.py
+++ b/test/tests/functional/pbs_gen_nodefile_on_sister_mom.py
@@ -40,6 +40,7 @@
 
 from tests.functional import *
 
+
 @requirements(num_moms=2)
 class TestGenNodefileOnSisterMom(TestFunctional):
     """

--- a/test/tests/functional/pbs_gen_nodefile_on_sister_mom.py
+++ b/test/tests/functional/pbs_gen_nodefile_on_sister_mom.py
@@ -40,7 +40,7 @@
 
 from tests.functional import *
 
-
+@requirements(num_moms=2)
 class TestGenNodefileOnSisterMom(TestFunctional):
     """
     This test suite tests the PBS_NODEFILE creation on

--- a/test/tests/functional/pbs_job_task.py
+++ b/test/tests/functional/pbs_job_task.py
@@ -104,6 +104,7 @@ class TestJobTask(TestFunctional):
             job_output_file = job_status[0]['Output_Path'].split(':')[1]
         self.check_jobs_file(job_output_file)
 
+    @requirements(num_moms=3)
     def test_invoke_pbs_tmrsh_from_sister_mom(self):
         """
         This test cases verifies pbs_tmrsh invoked from sister mom


### PR DESCRIPTION

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Tests of TestGenNodefileOnSisterMom are getting skipped during regression. Requirement of the test is to have 2 moms and  the test is getting skipped even if there are 2 moms available. This is because the test doesn't have requirement decorator.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Add a requirement decorator to the tests introduced as part of https://github.com/openpbs/openpbs/pull/2147

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[TestGenNodefileOnSisterMom.txt](https://github.com/openpbs/openpbs/files/5714398/TestGenNodefileOnSisterMom.txt)
[test_invoke_pbs_tmrsh_from_sister_mom.txt](https://github.com/openpbs/openpbs/files/5714399/test_invoke_pbs_tmrsh_from_sister_mom.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
