### PR TITLE
Update tests of TestTPP accordingly

### DIFF
--- a/test/tests/functional/pbs_test_tpp.py
+++ b/test/tests/functional/pbs_test_tpp.py
@@ -265,7 +265,6 @@ class TestTPP(TestFunctional):
         self.common_steps(job=True, interactive=True, resv=True,
                           resv_job=True)
 
-    @skip(reason="Run this through cmd-line by removing this decorator")
     @requirements(num_moms=2, num_clients=1)
     def test_client_with_mom(self):
         """
@@ -276,6 +275,10 @@ class TestTPP(TestFunctional):
         Node 2 : Mom
         Node 3 : Client
         """
+        if self.server.client == self.server.hostname:
+            msg = "Test requires client as input which is on non server"
+            msg += " host"
+            self.skipTest(msg)
         self.momA = self.moms.values()[0]
         self.momB = self.moms.values()[1]
         self.hostA = self.momA.shortname
@@ -286,8 +289,7 @@ class TestTPP(TestFunctional):
         self.common_steps(job=True, interactive=True)
         self.common_steps(resv=True, resv_job=True, client=self.hostB)
 
-    @skip(reason="Run this through cmd-line by removing this decorator")
-    @requirements(num_moms=2, num_clients=1, num_comms=1)
+    @requirements(num_moms=2, num_clients=1, no_comm_on_server=True)
     def test_comm_non_server_host(self):
         """
         This test verifies communication between server-mom,
@@ -299,8 +301,10 @@ class TestTPP(TestFunctional):
         Node 3 : Mom
         Node 4 : Comm
         """
-        msg = "Need atleast 2 moms and a comm installed on host"
-        msg += " other than server host"
+        if self.server.client == self.server.hostname:
+            msg = "Test requires client as input which is on non server"
+            msg += " host"
+            self.skipTest(msg)
         self.momA = self.moms.values()[0]
         self.momB = self.moms.values()[1]
         self.comm1 = self.comms.values()[0]

--- a/test/tests/functional/pbs_test_tpp.py
+++ b/test/tests/functional/pbs_test_tpp.py
@@ -923,19 +923,24 @@ class TestTPP(TestFunctional):
                 existence = False
             else:
                 existence = True
-            self.set_pbs_conf(host_name=self.mom.shortname, conf_param=attrib)
+            start_time = time.time()
+            self.set_pbs_conf(host_name=self.server.shortname,
+                              conf_param=attrib)
             attrs = {'event': 'execjob_begin', 'enabled': 'True'}
             self.server.create_hook(hook_name, attrs)
             exp_msg = ["MCAST packet from %s:15001" % server_ip,
                        "mcast done"]
             for msg in exp_msg:
-                self.comm.log_match(msg, existence=existence, n=30)
+                self.comm.log_match(msg, existence=existence,
+                                    starttime=start_time)
             self.server.import_hook(hook_name, body="import pbs")
             for msg in exp_msg:
-                self.comm.log_match(msg, existence=existence, n=30)
+                self.comm.log_match(msg, existence=existence,
+                                    starttime=start_time)
             self.server.manager(MGR_CMD_DELETE, HOOK, id=hook_name)
             for msg in exp_msg:
-                self.comm.log_match(msg, existence=existence, n=30)
+                self.comm.log_match(msg, existence=existence,
+                                    starttime=start_time)
 
     def common_steps_for_mom_pool_tests(self):
         """


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature

- In the test we are setting the "PBS_COMM_LOG_EVENTS" to diff values (0,511, T(invalid value)).  There are few log msgs which appear only when the PBS_COMM_LOG_EVENT is set to 511 and when other values are set (0, invalid value(T)) the below log msgs should not appear in comm-logs. 
Log msgs:

- In failed scenario, when PBS_COMM_LOG_EVENTS is set to T and the test is trying to verify the non-existence of the logs msg the test is failing as the msg exists. The msg is not appearing but its older msgs (appeared when PBS_COMM_LOG_EVENT is set to 511). The log_match fails as we are passing n=30 to log_match.

- Test "test_comm_non_serverhost" and "test_client_non_serverhost" are currently getting skipped even if the requirements are satisfied.

#### Describe Your Change

- Removed n=30 from the log_match and used starttime parameter in log_match function
-  For test "test_comm_non_serverhost" and test_mom_non_server_host remove the below code and update the test's requirement and skip condition in the test
**code to be removed: ** @skip(reason="Run this through cmd-line by removing this decorator")


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output

- [test_comm_log_events_bfr_fix.txt](https://github.com/openpbs/openpbs/files/5716548/test_comm_log_events_bfr_fix.txt)


- [test_comm_log_events_after_fix.txt.txt](https://github.com/openpbs/openpbs/files/5716530/test_comm_log_events_after_fix.txt.txt)


5384 | regression | client_non_server_fix | Mahalty/pbspro@tpp | 19th Dec 2020 01:00:00.293 PM +05:30 | 00:00:00.089 | 2 | 0 | 0 | 0 | 0 | 0 | 2 | 0
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --


- [Execution_logs_client_with_mom_aftr_fix.txt](https://github.com/openpbs/openpbs/files/5719030/Execution_logs_client_with_mom_aftr_fix.txt)

- [Execution_logs_comm_with_nonserver_aftr_fix.txt](https://github.com/openpbs/openpbs/files/5719049/Execution_logs_comm_with_nonserver_aftr_fix.txt)






<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
