### PR TITLE
Multi-Server: Handling PSI variable for qsub daemon

### DIFF
--- a/src/cmds/Makefile.am
+++ b/src/cmds/Makefile.am
@@ -234,7 +234,9 @@ qstop_LDADD = ${common_libs}
 qstop_SOURCES = qstop.c ${common_sources}
 
 qsub_CPPFLAGS = ${common_cflags}
-qsub_LDADD = ${common_libs}
+qsub_LDADD = ${common_libs} \
+		-lssl \
+		-lcrypto
 qsub_SOURCES = qsub.c qsub_sup.c ${common_sources}
 
 qterm_CPPFLAGS = ${common_cflags}

--- a/src/cmds/qsub_sup.c
+++ b/src/cmds/qsub_sup.c
@@ -1440,9 +1440,9 @@ get_comm_filename(char *fname)
 			 (env_svr == NULL) ? "" : env_svr,
 			 (env_port == NULL) ? "" : env_port,
 			 psi_var ? psi_var : "");
+
 		if (len + count < MAXPIPENAME) {
-			memcpy(fname + count, buf, MAXPIPENAME - count);
-			fname[MAXPIPENAME - 1] = '\0';
+			pbs_strncpy(fname + count, buf, MAXPIPENAME - count);
 		} else {
 			if (SHA1((const unsigned char *) buf, SHA_DIGEST_LENGTH, (unsigned char *) &hash)) {
 				for (i = 0; i < SHA_DIGEST_LENGTH; i++)
@@ -1450,8 +1450,7 @@ get_comm_filename(char *fname)
 					
 				buf[SHA_DIGEST_LENGTH*2] = 0;
 			}
-			memcpy(fname + count, buf, MAXPIPENAME - count);
-			fname[MAXPIPENAME - 1] = '\0';
+			pbs_strncpy(fname + count, buf, MAXPIPENAME - count);
 		}
 	}
 

--- a/src/include/cmds.h
+++ b/src/include/cmds.h
@@ -65,6 +65,7 @@
 #define NULLstr(x)	(((x)==NULL) || (strlen(x)==0))
 
 #define MAX_LINE_LEN 4095
+#define LARGE_BUF_LEN 4096
 #define MAXSERVERNAME PBS_MAXSERVERNAME+PBS_MAXPORTNUM+2
 #define PBS_DEPEND_LEN 2040
 

--- a/src/include/pbs_internal.h
+++ b/src/include/pbs_internal.h
@@ -226,6 +226,7 @@ struct pbs_config
 	char *pbs_server_id;                  /* name of the database PBS server id associated with the server hostname, pbs_server_name */
 	unsigned int pbs_num_servers;	/* currently configured number of instances */
 	psi_t *psi;						/* array of pbs server instances loaded from comma separated host:port[,host:port] */
+	char *psi_str;			/* psi in string format */
 	char *cp_path;			/* path to local copy function */
 	char *scp_path;			/* path to ssh */
 	char *rcp_path;			/* path to pbs_rsh */
@@ -500,7 +501,7 @@ extern char *pbs_get_tmpdir(void);
 
 extern char *pbs_get_conf_var(char *);
 
-extern char *psi_to_str(psi_t *, int);
+extern char *get_psi_str();
 
 extern FILE *pbs_popen(const char *, const char *);
 

--- a/src/include/pbs_internal.h
+++ b/src/include/pbs_internal.h
@@ -498,6 +498,10 @@ extern int pbs_query_max_connections(void);
 
 extern char *pbs_get_tmpdir(void);
 
+extern char *pbs_get_conf_var(char *);
+
+extern char *psi_to_str(psi_t *, int);
+
 extern FILE *pbs_popen(const char *, const char *);
 
 extern int pbs_pkill(FILE *, int);

--- a/src/lib/Libifl/pbs_loadconf.c
+++ b/src/lib/Libifl/pbs_loadconf.c
@@ -102,6 +102,7 @@ struct pbs_config pbs_conf = {
 	NULL,					/* PBS server id */
 	0,					/* single pbs server instance by default */
 	NULL,					/* pbs_server_instances */
+	NULL,					/* pbs_server_instances str */
 	NULL,					/* cp_path */
 	NULL,					/* scp_path */
 	NULL,					/* rcp_path */
@@ -318,6 +319,7 @@ parse_psi(char *conf_value)
 	}
 	free_string_array(list);
 	pbs_conf.pbs_num_servers = i;
+	pbs_conf.psi_str = strdup(conf_value);
 
 	return 0;
 }
@@ -1191,36 +1193,16 @@ err:
 
 /**
  * @brief
- *	convert psi to comma separated string.
- *
- * @param[in] psi - psi structure
- * @param[in] nsvrs - num of servers
- * 
- * @note
- * return string has to be freed by the caller
+ *	returns psi in string format
  *
  * @return char *
  * @retval !NULL pointer psi string
  * @retval NULL failure
  */
 char *
-psi_to_str(psi_t *psi, int nsvrs)
+get_psi_str()
 {
-	char buf[LARGE_BUF_LEN];
-	int len = 0;
-	int i;
-
-	if (!psi)
-		return NULL;
-
-	for (i = 0; i < nsvrs; i++) {
-		if (len == 0)
-			len += snprintf(buf, LARGE_BUF_LEN, "%s:%d", psi[i].name, psi[i].port);
-		else
-			len += snprintf(buf + len, LARGE_BUF_LEN, ",%s:%d", psi[i].name, psi[i].port);
-	}
-
-	return strdup(buf);
+	return pbs_conf.psi_str;
 }
 
 /**
@@ -1253,7 +1235,7 @@ pbs_get_conf_var(char *conf_var_name)
 	/* If pbs_conf already been populated use that value. */
 	if (pbs_conf.loaded != 0) {
 		if (!strcmp(conf_var_name, PBS_CONF_SERVER_INSTANCES))
-			conf_val_out = psi_to_str(pbs_conf.psi, pbs_conf.pbs_num_servers);
+			conf_val_out = get_psi_str();
 	}
 
 	if (conf_val_out)

--- a/src/lib/Libifl/pbs_loadconf.c
+++ b/src/lib/Libifl/pbs_loadconf.c
@@ -56,6 +56,7 @@
 #include "pbs_client_thread.h"
 #include "net_connect.h"
 #include "portability.h"
+#include "cmds.h"
 
 #include <sys/stat.h>
 #include <unistd.h>
@@ -65,8 +66,6 @@
 #endif
 
 char *pbs_conf_env = "PBS_CONF_FILE";
-
-#define LARGE_BUF_LEN 4096
 
 static char *pbs_loadconf_buf = NULL;
 static int   pbs_loadconf_len = 0;
@@ -1212,7 +1211,7 @@ psi_to_str(psi_t *psi, int nsvrs)
 	int i;
 
 	if (!psi)
-		return strdup("");
+		return NULL;
 
 	for (i = 0; i < nsvrs; i++) {
 		if (len == 0)
@@ -1288,7 +1287,7 @@ pbs_get_conf_var(char *conf_var_name)
 		return conf_val_out;
 
 	/* Finally, resort to the default. */
-	return strdup("");
+	return NULL;
 }
 
 /**


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
* Handling PSI variable for qsub


#### Describe Your Change
* qsub will use a named pipe to talk to the background daemon. When qsub wants to submit a job, it will check whether a background daemon is running by checking the pipe belongs to that configuration exists. If the file could not be found, qsub will go ahead and create another daemon and a new pipe for the new configuration.
* There can be more than one daemon based on configurations.
* The name of the pipe should be the unique signature of the background daemon server it is talking to.
* Since pbs_server_instances has been added to conf file we need to account that while generating the name of the pipe.
* Since the name of the pipe is restricted to 108 in Linux, a hash of the configuration string is used as the pipe name, in case the string length exceeds 108.


#### Attach Test and Valgrind Logs/Output
* Filename with small PSI
[root@centos8 test-scripts]# qsub -- /bin/sleep 10
get_comm_filename, fname: /var/tmp/pbs_default_0_____centos8,centos8_2

* File name with large PSI
[root@centos8 test-scripts]# PBS_SERVER_INSTANCES=centos8.localhost12345.localdomain:15001,centos8_2.localhost67890.localdomain:15001 qsub -- /bin/sleep 10
get_comm_filename, fname: /var/tmp/pbs_4d05ffff73ffffffff4058ff280e3b090c3bffff

* Repeating the test to see if it generates the same file name
[root@centos8 test-scripts]# PBS_SERVER_INSTANCES=centos8.localhost12345.localdomain:15001,centos8_2.localhost67890.localdomain:15001 qsub -- /bin/sleep 10
get_comm_filename, fname: /var/tmp/pbs_4d05ffff73ffffffff4058ff280e3b090c3bffff



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
