### PR TITLE
PBS snapshot failed while importing module

### DIFF
--- a/test/fw/Makefile.am
+++ b/test/fw/Makefile.am
@@ -91,7 +91,22 @@ dist_ptlmodulelib_PYTHON = \
 	ptl/lib/pbs_api_to_cli.py \
 	ptl/lib/pbs_ifl_mock.py \
 	ptl/lib/pbs_testlib.py \
-	ptl/lib/__init__.py
+	ptl/lib/__init__.py \
+	ptl/lib/ptl_config.py \
+	ptl/lib/ptl_error.py \
+	ptl/lib/ptl_types.py \
+	ptl/lib/ptl_batchutils.py \
+	ptl/lib/ptl_constants.py \
+	ptl/lib/ptl_expect_action.py \
+	ptl/lib/ptl_object.py \
+	ptl/lib/ptl_mom.py \          
+	ptl/lib/ptl_sched.py \
+	ptl/lib/ptl_server.py \
+	ptl/lib/ptl_comm.py \
+	ptl/lib/ptl_entities.py \
+	ptl/lib/ptl_fairshare.py \
+	ptl/lib/ptl_resourceresv.py \
+	ptl/lib/ptl_service.py
 
 ptlmoduleutilsdir = $(ptlmoduledir)/utils
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
PBS snapshot failed while importing module because PTL library files are missing for PBS snapshot


#### Describe Your Change
Added PTL library files to run PBS snapshot


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->


**Before changes**
/opt/pbs/unsupported/fw/ptl/lib> ls
__init__.py     pbs_api_to_cli.py     pbs_ifl_mock.py     pbs_testlib.py     __pycache__

2020-12-13 21:53:32,509 DEBUG2 centos: /opt/pbs/sbin/pbs_snapshot -H centos --daemon-logs 2 --accounting-logs 2 --with-sudo -o /home/pbsroot
2020-12-13 21:53:34,382 DEBUG2 out: []
2020-12-13 21:53:34,383 DEBUG <DshUtils.run_cmd>err: ['Traceback (most recent call last):', ' File "/opt/pbs/unsupported/fw/bin/pbs_snapshot.py", line 54, in <module>', ' from ptl.lib.pbs_testlib import PtlConfig', ' File "/opt/pbs/unsupported/fw/ptl/lib/pbs_testlib.py", line 41, in <module>', ' from ptl.lib.ptl_error import *', "*ModuleNotFoundError: No module named 'ptl.lib.ptl_error'"]*


**After changes**
/opt/pbs/unsupported/fw/ptl/lib> ls
__init__.py        pbs_ifl_mock.py                      ptl_batchutils.py     ptl_config.py       ptl_entities.py  ptl_expect_action.py     ptl_mom.py     ptl_resourceresv.py     ptl_server.py      ptl_types.py    pbs_api_to_cli.py      pbs_testlib.py      ptl_comm.py        ptl_constants.py  ptl_error.py       ptl_fairshare.py        ptl_object.py  ptl_sched.py         ptl_service.py          __pycache__

2020-12-20 22:56:20,883 DEBUG2   centos: /opt/pbs/sbin/pbs_snapshot -H **centos** --daemon-logs 2 --accounting-logs 2 --with-sudo -o /home/pbsroot
2020-12-20 22:56:55,818 DEBUG2   out: ['Snapshot available at: /home/pbsroot/snapshot_20201220_22_56_22.tgz']




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
