### PR TITLE
Test issues due to slow server response

### DIFF
--- a/test/tests/functional/pbs_reservations.py
+++ b/test/tests/functional/pbs_reservations.py
@@ -300,7 +300,7 @@ class TestReservations(TestFunctional):
         Verify that degraded standing reservations are reconfirmed
         on other nodes
         """
-        self.degraded_resv_reconfirm(start=25, end=625,
+        self.degraded_resv_reconfirm(start=125, end=625,
                                      rrule='freq=HOURLY;count=5')
 
     def test_degraded_advance_reservations(self):
@@ -308,7 +308,7 @@ class TestReservations(TestFunctional):
         Verify that degraded advance reservations are reconfirmed
         on other nodes
         """
-        self.degraded_resv_reconfirm(start=25, end=625)
+        self.degraded_resv_reconfirm(start=125, end=625)
 
     def test_degraded_standing_running_reservations(self):
         """

--- a/test/tests/functional/pbs_sched_preempt_enforce_resumption.py
+++ b/test/tests/functional/pbs_sched_preempt_enforce_resumption.py
@@ -211,7 +211,7 @@ class TestSchedPreemptEnforceResumption(TestFunctional):
         j4 = Job(TEST_USER)
         j4.set_attributes({ATTR_l + '.select': '1:ncpus=2',
                            ATTR_q: 'expressq',
-                           ATTR_l + '.walltime': 5})
+                           ATTR_l + '.walltime': 15})
         jid4 = self.server.submit(j4)
 
         self.server.expect(JOB, {ATTR_state: 'S'}, id=jid1)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Few tests have been seen failing because of slowness in server


#### Describe Your Change
There were mainly two issues - 
- In the first issue, we try to see if a reservation that is going to start 25 seconds in future, when degraded is able to reconfirm before moving to running state. There are various steps that happen before the job moves to degraded state and if the machine is too slow, the test may never see the reservation getting reconfirmed. It rather sees the reservation moving from a degraded state to running directly. Since the test does not wait for the reservation to start, I just pushed the reservation to 125 seconds in future.
- In the second test a job is submitted to run for only 5 seconds and by the time test tries to check its state, it's already finished. I've increased the walltime to 15 seconds instead.

#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
Running tests



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
