### PR TITLE
Scheduler crash while confirming multiple reservations in same cycle

### DIFF
--- a/src/scheduler/resv_info.cpp
+++ b/src/scheduler/resv_info.cpp
@@ -1182,8 +1182,8 @@ check_new_reservations(status *policy, int pbs_sd, resource_resv **resvs, server
 						release_nodes(nresv_copy);
 
 						nresv_copy->resv->orig_nspec_arr = parse_execvnode(occr_execvnodes_arr[j], sinfo, nresv_copy->select);
-						nresv_copy->ninfo_arr = create_node_array_from_nspec(nresv_copy->nspec_arr);
 						nresv_copy->nspec_arr = combine_nspec_array(nresv_copy->resv->orig_nspec_arr);
+						nresv_copy->ninfo_arr = create_node_array_from_nspec(nresv_copy->nspec_arr);
 						nresv_copy->resv->resv_nodes = create_resv_nodes(nresv_copy->nspec_arr, sinfo);
 					}
 
@@ -1217,6 +1217,10 @@ check_new_reservations(status *policy, int pbs_sd, resource_resv **resvs, server
 						add_event(sinfo->calendar, te_end);
 
 						if (j > 0) {
+							tmp_resresv = add_resresv_to_array(sinfo->all_resresv, nresv_copy, SET_RESRESV_INDEX);
+							if (tmp_resresv == NULL)
+								break;
+							sinfo->all_resresv = tmp_resresv;
 							tmp_resresv = add_resresv_to_array(sinfo->resvs, nresv_copy, NO_FLAGS);
 							if (tmp_resresv == NULL)
 								break;

--- a/src/scheduler/simulate.cpp
+++ b/src/scheduler/simulate.cpp
@@ -1348,7 +1348,10 @@ dup_timed_event_list(timed_event *ote_list, server_info *nsinfo)
 
 	for (ote = ote_list; ote != NULL; ote = ote->next) {
 		nte = dup_timed_event(ote, nsinfo);
-
+		if (nte == NULL) {
+			free_timed_event_list(nte_head);
+			return NULL;
+		}
 		if (nte_prev != NULL)
 			nte_prev->next = nte;
 		else

--- a/test/tests/functional/pbs_reservations.py
+++ b/test/tests/functional/pbs_reservations.py
@@ -2428,3 +2428,34 @@ class TestReservations(TestFunctional):
         self.assertEqual(
             jid2[1], '(' + vn + '[1]:ncpus=4+' + vn + '[2]:ncpus=4)')
         self.assertNotIn(job1_node, job2_node, errmsg)
+
+    def test_clashing_reservations(self):
+        """
+        Test that when a standing reservation and advance reservation
+        are submitted to start at the same time on the same set of
+        resources, then the one that is submitted first wins and second
+        is deleted.
+        """
+
+        self.common_config()
+
+        a = {'scheduling': 'False'}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+
+        start = int(time.time()) + 300
+        end = int(time.time()) + 1200
+        srid = self.submit_reservation(user=PBSROOT_USER,
+                                       select='2:ncpus=4',
+                                       rrule='FREQ=DAILY;COUNT=2',
+                                       start=start,
+                                       end=end)
+
+        arid = self.submit_reservation(user=PBSROOT_USER,
+                                       select='2:ncpus=4',
+                                       start=start,
+                                       end=end)
+        a = {'scheduling': 'True'}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+        self.server.expect(RESV, {'reserve_state':
+                                  (MATCH_RE, 'RESV_CONFIRMED|2')}, id=srid)
+        self.server.log_match(arid + ";Reservation denied", id=arid)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
scheduler crashes while trying to confirm a standing reservation with any other reservation in the same cycle.


#### Describe Your Change
The problem happens at two different places - 
First, the scheduler when confirms a standing reservation it creates the node info array before it creates node_spec array even though it needs node_spec array to create node info array. So order of execution was wrong there.
Second, When the scheduler adds an occurrence of a standing reservation to the actual universe, it does not update the server's all_resresv array. This results in failure to duplicate the calendar because while duplicating we try to search for reservations in the all_resresv array.

#### Link to Design Doc
NA
#### Attach Test and Valgrind Logs/Output
In progress, will post results soon.

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
