### PR TITLE
fixed test 'test_exclusive_state' from 'TestReservations' when mom is  on cpuset machine.

### DIFF
--- a/test/tests/functional/pbs_reservations.py
+++ b/test/tests/functional/pbs_reservations.py
@@ -681,8 +681,10 @@ class TestReservations(TestFunctional):
         exp_attr['reserve_state'] = (MATCH_RE, 'RESV_RUNNING|5')
         self.server.expect(RESV, exp_attr, id=rid, offset=30)
 
+        self.server.status(RESV, 'resv_nodes', id=rid)
+        resv_vnode = self.server.reservations[rid].get_vnodes()[0]
         self.server.expect(NODE, {'state': 'resv-exclusive'},
-                           id=self.mom.shortname)
+                           id=resv_vnode)
 
         a = {'Resource_List.select': '1:ncpus=1',
              'Resource_List.place': 'excl', 'queue': rid.split('.')[0]}
@@ -690,7 +692,7 @@ class TestReservations(TestFunctional):
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
 
-        n = self.server.status(NODE)
+        n = self.server.status(NODE, id=resv_vnode)
         states = n[0]['state'].split(',')
         self.assertIn('resv-exclusive', states)
         self.assertIn('job-exclusive', states)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
fixed test 'test_exclusive_state' from 'TestReservations' when mom is  on cpuset machine. test expect node state should be 'resv-exclusive', but on cpuset machine reservation run on vnode due to PTL didnt get expected result and test got failed.

#### Describe Your Change
find out reservation node value and that value in expect while checking node_state=resv-exclusive.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
Before fix:
[res_TestReservations_before_fix.txt](https://github.com/openpbs/openpbs/files/5734625/res_TestReservations_before_fix.txt)

After fix:
[res_after_fix_cpuset_machine.txt](https://github.com/openpbs/openpbs/files/5734626/res_after_fix_cpuset_machine.txt)
[res_after_fix_normal_machine.txt](https://github.com/openpbs/openpbs/files/5734627/res_after_fix_normal_machine.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
