### PR TITLE
Test 'test_pbsnodes_as_user' from TestPbsnodes is failing on cpuset machine while verifying node attributes

### DIFF
--- a/test/tests/functional/pbs_pbsnodes.py
+++ b/test/tests/functional/pbs_pbsnodes.py
@@ -83,6 +83,9 @@ class TestPbsnodes(TestFunctional):
             expect_dict[ATTR_version] = self.server.pbs_version
             expect_dict[ATTR_NODE_Port] = '15002'
 
+        if self.mom.is_cpuset_mom():
+            del expect_dict['resources_available.vnode']
+
         return expect_dict
 
     def verify_node_dynamic_val(self, last_state_change_time, available_ncpus,
@@ -236,8 +239,6 @@ class TestPbsnodes(TestFunctional):
             attr = attr_list[i].split('=')[0].strip()
             val = attr_list[i].split('=')[1].strip()
             attr_dict[attr] = val
-        if self.mom.is_cpuset_mom():
-            del expected_attrs['resources_available.vnode']
 
         # comparing the pbsnodes -a output with expected result
         for attr in expected_attrs:


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
fixed test 'test_pbsnodes_as_user' from 'TestPbsnodes' failed on cpuset machine.
on cpuset machine we have vnodes due to 'resources_available.vnode' value is 'various' for physical node. Test expecting that resources_available.vnode value should be hostname, but didn't get expected value and test got failed.
self.assertEqual(expected_attrs[attr], attr_dict[attr])
AssertionError: 'pbspro-cpuset' != 'various'

#### Describe Your Change
remove 'resources_available.vnode' expected attribute dictionary, if mom is on cpuset machine.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
Before fix:
[res_before_fix.txt](https://github.com/openpbs/openpbs/files/5779932/res_before_fix.txt)

After fix:
[res_after_fix_cpuset.txt](https://github.com/openpbs/openpbs/files/5779933/res_after_fix_cpuset.txt)
[res_after_fix_normal_machine.txt](https://github.com/openpbs/openpbs/files/5779934/res_after_fix_normal_machine.txt)
 
<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
