### PR TITLE
Fix nd_index duplication and mom wrong vnode map (and nodefile) due to mismatch in execvnode and exechost2 parsing

### DIFF
--- a/src/lib/Liblog/log_event.c
+++ b/src/lib/Liblog/log_event.c
@@ -144,6 +144,7 @@ void
 log_eventf(int eventtype, int objclass, int sev, const char *objname, const char *fmt, ...)
 {
 	va_list args;
+	va_list args_copy;
 	int len;
 	char logbuf[LOG_BUF_SIZE];
 	char *buf;
@@ -152,8 +153,10 @@ log_eventf(int eventtype, int objclass, int sev, const char *objname, const char
 		return;
 
 	va_start(args, fmt);
+	va_copy(args_copy, args);
 
-	len = vsnprintf(logbuf, sizeof(logbuf), fmt, args);
+	len = vsnprintf(logbuf, sizeof(logbuf), fmt, args_copy);
+	va_end(args_copy);
 
 	if (len >= sizeof(logbuf)) {
 		buf = pbs_asprintf_format(len, fmt, args);

--- a/src/lib/Liblog/pbs_log.c
+++ b/src/lib/Liblog/pbs_log.c
@@ -784,13 +784,16 @@ void
 log_errf(int errnum, const char *routine, const char *fmt, ...)
 {
 	va_list args;
+	va_list args_copy;
 	int len;
 	char logbuf[LOG_BUF_SIZE];
 	char *buf;
 
 	va_start(args, fmt);
+	va_copy(args_copy, args);
 
-	len = vsnprintf(logbuf, sizeof(logbuf), fmt, args);
+	len = vsnprintf(logbuf, sizeof(logbuf), fmt, args_copy);
+	va_end(args_copy);
 
 	if (len >= sizeof(logbuf)) {
 		buf = pbs_asprintf_format(len, fmt, args);

--- a/src/server/node_recov_db.c
+++ b/src/server/node_recov_db.c
@@ -215,13 +215,16 @@ node_to_db(struct pbsnode *pnode, pbs_db_node_info_t *pdbnd)
 	/* nodes do not have a qs area, so we cannot check whether qs changed or not 
 	 * hence for now, we always write the qs area, for now!
 	 */
-		
+
 	/* node_index is used to sort vnodes upon recovery.
 	* For Cray multi-MoM'd vnodes, we ensure that natural vnodes come
 	* before the vnodes that it manages by introducing offsetting all
 	* non-natural vnodes indices to come after natural vnodes.
 	*/
-	pdbnd->nd_index = (pnode->nd_nummoms * svr_totnodes) + pnode->nd_index;
+	if (pnode->nd_nummoms > 1)
+		pdbnd->nd_index = 1; /* multiple parent moms, Cray case */
+	else
+		pdbnd->nd_index = 0; /* default, single parent mom */
 
 	if (pnode->nd_hostname)
 		strcpy(pdbnd->nd_hostname, pnode->nd_hostname);

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -2762,7 +2762,8 @@ create_pbs_node2(char *objname, svrattrl *plist, int perms, int *bad, struct pbs
 		if (tmpndlist != NULL) {
 			/*add in the new entry etc*/
 			pbsndlist = tmpndlist;
-			pnode->nd_index = svr_totnodes;
+			/* nd_index = 0 (regular node, single parent mom), nd_index = 1 (multiple parent moms, usually Cray) */
+			pnode->nd_index = 0;
 			pnode->nd_arr_index = svr_totnodes; /* this is only in mem, not from db */
 			pbsndlist[svr_totnodes++] = pnode;
 		} else {


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
1. nd_index stored in the database is computed based on total number of nodes, which is dynamic. Thus, the computation is wrong. This results in nodes loaded in the wrong order on server restart and other problems occur after that.

2. When using exclhost with qsub (similar to follwing), the nodefile contains wrong entries.

3. Mom dumps core on running TestPbsHookAlarmLargeMultinodeJob.



#### Describe Your Change
1. This was working fine when upon any change to any node, we used to save ALL nodes to the database, in which case the nd_index would get recomputed and saved for every node. However, saving every node does not scale well. So we had changed to save only the node that has been updated, and this exposed the issue with nd_index (of the other nodes).
Use nd_creattm (the time of creation of the vnode) as the primary means of sorting the nodes. However, in the case of Cray Xt, parent moms of vnodes having multiple parents must be loaded before such vnodes are loaded from the database (on server restart)

2. The server does not send vnodemap to moms any more. The server instead sends the exec_host2 string (along with exec_vnode and schedselect) so that the mom can deduce the information by herself. However, the mom caches the information in the vnode table after she deduces the first time (for any vnode to host map).
Move the exechost2 parsing code to a separate function and call it also from the place where to skip a vnode in execvnode. This ensures that the corresponding exechost2 entry is also skipped

3. we use variable number of args for log_eventf()
if we pass larger buffers to log_eventf()
vsnprintf() is called twice
in the first call we get to know that the internal buffer is not sufficient
we malloc another buffer and call vsnprintf() again -
we pass the same variable args list to the second call as well -
however - this list was already scanned by the first call
So, we just need to reset the list before the second call

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, WIN2K16
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|5484|3850|1|0|0|1|3848|



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
