### PR TITLE
Fixing memory related errors while the server is deleting more number of jobs.

### DIFF
--- a/src/server/process_request.c
+++ b/src/server/process_request.c
@@ -1654,7 +1654,7 @@ free_br(struct batch_request *preq)
 			break;
 		case PBS_BATCH_DeleteJobList:
 			if (preq->rq_ind.rq_deletejoblist.rq_jobslist)
-				free(preq->rq_ind.rq_deletejoblist.rq_jobslist);
+				free_string_array(preq->rq_ind.rq_deletejoblist.rq_jobslist);
 			break;
 		case PBS_BATCH_CopyFiles:
 		case PBS_BATCH_DelFiles:

--- a/src/server/req_delete.c
+++ b/src/server/req_delete.c
@@ -554,9 +554,10 @@ req_deletejob(struct batch_request *preq)
 			/* If not deleteing running subjobs, delete2 to del parent   */
 
 			if (--preq->rq_refct == 0) {
-				if ((parent = find_job(jid)) != NULL)
+				if ((parent = find_job(jid)) != NULL) {
 					req_deletejob2(preq, parent);
-				else {
+					del_parent = 0;
+				} else {
 					preply->brp_un.brp_deletejoblist.tot_rpys++;
 					if (preply->brp_un.brp_deletejoblist.tot_rpys == preply->brp_un.brp_deletejoblist.tot_jobs)
 						reply_send(preq);

--- a/src/server/svr_chk_owner.c
+++ b/src/server/svr_chk_owner.c
@@ -439,7 +439,7 @@ chk_job_request(char *jobid, struct batch_request *preq, int *rc, int *err)
 	if ((t == IS_ARRAY_NO) && (check_job_state(pjob, JOB_STATE_LTR_EXITING))) {
 
 		/* special case Deletejob with "force" */
-		if ((preq->rq_type == PBS_BATCH_DeleteJob) &&
+		if (((preq->rq_type == PBS_BATCH_DeleteJob) || (preq->rq_type == PBS_BATCH_DeleteJobList)) &&
 			(preq->rq_extend != NULL) &&
 			(strcmp(preq->rq_extend, "force") == 0)) {
 			return pjob;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
1) Memory leaks and invalid read/write errors.
2) Not able to delete the job in E state. 

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
1) There is the code that calls the same function req_deletejob2() for the same request even after freeing the memory allocated for user request (preq). Made the code changes to avoid successive call on the invalid memory. 
2) Added the code to delete the job in E state. 

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

1) Vagrind Invalid read/write issue 
[afterfix_valgraind.out.txt](https://github.com/openpbs/openpbs/files/5782052/afterfix_valgraind.out.txt)
[before_fix_valgrind.out.txt](https://github.com/openpbs/openpbs/files/5782053/before_fix_valgrind.out.txt)
2) E state job deletion:  (hostname: pbs-mom) 

a) Before Fix
root@pbs-mom:/code/localrepo/ubuntu_source/pbspro# qsub -- /bin/date
16.pbs-mom
root@pbs-mom:/code/localrepo/ubuntu_source/pbspro# qstat
Job id            Name             User              Time Use S Queue
----------------  ---------------- ----------------  -------- - -----
16.pbs-mom        STDIN            root              00:00:00 E workq           
root@pbs-mom:/code/localrepo/ubuntu_source/pbspro# qdel -Wforce 16
qdel: Request invalid for state of job 16.pbs-mom
root@pbs-mom:/code/localrepo/ubuntu_source/pbspro# 

b) After fix
root@pbs-mom:/code/localrepo/ubuntu_source/pbspro# qstat -swn

pbs-mom: 
                                                                                                   Req'd  Req'd   Elap
Job ID                         Username        Queue           Jobname         SessID   NDS  TSK   Memory Time  S Time
------------------------------ --------------- --------------- --------------- -------- ---- ----- ------ ----- - -----
17.pbs-mom                     root            workq           STDIN                --     1     1    --    --  E 00:00
   pbs-mom/0
   Job run at Thu Jan 07 at 02:27 on (pbs-mom:ncpus=1)
root@pbs-mom:/code/localrepo/ubuntu_source/pbspro# qdel -Wforce 17
root@pbs-mom:/code/localrepo/ubuntu_source/pbspro# qstat -swn

![image](https://user-images.githubusercontent.com/17980660/103902566-b4af4a00-50c8-11eb-82c2-b73c34712721.png)

![image](https://user-images.githubusercontent.com/17980660/103902611-c55fc000-50c8-11eb-93aa-abcf7af51147.png)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
