### PR TITLE
qsub should distribute jobs uniformly amongst server instances

### DIFF
--- a/src/include/libpbs.h
+++ b/src/include/libpbs.h
@@ -407,6 +407,7 @@ void *get_conn_svr_instances(int);
 int pbs_register_sched(const char *sched_id, int primary_conn_id, int secondary_conn_id);
 int get_svr_inst_fd(int vfd, char *svr_inst_id);
 int random_srv_conn(svr_conn_t **);
+int get_available_conn(svr_conn_t **);
 int starting_index(char *);
 char *PBS_get_server(char *, char *, uint *);
 int encode_DIS_JobsList(int sock, char **jobs_list, int numofjobs);

--- a/src/lib/Libifl/ifl_util.c
+++ b/src/lib/Libifl/ifl_util.c
@@ -99,7 +99,7 @@ PBS_get_server(char *server_id_in, char *server_name_out, unsigned int *port)
  * @retval -1: error
  * @retval != -1 fd corresponding to the connection
  */
-static int
+int
 get_available_conn(svr_conn_t **svr_conns)
 {
 	int i;

--- a/src/lib/Libifl/pbsD_submit.c
+++ b/src/lib/Libifl/pbsD_submit.c
@@ -67,6 +67,37 @@ struct cred_info {
 
 /**
  * @brief
+ *	get the next connection from the connection list based on the
+ *	last used value
+ *
+ * @param[in] c - connection fd
+ *
+ * @return int
+ * @retval -1: error
+ * @retval != -1 fd corresponding to the connection
+ */
+static int
+get_nxt_conn(int c)
+{
+	svr_conn_t **svr_conns = get_conn_svr_instances(c);
+	static int ind = -1;
+
+	if (!svr_conns || svr_conns[0]->sd == c)
+		return c;
+
+	if (ind == -1)
+		ind = rand_num() % get_num_servers();
+	else
+		ind = (ind + 1) % get_num_servers();
+
+	if (svr_conns[ind] && svr_conns[ind]->state == SVR_CONN_STATE_UP)
+		return svr_conns[ind]->sd;
+
+	return get_available_conn(svr_conns);
+}
+
+/**
+ * @brief
  *	-wrapper function for pbs_submit where submission takes credentials.
  *
  * @param[in] c - communication handle
@@ -91,8 +122,7 @@ pbs_submit_with_cred(int c, struct attropl  *attrib, char *script,
 	char					*ret;
 	struct pbs_client_thread_context	*ptr;
 	struct cred_info			*cred_info;
-	svr_conn_t **svr_conns = get_conn_svr_instances(c);
-	c = random_srv_conn(svr_conns);
+	c = get_nxt_conn(c);
 
 	/* initialize the thread context data, if not already initialized */
 	if (pbs_client_thread_init_thread_context() != 0)
@@ -166,8 +196,7 @@ __pbs_submit(int c, struct attropl  *attrib, char *script, char *destination, ch
 	struct cred_info *cred_info = NULL;
 	int commit_done = 0;
 	char *lextend = NULL;
-	svr_conn_t **svr_conns = get_conn_svr_instances(c);
-	c = random_srv_conn(svr_conns);
+	c = get_nxt_conn(c);
 
 	/* initialize the thread context data, if not already initialized */
 	if ((pbs_errno = pbs_client_thread_init_thread_context()) != 0)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
qsub daemon was distributing jobs randomly which could result in skewed submissions


#### Describe Your Change
Instead of random, pbs_submit will pick the next available instance from the list based on the last used instance. The first job will be still going to a random server in the list. All other server instances will be attempted before we reach back at this instance again.


#### Attach Test and Valgrind Logs/Output
Before:
```
[root@centos8 pbspro]# for i in {1..6}; do qsub -- /bin/sleep 100; done
2018.centos8
2019.centos8
13.centos8_2
2020.centos8
2021.centos8
2022.centos8
```
After:
```
[root@centos8 pbspro]# for i in {1..6}; do qsub -- /bin/sleep 100; done
29.centos8_2
60.centos8
30.centos8_2
61.centos8
31.centos8_2
62.centos8
````
