### PR TITLE
Redesigning jobid namespace for multi-server

### DIFF
--- a/src/cmds/qstat.c
+++ b/src/cmds/qstat.c
@@ -2931,7 +2931,7 @@ job_no_args:
 					break;
 				}
 				show_svr_inst_fail(conn, "qstat");
-				
+
 				if (strcmp(pbs_server, server_old) != 0) {
 					/* changing to a different server */
 					p_server = pbs_statserver(conn, NULL, NULL);

--- a/src/include/libpbs.h
+++ b/src/include/libpbs.h
@@ -75,6 +75,8 @@ extern "C" {
 #define EOF (-1)
 #endif
 
+#define MSVR_JID_NCHARS_SVR	2	/* No. of chars reserved for svr instance in job ids for multi-server */
+
 /* enums for standard job files */
 enum job_file {
 	JScript,
@@ -405,7 +407,7 @@ svr_conn_t **get_conn_svr_instances(int);
 int pbs_register_sched(const char *sched_id, int primary_conn_id, int secondary_conn_id);
 int get_svr_inst_fd(int vfd, char *svr_inst_id);
 int random_srv_conn(svr_conn_t **);
-int starting_index(char *);
+int get_job_location_hint(char *);
 char *PBS_get_server(char *, char *, uint *);
 int encode_DIS_JobsList(int sock, char **jobs_list, int numofjobs);
 int get_server_fd_from_jid(int c, char *jobid);

--- a/src/include/libpbs.h
+++ b/src/include/libpbs.h
@@ -75,8 +75,6 @@ extern "C" {
 #define EOF (-1)
 #endif
 
-#define MSVR_JID_NCHARS_SVR	2	/* No. of chars reserved for svr instance in job ids for multi-server */
-
 /* enums for standard job files */
 enum job_file {
 	JScript,

--- a/src/include/pbs_ifl.h
+++ b/src/include/pbs_ifl.h
@@ -463,6 +463,7 @@ enum mgr_obj {
 #ifndef MAXNAMLEN
 #define MAXNAMLEN		255
 #endif
+#define MSVR_JID_NCHARS_SVR	2	/* No. of chars reserved for svr instance in job ids for multi-server */
 #define PBS_MAXSCHEDNAME 	15
 #define PBS_MAXUSER		256		/* max user name length */
 #define PBS_MAXPWLEN		256		/* max password length */
@@ -474,7 +475,7 @@ enum mgr_obj {
 #define PBS_MAXSEQNUM		12		/* max sequence number length */
 #define PBS_DFLT_MAX_JOB_SEQUENCE_ID 9999999	/* default value of max_job_sequence_id server attribute */
 #define PBS_MAXPORTNUM	5		/* udp/tcp port numbers max=16 bits */
-#define PBS_MAXSVRJOBID	(PBS_MAXSEQNUM - 1 + PBS_MAXSERVERNAME + PBS_MAXPORTNUM + 2) /* server job id size, -1 to keep same length when made SEQ 7 */
+#define PBS_MAXSVRJOBID	(PBS_MAXSEQNUM + MSVR_JID_NCHARS_SVR - 1 + PBS_MAXSERVERNAME + PBS_MAXPORTNUM + 2) /* server job id size, -1 to keep same length when made SEQ 7 */
 #define PBS_MAXSVRRESVID	(PBS_MAXSVRJOBID + 1)
 #define PBS_MAXQRESVNAME	(PBS_MAXQUEUENAME)
 #define PBS_MAXCLTJOBID		(PBS_MAXSVRJOBID + PBS_MAXSERVERNAME + PBS_MAXPORTNUM + 2) /* client job id size */

--- a/src/lib/Libifl/ifl_util.c
+++ b/src/lib/Libifl/ifl_util.c
@@ -135,9 +135,8 @@ random_srv_conn(svr_conn_t **svr_conns)
 }
 
 /**
- * @brief
- *	Process object id and decide on the server index
- *	based on server part in the object id.
+ * @brief	Get the server instance index from the jobid, which will act as a hint
+ * 			as to which server the job might possibly be located
 
  * @param[in] id - object id
  *
@@ -146,27 +145,28 @@ random_srv_conn(svr_conn_t **svr_conns)
  * @retval < 0: could not find appropriate index
  */
 int
-starting_index(char *id)
+get_job_location_hint(char *jobid)
 {
-	char job_id_out[PBS_MAXCLTJOBID];
-	char server_out[PBS_MAXSERVERNAME + 1];
-	char server_name[PBS_MAXSERVERNAME + 1];
-	uint server_port;
-	int i;
 	int nsvrs = get_num_servers();
+	char *ptr = NULL;
+	int svridx = -1;
+	char *endptr = NULL;
 
-	if ((get_server(id, job_id_out, server_out) == 0)) {
-		if (PBS_get_server(server_out, server_name, &server_port)) {
-			for (i = 0; i < nsvrs; i++) {
-				if (!strcmp(server_name, pbs_conf.psi[i].name) &&
-				    (server_port == pbs_conf.psi[i].port)) {
-					return i;
-				}
-			}
-		}
-	}
+	if (jobid == NULL)
+		return -1;
 
-	return -1;
+	ptr = strchr(jobid, '.');
+	if (ptr == NULL)
+		return -1;
+	*ptr = '\0';
+	ptr -= MSVR_JID_NCHARS_SVR;
+	svridx = strtol(ptr, &endptr, 10);
+	ptr += MSVR_JID_NCHARS_SVR;
+	*ptr = '.';
+	if (*endptr != '\0' || svridx >= nsvrs)
+		return -1;
+
+	return svridx;
 }
 
 /**

--- a/src/lib/Libifl/ifl_util.c
+++ b/src/lib/Libifl/ifl_util.c
@@ -152,13 +152,17 @@ get_job_location_hint(char *jobid)
 	int svridx = -1;
 	char *endptr = NULL;
 
-	if (jobid == NULL)
+	if (jobid == NULL || !msvr_mode())
 		return -1;
 
 	ptr = strchr(jobid, '.');
 	if (ptr == NULL)
 		return -1;
 	*ptr = '\0';
+	if (strlen(jobid) <= MSVR_JID_NCHARS_SVR) {	/* Minimum length of sequence will be MSVR_JID_NCHARS_SVR + 1 */
+		*ptr = '.';
+		return -1;
+	}
 	ptr -= MSVR_JID_NCHARS_SVR;
 	svridx = strtol(ptr, &endptr, 10);
 	ptr += MSVR_JID_NCHARS_SVR;

--- a/src/lib/Libifl/int_manager.c
+++ b/src/lib/Libifl/int_manager.c
@@ -143,7 +143,7 @@ PBSD_manager(int c, int rq_type, int command, int objtype, char *objname, struct
 
 	if (svr_conns) {
 		if (objtype == MGR_OBJ_JOB &&
-		    (start = starting_index(objname)) == -1)
+		    (start = get_job_location_hint(objname)) == -1)
 			start = 0;
 
 		for (i = start, ct = 0; ct < nsvrs; i = (i + 1) % nsvrs, ct++) {

--- a/src/lib/Libifl/int_status.c
+++ b/src/lib/Libifl/int_status.c
@@ -510,7 +510,7 @@ PBSD_status_aggregate(int c, int cmd, char *id, void *attrib, char *extend, int 
 		return NULL;
 
 	if (parent_object == MGR_OBJ_JOB) {
-		if ((start = starting_index(id)) == -1)
+		if ((start = get_job_location_hint(id)) == -1)
 			start = 0;
 		else
 			single_itr = 1;

--- a/src/lib/Libifl/pbsD_runjob.c
+++ b/src/lib/Libifl/pbsD_runjob.c
@@ -186,14 +186,14 @@ __runjob_helper(int c, char *jobid, char *location, char *extend, int req_type)
 		return (pbs_errno = PBSE_IVALREQ);
 
 	if (svr_conns) {
-		if ((start = starting_index(jobid)) == -1)
+		if ((start = get_job_location_hint(jobid)) == -1)
 			start = 0;
 
 		for (i = start, ct = 0; ct < nsvrs; i = (i + 1) % nsvrs, ct++) {
 
 			if (!svr_conns[i] || svr_conns[i]->state != SVR_CONN_STATE_UP)
 				continue;
-			
+
 			/* if the vfd comes without node owning server, ifl need to figure out */
 			if (!extend && location && msvr_mode()) {
 				dest = get_dest_server(c, location);

--- a/src/lib/Libifl/pbsD_sigjob.c
+++ b/src/lib/Libifl/pbsD_sigjob.c
@@ -125,7 +125,7 @@ __pbs_sigjob(int c, char *jobid, char *sig, char *extend)
 		return (pbs_errno = PBSE_IVALREQ);
 
 	if (svr_conns) {
-		if ((start = starting_index(jobid)) == -1)
+		if ((start = get_job_location_hint(jobid)) == -1)
 			start = 0;
 
 		for (i = start, ct = 0; ct < nsvrs; i = (i + 1) % nsvrs, ct++) {

--- a/src/lib/Libifl/pbs_loadconf.c
+++ b/src/lib/Libifl/pbs_loadconf.c
@@ -275,7 +275,7 @@ parse_psi(char *conf_value)
 	char **list;
 	int i;
 	char *svrname = NULL;
-	
+
 	free(pbs_conf.psi);
 
 	if (conf_value == NULL)
@@ -308,12 +308,8 @@ parse_psi(char *conf_value)
         			get_fullhostname(pbs_conf.psi[i].name, pbs_conf.psi[i].name, PBS_MAXHOSTNAME);
 		}
 
-		if (pbs_conf.psi[i].port == 0) {
-			if (is_same_host(pbs_conf.psi[i].name, pbs_conf.pbs_server_name))
-				pbs_conf.psi[i].port = pbs_conf.batch_service_port;
-			else
-				pbs_conf.psi[i].port = PBS_BATCH_SERVICE_PORT;
-		}
+		if (pbs_conf.psi[i].port == 0)
+			pbs_conf.psi[i].port = PBS_BATCH_SERVICE_PORT;
 	}
 	free_string_array(list);
 	pbs_conf.pbs_num_servers = i;
@@ -1368,4 +1364,3 @@ get_num_servers(void)
 {
 	return pbs_conf.pbs_num_servers;
 }
-


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Post multi-server, there will be multiple servers independently generating jobids. In order for these jobids to not collide, we need to relax the existing jobid namespace requirements to allow each server to generate unique jobids (explained more in the design). This PR adds ability to each server to generate unique jobids so that they don't collide using the following:

- each server will add its unique PBS_SERVER_INSTANCES index as the last 2 digits of the jobid

This allows upto 100 servers (00 to 99) to be configured at a time.

**Since the algorithm may change in the future, users are expected to treat jobids as opaque strings and not expect them to be in the above, or any other format (see design), at least for the purposes of multi-server**. Single server jobids will continue to look the same as before.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
https://openpbs.atlassian.net/wiki/spaces/PD/pages/2320924673/jobid+namespace+redesign+for+multi-server

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Single server:
```
[ravi@pbsc8 ~]$ ps -ef | grep pbs_server
root      3620     1  0 08:41 ?        00:00:00 /opt/pbs/sbin/pbs_server.bin
ravi      3632    34  0 08:42 pts/0    00:00:00 grep --color=auto pbs_server
[ravi@pbsc8 ~]$ qsub -- /bin/sleep 1000
2014.pbsc8
[ravi@pbsc8 ~]$ qsub -- /bin/sleep 1000
2015.pbsc8
[ravi@pbsc8 ~]$ qsub -- /bin/sleep 1000
2016.pbsc8
[ravi@pbsc8 ~]$ qsub -- /bin/sleep 1000
2017.pbsc8
[ravi@pbsc8 ~]$ qsub -- /bin/sleep 1000
2018.pbsc8
```

2 servers:
```
[ravi@pbsc8 ~]$ qsub -- /bin/sleep 100
201001.pbsc8
[ravi@pbsc8 ~]$ qsub -- /bin/sleep 100
200900.pbsc8
[ravi@pbsc8 ~]$ qsub -- /bin/sleep 100
201000.pbsc8
[ravi@pbsc8 ~]$ qsub -- /bin/sleep 100
201101.pbsc8
[ravi@pbsc8 ~]$ qsub -- /bin/sleep 100
201100.pbsc8
[ravi@pbsc8 ~]$ qsub -- /bin/sleep 100
201200.pbsc8
[ravi@pbsc8 ~]$ qsub -- /bin/sleep 100
201201.pbsc8
[ravi@pbsc8 ~]$ qsub -- /bin/sleep 100
201300.pbsc8
[ravi@pbsc8 ~]$ qsub -- /bin/sleep 100
201301.pbsc8
[ravi@pbsc8 ~]$ qstat
Job id            Name             User              Time Use S Queue
----------------  ---------------- ----------------  -------- - -----
201001.pbsc8      STDIN            ravi              00:00:00 R workq           
200900.pbsc8      STDIN            ravi              00:00:00 R workq           
201000.pbsc8      STDIN            ravi              00:00:00 R workq           
201101.pbsc8      STDIN            ravi              00:00:00 R workq           
201100.pbsc8      STDIN            ravi              00:00:00 R workq           
201200.pbsc8      STDIN            ravi              00:00:00 R workq           
201201.pbsc8      STDIN            ravi              00:00:00 R workq           
201300.pbsc8      STDIN            ravi              00:00:00 R workq           
201301.pbsc8      STDIN            ravi                     0 Q workq  
```

**Regression**
Description: Rerun All Tests From #5671
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|5672|3854|3|0|0|18|3833|


Description: Rerun Only Failed Tests From #5672
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|5675|3|0|0|0|0|3|

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
