### PR TITLE
Addressing memory leaks with multi-server checkins

### DIFF
--- a/src/lib/Libifl/int_status.c
+++ b/src/lib/Libifl/int_status.c
@@ -223,8 +223,10 @@ aggr_job_ct(struct batch_status *cur, struct batch_status *nxt)
 
 	if (orig_st_ct)
 		encode_states(orig_st_ct, cur_st_ct, nxt_st_ct);
-	if (tot_jobs_attr)
-		sprintf(tot_jobs_attr, "%ld", tot_jobs);
+	if (tot_jobs_attr) {
+		free(tot_jobs_attr);
+		pbs_asprintf(&tot_jobs_attr, "%ld", tot_jobs);
+	}
 }
 
 /**

--- a/src/lib/Libifl/pbsD_connect.c
+++ b/src/lib/Libifl/pbsD_connect.c
@@ -463,6 +463,9 @@ dealloc_conn_entry(int parentfd)
 
 			for (i = 0; iter_conns->conn_arr[i]; i++)
 				free(iter_conns->conn_arr[i]);
+			/* virtual fd */
+			if (i > 1)
+				closesocket(iter_conns->cfd);
 			free(iter_conns->conn_arr);
 			free(iter_conns);
 			break;

--- a/src/lib/Libifl/pbs_loadconf.c
+++ b/src/lib/Libifl/pbs_loadconf.c
@@ -277,6 +277,7 @@ parse_psi(char *conf_value)
 	char *svrname = NULL;
 	
 	free(pbs_conf.psi);
+	free(pbs_conf.psi_str);
 
 	if (conf_value == NULL)
 		return -1;

--- a/src/scheduler/pbs_sched_utils.cpp
+++ b/src/scheduler/pbs_sched_utils.cpp
@@ -521,8 +521,7 @@ close_servers(void)
 			free(qrun_list[i].jid);
 	}
 	free(qrun_list);
-
-	sched_svr_init();
+	qrun_list = NULL;
 
 	clust_primary_sock = -1;
 	clust_secondary_sock = -1;
@@ -602,11 +601,15 @@ connect_svrpool()
 		/* Reached here means everything is success, so we will break out of the loop */
 		break;
 	}
+	log_eventf(PBSEVENT_ADMIN | PBSEVENT_FORCE, PBS_EVENTCLASS_SCHED,
+		   LOG_INFO, msg_daemonname, "Connected to all the configured servers");
 
-	log_eventf(PBSEVENT_ADMIN | PBSEVENT_FORCE, PBS_EVENTCLASS_SCHED, LOG_INFO, msg_daemonname, "Connected to all the configured servers");
+	sched_svr_init();
+
 	for (i = 0; svr_conns_secondary[i] != NULL; i++) {
 		if (tpp_em_add_fd(poll_context, svr_conns_secondary[i]->sd, EM_IN | EM_HUP | EM_ERR) < 0) {
-			log_errf(errno, __func__, "Couldn't add secondary connection to poll list for server %s", svr_conns_secondary[i]->name);
+			log_errf(errno, __func__, "Couldn't add secondary connection to poll list for server %s",
+				 svr_conns_secondary[i]->name);
 			die(-1);
 		}
 	}
@@ -643,7 +646,6 @@ sched_svr_init(void)
 static void
 reconnect_servers()
 {
-
 	close_servers();
 	connect_svrpool();
 }
@@ -1115,7 +1117,6 @@ sched_main(int argc, char *argv[], schedule_func sched_ptr)
 
 	pthread_mutex_init(&cleanup_lock, &attr);
 
-	sched_svr_init();
 	connect_svrpool();
 
 	for (go = 1; go;) {

--- a/src/scheduler/pbs_sched_utils.cpp
+++ b/src/scheduler/pbs_sched_utils.cpp
@@ -646,8 +646,12 @@ sched_svr_init(void)
 static void
 reconnect_servers()
 {
+	pthread_mutex_lock(&cleanup_lock);
+
 	close_servers();
 	connect_svrpool();
+	
+	pthread_mutex_unlock(&cleanup_lock);
 }
 
 /**

--- a/src/scheduler/pbs_sched_utils.cpp
+++ b/src/scheduler/pbs_sched_utils.cpp
@@ -576,10 +576,6 @@ connect_svrpool()
 		for (i = 0; svr_conns_primary[i] != NULL && svr_conns_secondary[i] != NULL; i++) {
 			if (svr_conns_primary[i]->state == SVR_CONN_STATE_DOWN ||
 			    svr_conns_secondary[i]->state == SVR_CONN_STATE_DOWN) {
-				close_servers();
-				clust_primary_sock = -1;
-				clust_secondary_sock = -1;
-				log_errf(pbs_errno, __func__, "Couldn't connect the scheduler %s with all the configured servers", sc_name);
 				break;
 			}
 		}
@@ -589,7 +585,9 @@ connect_svrpool()
 			 * we should go to the top of the loop again and call pbs_connect
 			 * Also wait for 2s for not to burn too much CPU
 			 */
+			log_errf(pbs_errno, __func__, "Scheduler %s could not connect with all the configured servers", sc_name);
 			sleep(2);
+			close_servers();
 			continue;
 		}
 

--- a/src/scheduler/pbs_sched_utils.cpp
+++ b/src/scheduler/pbs_sched_utils.cpp
@@ -574,10 +574,14 @@ connect_svrpool()
 		}
 
 		for (i = 0; svr_conns_primary[i] != NULL && svr_conns_secondary[i] != NULL; i++) {
-			if (svr_conns_primary[i]->state == SVR_CONN_STATE_DOWN)
+			if (svr_conns_primary[i]->state == SVR_CONN_STATE_DOWN ||
+			    svr_conns_secondary[i]->state == SVR_CONN_STATE_DOWN) {
+				close_servers();
 				clust_primary_sock = -1;
-			if (svr_conns_secondary[i]->state == SVR_CONN_STATE_DOWN)
 				clust_secondary_sock = -1;
+				log_errf(pbs_errno, __func__, "Couldn't connect the scheduler %s with all the configured servers", sc_name);
+				break;
+			}
 		}
 
 		if (i != num_conf_svrs) {
@@ -586,7 +590,6 @@ connect_svrpool()
 			 * Also wait for 2s for not to burn too much CPU
 			 */
 			sleep(2);
-			close_servers();
 			continue;
 		}
 

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -1089,7 +1089,13 @@ get_vnode_state_op(enum vnode_state_op op)
 static void
 shallow_vnode_free(struct pbsnode *vnode)
 {
+	int i;
+
 	if (vnode) {
+		free(vnode->nd_moms);
+		for (i = 0; i < ND_ATR_LAST; i++) {
+			node_attr_def[i].at_free(&vnode->nd_attr[i]);
+		}
 		free(vnode);
 	}
 }
@@ -1156,6 +1162,7 @@ shallow_vnode_dup(struct pbsnode *vnode)
 	vnode_dup->nd_pque = vnode->nd_pque;
 	vnode_dup->newobj = vnode->newobj;
 	for (i = 0; i < (int)ND_ATR_LAST; i++) {
+		node_attr_def[i].at_free(&vnode_dup->nd_attr[i]);
 		vnode_dup->nd_attr[i] = vnode->nd_attr[i];
 	}
 	return vnode_dup;
@@ -1325,7 +1332,7 @@ fn_fire_event:
 	process_hooks(preq, hook_msg, sizeof(hook_msg), pbs_python_set_interrupt);
 
 fn_free_and_return:
-	shallow_vnode_free(vnode_o);
+	free(vnode_o);
 	free_br(preq);
 }
 

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -1104,13 +1104,7 @@ shallow_vnode_dup(struct pbsnode *vnode)
 	/* 
 	 * Allocate and initialize vnode_o, then copy vnode elements into vnode_o
 	 */
-	if ((vnode_dup = malloc(sizeof(struct pbsnode)))) {
-		if (initialize_pbsnode(vnode_dup, strdup(vnode->nd_name), NTYPE_PBS) != PBSE_NONE) {
-			log_err(PBSE_INTERNAL, __func__, "vnode_dup initialization failed");
-			free_pnode(vnode_dup);
-			return NULL;
-		}
-	} else {
+	if ((vnode_dup = calloc(1, sizeof(struct pbsnode))) == NULL) {
 		log_err(PBSE_INTERNAL, __func__, "vnode_dup alloc failed");
 		return NULL;
 	}
@@ -1118,11 +1112,8 @@ shallow_vnode_dup(struct pbsnode *vnode)
 	/*
 	 * Copy vnode elements (same order as "struct pbsnode" element definition)
 	 */
-	/* free the initialize_pbsnode() allocation before assigning */
 
-	free(vnode_dup->nd_name);
 	vnode_dup->nd_name = vnode->nd_name;
-	free(vnode_dup->nd_moms);
 	vnode_dup->nd_moms = vnode->nd_moms;
 	vnode_dup->nd_nummoms = vnode->nd_nummoms;
 	vnode_dup->nd_nummslots = vnode->nd_nummslots;
@@ -1141,7 +1132,6 @@ shallow_vnode_dup(struct pbsnode *vnode)
 	vnode_dup->nd_pque = vnode->nd_pque;
 	vnode_dup->newobj = vnode->newobj;
 	for (i = 0; i < ND_ATR_LAST; i++) {
-		node_attr_def[i].at_free(&vnode_dup->nd_attr[i]);
 		vnode_dup->nd_attr[i] = vnode->nd_attr[i];
 	}
 	return vnode_dup;

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -1118,11 +1118,11 @@ shallow_vnode_dup(struct pbsnode *vnode)
 	/*
 	 * Copy vnode elements (same order as "struct pbsnode" element definition)
 	 */
-	if (vnode_dup->nd_moms) {
-		/* free the initialize_pbsnode() allocation before assigning */
-		free(vnode_dup->nd_moms);
-		vnode_dup->nd_moms = NULL;
-	}
+	/* free the initialize_pbsnode() allocation before assigning */
+
+	free(vnode_dup->nd_name);
+	vnode_dup->nd_name = vnode->nd_name;
+	free(vnode_dup->nd_moms);
 	vnode_dup->nd_moms = vnode->nd_moms;
 	vnode_dup->nd_nummoms = vnode->nd_nummoms;
 	vnode_dup->nd_nummslots = vnode->nd_nummslots;

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -1078,27 +1078,6 @@ get_vnode_state_op(enum vnode_state_op op)
 	return "ND_state_unknown";
 }
 
-/**
- * @brief
- * 		Free a duplicated vnode
- *
- * @param[in]	vnode - the vnode to free
- *  
- * @return void
- */
-static void
-shallow_vnode_free(struct pbsnode *vnode)
-{
-	int i;
-
-	if (vnode) {
-		free(vnode->nd_moms);
-		for (i = 0; i < ND_ATR_LAST; i++) {
-			node_attr_def[i].at_free(&vnode->nd_attr[i]);
-		}
-		free(vnode);
-	}
-}
 
 /**
  * @brief
@@ -1128,7 +1107,7 @@ shallow_vnode_dup(struct pbsnode *vnode)
 	if ((vnode_dup = malloc(sizeof(struct pbsnode)))) {
 		if (initialize_pbsnode(vnode_dup, strdup(vnode->nd_name), NTYPE_PBS) != PBSE_NONE) {
 			log_err(PBSE_INTERNAL, __func__, "vnode_dup initialization failed");
-			shallow_vnode_free(vnode_dup);
+			free_pnode(vnode_dup);
 			return NULL;
 		}
 	} else {
@@ -1161,7 +1140,7 @@ shallow_vnode_dup(struct pbsnode *vnode)
 	vnode_dup->nd_accted = vnode->nd_accted;
 	vnode_dup->nd_pque = vnode->nd_pque;
 	vnode_dup->newobj = vnode->newobj;
-	for (i = 0; i < (int)ND_ATR_LAST; i++) {
+	for (i = 0; i < ND_ATR_LAST; i++) {
 		node_attr_def[i].at_free(&vnode_dup->nd_attr[i]);
 		vnode_dup->nd_attr[i] = vnode->nd_attr[i];
 	}

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -2767,13 +2767,11 @@ create_pbs_node2(char *objname, svrattrl *plist, int perms, int *bad, struct pbs
 			pbsndlist[svr_totnodes++] = pnode;
 		} else {
 			free_pnode(pnode);
-			free(pname);
 			return (PBSE_SYSTEM);
 		}
 		if (initialize_pbsnode(pnode, pname, ntype) != PBSE_NONE) {
 			svr_totnodes--;
 			free_pnode(pnode);
-			free(pname);
 			return (PBSE_SYSTEM);
 		}
 
@@ -2782,7 +2780,6 @@ create_pbs_node2(char *objname, svrattrl *plist, int perms, int *bad, struct pbs
 		if (create_subnode(pnode, NULL) == NULL) {
 			svr_totnodes--;
 			free_pnode(pnode);
-			free(pname);
 			return (PBSE_SYSTEM);
 		}
 
@@ -2791,7 +2788,6 @@ create_pbs_node2(char *objname, svrattrl *plist, int perms, int *bad, struct pbs
 			if ((node_idx = pbs_idx_create(0, 0)) == NULL) {
 				svr_totnodes--;
 				free_pnode(pnode);
-				free(pname);
 				return (PBSE_SYSTEM);
 			}
 		}
@@ -2800,7 +2796,6 @@ create_pbs_node2(char *objname, svrattrl *plist, int perms, int *bad, struct pbs
 		if (pbs_idx_insert(node_idx, pname, pnode) != PBS_IDX_RET_OK) {
 			svr_totnodes--;
 			free_pnode(pnode);
-			free(pname);
 			return (PBSE_SYSTEM);
 		}
 	} else if (nodup == TRUE) {

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -2766,6 +2766,7 @@ create_pbs_node2(char *objname, svrattrl *plist, int perms, int *bad, struct pbs
 			pnode->nd_arr_index = svr_totnodes; /* this is only in mem, not from db */
 			pbsndlist[svr_totnodes++] = pnode;
 		} else {
+			free(pname);
 			free_pnode(pnode);
 			return (PBSE_SYSTEM);
 		}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Addressing the following memory leaks:

8 bytes in 1 blocks are definitely lost in loss record 8 of 71
   at 0x4C29133: malloc (vg_replace_malloc.c:299)
   by 0x5728929: strdup (in /lib64/libc-2.19.so)
   by 0x423756: parse_psi (pbs_loadconf.c:320)
   by 0x4266A5: __pbs_loadconf (pbs_loadconf.c:1103)
   by 0x427B12: pbs_loadconf (ifl_impl.c:324)
   by 0x4062DF: main (pbs_comm.c:606)

24 bytes in 1 blocks are definitely lost in loss record 1,274 of 2,146
   at 0x4C28C23: malloc (vg_replace_malloc.c:299)
   by 0x50D19E: pbs_asprintf_format (misc_utils.c:529)
   by 0x50D300: pbs_asprintf (misc_utils.c:570)
   by 0x4736F5: gen_svr_inst_id (multi_svr.c:304)
   by 0x473C4F: initialize_pbsnode (node_func.c:331)
   by 0x4781EE: shallow_vnode_dup (node_manager.c:1123)
   by 0x4784BC: set_vnode_state (node_manager.c:1212)
   by 0x477220: set_all_state (node_manager.c:547)
   by 0x47F97B: is_request (node_manager.c:4815)
   by 0x48BA22: do_tpp (pbsd_main.c:311)
   by 0x48BABE: tpp_request (pbsd_main.c:355)
   by 0x520EB0: process_socket (net_server.c:511)

48 bytes in 2 blocks are definitely lost in loss record 1,345 of 2,186
   at 0x4C28C23: malloc (vg_replace_malloc.c:299)
   by 0x50D19E: pbs_asprintf_format (misc_utils.c:529)
   by 0x50D300: pbs_asprintf (misc_utils.c:570)
   by 0x4736F5: gen_svr_inst_id (multi_svr.c:304)
   by 0x473C4F: initialize_pbsnode (node_func.c:331)
   by 0x4781EE: shallow_vnode_dup (node_manager.c:1123)
   by 0x4784BC: set_vnode_state (node_manager.c:1212)
   by 0x483AB7: set_nodes (node_manager.c:6803)
   by 0x4BA3B9: assign_hosts (req_runjob.c:1892)
   by 0x4BA1EB: where_to_runjob (req_runjob.c:1824)
   by 0x4B78BC: req_runjob (req_runjob.c:578)
   by 0x490885: dispatch_request (process_request.c:963)

50 bytes in 2 blocks are definitely lost in loss record 1,337 of 2,175
   at 0x4C29133: malloc (vg_replace_malloc.c:299)
   by 0x516CD2: pbs_asprintf_format (misc_utils.c:529)
   by 0x516E34: pbs_asprintf (misc_utils.c:570)
   by 0x47D2A1: gen_svr_inst_id (multi_svr.c:304)
   by 0x47D7FA: initialize_pbsnode (node_func.c:331)
   by 0x481D97: shallow_vnode_dup (node_manager.c:1123)
   by 0x482065: set_vnode_state (node_manager.c:1212)
   by 0x4847A9: deallocate_job_from_node (node_manager.c:2670)
   by 0x48DF4B: free_nodes (node_manager.c:7013)
   by 0x4A1A0C: rel_resc (req_jobobit.c:207)
   by 0x49F5C1: req_deletejob2 (req_delete.c:897)
   by 0x49E29C: req_deletejob (req_delete.c:449)


#### Describe Your Change
* parse_psi will free the variable first to handle the pbs conf reload case.
* shallow_vnode_dup will free attributes before assigning a value on them


#### Attach Test and Valgrind Logs/Output
[valgrind.log](https://github.com/openpbs/openpbs/files/5821837/valgrind.log)

Regression Results:
Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, WIN2K16
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|5785|3852|2|1|0|1|3848|

Description: Rerun Only Failed Tests From #5785
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|5789|3|0|0|0|0|3|


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
