### PR TITLE
Making qterm to work with multi-server

### DIFF
--- a/src/cmds/scripts/pbs_dataservice
+++ b/src/cmds/scripts/pbs_dataservice
@@ -227,7 +227,7 @@ case "$1" in
 		fi
 
 		# Check if PBS is running
-		${PBS_EXEC}/bin/qstat -Bf >/dev/null 2>&1
+		PBS_SERVER_INSTANCES= ${PBS_EXEC}/bin/qstat -Bf >/dev/null 2>&1
 		if [ $? -eq 0 ]; then
 			echo "PBS server is running. Cannot stop PBS Data Service now."
 			server_pid="`ps -ef | grep "pbs_server.bi[n]" | awk '{print $2}'`"

--- a/src/cmds/scripts/pbs_dataservice
+++ b/src/cmds/scripts/pbs_dataservice
@@ -227,7 +227,7 @@ case "$1" in
 		fi
 
 		# Check if PBS is running
-		PBS_SERVER_INSTANCES= ${PBS_EXEC}/bin/qstat -Bf >/dev/null 2>&1
+		env -u PBS_SERVER_INSTANCES ${PBS_EXEC}/bin/qstat -Bf >/dev/null 2>&1
 		if [ $? -eq 0 ]; then
 			echo "PBS server is running. Cannot stop PBS Data Service now."
 			server_pid="`ps -ef | grep "pbs_server.bi[n]" | awk '{print $2}'`"

--- a/src/cmds/scripts/pbs_init.d.in
+++ b/src/cmds/scripts/pbs_init.d.in
@@ -450,7 +450,7 @@ stop_pbs() {
 					echo "pbs_server evaluating ${PBS_HOME}/server_priv/qmgr_shutdown"
 					${PBS_EXEC}/bin/qmgr <"${PBS_HOME}/server_priv/qmgr_shutdown"
 				fi
-				${PBS_EXEC}/bin/qterm -t quick
+				PBS_SERVER_INSTANCES= ${PBS_EXEC}/bin/qterm -t quick
 				echo "PBS server - was pid: ${pbs_server_pid}"
 			elif [ ${is_secondary} -eq 1 ]; then
 				echo "This is secondary server, killing process."

--- a/src/cmds/scripts/pbs_init.d.in
+++ b/src/cmds/scripts/pbs_init.d.in
@@ -450,7 +450,7 @@ stop_pbs() {
 					echo "pbs_server evaluating ${PBS_HOME}/server_priv/qmgr_shutdown"
 					${PBS_EXEC}/bin/qmgr <"${PBS_HOME}/server_priv/qmgr_shutdown"
 				fi
-				PBS_SERVER_INSTANCES= ${PBS_EXEC}/bin/qterm -t quick
+				env -u PBS_SERVER_INSTANCES ${PBS_EXEC}/bin/qterm -t quick
 				echo "PBS server - was pid: ${pbs_server_pid}"
 			elif [ ${is_secondary} -eq 1 ]; then
 				echo "This is secondary server, killing process."

--- a/src/lib/Libifl/pbsD_termin.c
+++ b/src/lib/Libifl/pbsD_termin.c
@@ -63,8 +63,8 @@
  * @retval	pbs_error	error
  *
  */
-int
-__pbs_terminate(int c, int manner, char *extend)
+static int
+PBSD_terminate(int c, int manner, char *extend)
 {
 	struct batch_reply *reply;
 	int rc = 0;
@@ -111,4 +111,38 @@ __pbs_terminate(int c, int manner, char *extend)
 		return pbs_errno;
 
 	return rc;
+}
+
+
+/**
+ * @brief
+ *	-send termination batch_request to server.
+ *
+ * @param[in] c - communication handle
+ * @param[in] manner - manner in which server to be terminated
+ * @param[in] extend - extension string for request
+ *
+ * @return	int
+ * @retval	0		success
+ * @retval	pbs_error	error
+ *
+ */
+int
+__pbs_terminate(int c, int manner, char *extend)
+{
+	int rc = 0;
+	int final_rc = rc;
+	svr_conn_t **svr_conns = get_conn_svr_instances(c);
+	int i;
+
+	if (!svr_conns)
+		return PBSD_terminate(c, manner, extend);
+
+	for (i = 0; svr_conns[i]; i++) {
+		rc = PBSD_terminate(svr_conns[i]->sd, manner, extend);
+		if (rc != 0)
+			final_rc = rc;
+	}
+
+	return final_rc;
 }


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
* qterm is not functioning in a multi-svr setup as it is trying to operate on a virtual fd.


#### Describe Your Change
* PBSD_terminate should handle virtual fds
* Stopping/Restarting a server instance should not cause in termination of other instances in the cluster
* Server instance should start even if other instances mentioned in the PSI are running


#### Attach Test and Valgrind Logs/Output
```
[root@centos8 pbspro]# echo $PBS_SERVER_INSTANCES
centos8,centos8_2
[root@centos8 pbspro]# qstat
[root@centos8 pbspro]# /etc/init.d/pbs stop
Stopping PBS
Shutting server down with qterm.
PBS server - was pid: 8454
PBS mom - was pid: 8188
PBS sched - was pid: 8201
PBS comm - was pid: 8178
Waiting for shutdown to complete
[root@centos8 pbspro]# PBS_SERVER_INSTANCES=centos8 qstat
Connection refused
qstat: cannot connect to server centos8 (errno=111)
# Make sure other instance is still alive
[root@centos8 pbspro]# PBS_SERVER_INSTANCES=centos8_2 qstat
[root@centos8 pbspro]# qterm
# Make sure that kills all instances
[root@centos8 pbspro]# PBS_SERVER_INSTANCES=centos8_2 qstat
Connection refused
qstat: cannot connect to server centos8 (errno=111)
```



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
