### PR TITLE
fix tpp leak/crash

### DIFF
--- a/src/include/avltree.h
+++ b/src/include/avltree.h
@@ -81,6 +81,7 @@ typedef struct {
 
 extern void avl_set_maxthreads(int n);
 extern void *get_avl_tls(void);
+extern void free_avl_tls(void);
 extern int avl_create_index(AVL_IX_DESC *pix, int flags, int keylength);
 extern void avl_destroy_index(AVL_IX_DESC *pix);
 extern int avl_find_key(AVL_IX_REC *pe, AVL_IX_DESC *pix);

--- a/src/include/tpp.h
+++ b/src/include/tpp.h
@@ -123,6 +123,7 @@ extern int tpp_init(struct tpp_config *);
 extern void tpp_set_app_net_handler(void (*app_net_down_handler)(void *), void (*app_net_restore_handler)(void *));
 extern void tpp_set_logmask(long);
 extern int set_tpp_config(struct pbs_config *, struct tpp_config *, char *, int, char *);
+extern void free_tpp_config(struct tpp_config *);
 extern void DIS_tpp_funcs();
 extern int tpp_open(char *, unsigned int);
 extern int tpp_close(int);

--- a/src/lib/Libtpp/tpp_client.c
+++ b/src/lib/Libtpp/tpp_client.c
@@ -1312,6 +1312,8 @@ tpp_shutdown()
 	if (strmarray)
 		free(strmarray);
 	tpp_destroy_rwlock(&strmarray_lock);
+
+	free_tpp_config(tpp_conf);
 }
 
 /**
@@ -2986,13 +2988,13 @@ leaf_close_handler(int tfd, int error, void *c, void *extra)
 		tpp_transport_set_conn_extra(tfd, NULL);
 	}
 
-	if (tpp_going_down == 1)
-		return -1; /* while we are doing shutdown don't try to reconnect etc */
-
 	r = (tpp_router_t *) ctx->ptr;
 
 	/* deallocate the connection structure associated with ctx */
 	tpp_transport_close(r->conn_fd);
+
+	if (tpp_going_down == 1)
+		return -1; /* while we are doing shutdown don't try to reconnect etc */
 
 	/*
 	 * Disassociate the older context, so we can attach

--- a/src/lib/Libtpp/tpp_client.c
+++ b/src/lib/Libtpp/tpp_client.c
@@ -2874,7 +2874,7 @@ again:
 
 		case TPP_DATA:
 		case TPP_CLOSE_STRM: {
-			char msg[TPP_GEN_BUF_SZ];
+			char msg[TPP_GEN_BUF_SZ] = "";
 			unsigned int src_sd;
 			unsigned int dest_sd;
 			unsigned int src_magic;

--- a/src/lib/Libtpp/tpp_client.c
+++ b/src/lib/Libtpp/tpp_client.c
@@ -2551,6 +2551,9 @@ leaf_pkt_presend_handler(int tfd, tpp_packet_t *pkt, void *c, void *extra)
 	tpp_chunk_t *first_chunk;
 	unsigned char type;
 
+	if (!pkt)
+		return 0;
+		
 	first_chunk = GET_NEXT(pkt->chunks);
 	if (!first_chunk)
 		return 0;

--- a/src/lib/Libtpp/tpp_em.c
+++ b/src/lib/Libtpp/tpp_em.c
@@ -1129,7 +1129,7 @@ tpp_mbox_read(tpp_mbox_t *mbox, unsigned int *tfd, int *cmdval, void **data)
  * @param[in] - n      - The node/position to start searching from
  * @param[in] - tfd    - The Virtual file descriptor
  * @param[out] - cmdval - Return the cmdval
- * @param[out] - data - Any data associated
+ * @param[out] - data - Return any data associated
  *
  * @par Side Effects:
  *	None
@@ -1150,15 +1150,16 @@ tpp_mbox_clear(tpp_mbox_t *mbox, tpp_que_elem_t **n, unsigned int tfd, short *cm
 		cmd = TPP_QUE_DATA(*n);
 		if (cmd && cmd->tfd == tfd) {
 			*n = tpp_que_del_elem(&mbox->mbox_queue, *n);
+			mbox->mbox_size -= cmd->sz;
 			if (cmdval)
 				*cmdval = cmd->cmdval;
-			*data = cmd->data;
+			if (data)
+				*data = cmd->data;
 			free(cmd);
 			ret = 0;
 			break;
 		}
 	}
-	mbox->mbox_size = 0;
 
 	tpp_unlock(&mbox->mbox_mutex);
 

--- a/src/lib/Libtpp/tpp_internal.h
+++ b/src/lib/Libtpp/tpp_internal.h
@@ -51,6 +51,7 @@ extern "C" {
 #include <netinet/in.h>
 #include "log.h"
 #include "list_link.h"
+#include "avltree.h"
 
 #include "tpp.h"
 
@@ -301,9 +302,8 @@ enum TPP_MSG_TYPES {
 #define TPP_CMD_NET_RESTORE     9
 #define TPP_CMD_NET_DOWN        10
 #define TPP_CMD_WAKEUP          11
-#define TPP_CMD_FREECONN		12
-#define TPP_CMD_READ			13
-#define TPP_CMD_CONNECT			14
+#define TPP_CMD_READ			12
+#define TPP_CMD_CONNECT			13
 
 #define TPP_DEF_ROUTER_PORT     17001
 #define TPP_SCRATCHSIZE         8192

--- a/src/lib/Libtpp/tpp_router.c
+++ b/src/lib/Libtpp/tpp_router.c
@@ -1037,7 +1037,7 @@ router_pkt_presend_handler(int tfd, tpp_packet_t *pkt, void *c, void *extra)
 	 * then extra will be NULL and this is just a sending simulation
 	 * so no encryption needed
 	 */
-	if (authdata == NULL || authdata->encryptdef == NULL)
+	if (authdata == NULL || authdata->encryptdef == NULL || pkt == NULL)
 		return 0;
 
 	return (tpp_encrypt_pkt(authdata, pkt));

--- a/src/lib/Libtpp/tpp_router.c
+++ b/src/lib/Libtpp/tpp_router.c
@@ -2257,6 +2257,8 @@ tpp_router_shutdown()
 
 	TPP_DBPRT("from pid = %d", getpid());
 	tpp_transport_shutdown();
+
+	free_tpp_config(tpp_conf);
 }
 
 /**

--- a/src/lib/Libtpp/tpp_transport.c
+++ b/src/lib/Libtpp/tpp_transport.c
@@ -2055,6 +2055,8 @@ free_phy_conn(phy_conn_t *conn)
 			tpp_free_pkt(pkt);
 	}
 
+	tpp_mbox_destroy(&conn->send_mbox);
+
 	free(conn->ctx);
 	free(conn->scratch.data);
 	free(conn);

--- a/src/lib/Libtpp/tpp_transport.c
+++ b/src/lib/Libtpp/tpp_transport.c
@@ -1727,22 +1727,12 @@ handle_disconnect(phy_conn_t *conn)
 	/*
 	 * Since we are freeing the socket connection we must
 	 * empty any pending commands that were in this thread's
-	 * mbox (since this thread is the connection's manager.
+	 * mbox (since this thread is the connection's manager
 	 *
-	 * Simulate a successful data-send by allowing the packets to
-	 * flow through the_call back functions the_pkt_presend_handler
-	 * This is similar to us having just sent out the packets
-	 * but they failed in transit.
 	 */
 	n = NULL;
-	while (tpp_mbox_clear(&conn->td->mbox, &n, conn->sock_fd, &cmd, (void **) &pkt) == 0) {
-		if (cmd == TPP_CMD_SEND) {
-			if (the_pkt_presend_handler)
-				the_pkt_presend_handler(conn->sock_fd, pkt, conn->ctx, conn->extra);
-
-			tpp_free_pkt(pkt);
-		}
-	}
+	while (tpp_mbox_clear(&conn->td->mbox, &n, conn->sock_fd, &cmd, (void **) &pkt) == 0)
+		tpp_free_pkt(pkt);
 
 	conns_array[conn->sock_fd].slot_state = TPP_SLOT_FREE;
 	conns_array[conn->sock_fd].conn = NULL;

--- a/src/lib/Libtpp/tpp_util.c
+++ b/src/lib/Libtpp/tpp_util.c
@@ -489,6 +489,22 @@ set_tpp_config(struct pbs_config *pbs_conf, struct tpp_config *tpp_conf, char *n
 	return 0;
 }
 
+/* 
+ * free tpp conf member variables
+ * to be called before exit
+ * 
+ * @param[in] tpp_conf - pointer to the tpp conf structure
+ * 
+ */
+void
+free_tpp_config(struct tpp_config *tpp_conf)
+{
+	free(tpp_conf->routers);
+	free_string_array(tpp_conf->supported_auth_methods);
+	free(tpp_conf->node_name);
+	free_auth_config(tpp_conf->auth_config);
+}
+
 /**
  * @brief tpp_make_authdata - allocate conn_auth_t structure based given values
  *

--- a/src/lib/Libtpp/tpp_util.c
+++ b/src/lib/Libtpp/tpp_util.c
@@ -2354,6 +2354,9 @@ tpp_encrypt_pkt(conn_auth_t *authdata, tpp_packet_t *pkt)
 	void *buf = NULL;
 	char *p;
 
+	if (!pkt)
+		return 0;
+
 	if (type == TPP_AUTH_CTX && data->for_encrypt == FOR_ENCRYPT)
 		return 0;
 

--- a/src/lib/Libtpp/tpp_util.c
+++ b/src/lib/Libtpp/tpp_util.c
@@ -2354,9 +2354,6 @@ tpp_encrypt_pkt(conn_auth_t *authdata, tpp_packet_t *pkt)
 	void *buf = NULL;
 	char *p;
 
-	if (!pkt)
-		return 0;
-
 	if (type == TPP_AUTH_CTX && data->for_encrypt == FOR_ENCRYPT)
 		return 0;
 

--- a/src/lib/Libutil/avltree.c
+++ b/src/lib/Libutil/avltree.c
@@ -209,6 +209,22 @@ get_avl_tls(void)
 	return p_avl_tls;
 }
 
+
+/**
+ * @brief
+ *	Free the thread local storage used for avltree for this thread
+ */
+void
+free_avl_tls(void)
+{
+	avl_tls_t *p_avl_tls = NULL;
+
+	pthread_once(&avl_init_once, avl_init_func);
+
+	if ((p_avl_tls = (avl_tls_t *) pthread_getspecific(avl_tls_key))) 
+		free(p_avl_tls);
+}
+
 #define tind             (((avl_tls_t *) get_avl_tls())->__tind)
 #define ix_keylength  (((avl_tls_t *) get_avl_tls())->__ix_keylength)
 #define ix_flags   (((avl_tls_t *) get_avl_tls())->__ix_flags)

--- a/src/server/pbs_comm.c
+++ b/src/server/pbs_comm.c
@@ -127,7 +127,7 @@ enum failover_state are_we_primary(void)
 		return FAILOVER_CONFIG_ERROR;
 
 	if (get_fullhostname(pbs_conf.pbs_primary, primary_host, (sizeof(primary_host) - 1))==-1) {
-		log_err(-1, "comm_main", "Unable to get full host name of primary");
+		log_err(-1, __func__, "Unable to get full host name of primary");
 		return FAILOVER_CONFIG_ERROR;
 	}
 
@@ -135,7 +135,7 @@ enum failover_state are_we_primary(void)
 		return FAILOVER_PRIMARY;   /* we are the listed primary */
 
 	if (get_fullhostname(pbs_conf.pbs_secondary, hn1, (sizeof(hn1) - 1))==-1) {
-		log_err(-1, "comm_main", "Unable to get full host name of secondary");
+		log_err(-1, __func__, "Unable to get full host name of secondary");
 		return FAILOVER_CONFIG_ERROR;
 	}
 	if (strcmp(hn1, server_host) == 0)
@@ -578,7 +578,7 @@ main(int argc, char **argv)
 	}
 
 	if (load_auths(AUTH_SERVER)) {
-		log_err(-1, "pbs_comm", "Failed to load auth lib");
+		log_err(-1, __func__, "Failed to load auth lib");
 		return 2;
 	}
 
@@ -604,14 +604,14 @@ main(int argc, char **argv)
 			memcpy(&pbs_conf_bak, &pbs_conf, sizeof(struct pbs_config));
 
 			if (pbs_loadconf(1) == 0) {
-				log_err(-1, NULL, "Configuration error, ignoring");
+				log_err(-1, __func__, "Configuration error, ignoring");
 				memcpy(&pbs_conf, &pbs_conf_bak, sizeof(struct pbs_config));
 			} else {
 				/* restore old pbs.conf */
 				new_logevent = pbs_conf.pbs_comm_log_events;
 				memcpy(&pbs_conf, &pbs_conf_bak, sizeof(struct pbs_config));
 				pbs_conf.pbs_comm_log_events = new_logevent;
-				log_err(-1, NULL, "Processed SIGHUP");
+				log_err(-1, __func__, "Processed SIGHUP");
 
 				log_event_mask = &pbs_conf.pbs_comm_log_events;
 				tpp_set_logmask(*log_event_mask);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Valgrind reported a few pseudo leaks - fixing those so that valgrind does not complain
Valgrind also reported a simple crash - log_err() was called with NULL as the second parameter
leak reports from valgrind:
16 bytes in 1 blocks are definitely lost in loss record 34 of 620
   at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
   by 0x238149: set_tpp_config (tpp_util.c:439)
   by 0x1DFCCE: main (mom_main.c:8201)

24 bytes in 1 blocks are definitely lost in loss record 50 of 620
   at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
   by 0x23348D: tpp_em_init (tpp_em.c:132)
   by 0x234778: tpp_transport_init (tpp_transport.c:579)
   by 0x22F67E: tpp_init (tpp_client.c:646)
   by 0x1DFD9D: main (mom_main.c:8214)

53 bytes in 1 blocks are definitely lost in loss record 68 of 620
   at 0x4C31D2F: realloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
   by 0x237C22: set_tpp_config (tpp_util.c:324)
   by 0x1DFCCE: main (mom_main.c:8201)

56 bytes in 1 blocks are definitely lost in loss record 71 of 620
   at 0x4C31B25: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
   by 0x24697C: get_avl_tls (avltree.c:200)
   by 0x247B43: avl_find_key (avltree.c:705)
   by 0x22ED24: pbs_idx_find (pbs_idx.c:246)
   by 0x232CEE: leaf_pkt_handler_inner (tpp_client.c:2842)
   by 0x2324CA: leaf_pkt_handler (tpp_client.c:2669)
   by 0x236CCF: add_pkt (tpp_transport.c:1902)
   by 0x236BBE: handle_incoming_data (tpp_transport.c:1864)
   by 0x236320: work (tpp_transport.c:1579)
   by 0x504E6DA: start_thread (pthread_create.c:463)
   by 0x621488E: clone (clone.S:95)

8,431 (192 direct, 8,239 indirect) bytes in 1 blocks are definitely lost in loss record 586 of 620
   at 0x4C31B25: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
   by 0x234B44: alloc_conn (tpp_transport.c:706)
   by 0x234F5C: tpp_transport_connect_spl (tpp_transport.c:823)
   by 0x2350AE: tpp_transport_connect (tpp_transport.c:874)
   by 0x22F404: connect_router (tpp_client.c:550)
   by 0x22F8ED: tpp_init (tpp_client.c:681)
   by 0x1DFD9D: main (mom_main.c:8214)

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Most of the leak reports are false positives, since we intentionally do not free memory at the end of the process. However, a few of them are easy to free and not going to cause performance issues, so added frees for those.

The comm crash was fixed by passing __func__ instead of NULL to log_err()

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[comm.log](https://github.com/openpbs/openpbs/files/5819039/comm.log)
[mom.log](https://github.com/openpbs/openpbs/files/5819040/mom.log)
**[valgrind.log from full regression run](https://github.com/openpbs/openpbs/files/5831238/valgrind.log)**


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
