### PR TITLE
Interleave the qdel request with larger job array to handle others requests.

### DIFF
--- a/src/include/batch_request.h
+++ b/src/include/batch_request.h
@@ -107,6 +107,9 @@ struct rq_manage {
 struct rq_deletejoblist {
 	int rq_count;
 	char **rq_jobslist;
+	int rq_resume;
+	int jobid_to_resume;
+	int subjobid_to_resume;
 };
 
 /* Management - used by PBS_BATCH_Manager requests */

--- a/src/include/pbs_v1_module_common.i
+++ b/src/include/pbs_v1_module_common.i
@@ -118,6 +118,7 @@ pbs_list_head svr_execjob_postsuspend_hooks;
 pbs_list_head svr_execjob_preresume_hooks;
 
 pbs_list_head task_list_immed;
+pbs_list_head task_list_interleave;
 pbs_list_head task_list_timed;
 pbs_list_head task_list_event;
 

--- a/src/include/work_task.h
+++ b/src/include/work_task.h
@@ -57,6 +57,7 @@ extern "C" {
 
 enum work_type {
 	WORK_Immed,		/* immediate action: see state */
+	WORK_Interleave,	/* immediate action: but allow other work to interleave */
 	WORK_Timed,		/* action at certain time */
 	WORK_Deferred_Child,	/* On Death of a Child */
 	WORK_Deferred_Reply,	/* On reply to an outgoing service request */

--- a/src/lib/Libifl/dec_DelJobList.c
+++ b/src/lib/Libifl/dec_DelJobList.c
@@ -118,5 +118,6 @@ decode_DIS_DelJobList(int sock, struct batch_request *preq)
 	}
 	tmp_jobslist[i] = NULL;
 	preq->rq_ind.rq_deletejoblist.rq_jobslist = tmp_jobslist;
+	preq->rq_ind.rq_deletejoblist.rq_resume = 0;
 	return rc;
 }

--- a/src/lib/Libutil/work_task.c
+++ b/src/lib/Libutil/work_task.c
@@ -58,7 +58,7 @@
 /* Global Data Items: */
 
 extern pbs_list_head task_list_immed; /* list of tasks that can execute now */
-extern pbs_list_head task_list_interleave;
+extern pbs_list_head task_list_interleave; /* list of tasks that can execute after interleaving other tasks */
 extern pbs_list_head task_list_timed; /* list of tasks that have set start times */
 extern pbs_list_head task_list_event; /* list of tasks responding to an event */
 extern int svr_delay_entry;

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -364,6 +364,7 @@ pbs_list_head	svr_execjob_preresume_hooks;
 
 /* the task lists */
 pbs_list_head	task_list_immed;
+pbs_list_head	task_list_interleave;
 pbs_list_head	task_list_timed;
 pbs_list_head	task_list_event;
 
@@ -7911,6 +7912,7 @@ main(int argc, char *argv[])
 	CLEAR_HEAD(task_list_immed);
 	CLEAR_HEAD(task_list_timed);
 	CLEAR_HEAD(task_list_event);
+	CLEAR_HEAD(task_list_interleave);
 
 #if defined(PBS_SECURITY) && (PBS_SECURITY == KRB5)
 	CLEAR_HEAD(svr_allcreds);

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -865,6 +865,7 @@ main(int argc, char **argv)
 
 	CLEAR_HEAD(svr_requests);
 	CLEAR_HEAD(task_list_immed);
+	CLEAR_HEAD(task_list_interleave);
 	CLEAR_HEAD(task_list_timed);
 	CLEAR_HEAD(task_list_event);
 	CLEAR_HEAD(svr_queues);

--- a/src/server/process_request.c
+++ b/src/server/process_request.c
@@ -1577,6 +1577,9 @@ free_br(struct batch_request *preq)
 		}
 
 		free(preq->tppcmd_msgid);
+		if (preq->rq_type == PBS_BATCH_DeleteJobList)
+			if (preq->rq_ind.rq_deletejoblist.rq_jobslist)
+				free_string_array(preq->rq_ind.rq_deletejoblist.rq_jobslist);
 		free(preq);
 		return;
 	}

--- a/src/server/reply_send.c
+++ b/src/server/reply_send.c
@@ -468,6 +468,8 @@ reply_free(struct batch_reply *prep)
 		pdelstat = prep->brp_un.brp_deletejoblist.brp_delstatc;
 		while (pdelstat) {
 			pdelstatx = pdelstat->next;
+			if (pdelstat->name)
+				free(pdelstat->name);
 			free(pdelstat);
 			pdelstat = pdelstatx;
 	}

--- a/src/server/req_delete.c
+++ b/src/server/req_delete.c
@@ -80,7 +80,7 @@
 #include "pbs_nodes.h"
 #include "svrfunc.h"
 
-#define QDEL_DURATION 5
+#define QDEL_BREAKER_SECS 5
 
 /* Global Data Items: */
 
@@ -371,7 +371,8 @@ decr_single_subjob_usage(job *parent)
  * @retval	0	- success in updating jobs status 
  * @retval	!0	- failure to update status
  */
-int update_deletejob_stat(char *jid, struct batch_request *preq, int errcode)
+int 
+update_deletejob_stat(char *jid, struct batch_request *preq, int errcode)
 {
 	struct batch_deljob_status *pdelstat;
 	struct batch_reply *preply = &preq->rq_reply;
@@ -566,7 +567,7 @@ req_deletejob(struct batch_request *preq)
 			parent->ji_ajinfo->tkm_flags |= TKMFLG_NO_DELETE;
 			for (i = start; i <= parent->ji_ajinfo->tkm_end; i += parent->ji_ajinfo->tkm_step) {
 				end_time = time(NULL);
-				if ((end_time - begin_time) > QDEL_DURATION) {
+				if ((end_time - begin_time) > QDEL_BREAKER_SECS) {
 					preq->rq_ind.rq_deletejoblist.jobid_to_resume = j;
 					preq->rq_ind.rq_deletejoblist.subjobid_to_resume = i;
 					set_task(WORK_Interleave, 0, resume_deletion, preq); 

--- a/src/server/req_delete.c
+++ b/src/server/req_delete.c
@@ -80,6 +80,7 @@
 #include "pbs_nodes.h"
 #include "svrfunc.h"
 
+#define QDEL_DURATION 5
 
 /* Global Data Items: */
 
@@ -565,7 +566,7 @@ req_deletejob(struct batch_request *preq)
 			parent->ji_ajinfo->tkm_flags |= TKMFLG_NO_DELETE;
 			for (i = start; i <= parent->ji_ajinfo->tkm_end; i += parent->ji_ajinfo->tkm_step) {
 				end_time = time(NULL);
-				if ((end_time - begin_time) > 5) {
+				if ((end_time - begin_time) > QDEL_DURATION) {
 					preq->rq_ind.rq_deletejoblist.jobid_to_resume = j;
 					preq->rq_ind.rq_deletejoblist.subjobid_to_resume = i;
 					set_task(WORK_Interleave, 0, resume_deletion, preq); 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Server quasihangs when large job arrays with many running sub-jobs are deleted.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* Introduced a new type of work task namely task_list_interleave. 
* After the fixed duration of time (say 5 sec), the qdel request would create this work task and allow the server to handle other requests. 
* In case no other pending requests are available on the server, qdel request would resume finishing the deletion operation.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

After change: 
Server logs:

01/15/2021 23:29:10.343414;0008;Server@pbs-server;Job;3[].pbs-server;Job to be deleted at request of root@pbs-server.pbspro.org
01/15/2021 23:29:10.343435;0100;Server@pbs-server;Job;3[].pbs-server;in free_nodes and no exec_vnode
01/15/2021 23:29:10.344232;0100;Server@pbs-server;Job;3[].pbs-server;dequeuing from workq, state E
01/15/2021 23:29:10.345455;0100;Server@pbs-server;Req;;Type 51 request received from Scheduler@pbs-server.pbspro.org, sock=16
01/15/2021 23:29:10.345611;0100;Server@pbs-server;Req;;Type 19 request received from pbsuser@pbs-server.pbspro.org, sock=20
01/15/2021 23:29:10.346027;0040;Server@pbs-server;Svr;pbs-server;Scheduler sent command 2
01/15/2021 23:29:10.346775;0100;Server@pbs-server;Req;;Type 21 request received from Scheduler@pbs-server.pbspro.org, soc

We can see the other user requests are served while qdel request is processing.

Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, WIN2K16
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|5625|3849|2|0|0|1|3846|


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
