### PR TITLE
used mapping directory with -kd to direct write

### DIFF
--- a/test/tests/functional/pbs_qsub_remove_files.py
+++ b/test/tests/functional/pbs_qsub_remove_files.py
@@ -103,26 +103,26 @@ class TestQsub_remove_files(TestFunctional):
         submit a job with -Re option and make sure the error file
         gets deleted after job finishes and works with direct_write
         """
-        j = Job(TEST_USER, attrs={ATTR_k: 'de', ATTR_R: 'e'})
-        j.set_sleep_time(5)
         sub_dir = self.du.create_temp_dir(asuser=TEST_USER)
         mapping_dir = self.du.create_temp_dir(asuser=TEST_USER)
-        self.mom.add_config(
-            {'$usecp': self.server.hostname + ':' + sub_dir +
-             ' ' + mapping_dir})
-        self.mom.restart()
+        j = Job(TEST_USER, attrs={ATTR_k: 'de', ATTR_e: mapping_dir,
+                                  ATTR_R: 'e'})
+        j.set_sleep_time(5)
         jid = self.server.submit(j, submit_dir=sub_dir)
         self.server.expect(JOB, {ATTR_R: 'e'}, id=jid)
         self.server.expect(JOB, 'job_state', op=UNSET, id=jid)
-        for name in os.listdir(mapping_dir):
+        for name in os.listdir(sub_dir):
             p = re.search('STDIN.o*', name)
             if p:
                 self.logger.info('Match found: ' + p.group())
             else:
                 self.assertTrue(False)
         file_count = len([name for name in os.listdir(
-            mapping_dir) if os.path.isfile(os.path.join(mapping_dir, name))])
+            sub_dir) if os.path.isfile(os.path.join(sub_dir, name))])
         self.assertEqual(1, file_count)
+        file_count = len([name for name in os.listdir(
+            mapping_dir) if os.path.isfile(os.path.join(mapping_dir, name))])
+        self.assertEqual(0, file_count)
 
     def test_remove_files_error_custom_path(self):
         """


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Test "test_remove_files_error_file" of testsuite "TestQsub_remove_files" failed to direct write stderr.


#### Describe Your Change
Uses qsub -kde -e /<mapping_directory>/ to direct write stderr in mapping directory. Checking stdout should be present in submission directory and stderr is deleted from mapping directory.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
no mom on server
Description: Tests from given sources on platforms SUSE15, CENTOS8
Platforms: SUSE15,CENTOS8
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|5656|1|0|0|0|0|1|

mom on server
[direct_write_mom_on_server.txt](https://github.com/openpbs/openpbs/files/5829983/direct_write_mom_on_server.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
