### PR TITLE
Fixing a mem leak in sched wrt server psets

### DIFF
--- a/src/scheduler/server_info.cpp
+++ b/src/scheduler/server_info.cpp
@@ -989,13 +989,11 @@ find_resource(schd_resource *reslist, resdef *def)
  * @return void
  */
 static void
-free_server_psets(std::vector<server_psets> spsets)
+free_server_psets(std::vector<server_psets>& spsets)
 {
 	for (auto& spset: spsets) {
 		free_node_partition(spset.np);
 	}
-
-	spsets.clear();
 }
 
 /**

--- a/src/scheduler/server_info.cpp
+++ b/src/scheduler/server_info.cpp
@@ -982,6 +982,23 @@ find_resource(schd_resource *reslist, resdef *def)
 }
 
 /**
+ * @brief	free server_psets vector
+ *
+ * @param[out]	spsets - vector of server psets
+ *
+ * @return void
+ */
+static void
+free_server_psets(std::vector<server_psets> spsets)
+{
+	for (auto& spset: spsets) {
+		free_node_partition(spset.np);
+	}
+
+	spsets.clear();
+}
+
+/**
  * @brief
  * 		free_server_info - free the space used by a server_info
  *		structure
@@ -1031,7 +1048,7 @@ free_server_info(server_info *sinfo)
 	if (sinfo->allpart)
 		free_node_partition(sinfo->allpart);
 	if (!(sinfo->svr_to_psets.empty()))
-		sinfo->svr_to_psets.clear();
+		free_server_psets(sinfo->svr_to_psets);
 	if (sinfo->hostsets != NULL)
 		free_node_partition_array(sinfo->hostsets);
 	if (sinfo->nodesigs)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
The recent server pset PR added a leak wrt the new vector of psets. I was not freeing up the node_partition objects in the vector. This PR adds a function to clean them up.


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
**Before:**
==44119== 48,218 (1,728 direct, 46,490 indirect) bytes in 24 blocks are definitely lost in loss record 3,701 of 3,703
==44119==    at 0x4C30F0B: malloc (vg_replace_malloc.c:307)
==44119==    by 0x43BDCA: new_node_partition() (node_partition.cpp:111)
==44119==    by 0x43C68B: create_node_partitions(status*, node_info**, char const* const*, unsigned int, int*) (node_partition.cpp:485)
==44119==    by 0x45065B: query_server(status*, int) (server_info.cpp:468)
==44119==    by 0x423C18: scheduling_cycle(int, sched_cmd const*) (fifo.cpp:629)
==44119==    by 0x423F66: intermediate_schedule(int, sched_cmd const*) (fifo.cpp:562)
==44119==    by 0x45AAA6: schedule_wrapper(sched_cmd*, int) (pbs_sched_utils.cpp:1201)
==44119==    by 0x45BAEA: sched_main(int, char**, int (*)(int, sched_cmd const*)) (pbs_sched_utils.cpp:1147)
==44119==    by 0x679D7B2: (below main) (in /usr/lib64/libc-2.28.so)
==44119== 
==44119== LEAK SUMMARY:
==44119==    definitely lost: 1,748 bytes in 25 blocks
==44119==    indirectly lost: 46,490 bytes in 982 blocks
==44119==      possibly lost: 321,651 bytes in 2,667 blocks
==44119==    still reachable: 1,059,040 bytes in 8,895 blocks
==44119==         suppressed: 0 bytes in 0 blocks
==44119== Reachable blocks (those to which a pointer was found) are not shown.
==44119== To see them, rerun with: --leak-check=full --show-leak-kinds=all

**After:**
==74684== LEAK SUMMARY:
==74684==    definitely lost: 20 bytes in 1 blocks
==74684==    indirectly lost: 0 bytes in 0 blocks
==74684==      possibly lost: 321,536 bytes in 2,665 blocks
==74684==    still reachable: 1,059,145 bytes in 8,896 blocks
==74684==         suppressed: 0 bytes in 0 blocks
==74684== Reachable blocks (those to which a pointer was found) are not shown.
==74684== To see them, rerun with: --leak-check=full --show-leak-kinds=all

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
