### PR TITLE
fix for benchpress compilation issue

### DIFF
--- a/test/fw/bin/pbs_benchpress
+++ b/test/fw/bin/pbs_benchpress
@@ -376,11 +376,11 @@ if __name__ == '__main__':
 
     if outfile is not None:
         stream_hdlr = logging.StreamHandler()
-        stream_hdlr.setLevel(l)
+        stream_hdlr.setLevel(log_lvl)
         stream_hdlr.setFormatter(logging.Formatter(fmt))
         ptl_logger = logging.getLogger('ptl')
         ptl_logger.addHandler(stream_hdlr)
-        ptl_logger.setLevel(l)
+        ptl_logger.setLevel(log_lvl)
 
     pyver = platform.python_version()
     if minpyver is not None and LooseVersion(pyver) < LooseVersion(minpyver):


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
pbs_benchpress fails with "NameError" 


`Traceback (most recent call last):
File "/home/pbsbuild/ramdisk/workspace/build/openpbs/test/fw/bin/pbs_benchpress", line 379, in <module>
     stream_hdlr.setLevel(l)
NameError: name 'l' is not defined`

#### Describe Your Change
Updated pbs_benchpress

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
