### PR TITLE
pmix-devel contains headers instead of pmix libs

### DIFF
--- a/openpbs.spec
+++ b/openpbs.spec
@@ -120,7 +120,7 @@ BuildRequires: tk-devel
 BuildRequires: swig
 BuildRequires: zlib-devel
 %if %{with pmix}
-BuildRequires: pmix
+BuildRequires: pmix-devel
 %endif
 %if %{defined suse_version}
 BuildRequires: libexpat-devel

--- a/openpbs.spec
+++ b/openpbs.spec
@@ -72,11 +72,11 @@
 %if !%{defined _unitdir}
 %define _unitdir /usr/lib/systemd/system
 %endif
-%if %{_vendor} == debian && %(test -f /etc/os-release && echo 1 || echo 0)
+%if "%{_vendor}" == "debian" && %(test -f /etc/os-release && echo 1 || echo 0)
 %define _vendor_ver %(cat /etc/os-release | awk -F[=\\".] '/^VERSION_ID=/ {print \$3}')
 %define _vendor_id %(cat /etc/os-release | awk -F= '/^ID=/ {print \$2}')
 %endif
-%if 0%{?suse_version} >= 1210 || 0%{?rhel} >= 7 || (x%{?_vendor_id} == xdebian && 0%{?_vendor_ver} >= 8) || (x%{?_vendor_id} == xubuntu && 0%{?_vendor_ver} >= 16)
+%if ( 0%{?suse_version} >= 1210 ) || ( 0%{?rhel} >= 7 ) || ("x%{?_vendor_id}" == "xdebian" && 0%{?_vendor_ver} >= 8) || ("x%{?_vendor_id}" == "xubuntu" && 0%{?_vendor_ver} >= 16)
 %define have_systemd 1
 %endif
 
@@ -310,7 +310,7 @@ functionality of PBS.
 %if 0%{?opensuse_bs}
 # Do not specify debug_package for OBS builds.
 %else
-%if 0%{?suse_version} || x%{?_vendor_id} == xdebian || x%{?_vendor_id} == xubuntu
+%if 0%{?suse_version} || "x%{?_vendor_id}" == "xdebian" || "x%{?_vendor_id}" == "xubuntu"
 %debug_package
 %endif
 %endif

--- a/openpbs.spec.in
+++ b/openpbs.spec.in
@@ -120,7 +120,7 @@ BuildRequires: tk-devel
 BuildRequires: swig
 BuildRequires: zlib-devel
 %if %{with pmix}
-BuildRequires: pmix
+BuildRequires: pmix-devel
 %endif
 %if %{defined suse_version}
 BuildRequires: libexpat-devel

--- a/openpbs.spec.in
+++ b/openpbs.spec.in
@@ -72,11 +72,11 @@
 %if !%{defined _unitdir}
 %define _unitdir @_unitdir@
 %endif
-%if %{_vendor} == debian && %(test -f /etc/os-release && echo 1 || echo 0)
+%if "%{_vendor}" == "debian" && %(test -f /etc/os-release && echo 1 || echo 0)
 %define _vendor_ver %(cat /etc/os-release | awk -F[=\\".] '/^VERSION_ID=/ {print \$3}')
 %define _vendor_id %(cat /etc/os-release | awk -F= '/^ID=/ {print \$2}')
 %endif
-%if 0%{?suse_version} >= 1210 || 0%{?rhel} >= 7 || (x%{?_vendor_id} == xdebian && 0%{?_vendor_ver} >= 8) || (x%{?_vendor_id} == xubuntu && 0%{?_vendor_ver} >= 16)
+%if ( 0%{?suse_version} >= 1210 ) || ( 0%{?rhel} >= 7 ) || ("x%{?_vendor_id}" == "xdebian" && 0%{?_vendor_ver} >= 8) || ("x%{?_vendor_id}" == "xubuntu" && 0%{?_vendor_ver} >= 16)
 %define have_systemd 1
 %endif
 
@@ -310,7 +310,7 @@ functionality of PBS.
 %if 0%{?opensuse_bs}
 # Do not specify debug_package for OBS builds.
 %else
-%if 0%{?suse_version} || x%{?_vendor_id} == xdebian || x%{?_vendor_id} == xubuntu
+%if 0%{?suse_version} || "x%{?_vendor_id}" == "xdebian" || "x%{?_vendor_id}" == "xubuntu"
 %debug_package
 %endif
 %endif


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Cannot build RPM if pmix is enabled. Said:
```checking for udev_new in -ludev... no
checking for pci_system_init in -lpciaccess... no
checking for libical... /usr
checking for PMIx... configure: error: PMIx headers not found.
error: Bad exit status from /var/tmp/rpm-tmp.HFbpFm (%build)
```

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
pmix-devel packages contain headers. Replace it in BuildRequires.
pmix-devel was once not in RHEL 8 powertool/codeready repo. I filed a bug last year ([Please provide pmix-devel in RHEL8](https://bugzilla.redhat.com/show_bug.cgi?id=1816198), now private) and it is now available in RHEL 8.3 ([RHEA-2020:4653](https://access.redhat.com/errata/RHEA-2020:4653)).

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
