### PR TITLE
Fix for batchutils error by changing l to obj_list

### DIFF
--- a/test/fw/ptl/lib/ptl_batchutils.py
+++ b/test/fw/ptl/lib/ptl_batchutils.py
@@ -485,7 +485,7 @@ class BatchUtils(object):
                     obj_list = [obj_list[i]]
                     break
                 i += 1
-        self.display_dictlist(l, fmt=fmt)
+        self.display_dictlist(obj_list, fmt=fmt)
 
     def get_objtype(self, d={}):
         """


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Batchutils recent change was missing at one place causing error


#### Describe Your Change
Changed l to obj_list as per recent changes done for CI


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->


5733 | vishv | regression | Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, WIN2K16 | visheshh/pbspro@batchutils_error  altairengineering/pbspro-extensions@master | 22nd Jan 2021 04:04:35.360 PM +05:30 | 00:00:41.087 | 1 | 0 | 0 | 0 | 0 | 0 | 0 | 1
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
