### PR TITLE
Fix for runone dependency crash

### DIFF
--- a/src/server/issue_request.c
+++ b/src/server/issue_request.c
@@ -88,6 +88,7 @@ extern char	*msg_issuebad;
 extern char     *msg_norelytomom;
 extern char	*msg_err_malloc;
 
+extern pbs_net_t	 pbs_server_addr;
 extern int max_connection;
 
 /**
@@ -238,6 +239,7 @@ issue_to_svr(char *servern, struct batch_request *preq, void (*replyfunc)(struct
 	extern char primary_host[];
 	extern char server_host[];
 
+
 	(void)strcpy(preq->rq_host, servern);
 	preq->rq_fromsvr = 1;
 	preq->rq_perm = ATR_DFLAG_MGRD | ATR_DFLAG_MGWR | ATR_DFLAG_SvWR;
@@ -255,6 +257,9 @@ issue_to_svr(char *servern, struct batch_request *preq, void (*replyfunc)(struct
 				svrname = server_host;
 		}
 	}
+	if (comp_svraddr(pbs_server_addr, svrname) == 0)
+		return (issue_Drequest(PBS_LOCAL_CONNECTION, preq, replyfunc, 0, 0));
+
 	svraddr = get_hostaddr(svrname);
 	if (svraddr == (pbs_net_t)0) {
 		if (pbs_errno == PBS_NET_RC_RETRY)

--- a/src/server/req_delete.c
+++ b/src/server/req_delete.c
@@ -774,10 +774,7 @@ req_deletejob2(struct batch_request *preq, job *pjob)
 	} else if (((jt != IS_ARRAY_Range) && (jt != IS_ARRAY_Single)) &&
 		   (check_job_state(pjob, JOB_STATE_LTR_QUEUED) ||
 		    check_job_state(pjob, JOB_STATE_LTR_HELD))) {
-		struct depend *dp;
-		dp = find_depend(JOB_DEPEND_TYPE_RUNONE, &pjob->ji_wattr[(int)JOB_ATR_depend]);
-		if (dp != NULL)
-			depend_runone_remove_dependency(pjob);
+		depend_runone_remove_dependency(pjob);
 	}
 
 	if (is_mgr && forcedel) {

--- a/src/server/req_register.c
+++ b/src/server/req_register.c
@@ -474,11 +474,13 @@ req_register(struct batch_request *preq)
 						struct depend_job *dj_iter;
 						job *pr_job;
 						pr_job = find_job(preq->rq_ind.rq_register.rq_child);
-						for (dj_iter = (struct depend_job *)GET_NEXT(pdep->dp_jobs);
-						     dj_iter != NULL; dj_iter = (struct depend_job *)GET_NEXT(dj_iter->dc_link)) {
-							update_depend(pr_job, dj_iter->dc_child, dj_iter->dc_svr, DEPEND_REMOVE, JOB_DEPEND_TYPE_RUNONE);
-							log_eventf(PBSEVENT_JOB, PBS_EVENTCLASS_JOB,
-								LOG_INFO, pr_job->ji_qs.ji_jobid, msg_registerrel, dj_iter->dc_child);
+						if (pr_job){
+							for (dj_iter = (struct depend_job *)GET_NEXT(pdep->dp_jobs);
+							     dj_iter != NULL; dj_iter = (struct depend_job *)GET_NEXT(dj_iter->dc_link)) {
+								update_depend(pr_job, dj_iter->dc_child, dj_iter->dc_svr, DEPEND_REMOVE, JOB_DEPEND_TYPE_RUNONE);
+								log_eventf(PBSEVENT_JOB, PBS_EVENTCLASS_JOB,
+									LOG_INFO, pr_job->ji_qs.ji_jobid, msg_registerrel, dj_iter->dc_child);
+							}
 						}
 					}
 					update_depend(pjob, preq->rq_ind.rq_register.rq_parent, preq->rq_ind.rq_register.rq_svr, DEPEND_REMOVE, JOB_DEPEND_TYPE_RUNONE);
@@ -930,6 +932,7 @@ int depend_runone_remove_dependency(job *pjob)
 				}
 			}
 		}
+		del_depend(pdep);
 	}
 	return (0);
 }


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Server crashes while trying to get rid of a job that has runone dependency on it.

#### Describe Your Change
The problem does not show itself unless there are 2 NIC cards on the server machine. The problem happens on a machine with 2 NICs because while trying to delete a job server tries to update all other dependent jobs. When a dependent job is deleted, to update other jobs, the server usually issues a local batch request which updates other dependent jobs and then deletes the job in hand.
Now because of NICs server thinks that the server it is trying to send the batch request is remote and it sends a batch request over the network and deletes the job at hand. Now when the same server processes the batch request it had sent to itself, it tries to lookup the deleted job and crashes because the job is not there in the system.
 - I added a NULL check to make sure the server does not crash.
 - Removed runone dependency from the dependency list as soon as it is released.
 - Made a change in issue_to_svr to check all interfaces before deciding it's not a local request.

#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
[test.txt](https://github.com/openpbs/openpbs/files/5858365/test.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
