### PR TITLE
multi-server: per server scheduling for multi-node jobs & reservations

### DIFF
--- a/src/lib/Libattr/master_resv_attr_def.xml
+++ b/src/lib/Libattr/master_resv_attr_def.xml
@@ -886,6 +886,23 @@
          <ECL>NULL_VERIFY_VALUE_FUNC</ECL>
       </member_verify_function>
    </attributes>
+   <attributes>
+      <member_index>RESV_ATR_server_inst_id</member_index>
+      <member_name>ATTR_server_inst_id</member_name>
+      <member_at_decode>decode_str</member_at_decode>
+      <member_at_encode>encode_str</member_at_encode>
+      <member_at_set>set_str</member_at_set>
+      <member_at_comp>comp_str</member_at_comp>
+      <member_at_free>free_str</member_at_free>
+      <member_at_action>NULL_FUNC</member_at_action>
+      <member_at_flags>PRIV_READ | ATR_DFLAG_SSET | ATR_DFLAG_NOSAVM</member_at_flags>
+      <member_at_type>ATR_TYPE_STR</member_at_type>
+      <member_at_parent>PARENT_TYPE_RESV</member_at_parent>
+      <member_verify_function>
+         <ECL>NULL_VERIFY_DATATYPE_FUNC</ECL>
+         <ECL>NULL_VERIFY_VALUE_FUNC</ECL>
+      </member_verify_function>
+   </attributes>
    <attributes flag="SVR">
       #include "site_resv_attr_def.h"
       <member_name>

--- a/src/scheduler/buckets.cpp
+++ b/src/scheduler/buckets.cpp
@@ -1132,7 +1132,8 @@ check_node_buckets(status *policy, server_info *sinfo, queue_info *qinfo, resour
 			 * use that error code
 			 */
 			move_schd_error(err, failerr);
-	} else if (sinfo->svr_to_psets.find(resresv->svr_inst_id) != sinfo->svr_to_psets.end()) {
+	} else if (resresv->svr_inst_id != NULL &&
+		   sinfo->svr_to_psets.find(resresv->svr_inst_id) != sinfo->svr_to_psets.end()) {
 		nspec **nspecs;
 
 		nspecs = map_buckets(policy, sinfo->svr_to_psets[resresv->svr_inst_id]->bkts, resresv, err);

--- a/src/scheduler/buckets.cpp
+++ b/src/scheduler/buckets.cpp
@@ -1132,18 +1132,12 @@ check_node_buckets(status *policy, server_info *sinfo, queue_info *qinfo, resour
 			 * use that error code
 			 */
 			move_schd_error(err, failerr);
-	} else if (!(sinfo->svr_to_psets.empty())) {
-		/* Find buckets associated with nodes of the server which owns the job */
-		for (auto &spset: sinfo->svr_to_psets) {
-			if (spset.svr_inst_id == resresv->job->svr_inst_id) {
-				nspec **nspecs;
+	} else if (sinfo->svr_to_psets.find(resresv->svr_inst_id) != sinfo->svr_to_psets.end()) {
+		nspec **nspecs;
 
-				nspecs = map_buckets(policy, spset.np->bkts, resresv, err);
-				if (nspecs != NULL)
-					return nspecs;
-				break;
-			}
-		}
+		nspecs = map_buckets(policy, sinfo->svr_to_psets[resresv->svr_inst_id]->bkts, resresv, err);
+		if (nspecs != NULL)
+			return nspecs;
 	}
 
 	return map_buckets(policy, sinfo->buckets, resresv, err);

--- a/src/scheduler/check.cpp
+++ b/src/scheduler/check.cpp
@@ -1572,7 +1572,9 @@ check_normal_node_path(status *policy, server_info *sinfo, queue_info *qinfo, re
 				ninfo_arr = qinfo->nodes;
 		}
 
-		if (sinfo->svr_to_psets.find(resresv->svr_inst_id) != sinfo->svr_to_psets.end()) { /* Multi-server psets */
+		/* Handle multi-server psets */
+		if (resresv->svr_inst_id != NULL &&
+		    sinfo->svr_to_psets.find(resresv->svr_inst_id) != sinfo->svr_to_psets.end()) {
 			msvr_pset[0] = sinfo->svr_to_psets[resresv->svr_inst_id];
 
 			/* Restrict job arrays and reservations to owner server */

--- a/src/scheduler/check.cpp
+++ b/src/scheduler/check.cpp
@@ -1570,28 +1570,19 @@ check_normal_node_path(status *policy, server_info *sinfo, queue_info *qinfo, re
 			/* if there are nodes assigned to the queue, then check those */
 			if (qinfo->has_nodes)
 				ninfo_arr = qinfo->nodes;
-			else if (!(sinfo->svr_to_psets.empty())) {	/* Multi-server psets */
-				/* Find the pset of the server which owns the job */
-				for (auto &spset: sinfo->svr_to_psets) {
-					if (spset.svr_inst_id == resresv->job->svr_inst_id) {
-						msvr_pset[0] = spset.np;
-						if (!resresv->job->is_array && spec->total_chunks == 1) {
-							/* Allow job to be placed on nodes of other servers as well
-							 * For now, restricting job arrays and multi-chunk jobs
-							 * to nodes of just the local server
-							 */
-							msvr_pset[1] = sinfo->allpart;
-							msvr_pset[2] = NULL;
-						} else {
-							/* This prevents eval_selspec from considering all unassociated nodes */
-							flags &= ~SPAN_PSETS;
-							msvr_pset[1] = NULL;
-						}
-						nodepart = msvr_pset;
-						break;
-					}
-				}
+		}
+
+		if (sinfo->svr_to_psets.find(resresv->svr_inst_id) != sinfo->svr_to_psets.end()) { /* Multi-server psets */
+			msvr_pset[0] = sinfo->svr_to_psets[resresv->svr_inst_id];
+
+			/* Restrict job arrays and reservations to owner server */
+			if (resresv->is_resv || resresv->job->is_array)
+				msvr_pset[1] = NULL;
+			else {	/* If owner's nodes don't work, use all */
+				msvr_pset[1] = sinfo->allpart;
+				msvr_pset[2] = NULL;
 			}
+			nodepart = msvr_pset;
 		}
 	}
 

--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -65,7 +65,7 @@
 #include "site_queue.h"
 #endif
 
-#include <vector>
+#include <unordered_map>
 #include <string>
 
 struct server_info;
@@ -145,7 +145,6 @@ typedef struct th_data_free_ninfo th_data_free_ninfo;
 typedef struct th_data_dup_resresv th_data_dup_resresv;
 typedef struct th_data_query_jinfo th_data_query_jinfo;
 typedef struct th_data_free_resresv th_data_free_resresv;
-typedef struct server_psets server_psets;
 
 
 #ifdef NAS
@@ -477,7 +476,7 @@ struct server_info
 	resresv_set **equiv_classes;
 	node_bucket **buckets;		/* node bucket array */
 	node_info **unordered_nodes;
-	std::vector<server_psets> svr_to_psets;
+	std::unordered_map<std::string, node_partition *> svr_to_psets;
 #ifdef NAS
 	/* localmod 034 */
 	share_head *share_head;	/* root of share info */
@@ -575,7 +574,6 @@ struct job_info
 	unsigned topjob_ineligible:1;	/* Job is ineligible to be a top job */
 
 	char *job_name;			/* job name attribute (qsub -N) */
-	char *svr_inst_id;
 	char *comment;			/* comment field of job */
 	char *resv_id;			/* identifier of reservation job is in */
 	char *alt_id;			/* vendor assigned job identifier */
@@ -639,11 +637,6 @@ struct node_scratch
 	unsigned int to_be_sorted:1;	/* used for sorting of the nodes while
 					 * altering a reservation.
 					 */
-};
-
-struct server_psets {
-	std::string svr_inst_id;	/* server_instance_id (<hostname>:<port>) */
-	node_partition *np;	/* placement set of all nodes owned by this server */
 };
 
 struct node_info
@@ -824,6 +817,7 @@ struct resource_resv
 	job_info *job;			/* pointer to job specific structure */
 	resv_info *resv;		/* pointer to reservation specific structure */
 
+	char *svr_inst_id;		/* Server instance id of the job/reservation */
 	char *aoename;			   /* store name of aoe if requested */
 	char *eoename;			   /* store name of eoe if requested */
 	char **node_set_str;		   /* user specified node string */

--- a/src/scheduler/fifo.cpp
+++ b/src/scheduler/fifo.cpp
@@ -1387,17 +1387,17 @@ run_job(int pbs_sd, resource_resv *rjob, char *execvnode, int has_runjob_hook, s
 					log_eventf(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_NOTICE, rjob->name,
 						"Job will run for duration=%s", timebuf);
 				rc = send_run_job(pbs_sd, has_runjob_hook, rjob->name, execvnode, svr_id_node,
- 						  rjob->job->svr_inst_id);
+ 						  rjob->svr_inst_id);
 			}
 		} else
 			rc = send_run_job(pbs_sd, has_runjob_hook, rjob->name, execvnode, svr_id_node,
- 					  rjob->job->svr_inst_id);
+ 					  rjob->svr_inst_id);
 	}
 
 	if (rc) {
 		char buf[MAX_LOG_SIZE];
 		set_schd_error_codes(err, NOT_RUN, RUN_FAILURE);
-		errbuf = pbs_geterrmsg(get_svr_inst_fd(pbs_sd, rjob->job->svr_inst_id));
+		errbuf = pbs_geterrmsg(get_svr_inst_fd(pbs_sd, rjob->svr_inst_id));
 		if (errbuf == NULL)
 			errbuf = "";
 		set_schd_error_arg(err, ARG1, errbuf);
@@ -1515,7 +1515,7 @@ run_update_resresv(status *policy, int pbs_sd, server_info *sinfo,
 	pbs_errno = PBSE_NONE;
 	if (resresv->is_job && resresv->job->is_suspended) {
 		if (pbs_sd != SIMULATE_SD) {
-			pbsrc = pbs_sigjob(get_svr_inst_fd(pbs_sd, resresv->job->svr_inst_id), resresv->name, const_cast<char *>("resume"), NULL);
+			pbsrc = pbs_sigjob(get_svr_inst_fd(pbs_sd, resresv->svr_inst_id), resresv->name, const_cast<char *>("resume"), NULL);
 			if (!pbsrc)
 				ret = 1;
 			else {

--- a/src/scheduler/job_info.cpp
+++ b/src/scheduler/job_info.cpp
@@ -1239,8 +1239,8 @@ query_job(struct batch_status *job, server_info *sinfo, schd_error *err)
 				resresv->qrank = -1;
 		}
 		else if (!strcmp(attrp->name, ATTR_server_inst_id)) {
-			resresv->job->svr_inst_id = string_dup(attrp->value);
-			if (resresv->job->svr_inst_id == NULL) {
+			resresv->svr_inst_id = string_dup(attrp->value);
+			if (resresv->svr_inst_id == NULL) {
 				free_resource_resv(resresv);
 				return NULL;
 			}
@@ -1441,7 +1441,6 @@ new_job_info()
 		return NULL;
 	}
 
-	jinfo->svr_inst_id = NULL;
 	jinfo->is_queued = 0;
 	jinfo->is_running = 0;
 	jinfo->is_held = 0;
@@ -1562,9 +1561,6 @@ free_job_info(job_info *jinfo)
 
 	if (jinfo->dependent_jobs != NULL)
 		free(jinfo->dependent_jobs);
-
-	if (jinfo->svr_inst_id != NULL)
-		free(jinfo->svr_inst_id);
 
 	free_resource_req_list(jinfo->resused);
 
@@ -1788,7 +1784,7 @@ update_job_attr(int pbs_sd, resource_resv *resresv, const char *attr_name,
 
 	if (pattr != NULL && (flags & UPDATE_NOW)) {
 		int rc;
-		rc = send_attr_updates(get_svr_inst_fd(pbs_sd, resresv->job->svr_inst_id), resresv->name, pattr);
+		rc = send_attr_updates(get_svr_inst_fd(pbs_sd, resresv->svr_inst_id), resresv->name, pattr);
 		free_attrl_list(pattr);
 		return rc;
 	}
@@ -1832,7 +1828,7 @@ int send_job_updates(int pbs_sd, resource_resv *job)
 			return 0;
 	}
 
-	rc = send_attr_updates(get_svr_inst_fd(pbs_sd, job->job->svr_inst_id), job->name, job->job->attr_updates);
+	rc = send_attr_updates(get_svr_inst_fd(pbs_sd, job->svr_inst_id), job->name, job->job->attr_updates);
 
 	free_attrl_list(job->job->attr_updates);
 	job->job->attr_updates = NULL;
@@ -2762,8 +2758,6 @@ dup_job_info(job_info *ojinfo, queue_info *nqinfo, server_info *nsinfo)
 		return NULL;
 
 	njinfo->queue = nqinfo;
-
-	njinfo->svr_inst_id = string_dup(ojinfo->svr_inst_id);
 	njinfo->is_queued = ojinfo->is_queued;
 	njinfo->is_running = ojinfo->is_running;
 	njinfo->is_held = ojinfo->is_held;

--- a/src/scheduler/pbs_sched_bare.cpp
+++ b/src/scheduler/pbs_sched_bare.cpp
@@ -113,7 +113,7 @@ main_sched_loop_bare(int sd, server_info *sinfo)
 
 			/* Send the run request */
 			send_run_job(sd, 0, jobs[ij]->name, execvnode, node->svr_inst_id,
-					     jobs[ij]->job->svr_inst_id);
+					     jobs[ij]->svr_inst_id);
 
 			break;
 		}

--- a/src/scheduler/resource_resv.cpp
+++ b/src/scheduler/resource_resv.cpp
@@ -138,7 +138,7 @@ new_resource_resv()
 		return NULL;
 	}
 
-
+	resresv->svr_inst_id = NULL;
 	resresv->name = NULL;
 	resresv->user = NULL;
 	resresv->group = NULL;
@@ -397,6 +397,8 @@ free_resource_resv(resource_resv *resresv)
 	if (resresv->end_event != NULL)
 		delete_event(resresv->server, resresv->end_event);
 
+	free(resresv->svr_inst_id);
+
 	free(resresv);
 }
 
@@ -611,6 +613,7 @@ dup_resource_resv(resource_resv *oresresv, server_info *nsinfo, queue_info *nqin
 
 	nresresv->server = nsinfo;
 
+	nresresv->svr_inst_id = string_dup(oresresv->svr_inst_id);
 	nresresv->name = string_dup(oresresv->name);
 	nresresv->user = string_dup(oresresv->user);
 	nresresv->group = string_dup(oresresv->group);

--- a/src/scheduler/resv_info.cpp
+++ b/src/scheduler/resv_info.cpp
@@ -750,6 +750,12 @@ query_resv(struct batch_status *resv, server_info *sinfo)
 			advresv->resv->partition = strdup(attrp->value);
 		} else if (!strcmp(attrp->name, ATTR_SchedSelect_orig)) {
 			advresv->resv->select_orig = parse_selspec(attrp->value);
+		} else if (!strcmp(attrp->name, ATTR_server_inst_id)) {
+			advresv->svr_inst_id = string_dup(attrp->value);
+			if (advresv->svr_inst_id == NULL) {
+				free_resource_resv(advresv);
+				return NULL;
+			}
 		}
 		attrp = attrp->next;
 	}

--- a/src/server/job_func.c
+++ b/src/server/job_func.c
@@ -387,6 +387,7 @@ job_alloc(void)
 
 	if ((svr_inst_id = gen_svr_inst_id()) == NULL) {
 		log_err(errno, __func__, "unable to get server_instance_id");
+		free(pj);
 		return NULL;
 	}
 
@@ -1679,6 +1680,7 @@ resv_alloc(char *resvid)
 	int i;
 	resc_resv *resvp;
 	char *dot = NULL;
+	char *svr_inst_id = NULL;
 
 	resvp = (resc_resv *) calloc(1, sizeof(resc_resv));
 	if (resvp == NULL) {
@@ -1700,6 +1702,15 @@ resv_alloc(char *resvid)
 
 	if ((dot = strchr(resvid, (int)'.')) != 0)
 		*dot = '\0';
+
+	if ((svr_inst_id = gen_svr_inst_id()) == NULL) {
+		log_err(errno, __func__, "unable to get server_instance_id");
+		free(resvp);
+		return NULL;
+	}
+	set_attr_generic(&resvp->ri_wattr[RESV_ATR_server_inst_id],
+			 &resv_attr_def[RESV_ATR_server_inst_id], svr_inst_id, NULL, INTERNAL);
+	free(svr_inst_id);
 
 	/*
 	 * ignore first char in given id as it can change, see req_resvSub()

--- a/src/server/multi_svr.c
+++ b/src/server/multi_svr.c
@@ -283,7 +283,7 @@ init_msi()
 /**
  * @brief
  * 	Used to Create serverer_instance_id which is of the form server_instance_name:server_instance_port
- * 
+ *
  * @return char *
  * @return NULL - failure
  * @retval !NULL - pointer to server_instance_id


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Right now, multi-node jobs can only run on nodes of the owner server. This limitation was added in the spirit of Agile, one step at a time. With this PR, we are lifting this limitation and making it so that multi-node jobs will be scheduled on the owner's nodes first, then each server's nodes one by one to try to fit it in any single server. Finally, if that also doesn't work, we will consider all nodes. Please note, the server side doesn't yet support job spanning across multiple servers, but we are going to add it soon, so lifting the limitation from scheduler side preemptively.
This also restricts reservations to the owner server's nodes. Again, this cannot be tested right now because multi-server reservation support is absent, but it's coming soon, so adding this preemptively.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
**multi-node job testing, job "moved and run" on a different server's nodes**
```
[ravi@pbsc8 ~]$ PBS_SERVER_INSTANCES=pbsc8:15001 /opt/pbs/bin/qsub -lselect=2:ncpus=4 -- /bin/sleep 100
1091.pbsc8
[ravi@pbsc8 ~]$ qstat
Job id            Name             User              Time Use S Queue
----------------  ---------------- ----------------  -------- - -----
1090.pbsc8        STDIN            ravi              00:00:00 R workq           
1091.pbsc8        STDIN            ravi              00:00:00 R workq           
[ravi@pbsc8 ~]$ pbsnodes -av
pbsc8
     Mom = pbsc8
     ntype = PBS
     state = free
     pcpus = 4
     jobs = 1090.pbsc8/0
     resources_available.arch = linux
     resources_available.host = pbsc8
     resources_available.mem = 2036452kb
     resources_available.ncpus = 4
     resources_available.vnode = pbsc8
     resources_assigned.accelerator_memory = 0kb
     resources_assigned.hbmem = 0kb
     resources_assigned.mem = 0kb
     resources_assigned.naccelerators = 0
     resources_assigned.ncpus = 1
     resources_assigned.vmem = 0kb
     resv_enable = True
     sharing = default_shared
     license = l
     last_state_change_time = Fri Jan 22 23:05:31 2021
     last_used_time = Wed Jan 20 22:12:41 2021

pbsc8[1]
     Mom = pbsc8
     ntype = PBS
     state = free
     pcpus = 4
     resources_available.arch = linux
     resources_available.host = pbsc8
     resources_available.ncpus = 4
     resources_available.vnode = pbsc8[1]
     resources_assigned.accelerator_memory = 0kb
     resources_assigned.hbmem = 0kb
     resources_assigned.mem = 0kb
     resources_assigned.naccelerators = 0
     resources_assigned.ncpus = 0
     resources_assigned.vmem = 0kb
     resv_enable = True
     sharing = default_shared
     license = l
     last_state_change_time = Fri Jan 22 23:05:31 2021
     last_used_time = Wed Jan 20 22:13:05 2021

pbsc8-2
     Mom = pbsc8
     ntype = PBS
     state = job-busy
     pcpus = 4
     jobs = 1091.pbsc8/0, 1091.pbsc8/1, 1091.pbsc8/2, 1091.pbsc8/3
     resources_available.arch = linux
     resources_available.host = pbsc8
     resources_available.mem = 2036452kb
     resources_available.ncpus = 4
     resources_available.vnode = pbsc8-2
     resources_assigned.accelerator_memory = 0kb
     resources_assigned.hbmem = 0kb
     resources_assigned.mem = 0kb
     resources_assigned.naccelerators = 0
     resources_assigned.ncpus = 4
     resources_assigned.vmem = 0kb
     resv_enable = True
     sharing = default_shared
     license = l
     last_state_change_time = Fri Jan 22 23:07:15 2021
     last_used_time = Wed Jan 20 22:12:44 2021

pbsc8-2[1]
     Mom = pbsc8
     ntype = PBS
     state = job-busy
     pcpus = 4
     jobs = 1091.pbsc8/0, 1091.pbsc8/1, 1091.pbsc8/2, 1091.pbsc8/3
     resources_available.arch = linux
     resources_available.host = pbsc8-2
     resources_available.ncpus = 4
     resources_available.vnode = pbsc8-2[1]
     resources_assigned.accelerator_memory = 0kb
     resources_assigned.hbmem = 0kb
     resources_assigned.mem = 0kb
     resources_assigned.naccelerators = 0
     resources_assigned.ncpus = 4
     resources_assigned.vmem = 0kb
     resv_enable = True
     sharing = default_shared
     license = l
     last_state_change_time = Fri Jan 22 23:07:15 2021
     last_used_time = Wed Jan 20 22:13:06 2021
```


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
