### PR TITLE
scheduler might crash if secondary connection is not found

### DIFF
--- a/src/scheduler/fifo.cpp
+++ b/src/scheduler/fifo.cpp
@@ -764,6 +764,11 @@ get_high_prio_cmd(int *is_conn_lost, sched_cmd *high_prior_cmd)
 	sched_cmd cmd;
 	int nsvrs = get_num_servers();
 	svr_conn_t **svr_conns = get_conn_svr_instances(clust_secondary_sock);
+	if (svr_conns == NULL) {
+		log_event(PBSEVENT_SCHED, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__,
+			"Unable to fetch secondary connections");
+		return 0;
+	}
 
 	for (i = 0; svr_conns[i]; i++) {
 		int rc;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
If in some corner case scheduler does not make a secondary connection, it might crash while trying to find one.

#### Describe Your Change
Added a null check

#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
NA

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
