### PR TITLE
pbsfs -e/-d does not set last decay time

### DIFF
--- a/src/scheduler/pbsfs.cpp
+++ b/src/scheduler/pbsfs.cpp
@@ -214,8 +214,10 @@ main(int argc, char *argv[])
 	if (parse_group(RESGROUP_FILE, conf.fairshare->root) == 0)
 		return 1;
 
-	if (flags & FS_TRIM_TREE)
+	if (flags & FS_TRIM_TREE) {
 		read_usage(USAGE_FILE, FS_TRIM, conf.fairshare);
+		conf.fairshare->last_decay = time(0);
+	}
 	else
 		read_usage(USAGE_FILE, 0, conf.fairshare);
 
@@ -228,8 +230,10 @@ main(int argc, char *argv[])
 		printf("Fairshare usage units are in: %s\n", conf.fairshare_res);
 		print_fairshare(conf.fairshare->root, -1);
 	}
-	else if (flags & FS_DECAY)
+	else if (flags & FS_DECAY) {
 		decay_fairshare_tree(conf.fairshare->root);
+		conf.fairshare->last_decay = time(0);
+	}
 	else if (flags & (FS_GET | FS_SET | FS_COMP)) {
 		ginfo = find_group_info(argv[optind], conf.fairshare->root);
 

--- a/src/scheduler/pbsfs.cpp
+++ b/src/scheduler/pbsfs.cpp
@@ -216,7 +216,7 @@ main(int argc, char *argv[])
 
 	if (flags & FS_TRIM_TREE) {
 		read_usage(USAGE_FILE, FS_TRIM, conf.fairshare);
-		conf.fairshare->last_decay = time(0);
+		conf.fairshare->last_decay = time(NULL);
 	}
 	else
 		read_usage(USAGE_FILE, 0, conf.fairshare);
@@ -232,7 +232,7 @@ main(int argc, char *argv[])
 	}
 	else if (flags & FS_DECAY) {
 		decay_fairshare_tree(conf.fairshare->root);
-		conf.fairshare->last_decay = time(0);
+		conf.fairshare->last_decay = time(NULL);
 	}
 	else if (flags & (FS_GET | FS_SET | FS_COMP)) {
 		ginfo = find_group_info(argv[optind], conf.fairshare->root);

--- a/test/fw/ptl/lib/ptl_sched.py
+++ b/test/fw/ptl/lib/ptl_sched.py
@@ -802,6 +802,21 @@ class Scheduler(PBSService):
                          str(filename))
         self.dedicated_time_file = filename
 
+    def revert_fairshare(self):
+        """
+        Helper method to revert scheduler's fairshare tree.
+        """
+        cmd = [os.path.join(self.pbs_conf['PBS_EXEC'], 'sbin', 'pbsfs'), '-e']
+        if self.sc_name is not 'default':
+            cmd += ['-I', self.sc_name]
+        self.du.run_cmd(cmd=cmd, runas=self.user)
+        self.parse_sched_config()
+        if self.platform == 'cray' or self.platform == 'craysim':
+            self.add_resource('vntype')
+            self.add_resource('hbmem')
+        self.fairshare_tree = None
+        self.resource_group = None
+
     def revert_to_defaults(self):
         """
         Revert scheduler configuration to defaults.
@@ -841,16 +856,7 @@ class Scheduler(PBSService):
 
         self.signal('-HUP')
         # Revert fairshare usage
-        cmd = [os.path.join(self.pbs_conf['PBS_EXEC'], 'sbin', 'pbsfs'), '-e']
-        if self.sc_name is not 'default':
-            cmd += ['-I', self.sc_name]
-        self.du.run_cmd(cmd=cmd, runas=self.user)
-        self.parse_sched_config()
-        if self.platform == 'cray' or self.platform == 'craysim':
-            self.add_resource('vntype')
-            self.add_resource('hbmem')
-        self.fairshare_tree = None
-        self.resource_group = None
+        self.revert_fairshare()
         return self.isUp()
 
     def create_scheduler(self, sched_home=None):

--- a/test/fw/ptl/lib/ptl_sched.py
+++ b/test/fw/ptl/lib/ptl_sched.py
@@ -811,9 +811,6 @@ class Scheduler(PBSService):
             cmd += ['-I', self.sc_name]
         self.du.run_cmd(cmd=cmd, runas=self.user)
         self.parse_sched_config()
-        if self.platform == 'cray' or self.platform == 'craysim':
-            self.add_resource('vntype')
-            self.add_resource('hbmem')
         self.fairshare_tree = None
         self.resource_group = None
 
@@ -855,6 +852,9 @@ class Scheduler(PBSService):
                              uid=self.user)
 
         self.signal('-HUP')
+        if self.platform == 'cray' or self.platform == 'craysim':
+            self.add_resource('vntype')
+            self.add_resource('hbmem')
         # Revert fairshare usage
         self.revert_fairshare()
         return self.isUp()

--- a/test/fw/ptl/lib/ptl_sched.py
+++ b/test/fw/ptl/lib/ptl_sched.py
@@ -810,7 +810,6 @@ class Scheduler(PBSService):
         if self.sc_name is not 'default':
             cmd += ['-I', self.sc_name]
         self.du.run_cmd(cmd=cmd, runas=self.user)
-        self.parse_sched_config()
         self.fairshare_tree = None
         self.resource_group = None
 
@@ -857,6 +856,7 @@ class Scheduler(PBSService):
             self.add_resource('hbmem')
         # Revert fairshare usage
         self.revert_fairshare()
+        self.parse_sched_config()
         return self.isUp()
 
     def create_scheduler(self, sched_home=None):


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
When an admin issues pbsfs with '-e' or '-d' option to decay or erase the fair share usage, it does not set the decay time in the usage file. This can potentially lead to scheduler decaying the usage again when the scheduling cycle is triggered.


#### Describe Your Change
Updated pbsfs to set last_decay timestamp. Also, refactored the scheduler PTL class to revert fairshare.

#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
Test are running


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
