### PR TITLE
Skip TestProvisioningJob's tests on cpuset moms

### DIFF
--- a/test/tests/functional/pbs_provisioning.py
+++ b/test/tests/functional/pbs_provisioning.py
@@ -90,7 +90,7 @@ class TestProvisioningJob(TestFunctional):
         TestFunctional.setUp(self)
         self.momA = self.moms.values()[0]
         self.hostA = self.momA.shortname
-        msg = ("We cannot provision on cpuset mom ,host has vnodes")
+        msg = ("We cannot provision on cpuset mom, host has vnodes")
         if self.momA.is_cpuset_mom():
             self.skipTest(msg)
         self.momA.delete_vnode_defs()
@@ -178,7 +178,7 @@ class TestProvisioningJob(TestFunctional):
             self.skip_test(reason=cmt)
         self.momB = self.moms.values()[1]
         self.hostB = self.momB.shortname
-        msg = ("We cannot provision on cpuset mom ,host has vnodes")
+        msg = ("We cannot provision on cpuset mom, host has vnodes")
         if self.momA.is_cpuset_mom() or self.momB.is_cpuset_mom():
             self.skipTest(msg)
         a = {'resources_available.aoe': 'osimage1'}

--- a/test/tests/functional/pbs_provisioning.py
+++ b/test/tests/functional/pbs_provisioning.py
@@ -89,21 +89,12 @@ class TestProvisioningJob(TestFunctional):
     def setUp(self):
         TestFunctional.setUp(self)
         self.momA = self.moms.values()[0]
-        serverA = (self.servers.values()[0]).shortname
         self.hostA = self.momA.shortname
-        msg = ("Server and Mom can't be on the same host. "
-               "Provide a mom not present on server host "
-               "while invoking the test: -p moms=<m1>")
-        if serverA == self.hostA:
+        msg = ("We cannot provision on cpuset mom ,host has vnodes")
+        if self.momA.is_cpuset_mom():
             self.skipTest(msg)
         self.momA.delete_vnode_defs()
         self.logger.info(self.momA.shortname)
-
-        self.server.manager(
-            MGR_CMD_DELETE, NODE, None, "", runas=ROOT_USER)
-
-        self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostA)
-
         a = {'provision_enable': 'true'}
         self.server.manager(MGR_CMD_SET, NODE, a, id=self.hostA)
 
@@ -185,13 +176,13 @@ class TestProvisioningJob(TestFunctional):
         if len(self.moms) < 2:
             cmt = "need 2 non-server mom hosts: -p moms=<m1>:<m2>"
             self.skip_test(reason=cmt)
-
-        a = {'resources_available.aoe': 'osimage1'}
-        self.server.manager(MGR_CMD_SET, NODE, a, id=self.hostA)
-
         self.momB = self.moms.values()[1]
         self.hostB = self.momB.shortname
-        self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostB)
+        msg = ("We cannot provision on cpuset mom ,host has vnodes")
+        if self.momA.is_cpuset_mom() or self.momB.is_cpuset_mom():
+            self.skipTest(msg)
+        a = {'resources_available.aoe': 'osimage1'}
+        self.server.manager(MGR_CMD_SET, NODE, a, id=self.hostA)
         self.server.expect(NODE, {'state': 'free'}, id=self.hostB)
         self.server.expect(NODE, {'state': 'free'}, id=self.hostA)
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
TestProvisioningJob's tests suite is failing on cpuset moms due to PtlExpectError as
Job in Q state  instead of R state and Node is free state instead of 
provisioning state .

#### Describe Your Change
Add self.skipTest(msg) in code because, cpuset moms have vnodes and we cannot provision on moms having vnodes.
Add if condition to skip test  when cluster has cpuset mom only.
Also removed  skip code  which handling "Server and Mom can't be on the same host" part 
because now @requirements(no_mom_on_server=True) is enable on TestSuite level , so no need 
of explicit skipTest to handle this.

#### Attach Test and Valgrind Logs/Output
Without fix 
[Without_fix_mom_cpuset.txt](https://github.com/openpbs/openpbs/files/5884264/Without_fix_mom_cpuset.txt)

With fix :
[with_fix_mom1_cpuset.txt](https://github.com/openpbs/openpbs/files/5884227/with_fix_mom1_cpuset.txt)
[with_fix_mom2_cpuset.txt](https://github.com/openpbs/openpbs/files/5884228/with_fix_mom2_cpuset.txt)
[with_fix_only_mom_cpuset.txt](https://github.com/openpbs/openpbs/files/5884229/with_fix_only_mom_cpuset.txt)
[with_fix_only_mom_non_cpuset.txt](https://github.com/openpbs/openpbs/files/5884230/with_fix_only_mom_non_cpuset.txt)
[with_fix_server_as_cpuset.txt](https://github.com/openpbs/openpbs/files/5884247/with_fix_server_as_cpuset.txt)



