### PR TITLE
Fix permission issue while exporting hook in TestHookSmokeTest.test_import_and_export_hook

### DIFF
--- a/test/tests/functional/pbs_hooksmoketest.py
+++ b/test/tests/functional/pbs_hooksmoketest.py
@@ -134,7 +134,7 @@ e.accept()"""
         exp_hook_body = imp_hook_body
         attrs = {'event': 'queuejob'}
         self.server.create_import_hook(self.hook_name, attrs, hook_body)
-        fn = self.du.create_temp_file()
+        fn = self.du.create_temp_file(asuser=ROOT_USER)
         hook_attrs = 'application/x-config default %s' % fn
         rc = self.server.manager(MGR_CMD_EXPORT, HOOK, hook_attrs,
                                  self.hook_name)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
TestHookSmokeTest.test_import_and_export_hook test case is failing while exporting hook config contents to a file with permission issue;
Traceback (most recent call last):
File "/home/pbsroot/TEST/tmp/tests/functional/pbs_hooksmoketest.py", line 119, in test_import_and_export_hook
self.hook_name)
File "/home/pbsroot/TEST/tmp/2021.1.0.20201126134342/lib/python3.6/site-packages/ptl/lib/pbs_testlib.py", line 6940, in manager
post=self._disconnect, conn=c)
ptl.lib.pbs_testlib.PbsManagerError: rc=1, rv=False, msg=['/tmp/PtlPbsz8voigvm - Permission denied'] 



#### Describe Your Change
We need to create tmp file as root instead of current user.


#### Attach Test and Valgrind Logs/Output
[test_import_and_export_hook_after_fix.txt](https://github.com/openpbs/openpbs/files/5885607/test_import_and_export_hook_after_fix.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
