### PR TITLE
Skipping direct write tests while no mom on server

### DIFF
--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -89,7 +89,7 @@ default_requirements = {
     'min_mom_disk': 1,
     'min_server_ram': .128,
     'min_server_disk': 1,
-    'no_mom_on_server': False,
+    'no_mom_on_server': "not_set",
     'no_comm_on_server': False,
     'no_comm_on_mom': True
 }

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -89,7 +89,8 @@ default_requirements = {
     'min_mom_disk': 1,
     'min_server_ram': .128,
     'min_server_disk': 1,
-    'no_mom_on_server': "not_set",
+    'mom_on_server': False,
+    'no_mom_on_server': False,
     'no_comm_on_server': False,
     'no_comm_on_mom': True
 }

--- a/test/fw/ptl/utils/plugins/ptl_test_runner.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_runner.py
@@ -676,7 +676,8 @@ class PTLTestRunner(Plugin):
         shortname = (socket.gethostname()).split('.', 1)[0]
         for key in ['servers', 'moms', 'comms', 'clients', 'nomom']:
             tparam_contents[key] = []
-        tparam_contents['no_mom_on_server'] = "not_set"
+        tparam_contents['mom_on_server'] = False
+        tparam_contents['no_mom_on_server'] = False
         tparam_contents['no_comm_on_server'] = False
         tparam_contents['no_comm_on_mom'] = False
         if self.param is not None:
@@ -694,6 +695,8 @@ class PTLTestRunner(Plugin):
                         tparam_contents['clients'] = hosts
                     elif k == 'nomom':
                         nomomlist = hosts
+                    elif k == 'mom_on_server':
+                        tparam_contents['mom_on_server'] = v
                     elif k == 'no_mom_on_server':
                         tparam_contents['no_mom_on_server'] = v
                     elif k == 'no_comm_on_mom':
@@ -729,6 +732,7 @@ class PTLTestRunner(Plugin):
         _moms = set(param_dic['moms'])
         _comms = set(param_dic['comms'])
         _nomom = set(param_dic['nomom'])
+        _mom_on_server = param_dic['mom_on_server']
         _no_mom_on_server = param_dic['no_mom_on_server']
         _no_comm_on_mom = param_dic['no_comm_on_mom']
         _no_comm_on_server = param_dic['no_comm_on_server']
@@ -829,18 +833,16 @@ class PTLTestRunner(Plugin):
                 logger.error(_msg)
                 return _msg
         if _moms & _servers:
-            if (eff_tc_req['no_mom_on_server'] and
-                eff_tc_req['no_mom_on_server'] != "not_set") or \
+            if eff_tc_req['no_mom_on_server'] or \
                (_nomom - _servers) or \
-               (_no_mom_on_server and
-                    _no_mom_on_server != "not_set"):
+               _no_mom_on_server:
                 _msg = 'no mom on server'
                 logger.error(_msg)
                 return _msg
         else:
-            if not (eff_tc_req['no_mom_on_server'] and
-                    _no_mom_on_server):
-                _msg = 'mom should be on server'
+            if eff_tc_req['mom_on_server'] or \
+               _mom_on_server:
+                _msg = 'mom on server'
                 logger.error(_msg)
                 return _msg
         if _comms & _servers:

--- a/test/fw/ptl/utils/plugins/ptl_test_runner.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_runner.py
@@ -676,7 +676,7 @@ class PTLTestRunner(Plugin):
         shortname = (socket.gethostname()).split('.', 1)[0]
         for key in ['servers', 'moms', 'comms', 'clients', 'nomom']:
             tparam_contents[key] = []
-        tparam_contents['no_mom_on_server'] = False
+        tparam_contents['no_mom_on_server'] = "not_set"
         tparam_contents['no_comm_on_server'] = False
         tparam_contents['no_comm_on_mom'] = False
         if self.param is not None:
@@ -829,10 +829,18 @@ class PTLTestRunner(Plugin):
                 logger.error(_msg)
                 return _msg
         if _moms & _servers:
-            if eff_tc_req['no_mom_on_server'] or \
+            if (eff_tc_req['no_mom_on_server'] and
+                eff_tc_req['no_mom_on_server'] != "not_set") or \
                (_nomom - _servers) or \
-               _no_mom_on_server:
+               (_no_mom_on_server and
+                    _no_mom_on_server != "not_set"):
                 _msg = 'no mom on server'
+                logger.error(_msg)
+                return _msg
+        else:
+            if not (eff_tc_req['no_mom_on_server'] and
+                    _no_mom_on_server):
+                _msg = 'mom should be on server'
                 logger.error(_msg)
                 return _msg
         if _comms & _servers:

--- a/test/tests/functional/pbs_qsub_direct_write.py
+++ b/test/tests/functional/pbs_qsub_direct_write.py
@@ -62,7 +62,7 @@ class TestQsub_direct_write(TestFunctional):
             if total_ncpus < ncpus:
                 self.skip_test(reason="need %d available ncpus" % ncpus)
 
-    @requirements(no_mom_on_server=False)
+    @requirements(mom_on_server=True)
     def test_direct_write_when_job_succeeds(self):
         """
         submit a sleep job and make sure that the std_files
@@ -85,7 +85,7 @@ class TestQsub_direct_write(TestFunctional):
         self.assertEqual(2, file_count)
         self.server.expect(JOB, {ATTR_k: 'doe'}, id=jid)
 
-    @requirements(no_mom_on_server=False)
+    @requirements(mom_on_server=True)
     def test_direct_write_when_job_succeeds_controlled(self):
         """
         submit a sleep job and make sure that the std_files
@@ -115,7 +115,7 @@ class TestQsub_direct_write(TestFunctional):
         self.assertEqual(2, file_count)
         self.server.expect(JOB, {ATTR_k: 'doe'}, id=jid)
 
-    @requirements(no_mom_on_server=False)
+    @requirements(mom_on_server=True)
     def test_direct_write_output_file(self):
         """
         submit a sleep job and make sure that the output file
@@ -144,7 +144,7 @@ class TestQsub_direct_write(TestFunctional):
         self.assertEqual(1, file_count)
         self.server.expect(JOB, {ATTR_k: 'do'}, id=jid)
 
-    @requirements(no_mom_on_server=False)
+    @requirements(mom_on_server=True)
     def test_direct_write_error_file(self):
         """
         submit a sleep job and make sure that the error file
@@ -173,7 +173,7 @@ class TestQsub_direct_write(TestFunctional):
         self.assertEqual(1, file_count)
         self.server.expect(JOB, {ATTR_k: 'de'}, id=jid)
 
-    @requirements(no_mom_on_server=False)
+    @requirements(mom_on_server=True)
     def test_direct_write_error_custom_path(self):
         """
         submit a sleep job and make sure that the files
@@ -200,7 +200,7 @@ class TestQsub_direct_write(TestFunctional):
         self.assertEqual(2, file_count)
         self.server.expect(JOB, {ATTR_k: 'doe'}, id=jid)
 
-    @requirements(no_mom_on_server=False)
+    @requirements(mom_on_server=True)
     def test_direct_write_error_custom_dir(self):
         """
         submit a sleep job and make sure that the files
@@ -225,7 +225,7 @@ class TestQsub_direct_write(TestFunctional):
         self.assertEqual(2, file_count)
         self.server.expect(JOB, {ATTR_k: 'doe'}, id=jid)
 
-    @requirements(no_mom_on_server=False)
+    @requirements(mom_on_server=True)
     def test_direct_write_default_qsub_arguments(self):
         """
         submit a sleep job and make sure that the std_files
@@ -250,7 +250,7 @@ class TestQsub_direct_write(TestFunctional):
         self.assertEqual(2, file_count)
         self.server.expect(JOB, {ATTR_k: 'doe'}, id=jid)
 
-    @requirements(no_mom_on_server=False)
+    @requirements(mom_on_server=True)
     def test_direct_write_without_config_entry(self):
         """
         submit a sleep job and make sure that the std_files
@@ -310,7 +310,7 @@ class TestQsub_direct_write(TestFunctional):
                 'Cannot modify attribute while job running  Keep_Files'
                 in e.msg[0])
 
-    @requirements(no_mom_on_server=False)
+    @requirements(mom_on_server=True)
     def test_direct_write_qrerun(self):
         """
         submit a sleep job and make sure that the std_files
@@ -340,7 +340,7 @@ class TestQsub_direct_write(TestFunctional):
             mapping_dir) if os.path.isfile(os.path.join(mapping_dir, name))])
         self.assertEqual(2, file_count)
 
-    @requirements(no_mom_on_server=False)
+    @requirements(mom_on_server=True)
     def test_direct_write_job_array(self):
         """
         submit a job array and make sure that the std_files
@@ -370,7 +370,7 @@ class TestQsub_direct_write(TestFunctional):
                     raise self.failureException("std file " + f_name +
                                                 " not found")
 
-    @requirements(no_mom_on_server=False)
+    @requirements(mom_on_server=True)
     def test_direct_write_job_array_custom_dir(self):
         """
         submit a job array and make sure that the files

--- a/test/tests/functional/pbs_qsub_direct_write.py
+++ b/test/tests/functional/pbs_qsub_direct_write.py
@@ -62,6 +62,7 @@ class TestQsub_direct_write(TestFunctional):
             if total_ncpus < ncpus:
                 self.skip_test(reason="need %d available ncpus" % ncpus)
 
+    @requirements(no_mom_on_server=False)
     def test_direct_write_when_job_succeeds(self):
         """
         submit a sleep job and make sure that the std_files
@@ -73,7 +74,7 @@ class TestQsub_direct_write(TestFunctional):
         sub_dir = self.du.create_temp_dir(asuser=TEST_USER)
         mapping_dir = self.du.create_temp_dir(asuser=TEST_USER)
         self.mom.add_config(
-            {'$usecp': self.server.hostname + ':' + sub_dir +
+            {'$usecp': self.mom.hostname + ':' + sub_dir +
              ' ' + mapping_dir})
         self.mom.restart()
         jid = self.server.submit(j, submit_dir=sub_dir)
@@ -84,6 +85,7 @@ class TestQsub_direct_write(TestFunctional):
         self.assertEqual(2, file_count)
         self.server.expect(JOB, {ATTR_k: 'doe'}, id=jid)
 
+    @requirements(no_mom_on_server=False)
     def test_direct_write_when_job_succeeds_controlled(self):
         """
         submit a sleep job and make sure that the std_files
@@ -102,7 +104,7 @@ class TestQsub_direct_write(TestFunctional):
         mapping_dir = self.du.create_temp_dir(
             asuser=TEST_USER4, asgroup=TSTGRP5, mode=0o770)
         self.mom.add_config(
-            {'$usecp': self.server.hostname + ':' + sub_dir +
+            {'$usecp': self.mom.hostname + ':' + sub_dir +
              ' ' + mapping_dir})
         self.mom.restart()
         jid = self.server.submit(j, submit_dir=sub_dir)
@@ -113,6 +115,7 @@ class TestQsub_direct_write(TestFunctional):
         self.assertEqual(2, file_count)
         self.server.expect(JOB, {ATTR_k: 'doe'}, id=jid)
 
+    @requirements(no_mom_on_server=False)
     def test_direct_write_output_file(self):
         """
         submit a sleep job and make sure that the output file
@@ -124,7 +127,7 @@ class TestQsub_direct_write(TestFunctional):
         sub_dir = self.du.create_temp_dir(asuser=TEST_USER)
         mapping_dir = self.du.create_temp_dir(asuser=TEST_USER)
         self.mom.add_config(
-            {'$usecp': self.server.hostname + ':' + sub_dir +
+            {'$usecp': self.mom.hostname + ':' + sub_dir +
              ' ' + mapping_dir})
         self.mom.restart()
         jid = self.server.submit(j, submit_dir=sub_dir)
@@ -141,6 +144,7 @@ class TestQsub_direct_write(TestFunctional):
         self.assertEqual(1, file_count)
         self.server.expect(JOB, {ATTR_k: 'do'}, id=jid)
 
+    @requirements(no_mom_on_server=False)
     def test_direct_write_error_file(self):
         """
         submit a sleep job and make sure that the error file
@@ -152,7 +156,7 @@ class TestQsub_direct_write(TestFunctional):
         sub_dir = self.du.create_temp_dir(asuser=TEST_USER)
         mapping_dir = self.du.create_temp_dir(asuser=TEST_USER)
         self.mom.add_config(
-            {'$usecp': self.server.hostname + ':' + sub_dir +
+            {'$usecp': self.mom.hostname + ':' + sub_dir +
              ' ' + mapping_dir})
         self.mom.restart()
         jid = self.server.submit(j, submit_dir=sub_dir)
@@ -169,6 +173,7 @@ class TestQsub_direct_write(TestFunctional):
         self.assertEqual(1, file_count)
         self.server.expect(JOB, {ATTR_k: 'de'}, id=jid)
 
+    @requirements(no_mom_on_server=False)
     def test_direct_write_error_custom_path(self):
         """
         submit a sleep job and make sure that the files
@@ -184,7 +189,7 @@ class TestQsub_direct_write(TestFunctional):
         sub_dir = self.du.create_temp_dir(asuser=TEST_USER)
         mapping_dir = self.du.create_temp_dir(asuser=TEST_USER)
         self.mom.add_config(
-            {'$usecp': self.server.hostname + ':' + sub_dir +
+            {'$usecp': self.mom.hostname + ':' + sub_dir +
              ' ' + mapping_dir})
         self.mom.restart()
         jid = self.server.submit(j, submit_dir=sub_dir)
@@ -195,6 +200,7 @@ class TestQsub_direct_write(TestFunctional):
         self.assertEqual(2, file_count)
         self.server.expect(JOB, {ATTR_k: 'doe'}, id=jid)
 
+    @requirements(no_mom_on_server=False)
     def test_direct_write_error_custom_dir(self):
         """
         submit a sleep job and make sure that the files
@@ -208,7 +214,7 @@ class TestQsub_direct_write(TestFunctional):
         sub_dir = self.du.create_temp_dir(asuser=TEST_USER)
         mapping_dir = self.du.create_temp_dir(asuser=TEST_USER)
         self.mom.add_config(
-            {'$usecp': self.server.hostname + ':' + sub_dir +
+            {'$usecp': self.mom.hostname + ':' + sub_dir +
              ' ' + mapping_dir})
         self.mom.restart()
         jid = self.server.submit(j, submit_dir=sub_dir)
@@ -219,6 +225,7 @@ class TestQsub_direct_write(TestFunctional):
         self.assertEqual(2, file_count)
         self.server.expect(JOB, {ATTR_k: 'doe'}, id=jid)
 
+    @requirements(no_mom_on_server=False)
     def test_direct_write_default_qsub_arguments(self):
         """
         submit a sleep job and make sure that the std_files
@@ -232,7 +239,7 @@ class TestQsub_direct_write(TestFunctional):
         sub_dir = self.du.create_temp_dir(asuser=TEST_USER)
         mapping_dir = self.du.create_temp_dir(asuser=TEST_USER)
         self.mom.add_config(
-            {'$usecp': self.server.hostname + ':' + sub_dir +
+            {'$usecp': self.mom.hostname + ':' + sub_dir +
              ' ' + mapping_dir})
         self.mom.restart()
         jid = self.server.submit(j, submit_dir=sub_dir)
@@ -243,6 +250,7 @@ class TestQsub_direct_write(TestFunctional):
         self.assertEqual(2, file_count)
         self.server.expect(JOB, {ATTR_k: 'doe'}, id=jid)
 
+    @requirements(no_mom_on_server=False)
     def test_direct_write_without_config_entry(self):
         """
         submit a sleep job and make sure that the std_files
@@ -302,6 +310,7 @@ class TestQsub_direct_write(TestFunctional):
                 'Cannot modify attribute while job running  Keep_Files'
                 in e.msg[0])
 
+    @requirements(no_mom_on_server=False)
     def test_direct_write_qrerun(self):
         """
         submit a sleep job and make sure that the std_files
@@ -316,7 +325,7 @@ class TestQsub_direct_write(TestFunctional):
         sub_dir = self.du.create_temp_dir(asuser=TEST_USER)
         mapping_dir = self.du.create_temp_dir(asuser=TEST_USER)
         self.mom.add_config(
-            {'$usecp': self.server.hostname + ':' + sub_dir +
+            {'$usecp': self.mom.hostname + ':' + sub_dir +
              ' ' + mapping_dir})
         self.mom.restart()
         jid = self.server.submit(j, submit_dir=sub_dir)
@@ -331,6 +340,7 @@ class TestQsub_direct_write(TestFunctional):
             mapping_dir) if os.path.isfile(os.path.join(mapping_dir, name))])
         self.assertEqual(2, file_count)
 
+    @requirements(no_mom_on_server=False)
     def test_direct_write_job_array(self):
         """
         submit a job array and make sure that the std_files
@@ -360,6 +370,7 @@ class TestQsub_direct_write(TestFunctional):
                     raise self.failureException("std file " + f_name +
                                                 " not found")
 
+    @requirements(no_mom_on_server=False)
     def test_direct_write_job_array_custom_dir(self):
         """
         submit a job array and make sure that the files
@@ -376,7 +387,7 @@ class TestQsub_direct_write(TestFunctional):
         sub_dir = self.du.create_temp_dir(asuser=TEST_USER)
         mapping_dir = self.du.create_temp_dir(asuser=TEST_USER)
         self.mom.add_config(
-            {'$usecp': self.server.hostname + ':' + sub_dir +
+            {'$usecp': self.mom.hostname + ':' + sub_dir +
              ' ' + mapping_dir})
         self.mom.restart()
         jid = self.server.submit(j, submit_dir=sub_dir)

--- a/test/tests/functional/pbs_qsub_remove_files.py
+++ b/test/tests/functional/pbs_qsub_remove_files.py
@@ -98,7 +98,7 @@ class TestQsub_remove_files(TestFunctional):
             sub_dir) if os.path.isfile(os.path.join(sub_dir, name))])
         self.assertEqual(1, file_count)
 
-    @requirements(no_mom_on_server=False)
+    @requirements(mom_on_server=True)
     def test_remove_files_error_file(self):
         """
         submit a job with -Re option and make sure the error file

--- a/test/tests/functional/pbs_qsub_remove_files.py
+++ b/test/tests/functional/pbs_qsub_remove_files.py
@@ -98,6 +98,7 @@ class TestQsub_remove_files(TestFunctional):
             sub_dir) if os.path.isfile(os.path.join(sub_dir, name))])
         self.assertEqual(1, file_count)
 
+    @requirements(no_mom_on_server=False)
     def test_remove_files_error_file(self):
         """
         submit a job with -Re option and make sure the error file
@@ -108,7 +109,7 @@ class TestQsub_remove_files(TestFunctional):
         sub_dir = self.du.create_temp_dir(asuser=TEST_USER)
         mapping_dir = self.du.create_temp_dir(asuser=TEST_USER)
         self.mom.add_config(
-            {'$usecp': self.server.hostname + ':' + sub_dir +
+            {'$usecp': self.mom.hostname + ':' + sub_dir +
              ' ' + mapping_dir})
         self.mom.restart()
         jid = self.server.submit(j, submit_dir=sub_dir)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Tests related to direct write of stderr and stdout are failing while no mom on server because mapping path is not accessible by mom. Mapping path should be shared or local.

Tests are not skipping If tests requirement is mom must be on server and  it doesn't match. Means requirement is "mom on server" but mom and server are not same.


#### Describe Your Change
Skipping the direct write tests while mom is not on server.
Added a option "mom_on_server" to make sure mom must be on server.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
https://openpbs.atlassian.net/wiki/spaces/PD/pages/2497675265/Added+a+option+mom+on+server+boolean+to+existing+requirement+decorator


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
**mom on server**
Description: Tests from given sources on platforms SUSE15, CENTOS8, CENTOS7
Platforms: SUSE15,CENTOS8,CENTOS7
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|5871|1886|0|1|0|7|1878|

**no mom on server**
Description: Tests from given sources on platforms SUSE15, CENTOS8, CENTOS7
Platforms: SUSE15,CENTOS8,CENTOS7
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|5872|1886|24|3|0|18|1841|


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
