### PR TITLE
Removed an unnecessary hostname lookup

### DIFF
--- a/src/include/net_connect.h
+++ b/src/include/net_connect.h
@@ -190,7 +190,7 @@ void close_conn(int socket);
 pbs_net_t get_connectaddr(int sock);
 int  get_connecthost(int sock, char *namebuf, int size);
 pbs_net_t get_hostaddr(char *hostname);
-int comp_svraddr(pbs_net_t, char *);
+int comp_svraddr(pbs_net_t, char *, pbs_net_t *);
 int  compare_short_hostname(char *shost, char *lhost);
 unsigned int  get_svrport(char *servicename, char *proto, unsigned int df);
 int  init_network(unsigned int port);

--- a/src/lib/Libnet/get_hostaddr.c
+++ b/src/lib/Libnet/get_hostaddr.c
@@ -188,6 +188,7 @@ compare_short_hostname(char *shost, char *lhost)
  *
  * @param[in] svr_addr - net address of the server
  * @param[in] hostname - hostname whose internet addr needs to be compared
+ * @param[out] addr - one of the address associated with hostname is returned in this argument
  *
  * @return	int
  * @retval	0 address found
@@ -196,7 +197,7 @@ compare_short_hostname(char *shost, char *lhost)
  *
  */
 int
-comp_svraddr(pbs_net_t svr_addr, char *hostname)
+comp_svraddr(pbs_net_t svr_addr, char *hostname, pbs_net_t *addr)
 {
 	struct addrinfo *aip, *pai;
 	struct addrinfo hints;
@@ -206,6 +207,8 @@ comp_svraddr(pbs_net_t svr_addr, char *hostname)
 	if ((hostname == NULL) || (*hostname == '\0')) {
 		return (2);
 	}
+	if (addr)
+		*addr = 0;
 
 	memset(&hints, 0, sizeof(struct addrinfo));
 	hints.ai_family = AF_UNSPEC;
@@ -219,6 +222,8 @@ comp_svraddr(pbs_net_t svr_addr, char *hostname)
 		if (aip->ai_family == AF_INET) {
 			inp = (struct sockaddr_in *) aip->ai_addr;
 			res = ntohl(inp->sin_addr.s_addr);
+			if (addr && *addr == 0)
+				*addr = res;
 			if (res == svr_addr) {
 				freeaddrinfo(pai);
 				return 0;

--- a/src/server/issue_request.c
+++ b/src/server/issue_request.c
@@ -257,10 +257,9 @@ issue_to_svr(char *servern, struct batch_request *preq, void (*replyfunc)(struct
 				svrname = server_host;
 		}
 	}
-	if (comp_svraddr(pbs_server_addr, svrname) == 0)
+	if (comp_svraddr(pbs_server_addr, svrname, &svraddr) == 0)
 		return (issue_Drequest(PBS_LOCAL_CONNECTION, preq, replyfunc, 0, 0));
 
-	svraddr = get_hostaddr(svrname);
 	if (svraddr == (pbs_net_t)0) {
 		if (pbs_errno == PBS_NET_RC_RETRY)
 			/* Non fatal error - retry */

--- a/src/server/svr_movejob.c
+++ b/src/server/svr_movejob.c
@@ -165,7 +165,7 @@ svr_movejob(job	*jobp, char *destination, struct batch_request *req)
 	if ((toserver = strchr(destination, '@')) != NULL) {
 		/* check to see if the part after '@' is this server */
 		int comp = -1;
-		comp = comp_svraddr(pbs_server_addr, parse_servername(++toserver, &port));
+		comp = comp_svraddr(pbs_server_addr, parse_servername(++toserver, &port), NULL);
 		if ((comp == 1) ||
 			(port != pbs_server_port_dis)) {
 			return (net_move(jobp, req));	/* not a local dest */


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
WHile trying to issue batch request from one server to another, PBS server ends up calling get_addrinfo twice. 

#### Describe Your Change
Removed unnecessary call.

#### Link to Design Doc
NA


#### Attach Test and Valgrind Logs/Output
Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, WIN2K16
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|5846|3815|0|6|0|1|3808|

Tests failing are not related to this change



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
