### PR TITLE
test_rsc_used of TestMomMockRun is failing while verifying the job attributes on slow machines

### DIFF
--- a/test/tests/functional/pbs_mom_mock_run.py
+++ b/test/tests/functional/pbs_mom_mock_run.py
@@ -63,10 +63,8 @@ class TestMomMockRun(TestFunctional):
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
 
-        # This job should end in 20 seconds, let's sleep
-        msg = "This job should end in 20 seconds, let's sleep"
-        self.logger.info(msg)
-        time.sleep(22)
+        # Confirm job finish after 20 seconds
+        self.server.expect(JOB, 'queue', op=UNSET, id=jid, offset=22)
 
         # Check accounting record for this job
         used_ncpus = "resources_used.ncpus=1"

--- a/test/tests/functional/pbs_mom_mock_run.py
+++ b/test/tests/functional/pbs_mom_mock_run.py
@@ -58,13 +58,15 @@ class TestMomMockRun(TestFunctional):
 
         # Submit a job requesting ncpus, mem and walltime
         attr = {ATTR_l + ".select": "1:ncpus=1:mem=5mb",
-                ATTR_l + ".walltime": "00:00:05"}
+                ATTR_l + ".walltime": "00:00:20"}
         j = Job(attrs=attr)
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
 
-        # This job should end in 5 seconds, let's sleep
-        time.sleep(7)
+        # This job should end in 20 seconds, let's sleep
+        msg = "This job should end in 20 seconds, let's sleep"
+        self.logger.info(msg)
+        time.sleep(22)
 
         # Check accounting record for this job
         used_ncpus = "resources_used.ncpus=1"

--- a/test/tests/functional/pbs_mom_mock_run.py
+++ b/test/tests/functional/pbs_mom_mock_run.py
@@ -63,7 +63,7 @@ class TestMomMockRun(TestFunctional):
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
 
-        # Confirm job finish after 20 seconds
+        self.logger.info("Waiting until job finishes")
         self.server.expect(JOB, 'queue', op=UNSET, id=jid, offset=22)
 
         # Check accounting record for this job


### PR DESCRIPTION
#### Describe Bug or Feature
Test "test_rsc_used" of TestMomMockRun is failing while verifying the job attributes on slow machine some times in weekend regression with below error

ptl.lib.ptl_error.PtlExpectError: rc=1, rv=False, msg=expected on server xyz-05-c8p1:  no data for job_state = R && substate = 42 job 0.xyz-05-c8p1 attempt: 180


#### Describe Your Change
Test is failed because of race condition , in test we are submitting job which request walltime = 00:00:05 and confirming job is in R and state=42 
but on slow machine sometimes command itself take 5 sec to respond , so by the time job went to E state and it failed in getting expected value in qstat -f and 
test failed in PTL expect

Solution : Increased resource_list.walltime value  from 00:00:05 to 00:00:20sec


#### Attach Test and Valgrind Logs/Output
Before fix 
[Before_fix_TestMomMockRun.txt](https://github.com/openpbs/openpbs/files/5892685/Before_fix_TestMomMockRun.txt)

After fix 
[TestMomMockRun_30.txt](https://github.com/openpbs/openpbs/files/5892686/TestMomMockRun_30.txt)



