### PR TITLE
Ignore failures of OOM and RLIMIT set

### DIFF
--- a/src/cmds/pbs_dataservice.c
+++ b/src/cmds/pbs_dataservice.c
@@ -112,6 +112,8 @@ main(int argc, char *argv[])
 
 	if (strcmp(sopt, PBS_DB_CONTROL_START) == 0) {
 		rc = pbs_start_db(conn_db_host, pbs_conf.pbs_data_service_port);
+		if (rc == PBS_DB_OOM_ERR)
+			rc = 0;	/* Ignore OOM access error */
 	} else if (strcmp(sopt, PBS_DB_CONTROL_STOP) == 0) {
 		rc = pbs_stop_db(conn_db_host, pbs_conf.pbs_data_service_port);
 	} else if (strcmp(sopt, PBS_DB_CONTROL_STATUS) == 0) {

--- a/src/cmds/pbs_ds_password.c
+++ b/src/cmds/pbs_ds_password.c
@@ -481,7 +481,7 @@ main(int argc, char *argv[])
 		if (!conn) {
 			/* start db only if it was not already running */
 			failcode = pbs_start_db(conn_db_host, pbs_conf.pbs_data_service_port);
-			if (failcode != 0) {
+			if (failcode != 0 && failcode != PBS_DB_OOM_ERR) {
 				if (failcode == -1)
 					pbs_db_get_errmsg(PBS_DB_ERR, &db_errmsg);
 				else
@@ -610,7 +610,7 @@ main(int argc, char *argv[])
 		}
 
 		failcode = pbs_start_db(conn_db_host, pbs_conf.pbs_data_service_port);
-		if (failcode != 0) {
+		if (failcode != 0 && failcode != PBS_DB_OOM_ERR) {
 			pbs_db_get_errmsg(failcode, &db_errmsg);
 			if (db_errmsg)
 				fprintf(stderr, "%s: Failed to start PBS dataservice as new user:[%s]\n", prog, db_errmsg);

--- a/src/include/pbs_db.h
+++ b/src/include/pbs_db.h
@@ -250,6 +250,7 @@ typedef struct pbs_db_query_options pbs_db_query_options_t;
 #define PBS_DB_NOMEM		4
 #define PBS_DB_STILL_STARTING	5
 #define PBS_DB_ERR		6
+#define PBS_DB_OOM_ERR		7
 
 /* Database connection states */
 #define PBS_DB_CONNECT_STATE_NOT_CONNECTED	1

--- a/src/lib/Libdb/pgsql/db_common.c
+++ b/src/lib/Libdb/pgsql/db_common.c
@@ -157,7 +157,7 @@ pg_db_fn_t db_fn_arr[PBS_DB_NUM_TYPES] = {
  *	Initialize a query state variable, before being used in a cursor
  *
  * @param[in]	conn - Database connection handle
- * @param[in]	query_cb - Object handler query back function 
+ * @param[in]	query_cb - Object handler query back function
  *
  * @return	void *
  * @retval	NULL - Failure to allocate memory
@@ -445,7 +445,10 @@ pbs_dataservice_control(char *cmd, char *pbs_ds_host, int pbs_ds_port)
 	}
 
 	if (!(strcmp(cmd, PBS_DB_CONTROL_START))) {
-		/* Protect self from Linux OOM killer */
+		/*
+		 * try protect self from Linux OOM killer
+		 * but don't fail if can't update OOM score
+		 */
 		if (access(oom_score_adj, F_OK) != -1) {
 			strcpy(oom_file, oom_score_adj);
 			oom_val = strdup("-1000");
@@ -454,20 +457,11 @@ pbs_dataservice_control(char *cmd, char *pbs_ds_host, int pbs_ds_port)
 			oom_val = strdup("-17");
 		}
 		if (oom_val != NULL) {
-			if ((fd = open(oom_file, O_TRUNC | O_WRONLY, 0600)) == -1) {
-				if (errmsg_cache)
-					free(errmsg_cache);
-				errmsg_cache = strdup("OOM protect: file open failed");
-				return -1;
-			}
-			if (write(fd, oom_val, strlen(oom_val)) == -1) {
-				if (errmsg_cache)
-					free(errmsg_cache);
-				errmsg_cache = strdup("OOM protect: file write failed");
-				return -1;
+			if ((fd = open(oom_file, O_TRUNC | O_WRONLY, 0600)) != -1) {
+				(void)write(fd, oom_val, strlen(oom_val));
+				close(fd);
 			}
 			free(oom_val);
-			close(fd);
 		}
 		sprintf(errfile, "%s/spool/pbs_ds_monitor_errfile", pbs_conf.pbs_home_path);
 		/* launch monitoring program which will fork to background */
@@ -840,7 +834,7 @@ db_cnerr:
 	if (failcode != PBS_DB_SUCCESS) {
 		free(conn_data);
 		free(conn_trx);
-		*db_conn = NULL;		
+		*db_conn = NULL;
 	}
 	return failcode;
 }

--- a/src/lib/Libdb/pgsql/pbs_ds_systemd
+++ b/src/lib/Libdb/pgsql/pbs_ds_systemd
@@ -38,10 +38,10 @@
 
 . ${PBS_CONF_FILE:-/etc/pbs.conf}
 
-is_systemd=0
-systemctl --version >/dev/null 2>&1
-if [ $? -eq 0 ] ; then
-    is_systemd=1
+is_systemd=1
+_status=$(systemctl is-system-running 2>/dev/null)
+if [ "x${_status}" == "xoffline" -o "x${_status}" == "xunknown" ] ; then
+    is_systemd=0
 fi
 if [ $is_systemd -eq 1 ] ; then
     SYSTEMD_CGROUP=`grep ^cgroup /proc/mounts | grep systemd | head -1 | cut -d ' ' -f2`

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -7310,10 +7310,8 @@ main(int argc, char *argv[])
 
 #ifdef RLIMIT_NPROC
 		(void)getrlimit64(RLIMIT_NPROC, &orig_nproc_limit); /* get for later */
-		if (setrlimit64(RLIMIT_NPROC, &rlimit) == -1) {    /* set unlimited */
+		if (setrlimit64(RLIMIT_NPROC, &rlimit) == -1)    /* set unlimited */
 			perror(" setrlimit NPROC");
-			exit(1);
-		}
 #endif	/* RLIMIT_NPROC */
 #ifdef	RLIMIT_RSS
 		(void)setrlimit64(RLIMIT_RSS  , &rlimit);
@@ -7336,10 +7334,8 @@ main(int argc, char *argv[])
 		(void)setrlimit(RLIMIT_CPU,   &rlimit);
 #ifdef RLIMIT_NPROC
 		(void)getrlimit(RLIMIT_NPROC, &orig_nproc_limit); /* get for later */
-		if (setrlimit(RLIMIT_NPROC, &rlimit) == -1) {	  /* set unlimited */
+		if (setrlimit(RLIMIT_NPROC, &rlimit) == -1)	  /* set unlimited */
 			perror(" setrlimit NPROC");
-			exit(1);
-		}
 #endif	/* RLIMIT_NPROC */
 #ifdef	RLIMIT_RSS
 		(void)setrlimit(RLIMIT_RSS  , &rlimit);

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -7310,8 +7310,11 @@ main(int argc, char *argv[])
 
 #ifdef RLIMIT_NPROC
 		(void)getrlimit64(RLIMIT_NPROC, &orig_nproc_limit); /* get for later */
-		if (setrlimit64(RLIMIT_NPROC, &rlimit) == -1)    /* set unlimited */
-			perror(" setrlimit NPROC");
+		if (setrlimit64(RLIMIT_NPROC, &rlimit) == -1) {     /* set unlimited */
+			char msgbuf[] = "setrlimit NPROC setting failed";
+			curerror = errno;
+			log_err(curerror, __func__, msgbuf);
+		}
 #endif	/* RLIMIT_NPROC */
 #ifdef	RLIMIT_RSS
 		(void)setrlimit64(RLIMIT_RSS  , &rlimit);
@@ -7334,8 +7337,11 @@ main(int argc, char *argv[])
 		(void)setrlimit(RLIMIT_CPU,   &rlimit);
 #ifdef RLIMIT_NPROC
 		(void)getrlimit(RLIMIT_NPROC, &orig_nproc_limit); /* get for later */
-		if (setrlimit(RLIMIT_NPROC, &rlimit) == -1)	  /* set unlimited */
-			perror(" setrlimit NPROC");
+		if (setrlimit(RLIMIT_NPROC, &rlimit) == -1) { 	  /* set unlimited */
+			char msgbuf[] = "setrlimit NPROC setting failed";
+			curerror = errno;
+			log_err(curerror, __func__, msgbuf);
+		}
 #endif	/* RLIMIT_NPROC */
 #ifdef	RLIMIT_RSS
 		(void)setrlimit(RLIMIT_RSS  , &rlimit);

--- a/src/server/pbs_db_func.c
+++ b/src/server/pbs_db_func.c
@@ -146,12 +146,18 @@ start_db()
 
 	rc = pbs_start_db(conn_db_host, pbs_conf.pbs_data_service_port);
 	if (rc != 0) {
-		pbs_db_get_errmsg(PBS_DB_ERR, &failstr);
-		snprintf(log_buffer, LOG_BUF_SIZE, "%s %s", "Failed to start PBS dataservice.", failstr ? failstr : "");
+		if (rc == PBS_DB_OOM_ERR) {
+			pbs_db_get_errmsg(PBS_DB_OOM_ERR, &failstr);
+			snprintf(log_buffer, LOG_BUF_SIZE, "%s %s", "WARNING:", failstr ? failstr : "");
+		} else {
+			pbs_db_get_errmsg(PBS_DB_ERR, &failstr);
+			snprintf(log_buffer, LOG_BUF_SIZE, "%s %s", "Failed to start PBS dataservice.", failstr ? failstr : "");
+		}
 		log_eventf(PBSEVENT_SYSTEM | PBSEVENT_ADMIN, PBS_EVENTCLASS_SERVER, LOG_ERR, msg_daemonname, log_buffer);
 		fprintf(stderr, "%s\n", log_buffer);
 		free(failstr);
-		return PBS_DB_DOWN;
+		if (rc != PBS_DB_OOM_ERR)
+			return PBS_DB_DOWN;
 	}
 
 	sleep(1); /* give time for database to atleast establish the ports */


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Server start fails if OOM or RLIMIT set fails. This can make PBS start on containers fail if the privileged option is not used.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Ignore the failure and continue.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
N/A

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
