### PR TITLE
Bypass dev disc and nvidia-smi for compute nodes in cgroup hook

### DIFF
--- a/src/hooks/cgroups/pbs_cgroups.CF
+++ b/src/hooks/cgroups/pbs_cgroups.CF
@@ -8,6 +8,7 @@
     "online_offlined_nodes" : true,
     "use_hyperthreads"      : false,
     "ncpus_are_cores"       : false,
+    "discover_gpus"         : true,
     "cgroup" : {
         "cpuacct" : {
             "enabled"            : true,

--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -1078,7 +1078,9 @@ class HookUtils(object):
                 for key in cgroup.assigned_resources['device_names']:
                     if key.startswith('mic'):
                         mics.append(key[3:])
-                    elif key.startswith('nvidia'):
+                    elif (key.startswith('nvidia')
+                            and "gpu" in node.devices
+                            and key in node.devices['gpu']):
                         if 'uuid' in node.devices['gpu'][key]:
                             gpus.append(node.devices['gpu'][key]['uuid'])
                         if 'uuids' in node.devices['gpu'][key]:
@@ -1169,7 +1171,8 @@ class HookUtils(object):
             pbs.logmsg(pbs.EVENT_DEBUG4,
                        'assigned_resources: %s' %
                        (cgroup.assigned_resources))
-            cgroup.setup_job_devices_env(node.devices['gpu'])
+            if "gpu" in node.devices:
+                cgroup.setup_job_devices_env(node.devices['gpu'])
         return True
 
     def _exechost_periodic_handler(self, event, cgroup, jobutil):
@@ -1326,7 +1329,9 @@ class HookUtils(object):
                 for key in cgroup.assigned_resources['device_names']:
                     if key.startswith('mic'):
                         mics.append(key[3:])
-                    elif key.startswith('nvidia'):
+                    elif (key.startswith('nvidia')
+                            and "gpu" in node.devices
+                            and key in node.devices['gpu']):
                         if 'uuid' in node.devices['gpu'][key]:
                             gpus.append(node.devices['gpu'][key]['uuid'])
                         if 'uuids' in node.devices['gpu'][key]:
@@ -1521,8 +1526,10 @@ class NodeUtils(object):
             self.numa_nodes = self._discover_numa_nodes()
         if devices is not None:
             self.devices = devices
-        else:
+        elif self.cfg['cgroup']['devices']['enabled']:
             self.devices = self._discover_devices()
+        else:
+            self.devices = {}
         # Add the devices count i.e. nmics and ngpus to the numa nodes
         self._add_device_counts_to_numa_nodes()
         # Information for offlining nodes
@@ -1839,7 +1846,10 @@ class NodeUtils(object):
         """
         pbs.logmsg(pbs.EVENT_DEBUG4, '%s: Method called' % caller_name())
         gpus = {}
-        cmd = [self.cfg['nvidia-smi'], '-q', '-x']
+        if self.cfg['discover_gpus'] and self.cfg['nvidia-smi']:
+            cmd = [self.cfg['nvidia-smi'], '-q', '-x']
+        else:
+            return gpus
         pbs.logmsg(pbs.EVENT_DEBUG4, 'NVIDIA SMI command: %s' % cmd)
         time_start = time.time()
         mig_found = False
@@ -1938,8 +1948,8 @@ class NodeUtils(object):
         # +----------------------------------------------------+
         # |   0  MIG 1g.5gb       19        8          5:1     |
         r = re.compile(r'^\|\s+(\d+)\s+MIG\s+\S+\s+\d+\s+(\d+)\s+\S+\s+\|$')
-        for l in out:
-            match = r.match(l)
+        for out_line in out:
+            match = r.match(out_line)
             if not match:
                 continue
             gpu_num = int(match.group(1))
@@ -1989,8 +1999,8 @@ class NodeUtils(object):
         # |   0      7       MIG 1g.5gb       0         0          0:1     |
         r = re.compile(
             r'^\|\s+(\d+)\s+(\d+)\s+MIG\s+\S+\s+\d+\s+(\d+)\s+(\S+\s+)?\|$')
-        for l in out:
-            match = r.match(l)
+        for out_line in out:
+            match = r.match(out_line)
             if not match:
                 continue
             gpu_num = int(match.group(1))
@@ -2466,6 +2476,9 @@ class NodeUtils(object):
                 vnode_key = vnode_name + '[%d]' % nnid
                 vnode_list[vnode_key] = pbs.vnode(vnode_name)
                 vnode_resc_avail = vnode_list[vnode_key].resources_available
+                # ensure that if no devices were discovered that
+                # ngpus is set to 0; otherwise MoM may still use stale value
+                vnode_resc_avail['ngpus'] = 0
                 if (vntype and self.cfg['propagate_vntype_to_server']):
                     vnode_resc_avail['vntype'] = vntype
             for key, val in sorted(self.numa_nodes[nnid].items()):
@@ -2720,8 +2733,13 @@ class CgroupUtils(object):
         # but some of the code assumes only iterables are
         # in the "cgroup" dictionary,
         # without any guards to protect against extras!!
-        if "cgroup" in self.cfg and "enabled" in self.cfg['cgroup']:
+        if "enabled" in self.cfg['cgroup']:
             del self.cfg['cgroup']['enabled']
+
+        if not self.cfg['cgroup']['devices']['enabled']:
+            self.cfg['discover_gpus'] = False
+            pbs.logmsg(pbs.EVENT_DEBUG, 'discover_gpus set to False because '
+                       'devices subsystem is disabled')
 
         # Determine which subsystems we care about
         if subsystems is not None:
@@ -3126,6 +3144,7 @@ class CgroupUtils(object):
         defaults['cgroup_prefix'] = 'pbs_jobs'
         defaults['cgroup_lock_file'] = os.path.join(PBS_MOM_HOME, 'mom_priv',
                                                     'cgroups.lock')
+        defaults['discover_gpus'] = True
         defaults['nvidia-smi'] = os.path.join(os.sep, 'usr', 'bin',
                                               'nvidia-smi')
         defaults['exclude_hosts'] = []
@@ -4092,8 +4111,8 @@ class CgroupUtils(object):
             nmics = int(requested['nmics'])
             # Use a list comprehension to construct the mics list
             mics = [m.group(0)
-                    for l in available['devices']
-                    for m in [regex.search(l)] if m]
+                    for d in available['devices']
+                    for m in [regex.search(d)] if m]
             if nmics > len(mics):
                 pbs.logmsg(pbs.EVENT_DEBUG4, 'Insufficient nmics: %s/%s' %
                            (nmics, mics))
@@ -4112,8 +4131,8 @@ class CgroupUtils(object):
             ngpus = int(requested['ngpus'])
             # Use a list comprehension to construct the gpus list
             gpus = [m.group(0)
-                    for l in available['devices']
-                    for m in [regex.search(l)] if m]
+                    for d in available['devices']
+                    for m in [regex.search(d)] if m]
             if ngpus > len(gpus):
                 pbs.logmsg(pbs.EVENT_DEBUG4, 'Insufficient ngpus: %s/%s' %
                            (ngpus, gpus))


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
The cgroup hook spends a lot of time in _all_ events (not just exechost_startup) discovering devices and trying to run nvidia-smi. At many sites this takes up more than 2/3rds of the overhead of the cgroup hook, which gates throughput when there are a lot of small short jobs.

All of this is unnecessary on compute nodes without GPUs, or with Nvidia cards that are not used as GPUs. At many sites the cluster may have thousands of such nodes and tens or hundreds of GPU nodes only.

Also, sharing nodes between more than one job when using GPUs only works when the "devices" subsystem (cgroup controller) is enabled in the hook configuration, but the hook's execjob_startup still sets resources_available.ngpus to detected GPUs even when the devices subsystem is _dis_abled in the hook.

Another side effect of the hook's current strategy of always discovering devices when instantiating the NodeUtils classes is that at DEBUG4 the hook is slowed down by the sheer amount of lines printed in the log, which also make the log well nigh unreadable. All of this is noise if the site does not plan use 

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

The hook introduces an extra configuration variable in the config file, discover_gpus (it can be set differently on different nodes with the existing functionality to set booleans according to vntype or hostnames, so that e.g. GPU discovery). It is set to True by default except if the devices section is not enabled (when the devices section is disabled, then it is reset to False regardless of what it is set to, with a log line in the MoM log indicating it is disabled and why). Whenever it is utlitmately set to False, nvidia-smi is not called.

Alternatively, setting the 'nvidia-smi' flag to the empty string will also neuter GPU discovery. This, however does not offer the same functionality, since this is not a boolean that can be enabled/disabled depending on host vntype/hostname. 

When the devices section is disabled, device discovery is suppressed, and the "devices" discovered becomes an empty dictionary. Guards are inserted in existing code to avoid any danger of triggering an exception because of this.

Some lines were also edited to achieve a pycodestyle clean code (a recent commit introduced "l" (ell) variables that pycodestyle does not like because they are ambiguous when displayed in certain fonts. These pycodestyle errors can prevent certain QA tests from being run correctly on some build environments if they insist in pycodestyle clean hooks.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
N/A -- at most sites, discover_gpus would already be set to false whenever necessary (and without an explicit interface) since typically these sites do not enable the devices subsection _unless_ MIC or GPUs are being managed.

If necessary we might want a design document just to document the extra flag that is introduced just in case sites want to enable the devices controller but still _dis_able GPU discovery. I will leave that to the reviewers to decide.

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
