### PR TITLE
Fix ptl.csh shell startup script

### DIFF
--- a/test/fw/ptl.csh
+++ b/test/fw/ptl.csh
@@ -40,14 +40,14 @@
 
 # This file will set path variables in case of ptl installation
 if ( -f /etc/debian_version ) then
-    set __ptlpkgname=`dpkg -W -f='${binary:Package}\n' 2>/dev/null | grep -E '*-ptl$'`
+    set __ptlpkgname=`dpkg -W -f='${binary:Package}\n' | grep -E '*-ptl$'`
     if ( "x${__ptlpkgname}" != "x" ) then
-        set ptl_prefix_lib=`dpkg -L ${__ptlpkgname} 2>/dev/null | grep -m 1 lib$ 2>/dev/null`
+        set ptl_prefix_lib=`dpkg -L ${__ptlpkgname} | grep -m 1 lib$`
     endif
 else
     set __ptlpkgname=`rpm -qa | grep -E '*-ptl-[[:digit:]]'`
     if ( "x${__ptlpkgname}" != "x" ) then
-        set ptl_prefix_lib=`rpm -ql ${__ptlpkgname} | grep -m 1 lib$ `
+        set ptl_prefix_lib=`rpm -ql ${__ptlpkgname} | grep -m 1 lib$`
     endif
 endif
 if ( $?ptl_prefix_lib == 1 ) then

--- a/test/fw/ptl.csh
+++ b/test/fw/ptl.csh
@@ -50,12 +50,16 @@ else
         set ptl_prefix_lib=`rpm -ql ${__ptlpkgname} | grep -m 1 lib$`
     endif
 endif
-if ( $?ptl_prefix_lib == 1 ) then
+if ( $?ptl_prefix_lib ) then
 	set python_dir=`/bin/ls -1 ${ptl_prefix_lib}`
 	set prefix=`dirname ${ptl_prefix_lib}`
 
 	setenv PATH ${prefix}/bin/:${PATH}
-	setenv PYTHONPATH ${prefix}/lib/${python_dir}/site-packages/:$PYTHONPATH
+	if ( $?PYTHONPATH ) then
+		setenv PYTHONPATH ${prefix}/lib/${python_dir}/site-packages/:$PYTHONPATH
+	else
+		setenv PYTHONPATH ${prefix}/lib/${python_dir}/site-packages/
+	endif
 	unset python_dir
 	unset prefix
 	unset ptl_prefix_lib
@@ -75,8 +79,13 @@ else
 			if ( $?PATH && -d ${PTL_PREFIX}/bin ) then
 				setenv PATH "${PATH}:${PTL_PREFIX}/bin"
 			endif
-			if ( $?PYTHONPATH && -d "${PTL_PREFIX}/lib/${python_dir}" ) then
-				setenv PYTHONPATH "${PYTHONPATH}:${PTL_PREFIX}/lib/${python_dir}"
+			if ( -d "${PTL_PREFIX}/lib/${python_dir}" ) then
+				if ( $?PYTHONPATH ) then
+					setenv PYTHONPATH "${PYTHONPATH}:${PTL_PREFIX}/lib/${python_dir}"
+				else
+					setenv PYTHONPATH "${PTL_PREFIX}/lib/${python_dir}"
+				endif
+			endif
 			endif
 		endif
 		unset __PBS_EXEC

--- a/test/fw/ptl.csh
+++ b/test/fw/ptl.csh
@@ -45,17 +45,17 @@ if ( -f /etc/debian_version ) then
         set ptl_prefix_lib=`dpkg -L ${__ptlpkgname} 2>/dev/null | grep -m 1 lib$ 2>/dev/null`
     endif
 else
-    set __ptlpkgname=`rpm -qa 2>/dev/null | grep -E '*-ptl-[[:digit:]]'`
+    set __ptlpkgname=`rpm -qa | grep -E '*-ptl-[[:digit:]]'`
     if ( "x${__ptlpkgname}" != "x" ) then
-        set ptl_prefix_lib=`rpm -ql ${__ptlpkgname} 2>/dev/null | grep -m 1 lib$ 2>/dev/null`
+        set ptl_prefix_lib=`rpm -ql ${__ptlpkgname} | grep -m 1 lib$ `
     endif
 endif
-if ( ! $?ptl_prefix_lib ) then
+if ( $?ptl_prefix_lib == 1 ) then
 	set python_dir=`/bin/ls -1 ${ptl_prefix_lib}`
 	set prefix=`dirname ${ptl_prefix_lib}`
 
-	setenv PATH=${prefix}/bin/:${PATH}
-	setenv PYTHONPATH=${prefix}/lib/${python_dir}/site-packages/:$PYTHONPATH
+	setenv PATH ${prefix}/bin/:${PATH}
+	setenv PYTHONPATH ${prefix}/lib/${python_dir}/site-packages/:$PYTHONPATH
 	unset python_dir
 	unset prefix
 	unset ptl_prefix_lib
@@ -73,10 +73,10 @@ else
 			set PTL_PREFIX=`dirname ${__PBS_EXEC}`/ptl
 			set python_dir=`/bin/ls -1 ${PTL_PREFIX}/lib`/site-packages
 			if ( $?PATH && -d ${PTL_PREFIX}/bin ) then
-				setenv export PATH="${PATH}:${PTL_PREFIX}/bin"
+				setenv PATH "${PATH}:${PTL_PREFIX}/bin"
 			endif
 			if ( $?PYTHONPATH && -d "${PTL_PREFIX}/lib/${python_dir}" ) then
-				setenv PYTHONPATH="${PYTHONPATH}:${PTL_PREFIX}/lib/${python_dir}"
+				setenv PYTHONPATH "${PYTHONPATH}:${PTL_PREFIX}/lib/${python_dir}"
 			endif
 		endif
 		unset __PBS_EXEC


### PR DESCRIPTION
#### Describe Bug or Feature
The csh version of the shell startup script installed in /etc/profile.d for ptl has several logic and syntax errors. The net result is that it doesn't update PATH or PYTHONPATH.

#### Describe Your Change
Updated the script to use valid syntax and to improve logic.

#### Link to Design Doc
N/A

#### Attach Test and Valgrind Logs/Output
Before:

```
$ env -i PATH=/usr/bin:/bin tcsh -f -c 'source test/fw/ptl.csh ; env | grep PATH'
Ambiguous output redirect.
ptl_prefix_lib: Undefined variable.
ptl_prefix_lib: Undefined variable.
setenv: Variable name must contain alphanumeric characters.
PATH=/usr/bin:/bin
```

After:
```
$ env -i PATH=/usr/bin:/bin tcsh -f -c 'source test/fw/ptl.csh ; env | grep PATH'
PATH=/usr/bin:/bin:/opt/ptl/bin
PYTHONPATH=/opt/ptl/lib/python3.6/site-packages
```


