### PR TITLE
pbs_mom fails to come up, calling log_open again fails

### DIFF
--- a/src/lib/Liblog/pbs_log.c
+++ b/src/lib/Liblog/pbs_log.c
@@ -570,8 +570,8 @@ log_open_main(char *filename, char *directory, int silent)
 
 	pthread_once(&log_once_ctl, log_init); /* initialize mutex once */
 
-	if (log_opened > 0)
-		return (-1);	/* already open */
+	if (log_opened > 0)	/* Close existing log */
+		log_close(0);
 
 	if (locallog != 0 || syslogfac == 0) {
 

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -7274,7 +7274,6 @@ main(int argc, char *argv[])
 #if defined(RLIM64_INFINITY)
 	{
 		struct rlimit64 rlimit;
-		int curerror;
 
 		rlimit.rlim_cur = RLIM64_INFINITY;
 		rlimit.rlim_max = RLIM64_INFINITY;
@@ -7287,21 +7286,12 @@ main(int argc, char *argv[])
 				rlimit.rlim_cur = MIN_STACK_LIMIT;
 				rlimit.rlim_max = MIN_STACK_LIMIT;
 				if (setrlimit64(RLIMIT_STACK, &rlimit) == -1) {
-					char msgbuf[] = "Stack limit setting failed";
-					curerror = errno;
-					log_err(curerror, __func__, msgbuf);
-					sprintf(log_buffer, "%s errno=%d", msgbuf, curerror);
-					log_record(PBSEVENT_ERROR, PBS_EVENTCLASS_SERVER, LOG_ERR, (char *)__func__, log_buffer);
+					perror("Stack limit setting failed");
 					exit(1);
 				}
 			}
 		} else {
-			char msgbuf[] = "Getting current Stack limit failed";
-
-			curerror = errno;
-			log_err(curerror, __func__, msgbuf);
-			snprintf(log_buffer, sizeof(log_buffer), "%s errno=%d", msgbuf, curerror);
-			log_record(PBSEVENT_ERROR, PBS_EVENTCLASS_SERVER, LOG_ERR, (char *)__func__, log_buffer);
+			perror("Getting current Stack limit failed");
 			exit(1);
 		}
 
@@ -7310,11 +7300,8 @@ main(int argc, char *argv[])
 
 #ifdef RLIMIT_NPROC
 		(void)getrlimit64(RLIMIT_NPROC, &orig_nproc_limit); /* get for later */
-		if (setrlimit64(RLIMIT_NPROC, &rlimit) == -1) {     /* set unlimited */
-			char msgbuf[] = "setrlimit NPROC setting failed";
-			curerror = errno;
-			log_err(curerror, __func__, msgbuf);
-		}
+		if (setrlimit64(RLIMIT_NPROC, &rlimit) == -1)     /* set unlimited */
+			perror(" setrlimit NPROC");	/* Won't quit, will try to work within limits */
 #endif	/* RLIMIT_NPROC */
 #ifdef	RLIMIT_RSS
 		(void)setrlimit64(RLIMIT_RSS  , &rlimit);
@@ -7330,18 +7317,14 @@ main(int argc, char *argv[])
 #else	/* set rlimit 32 bit */
 	{
 		struct rlimit rlimit;
-		int curerror;
 
 		rlimit.rlim_cur = RLIM_INFINITY;
 		rlimit.rlim_max = RLIM_INFINITY;
 		(void)setrlimit(RLIMIT_CPU,   &rlimit);
 #ifdef RLIMIT_NPROC
 		(void)getrlimit(RLIMIT_NPROC, &orig_nproc_limit); /* get for later */
-		if (setrlimit(RLIMIT_NPROC, &rlimit) == -1) { 	  /* set unlimited */
-			char msgbuf[] = "setrlimit NPROC setting failed";
-			curerror = errno;
-			log_err(curerror, __func__, msgbuf);
-		}
+		if (setrlimit(RLIMIT_NPROC, &rlimit) == -1) 	  /* set unlimited */
+			perror(" setrlimit NPROC");	/* Won't quit, will try to work within limits */
 #endif	/* RLIMIT_NPROC */
 #ifdef	RLIMIT_RSS
 		(void)setrlimit(RLIMIT_RSS  , &rlimit);
@@ -7363,20 +7346,12 @@ main(int argc, char *argv[])
 				rlimit.rlim_cur = MIN_STACK_LIMIT;
 				rlimit.rlim_max = MIN_STACK_LIMIT;
 				if (setrlimit(RLIMIT_STACK, &rlimit) == -1) {
-					char msgbuf[] = "Stack limit setting failed";
-					curerror = errno;
-					log_err(curerror, __func__, msgbuf);
-					sprintf(log_buffer, "%s errno=%d", msgbuf, curerror);
-					log_record(PBSEVENT_ERROR, PBS_EVENTCLASS_SERVER, LOG_ERR, (char *)__func__, log_buffer);
+					perror("Stack limit setting failed");
 					exit(1);
 				}
 			}
 		} else {
-			char msgbuf[] = "Getting current Stack limit failed";
-			curerror = errno;
-			log_err(curerror, __func__, msgbuf);
-			sprintf(log_buffer, "%s errno=%d", msgbuf, curerror);
-			log_record(PBSEVENT_ERROR, PBS_EVENTCLASS_SERVER, LOG_ERR, (char *)__func__, log_buffer);
+			perror("Getting current Stack limit failed");
 			exit(1);
 		}
 #endif	/* not linux */
@@ -7386,11 +7361,11 @@ main(int argc, char *argv[])
 #endif /* !WIN32 */
 
 	if ((job_attr_idx = cr_attrdef_idx(job_attr_def, JOB_ATR_LAST)) == NULL) {
-		log_err(errno, __func__, "Failed creating job attribute search index");
+		perror("Failed creating job attribute search index");
 		return (-1);
 	}
 	if (cr_rescdef_idx(svr_resc_def, svr_resc_size) != 0) {
-		log_err(errno, __func__, "Failed creating resc definition search index");
+		perror("Failed creating resc definition search index");
 		return (-1);
 	}
 

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -7274,6 +7274,7 @@ main(int argc, char *argv[])
 #if defined(RLIM64_INFINITY)
 	{
 		struct rlimit64 rlimit;
+		int curerror;
 
 		rlimit.rlim_cur = RLIM64_INFINITY;
 		rlimit.rlim_max = RLIM64_INFINITY;
@@ -7286,12 +7287,21 @@ main(int argc, char *argv[])
 				rlimit.rlim_cur = MIN_STACK_LIMIT;
 				rlimit.rlim_max = MIN_STACK_LIMIT;
 				if (setrlimit64(RLIMIT_STACK, &rlimit) == -1) {
-					perror("Stack limit setting failed");
+					char msgbuf[] = "Stack limit setting failed";
+					curerror = errno;
+					log_err(curerror, __func__, msgbuf);
+					sprintf(log_buffer, "%s errno=%d", msgbuf, curerror);
+					log_record(PBSEVENT_ERROR, PBS_EVENTCLASS_SERVER, LOG_ERR, (char *)__func__, log_buffer);
 					exit(1);
 				}
 			}
 		} else {
-			perror("Getting current Stack limit failed");
+			char msgbuf[] = "Getting current Stack limit failed";
+
+			curerror = errno;
+			log_err(curerror, __func__, msgbuf);
+			snprintf(log_buffer, sizeof(log_buffer), "%s errno=%d", msgbuf, curerror);
+			log_record(PBSEVENT_ERROR, PBS_EVENTCLASS_SERVER, LOG_ERR, (char *)__func__, log_buffer);
 			exit(1);
 		}
 
@@ -7300,8 +7310,11 @@ main(int argc, char *argv[])
 
 #ifdef RLIMIT_NPROC
 		(void)getrlimit64(RLIMIT_NPROC, &orig_nproc_limit); /* get for later */
-		if (setrlimit64(RLIMIT_NPROC, &rlimit) == -1)     /* set unlimited */
-			perror(" setrlimit NPROC");	/* Won't quit, will try to work within limits */
+		if (setrlimit64(RLIMIT_NPROC, &rlimit) == -1) {     /* set unlimited */
+			char msgbuf[] = "setrlimit NPROC setting failed";
+			curerror = errno;
+			log_err(curerror, __func__, msgbuf);
+		}
 #endif	/* RLIMIT_NPROC */
 #ifdef	RLIMIT_RSS
 		(void)setrlimit64(RLIMIT_RSS  , &rlimit);
@@ -7317,14 +7330,18 @@ main(int argc, char *argv[])
 #else	/* set rlimit 32 bit */
 	{
 		struct rlimit rlimit;
+		int curerror;
 
 		rlimit.rlim_cur = RLIM_INFINITY;
 		rlimit.rlim_max = RLIM_INFINITY;
 		(void)setrlimit(RLIMIT_CPU,   &rlimit);
 #ifdef RLIMIT_NPROC
 		(void)getrlimit(RLIMIT_NPROC, &orig_nproc_limit); /* get for later */
-		if (setrlimit(RLIMIT_NPROC, &rlimit) == -1) 	  /* set unlimited */
-			perror(" setrlimit NPROC");	/* Won't quit, will try to work within limits */
+		if (setrlimit(RLIMIT_NPROC, &rlimit) == -1) { 	  /* set unlimited */
+			char msgbuf[] = "setrlimit NPROC setting failed";
+			curerror = errno;
+			log_err(curerror, __func__, msgbuf);
+		}
 #endif	/* RLIMIT_NPROC */
 #ifdef	RLIMIT_RSS
 		(void)setrlimit(RLIMIT_RSS  , &rlimit);
@@ -7346,12 +7363,20 @@ main(int argc, char *argv[])
 				rlimit.rlim_cur = MIN_STACK_LIMIT;
 				rlimit.rlim_max = MIN_STACK_LIMIT;
 				if (setrlimit(RLIMIT_STACK, &rlimit) == -1) {
-					perror("Stack limit setting failed");
+					char msgbuf[] = "Stack limit setting failed";
+					curerror = errno;
+					log_err(curerror, __func__, msgbuf);
+					sprintf(log_buffer, "%s errno=%d", msgbuf, curerror);
+					log_record(PBSEVENT_ERROR, PBS_EVENTCLASS_SERVER, LOG_ERR, (char *)__func__, log_buffer);
 					exit(1);
 				}
 			}
 		} else {
-			perror("Getting current Stack limit failed");
+			char msgbuf[] = "Getting current Stack limit failed";
+			curerror = errno;
+			log_err(curerror, __func__, msgbuf);
+			sprintf(log_buffer, "%s errno=%d", msgbuf, curerror);
+			log_record(PBSEVENT_ERROR, PBS_EVENTCLASS_SERVER, LOG_ERR, (char *)__func__, log_buffer);
 			exit(1);
 		}
 #endif	/* not linux */
@@ -7361,11 +7386,11 @@ main(int argc, char *argv[])
 #endif /* !WIN32 */
 
 	if ((job_attr_idx = cr_attrdef_idx(job_attr_def, JOB_ATR_LAST)) == NULL) {
-		perror("Failed creating job attribute search index");
+		log_err(errno, __func__, "Failed creating job attribute search index");
 		return (-1);
 	}
 	if (cr_rescdef_idx(svr_resc_def, svr_resc_size) != 0) {
-		perror("Failed creating resc definition search index");
+		log_err(errno, __func__, "Failed creating resc definition search index");
 		return (-1);
 	}
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
with https://github.com/openpbs/openpbs/pull/2227 we replaced a perror call with log_err, but it occurred before the call to log_open, so it opens the log with /dev/console. Since we don't exit the process in this particular instance, we go on and inside mom_main.c, we call log_open a second time, which make pbs_mom exit with failure

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Changed log_open to just close existing log when called a second time and proceed instead of exiting with error

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, WIN2K16
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|5955|3815|1|0|0|13|3801|

Description: Rerun Only Failed Tests From #5955
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|5957|1|0|0|0|0|1|

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
