### PR TITLE
Scheduler might leak memory in multi-sched mode

### DIFF
--- a/src/scheduler/fifo.cpp
+++ b/src/scheduler/fifo.cpp
@@ -2884,6 +2884,7 @@ parse_sched_obj(int connector, struct batch_status *status)
 				MGR_CMD_UNSET, MGR_OBJ_SCHED,
 			const_cast<char *>(sc_name), attribs, NULL);
 		free(attribs->value);
+		free(attribs);
 		if (err) {
 			log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__,
 				"Failed to update scheduler comment at the server");


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
The scheduler might leak some memory while trying to reset the scheduler comment.

#### Describe Your Change
This only happens in the case of a multi-sched when the scheduler is trying to update its comment attribute. I added a missing free().


#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
[sched.log](https://github.com/openpbs/openpbs/files/5915420/sched.log)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
