### PR TITLE
fixed test 'test_fairshare_usage' from 'TestMultipleSchedulers' failed on cpuset machine.

### DIFF
--- a/test/tests/functional/pbs_multi_sched.py
+++ b/test/tests/functional/pbs_multi_sched.py
@@ -744,9 +744,14 @@ class TestMultipleSchedulers(TestFunctional):
              'partition': 'P1'}
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='wq1')
         # Set resources to node
+        if self.mom.is_cpuset_mom():
+            hostname = self.server.status(NODE)[1]['id']
+        else:
+            hostname = self.mom.shortname
+
         resc = {'resources_available.ncpus': 1,
                 'partition': 'P1'}
-        self.server.manager(MGR_CMD_SET, NODE, resc, self.mom.shortname)
+        self.server.manager(MGR_CMD_SET, NODE, resc, hostname)
         # Add entry to the resource group of multisched 'sc1'
         self.scheds['sc1'].add_to_resource_group('grp1', 100, 'root', 60)
         self.scheds['sc1'].add_to_resource_group('grp2', 200, 'root', 40)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
fixed test 'test_fairshare_usage' from 'TestMultipleSchedulers' failed on cpuset machine. in test we are set node attributes and submit a job. after submitting job PTL expect job should run, but on cpuset machine job remain in Q state. on cpuset machine we need to set node attribute on vnode instead of physical node. 

#### Describe Your Change
on cpuset MoM, set node attributes on vnode instead of physical node.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
[res_after_fix_normal_machine.txt](https://github.com/openpbs/openpbs/files/5918128/res_after_fix_normal_machine.txt)
[res_after_fix.txt](https://github.com/openpbs/openpbs/files/5918129/res_after_fix.txt)
[res_before_fix.txt](https://github.com/openpbs/openpbs/files/5918130/res_before_fix.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
