### PR TITLE
qstat -T does not display estimated start time of array parent

### DIFF
--- a/src/cmds/qstat.c
+++ b/src/cmds/qstat.c
@@ -1022,7 +1022,7 @@ altdsp_statjob(struct batch_status *pstat, struct batch_status *prtheader, int a
 
 		if (alt_opt & ALT_DISPLAY_T) {
 			pc = get_attr(pstat->attribs, ATTR_state, NULL);
-			if (pc != NULL && (*pc == 'Q' || *pc == 'S'))
+			if (pc != NULL && (*pc == 'Q' || *pc == 'S' || *pc == 'B'))
 				timeval = cnvt_est_start_time(est_time, 0);
 			else
 				timeval = "--";


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
qstat -T does not display estimated start time of an array parent.


#### Describe Your Change
Changed qstat to expect estimated start time set for jobs in 'B' state.

#### Link to Design Doc
NA
#### Attach Test and Valgrind Logs/Output
Manual testing - 
```
[root@Nile-extn ~/Work/PBS]# qsub -J 1-10 -lwalltime=3600 -- /bin/sleep 1000
10[].Nile-extn
[root@Nile-extn ~/Work/PBS]# qstat
Job id            Name             User              Time Use S Queue
----------------  ---------------- ----------------  -------- - -----
10[].Nile-extn    STDIN            root                     0 B workq           
[root@Nile-extn ~/Work/PBS]# qstat -T

Nile-extn: 
                                                                           Est
                                                            Req'd  Req'd   Start
Job ID          Username Queue    Jobname    SessID NDS TSK Memory Time  S Time
--------------- -------- -------- ---------- ------ --- --- ------ ----- - -----
10[].Nile-extn  root     workq    STDIN         --    1   1    --  01:00 B 12:05
[root@Nile-extn ~/Work/PBS]# date
Wed Feb  3 11:05:19 PST 2021
[root@Nile-extn ~/Work/PBS]# 
```

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
