### PR TITLE
cleanup *e and *o files in user homedir

### DIFF
--- a/test/fw/ptl/utils/plugins/ptl_test_runner.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_runner.py
@@ -1045,15 +1045,15 @@ class PTLTestRunner(Plugin):
         for user in PBS_USERS:
             self.logger.info('Cleaning %s\'s home directory' % (str(user)))
             runas = PbsUser.get_user(user)
-            for mom in hosts:
-                ret = du.run_cmd(mom, cmd=['echo', '$HOME'], sudo=True,
+            for host in hosts:
+                ret = du.run_cmd(host, cmd=['echo', '$HOME'], sudo=True,
                                  runas=runas, logerr=False, as_script=True)
                 if ret['rc'] == 0:
                     path = ret['out'][0].strip()
                 else:
                     return None
                 ftd = []
-                files = du.listdir(mom, path=path, runas=user)
+                files = du.listdir(host, path=path, runas=user)
                 bn = os.path.basename
                 ftd.extend([f for f in files if bn(f).startswith('PtlPbs')])
                 ftd.extend([f for f in files if bn(f).startswith('STDIN')])
@@ -1061,7 +1061,7 @@ class PTLTestRunner(Plugin):
                 if len(ftd) > 1000:
                     for i in range(0, len(ftd), 1000):
                         j = i + 1000
-                        du.rm(mom, path=ftd[i:j], runas=user,
+                        du.rm(host, path=ftd[i:j], runas=user,
                               force=True, level=logging.DEBUG)
 
         root_dir = os.sep

--- a/test/fw/ptl/utils/plugins/ptl_test_runner.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_runner.py
@@ -1042,7 +1042,6 @@ class PTLTestRunner(Plugin):
             self.logger.info('Cleaning %s\'s home directory' % (str(user)))
             runas = PbsUser.get_user(user)
             for mom in self.param_dict['moms']:
-                self.logger.info(mom)
                 ret = du.run_cmd(mom, cmd=['echo', '$HOME'], sudo=True,
                                  runas=runas, logerr=False, as_script=True)
                 if ret['rc'] == 0:

--- a/test/fw/ptl/utils/plugins/ptl_test_runner.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_runner.py
@@ -70,7 +70,7 @@ from ptl.utils.pbs_dshutils import TimeOut
 from ptl.utils.pbs_testsuite import (MINIMUM_TESTCASE_TIMEOUT,
                                      REQUIREMENTS_KEY, TIMEOUT_KEY)
 from ptl.utils.plugins.ptl_test_info import get_effective_reqs
-from ptl.utils.pbs_testusers import PBS_ALL_USERS
+from ptl.utils.pbs_testusers import PBS_ALL_USERS, PBS_USERS, PbsUser
 from io import StringIO
 
 log = logging.getLogger('nose.plugins.PTLTestRunner')
@@ -1038,6 +1038,27 @@ class PTLTestRunner(Plugin):
     def _cleanup(self):
         self.logger.info('Cleaning up temporary files')
         du = DshUtils()
+        for user in PBS_USERS:
+            self.logger.info('Cleaning %s\'s home directory' % (str(user)))
+            runas = PbsUser.get_user(user)
+            hostname = (socket.gethostname()).split('.', 1)[0]
+            ret = du.run_cmd(hostname, cmd=['echo', '$HOME'], sudo=True,
+                             runas=runas, logerr=False, as_script=True)
+            if ret['rc'] == 0:
+                path = ret['out'][0].strip()
+            else:
+                return None
+            ftd = []
+            files = du.listdir(hostname, path=path, runas=user)
+            bn = os.path.basename
+            ftd.extend([f for f in files if bn(f).startswith('PtlPbs')])
+            ftd.extend([f for f in files if bn(f).startswith('STDIN')])
+            if len(ftd) > 1000:
+                for i in range(0, len(ftd), 1000):
+                    j = i + 1000
+                    du.rm(hostname, path=ftd[i:j], runas=user,
+                          force=True, level=logging.INFOCLI)
+
         root_dir = os.sep
         dirlist = set([os.path.join(root_dir, 'tmp'),
                        os.path.join(root_dir, 'var', 'tmp')])

--- a/test/fw/ptl/utils/plugins/ptl_test_runner.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_runner.py
@@ -1041,23 +1041,25 @@ class PTLTestRunner(Plugin):
         for user in PBS_USERS:
             self.logger.info('Cleaning %s\'s home directory' % (str(user)))
             runas = PbsUser.get_user(user)
-            hostname = (socket.gethostname()).split('.', 1)[0]
-            ret = du.run_cmd(hostname, cmd=['echo', '$HOME'], sudo=True,
-                             runas=runas, logerr=False, as_script=True)
-            if ret['rc'] == 0:
-                path = ret['out'][0].strip()
-            else:
-                return None
-            ftd = []
-            files = du.listdir(hostname, path=path, runas=user)
-            bn = os.path.basename
-            ftd.extend([f for f in files if bn(f).startswith('PtlPbs')])
-            ftd.extend([f for f in files if bn(f).startswith('STDIN')])
-            if len(ftd) > 1000:
-                for i in range(0, len(ftd), 1000):
-                    j = i + 1000
-                    du.rm(hostname, path=ftd[i:j], runas=user,
-                          force=True, level=logging.INFOCLI)
+            for mom in self.param_dict['moms']:
+                self.logger.info(mom)
+                ret = du.run_cmd(mom, cmd=['echo', '$HOME'], sudo=True,
+                                 runas=runas, logerr=False, as_script=True)
+                if ret['rc'] == 0:
+                    path = ret['out'][0].strip()
+                else:
+                    return None
+                ftd = []
+                files = du.listdir(mom, path=path, runas=user)
+                bn = os.path.basename
+                ftd.extend([f for f in files if bn(f).startswith('PtlPbs')])
+                ftd.extend([f for f in files if bn(f).startswith('STDIN')])
+
+                if len(ftd) > 1000:
+                    for i in range(0, len(ftd), 1000):
+                        j = i + 1000
+                        du.rm(mom, path=ftd[i:j], runas=user,
+                              force=True, level=logging.DEBUG)
 
         root_dir = os.sep
         dirlist = set([os.path.join(root_dir, 'tmp'),

--- a/test/fw/ptl/utils/plugins/ptl_test_runner.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_runner.py
@@ -1038,10 +1038,14 @@ class PTLTestRunner(Plugin):
     def _cleanup(self):
         self.logger.info('Cleaning up temporary files')
         du = DshUtils()
+        hosts = self.param_dict['moms']
+        for server in self.param_dict['servers']:
+            if server not in self.param_dict['moms']:
+                hosts.add(self.param_dict['servers'])
         for user in PBS_USERS:
             self.logger.info('Cleaning %s\'s home directory' % (str(user)))
             runas = PbsUser.get_user(user)
-            for mom in self.param_dict['moms']:
+            for mom in hosts:
                 ret = du.run_cmd(mom, cmd=['echo', '$HOME'], sudo=True,
                                  runas=runas, logerr=False, as_script=True)
                 if ret['rc'] == 0:


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Large number of *e and *o files in user home directory fills up the system after tests which may submit thousands of jobs.


#### Describe Your Change
Added cleanup in user's homedir by the user himself in ptl_test_runner.py for all PBS_USERS


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->


[cleanup.zip](https://github.com/openpbs/openpbs/files/5960496/cleanup.zip)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
