### PR TITLE
fixed test 'test_submit_job_with_script' from 'SmokeTest' failed with error 'no data for job_state'.

### DIFF
--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -550,16 +550,20 @@ class SmokeTest(PBSTestSuite):
         """
         Test to submit job with job script
         """
+        sleep_cmd = os.path.join(self.server.pbs_conf['PBS_EXEC'],
+                                 'bin', 'pbs_sleep')
+        script_body = sleep_cmd + ' 120'
         j = Job(TEST_USER, attrs={ATTR_N: 'test'})
-        j.create_script('pbs_sleep 120\n', hostname=self.server.client)
+        j.create_script(script_body, hostname=self.server.client)
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
         self.server.delete(id=jid, extend='force', wait=True)
         self.logger.info("Testing script with extension")
         j = Job(TEST_USER)
+
         fn = self.du.create_temp_file(hostname=self.server.client,
                                       suffix=".scr",
-                                      body="pbs_sleep 10",
+                                      body=script_body,
                                       asuser=str(TEST_USER))
         jid = self.server.submit(j, script=fn)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Test 'test_submit_job_with_script' from 'SmokeTest' failed with error 'no data for job_state'. issue is after submitting job with script, job didn't get pbs_sleep command to execute and immediately terminated with exit status 127. 
need to add complete path of pbs_sleep command in job script.

#### Describe Your Change
added complete pbs_sleep command path in job script.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
Before fix:
[res_before_fix.txt](https://github.com/openpbs/openpbs/files/5932381/res_before_fix.txt)

After fix:
[res_after_fix.txt](https://github.com/openpbs/openpbs/files/5932383/res_after_fix.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
