### PR TITLE
corrected the condition to check proc monitor

### DIFF
--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -1606,7 +1606,7 @@ class PBSTestSuite(unittest.TestCase):
         :param frequency: Frequency of monitoring
         :type frequency: int
         """
-        if self._procmon is not None:
+        if self._process_monitoring:
             self.logger.info('A process monitor is already instantiated')
             return
         self.logger.info('starting process monitoring of ' + name +


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Not getting proc monitor data for tests running multiple times because condition to check proc monitor is started or not is not correct. 


#### Describe Your Change
Instance "_process_monitoring" is used to start and stop proc monitor. It is "True" when proc monitor is started and  "False" when proc monitor is stopped so it is a correct instance to check  proc monitor is started or not.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[proc_monitior_file.txt](https://github.com/openpbs/openpbs/files/5934435/proc_monitior_file.txt)
[proc_monitor_json.txt](https://github.com/openpbs/openpbs/files/5934439/proc_monitor_json.txt)
[proc_monitior_ptl_logs.txt](https://github.com/openpbs/openpbs/files/5934442/proc_monitior_ptl_logs.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
