### PR TITLE
Test 'test_comm_log_events' is failing while verifying the log msg

### DIFF
--- a/test/tests/functional/pbs_test_tpp.py
+++ b/test/tests/functional/pbs_test_tpp.py
@@ -918,7 +918,6 @@ class TestTPP(TestFunctional):
         """
         Test for verifying the allowable values for PBS_COMM_LOG_EVENTS
         """
-        server_ip = socket.gethostbyname(self.server.hostname)
         a = [0, 511, "T"]
         for log_event in a:
             hook_name = "begin_" + str(log_event)
@@ -932,19 +931,19 @@ class TestTPP(TestFunctional):
                               conf_param=attrib)
             attrs = {'event': 'execjob_begin', 'enabled': 'True'}
             self.server.create_hook(hook_name, attrs)
-            exp_msg = ["MCAST packet from %s:15001" % server_ip,
+            exp_msg = ["MCAST packet from .*:15001",
                        "mcast done"]
             for msg in exp_msg:
                 self.comm.log_match(msg, existence=existence,
-                                    starttime=start_time)
+                                    starttime=start_time, regexp=True)
             self.server.import_hook(hook_name, body="import pbs")
             for msg in exp_msg:
                 self.comm.log_match(msg, existence=existence,
-                                    starttime=start_time)
+                                    starttime=start_time, regexp=True)
             self.server.manager(MGR_CMD_DELETE, HOOK, id=hook_name)
             for msg in exp_msg:
                 self.comm.log_match(msg, existence=existence,
-                                    starttime=start_time)
+                                    starttime=start_time, regexp=True)
 
     def common_steps_for_mom_pool_tests(self):
         """


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Problem description
* Test 'test_comm_log_events' is failing while verifying the log msg
* Expected msg: MCAST packet from 10.8.7.61:15001
* Observed msg: MCAST packet from 10.8.7.52:15001

#### Cause / Analysis
* This is because the machines on which the test failed has 2 NIC. 

#### Solution description
* Instead of matching exact Ip use regualr expression.



#### Testing
* [Execution_logs_TestTPP_bfr_fix.txt](https://github.com/altairengineering/pbspro-private/files/5943488/Execution_logs_TestTPP_bfr_fix.txt)

5990 | regression | log_events_test | Mahalty/pbspro@cp_tpp | 8th Feb 2021 10:22:47.420 PM +05:30 | 00:02:24.017 | 3 | 0 | 0 | 0 | 0 | 0 | 0 | 3
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --





#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the pull request** as evidence of testing/verification.

__***For further information please visit [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__

