### PR TITLE
Partial C++ refactor of resource_resv and node_info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,6 +192,7 @@ src/iff/pbs_iff
 src/mom_rcp/pbs_rcp
 src/resmom/pbs_mom
 src/scheduler/pbs_sched
+src/scheduler/pbs_sched_bare
 src/scheduler/pbsfs
 src/server/pbs_comm
 src/server/pbs_server.bin

--- a/src/include/libutil.h
+++ b/src/include/libutil.h
@@ -271,12 +271,12 @@ char **break_delimited_str(char *list, char delim);
 /*
  * find index of str in strarr
  */
-int find_string_idx(char **strarr, char *str);
+int find_string_idx(char **strarr, const char *str);
 
 /*
  *	is_string_in_arr - Does a string exist in the given array?
  */
-int is_string_in_arr(char **strarr, char *str);
+int is_string_in_arr(char **strarr, const char *str);
 
 /*
  * Make copy of string array

--- a/src/include/log.h
+++ b/src/include/log.h
@@ -116,6 +116,7 @@ extern void log_err(int err, const char *func, const char *text);
 extern void log_errf(int errnum, const char *routine, const char *fmt, ...);
 extern void log_joberr(int err, const char *func, const char *text, const char *pjid);
 extern void log_event(int type, int objclass, int severity, const char *objname, const char *text);
+extern void do_log_eventf(int eventtype, int objclass, int sev, const char *objname, const char *fmt, va_list args);
 extern void log_eventf(int eventtype, int objclass, int sev, const char *objname, const char *fmt, ...);
 extern int will_log_event(int type);
 extern void log_suspect_file(const char *func, const char *text, const char *file, struct stat *sb);

--- a/src/lib/Liblog/log_event.c
+++ b/src/lib/Liblog/log_event.c
@@ -160,10 +160,9 @@ do_log_eventf(int eventtype, int objclass, int sev, const char *objname, const c
 
 	if (len >= sizeof(logbuf)) {
 		buf = pbs_asprintf_format(len, fmt, args);
-		if (buf == NULL) {
-			va_end(args);
+		if (buf == NULL)
 			return;
-		}
+
 	} else
 		buf = logbuf;
 

--- a/src/lib/Libutil/misc_utils.c
+++ b/src/lib/Libutil/misc_utils.c
@@ -1208,7 +1208,7 @@ break_comma_list(char *strlist)
  *
  */
 int
-is_string_in_arr(char **strarr, char *str)
+is_string_in_arr(char **strarr, const char *str)
 {
 	int ind;
 
@@ -1271,7 +1271,7 @@ dup_string_arr(char **strarr)
  * @retval	-1	: if not found
  */
 int
-find_string_idx(char **strarr, char *str)
+find_string_idx(char **strarr, const char *str)
 {
 	int i;
 	if (strarr == NULL || str == NULL)

--- a/src/scheduler/buckets.cpp
+++ b/src/scheduler/buckets.cpp
@@ -43,7 +43,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
-#include <log.h>
 #include "data_types.h"
 #include "pbs_bitmap.h"
 #include "node_info.h"
@@ -57,6 +56,7 @@
 #include "sort.h"
 #include "node_partition.h"
 #include "check.h"
+#include <log.h>
 
 /* bucket_bitpool constructor */
 bucket_bitpool *

--- a/src/scheduler/check.cpp
+++ b/src/scheduler/check.cpp
@@ -1623,7 +1623,6 @@ check_normal_node_path(status *policy, server_info *sinfo, queue_info *qinfo, re
 	if (ninfo_arr == NULL || error)
 		return NULL;
 
-	err->status_code = NOT_RUN;
 	rc = eval_selspec(policy, spec, pl, ninfo_arr, nodepart, resresv, flags, &nspec_arr, err);
 
 	/* We can run, yippie! */

--- a/src/scheduler/check.cpp
+++ b/src/scheduler/check.cpp
@@ -1059,6 +1059,7 @@ is_ok_to_run(status *policy, server_info *sinfo,
 
 	ns_arr = check_nodes(policy, sinfo, qinfo, resresv, flags, err);
 
+
 	if (err->error_code != SUCCESS)
 		add_err(&prev_err, err);
 
@@ -1069,7 +1070,7 @@ is_ok_to_run(status *policy, server_info *sinfo,
 	 * didn't end up using it.  We have to check against perr, so we don't
 	 * free the caller's memory.
 	 */
-	if(err->status_code == SCHD_UNKWN && err != perr)
+	else if(err != perr)
 		free_schd_error(err);
 
 	return ns_arr;

--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -67,16 +67,10 @@
 #include "site_queue.h"
 #endif
 
-<<<<<<< HEAD
 #include <unordered_map>
 #include <string>
 
-=======
->>>>>>> 5747272f... Partial C++ refactor of resource_resv and node_info
 struct server_info;
-struct state_count;
-struct queue_info;
-struct node_info;
 struct job_info;
 struct schd_resource;
 struct resource_req;
@@ -89,7 +83,6 @@ struct counts;
 struct nspec;
 struct node_partition;
 struct range;
-struct resource_resv;
 struct place;
 struct schd_error;
 struct np_cache;
@@ -106,24 +99,23 @@ struct bucket_bitpool;
 struct chunk_map;
 struct node_bucket_count;
 struct preempt_job_st;
+class resource_resv;
+class node_info;
 
 
 typedef struct state_count state_count;
 typedef struct server_info server_info;
 typedef struct queue_info queue_info;
 typedef struct job_info job_info;
-typedef struct node_info node_info;
 typedef struct schd_resource schd_resource;
 typedef struct resource_req resource_req;
 typedef struct resource_count resource_count;
 typedef struct usage_info usage_info;
 typedef struct group_info group_info;
-typedef struct prev_job_info prev_job_info;
 typedef struct resv_info resv_info;
 typedef struct counts counts;
 typedef struct nspec nspec;
 typedef struct node_partition node_partition;
-typedef struct resource_resv resource_resv;
 typedef struct place place;
 typedef struct schd_error schd_error;
 typedef struct np_cache np_cache;
@@ -200,7 +192,7 @@ struct th_data_nd_eligible
 
 struct th_data_dup_nd_info
 {
-	unsigned int error:1;
+	bool error;
 	node_info **onodes;
 	node_info **nnodes;
 	server_info *nsinfo;
@@ -211,7 +203,7 @@ struct th_data_dup_nd_info
 
 struct th_data_query_ninfo
 {
-	unsigned int error:1;
+	bool error;
 	struct batch_status *nodes;
 	server_info *sinfo;
 	node_info **oarr;
@@ -228,7 +220,7 @@ struct th_data_free_ninfo
 
 struct th_data_dup_resresv
 {
-	unsigned int error:1;
+	bool error;
 	resource_resv **oresresv_arr;
 	resource_resv **nresresv_arr;
 	server_info *nsinfo;
@@ -239,7 +231,7 @@ struct th_data_dup_resresv
 
 struct th_data_query_jinfo
 {
-	unsigned int error:1;
+	bool error;
 	struct batch_status *jobs;
 	server_info *sinfo;
 	queue_info *qinfo;
@@ -287,13 +279,13 @@ struct state_count
 
 struct place
 {
-	unsigned int free:1;		/* free placement */
-	unsigned int pack:1;		/* pack placement */
-	unsigned int scatter:1;		/* scatter placement */
-	unsigned int vscatter:1;	/* scatter by vnode */
-	unsigned int excl:1;		/* need nodes exclusively */
-	unsigned int exclhost:1;	/* need whole hosts exclusively */
-	unsigned int share:1;		/* will share nodes */
+	bool free;		/* free placement */
+	bool pack;		/* pack placement */
+	bool scatter;		/* scatter placement */
+	bool vscatter;	/* scatter by vnode */
+	bool excl;		/* need nodes exclusively */
+	bool exclhost;	/* need whole hosts exclusively */
+	bool share;		/* will share nodes */
 
 	char *group;			/* resource to node group by */
 };
@@ -317,23 +309,23 @@ struct selspec
 /* for description of these bits, check the PBS admin guide or scheduler IDS */
 struct status
 {
-	unsigned round_robin:1;		/* Round robin around queues */
-	unsigned by_queue:1;		/* schedule per-queue */
-	unsigned strict_fifo:1;		/* deprecated */
-	unsigned strict_ordering:1;
-	unsigned fair_share:1;
-	unsigned help_starving_jobs:1;
-	unsigned backfill:1;
-	unsigned sort_nodes:1;
-	unsigned backfill_prime:1;
-	unsigned preempting:1;
+	bool round_robin;		/* Round robin around queues */
+	bool by_queue;		/* schedule per-queue */
+	bool strict_fifo;		/* deprecated */
+	bool strict_ordering;
+	bool fair_share;
+	bool help_starving_jobs;
+	bool backfill;
+	bool sort_nodes;
+	bool backfill_prime;
+	bool preempting;
 #ifdef NAS /* localmod 034 */
-	unsigned shares_track_only:1;
+	bool shares_track_only;
 #endif /* localmod 034 */
 
-	unsigned is_prime:1;
-	unsigned is_ded_time:1;
-	unsigned sync_fairshare_files:1;	/* sync fairshare files to disk */
+	bool is_prime;
+	bool is_ded_time;
+	bool sync_fairshare_files;	/* sync fairshare files to disk */
 
 	struct sort_info *sort_by;		/* job sorting */
 	struct sort_info *node_sort;		/* node sorting */
@@ -370,11 +362,11 @@ struct status
  */
 struct schedattrs
 {
-	unsigned do_not_span_psets:1;
-	unsigned only_explicit_psets:1;
-	unsigned preempt_targets_enable:1;
-	unsigned sched_preempt_enforce_resumption:1;
-	unsigned throughput_mode:1;
+	bool do_not_span_psets;
+	bool only_explicit_psets;
+	bool preempt_targets_enable;
+	bool sched_preempt_enforce_resumption;
+	bool throughput_mode;
 	long attr_update_period;
 	char *comment;
 	char *job_sort_formula;
@@ -394,26 +386,25 @@ struct schedattrs
 
 struct server_info
 {
-	unsigned has_soft_limit:1;	/* server has a soft user/grp limit set */
-	unsigned has_hard_limit:1;	/* server has a hard user/grp limit set */
-	unsigned has_mult_express:1;	/* server has multiple express queues */
-	unsigned has_user_limit:1;	/* server has user hard or soft limit */
-	unsigned has_grp_limit:1;	/* server has group hard or soft limit */
-	unsigned has_proj_limit:1;	/* server has project hard or soft limit */
-	unsigned has_all_limit:1;	/* server has PBS_ALL limits set on it */
-	unsigned has_prime_queue:1;	/* server has a primetime queue */
-	unsigned has_ded_queue:1;	/* server has a dedtime queue */
-	unsigned has_nonprime_queue:1;	/* server has a non primetime queue */
-	unsigned node_group_enable:1;	/* is node grouping enabled */
-	unsigned has_nodes_assoc_queue:1; /* nodes are associates with queues */
-	unsigned has_multi_vnode:1;	/* server has at least one multi-vnoded MOM  */
-	unsigned has_runjob_hook:1;	/* server has at least 1 runjob hook enabled */
-	unsigned eligible_time_enable:1;/* controls if we accrue eligible_time  */
-	unsigned provision_enable:1;	/* controls if provisioning occurs */
-	unsigned power_provisioning:1;	/* controls if power provisioning occurs */
-	unsigned use_hard_duration:1;	/* use hard duration when creating the calendar */
-	unsigned pset_metadata_stale:1;	/* The placement set meta data is stale and needs to be regenerated before the next use */
-	char *name;			/* name of server */
+	bool has_soft_limit;	/* server has a soft user/grp limit set */
+	bool has_hard_limit;	/* server has a hard user/grp limit set */
+	bool has_mult_express;	/* server has multiple express queues */
+	bool has_user_limit;	/* server has user hard or soft limit */
+	bool has_grp_limit;	/* server has group hard or soft limit */
+	bool has_proj_limit;	/* server has project hard or soft limit */
+	bool has_all_limit;	/* server has PBS_ALL limits set on it */
+	bool has_prime_queue;	/* server has a primetime queue */
+	bool has_ded_queue;	/* server has a dedtime queue */
+	bool has_nonprime_queue;	/* server has a non primetime queue */
+	bool node_group_enable;	/* is node grouping enabled */
+	bool has_nodes_assoc_queue; /* nodes are associates with queues */
+	bool has_multi_vnode;	/* server has at least one multi-vnoded MOM  */
+	bool has_runjob_hook;	/* server has at least 1 runjob hook enabled */
+	bool eligible_time_enable;/* controls if we accrue eligible_time  */
+	bool provision_enable;	/* controls if provisioning occurs */
+	bool power_provisioning;	/* controls if power provisioning occurs */
+	bool use_hard_duration;	/* use hard duration when creating the calendar */
+	bool pset_metadata_stale;	/* The placement set meta data is stale and needs to be regenerated before the next use */
 	struct schd_resource *res;	/* list of resources */
 	void *liminfo;			/* limit storage information */
 	int num_queues;			/* number of queues that reside on the server */
@@ -489,22 +480,22 @@ struct server_info
 
 struct queue_info
 {
-	unsigned is_started:1;		/* is queue started */
-	unsigned is_exec:1;		/* is the queue an execution queue */
-	unsigned is_route:1;		/* is the queue a routing queue */
-	unsigned is_ok_to_run:1;	/* is it ok to run jobs in this queue */
-	unsigned is_ded_queue:1;	/* only jobs in dedicated time */
-	unsigned is_prime_queue:1;	/* only run jobs in primetime */
-	unsigned is_nonprime_queue:1;	/* only run jobs in nonprimetime */
-	unsigned has_nodes:1;		/* does this queue have nodes assoc with it */
-	unsigned has_soft_limit:1;	/* queue has a soft user/grp limit set */
-	unsigned has_hard_limit:1;	/* queue has a hard user/grp limit set */
-	unsigned is_peer_queue:1;	/* queue is a peer queue */
-	unsigned has_resav_limit:1;	/* queue has resources_available limits */
-	unsigned has_user_limit:1;	/* queue has user hard or soft limit */
-	unsigned has_grp_limit:1;	/* queue has group hard or soft limit */
-	unsigned has_proj_limit:1;	/* queue has project hard or soft limit */
-	unsigned has_all_limit:1;	/* queue has PBS_ALL limits set on it */
+	bool is_started;		/* is queue started */
+	bool is_exec;		/* is the queue an execution queue */
+	bool is_route;		/* is the queue a routing queue */
+	bool is_ok_to_run;	/* is it ok to run jobs in this queue */
+	bool is_ded_queue;	/* only jobs in dedicated time */
+	bool is_prime_queue;	/* only run jobs in primetime */
+	bool is_nonprime_queue;	/* only run jobs in nonprimetime */
+	bool has_nodes;		/* does this queue have nodes assoc with it */
+	bool has_soft_limit;	/* queue has a soft user/grp limit set */
+	bool has_hard_limit;	/* queue has a hard user/grp limit set */
+	bool is_peer_queue;	/* queue is a peer queue */
+	bool has_resav_limit;	/* queue has resources_available limits */
+	bool has_user_limit;	/* queue has user hard or soft limit */
+	bool has_grp_limit;	/* queue has group hard or soft limit */
+	bool has_proj_limit;	/* queue has project hard or soft limit */
+	bool has_all_limit;	/* queue has PBS_ALL limits set on it */
 	struct server_info *server;	/* server where queue resides */
 	char *name;			/* queue name */
 	state_count sc;			/* number of jobs in different states */
@@ -516,9 +507,9 @@ struct queue_info
 	/* localmod 034 */
 	time_t max_borrow;		/* longest job that can borrow CPUs */
 	/* localmod 038 */
-	unsigned is_topjob_set_aside:1; /* draws topjobs from per_queues_topjobs */
+	bool is_topjob_set_aside; /* draws topjobs from per_queues_topjobs */
 	/* localmod 040 */
-	unsigned ignore_nodect_sort:1; /* job_sort_key nodect ignored in this queue */
+	bool ignore_nodect_sort; /* job_sort_key nodect ignored in this queue */
 #endif
 	int num_nodes;		/* number of nodes associated with queue */
 	struct schd_resource *qres;	/* list of resources on the queue */
@@ -550,32 +541,32 @@ struct queue_info
 
 struct job_info
 {
-	unsigned is_queued:1;		/* state booleans */
-	unsigned is_running:1;
-	unsigned is_held:1;
-	unsigned is_waiting:1;
-	unsigned is_transit:1;
-	unsigned is_exiting:1;
-	unsigned is_suspended:1;
-	unsigned is_susp_sched:1;	/* job is suspended by scheduler */
-	unsigned is_userbusy:1;
-	unsigned is_begin:1;		/* job array 'B' state */
-	unsigned is_expired:1;		/* 'X' pseudo state for simulated job end */
-	unsigned is_checkpointed:1;	/* job has been checkpointed */
+	bool is_queued;		/* state booleans */
+	bool is_running;
+	bool is_held;
+	bool is_waiting;
+	bool is_transit;
+	bool is_exiting;
+	bool is_suspended;
+	bool is_susp_sched;	/* job is suspended by scheduler */
+	bool is_userbusy;
+	bool is_begin;		/* job array 'B' state */
+	bool is_expired;		/* 'X' pseudo state for simulated job end */
+	bool is_checkpointed;	/* job has been checkpointed */
 
-	unsigned can_not_preempt:1;	/* this job can not be preempted */
+	bool can_not_preempt;	/* this job can not be preempted */
 
-	unsigned can_checkpoint:1;    /* this job can be checkpointed */
-	unsigned can_requeue:1;       /* this job can be requeued */
-	unsigned can_suspend:1;       /* this job can be suspended */
+	bool can_checkpoint;	/* this job can be checkpointed */
+	bool can_requeue;	/* this job can be requeued */
+	bool can_suspend;	/* this job can be suspended */
 
-	unsigned is_starving:1;		/* job has waited passed starvation time */
-	unsigned is_array:1;		/* is the job a job array object */
-	unsigned is_subjob:1;		/* is a subjob of a job array */
+	bool is_starving;		/* job has waited passed starvation time */
+	bool is_array;		/* is the job a job array object */
+	bool is_subjob;		/* is a subjob of a job array */
 
-	unsigned is_provisioning:1;	/* job is provisioning */
-	unsigned is_preempted:1;	/* job is preempted */
-	unsigned topjob_ineligible:1;	/* Job is ineligible to be a top job */
+	bool is_provisioning;	/* job is provisioning */
+	bool is_preempted;	/* job is preempted */
+	bool topjob_ineligible;	/* Job is ineligible to be a top job */
 
 	char *job_name;			/* job name attribute (qsub -N) */
 	char *comment;			/* comment field of job */
@@ -633,29 +624,30 @@ struct job_info
 
 struct node_info
 {
-	unsigned is_down:1;		/* node is down */
-	unsigned is_free:1;		/* node is free to run a job */
-	unsigned is_offline:1;	/* node is off-line */
-	unsigned is_unknown:1;	/* node is in an unknown state */
-	unsigned is_exclusive:1;	/* node is running in exclusive mode */
-	unsigned is_job_exclusive:1;	/* node is running in job-exclusive mode */
-	unsigned is_resv_exclusive:1;	/* node is reserved exclusively */
-	unsigned is_sharing:1;	/* node is running in job-sharing mode */
-	unsigned is_busy:1;		/* load on node is too high to schedule */
-	unsigned is_job_busy:1;	/* ntype = cluster all vp's allocated */
-	unsigned is_stale:1;		/* node is unknown by mom */
-	unsigned is_maintenance:1;	/* node is in maintenance */
+	public:
+	bool is_down;		/* node is down */
+	bool is_free;		/* node is free to run a job */
+	bool is_offline;	/* node is off-line */
+	bool is_unknown;	/* node is in an unknown state */
+	bool is_exclusive;	/* node is running in exclusive mode */
+	bool is_job_exclusive;	/* node is running in job-exclusive mode */
+	bool is_resv_exclusive;	/* node is reserved exclusively */
+	bool is_sharing;	/* node is running in job-sharing mode */
+	bool is_busy;		/* load on node is too high to schedule */
+	bool is_job_busy;	/* ntype = cluster all vp's allocated */
+	bool is_stale;		/* node is unknown by mom */
+	bool is_maintenance;	/* node is in maintenance */
 
 	/* license types */
-	unsigned lic_lock:1;		/* node has a node locked license */
+	bool lic_lock;		/* node has a node locked license */
 
-	unsigned has_hard_limit:1;	/* node has a hard user/grp limit set */
-	unsigned no_multinode_jobs:1;	/* do not run multnode jobs on this node */
+	bool has_hard_limit;	/* node has a hard user/grp limit set */
+	bool no_multinode_jobs;	/* do not run multnode jobs on this node */
 
-	unsigned resv_enable:1;	/* is this node available for reservations */
-	unsigned provision_enable:1;	/* is this node available for provisioning */
+	bool resv_enable;	/* is this node available for reservations */
+	bool provision_enable;	/* is this node available for provisioning */
 
-	unsigned is_provisioning:1;	/* node is provisioning */
+	bool is_provisioning;	/* node is provisioning */
 	/* node in wait-provision is considered as node in provisioning state
 	 * nodes in provisioning and wait provisioning states cannot run job
 	 * NOTE:
@@ -664,10 +656,10 @@ struct node_info
 	 * since we can't make the other job wait. In another cycle, the node is
 	 * either free or provisioning, then, the case is clear.
 	 */
-	unsigned is_multivnoded:1;	/* multi vnode */
-	unsigned power_provisioning:1;	/* can this node can power provision */
-	unsigned is_sleeping:1;		/* node put to sleep through power on/off or ramp rate limit */
-	unsigned has_ghost_job:1;	/* race condition occurred: recalculate resources_assigned */
+	bool is_multivnoded;	/* multi vnode */
+	bool power_provisioning;	/* can this node can power provision */
+	bool is_sleeping;		/* node put to sleep through power on/off or ramp rate limit */
+	bool has_ghost_job;	/* race condition occurred: recalculate resources_assigned */
 
 	/* sharing */
 	enum vnode_sharing sharing;	/* deflt or forced sharing/excl of the node */
@@ -734,8 +726,8 @@ struct node_info
 
 struct resv_info
 {
-	unsigned is_standing:1;		/* set to 1 for a standing reservation */
-	unsigned is_running:1;		/* the reservation is running (not necessarily in the running state) */
+	bool is_standing;		/* set to 1 for a standing reservation */
+	bool is_running;		/* the reservation is running (not necessarily in the running state) */
 	char *queuename;		/* the name of the queue */
 	char *rrule;			/* recurrence rule for standing reservations */
 	char *execvnodes_seq;		/* sequence of execvnodes for standing resvs */
@@ -762,20 +754,21 @@ struct resv_info
 };
 
 /* resource reservation - used for both jobs and advanced reservations */
-struct resource_resv 
+class resource_resv 
 {
-	unsigned can_not_run:1;   /* res resv can not run this cycle */
-	unsigned can_never_run:1; /* res resv can never run and will be deleted */
-	unsigned can_not_fit:1;   /* res resv can not fit into node group */
-	unsigned is_invalid:1;    /* res resv is invalid and will be ignored */
-	unsigned is_peer_ob:1;    /* res resv can from a peer server */
+	public:
+	bool can_not_run;   /* res resv can not run this cycle */
+	bool can_never_run; /* res resv can never run and will be deleted */
+	bool can_not_fit;   /* res resv can not fit into node group */
+	bool is_invalid;    /* res resv is invalid and will be ignored */
+	bool is_peer_ob;    /* res resv can from a peer server */
 
-	unsigned is_job:1;	       /* res resv is a job */
-	unsigned is_prov_needed:1;   /* res resv requires provisioning */
-	unsigned is_shrink_to_fit:1; /* res resv is a shrink-to-fit job */
-	unsigned is_resv:1;	       /* res resv is an advanced reservation */
+	bool is_job;	       /* res resv is a job */
+	bool is_prov_needed;   /* res resv requires provisioning */
+	bool is_shrink_to_fit; /* res resv is a shrink-to-fit job */
+	bool is_resv;	       /* res resv is an advanced reservation */
 
-	unsigned will_use_multinode:1;	/* res resv will use multiple nodes */
+	bool will_use_multinode;	/* res resv will use multiple nodes */
 
 	const std::string name;		/* name of res resv */
 	char *user;			/* username of the owner of the res resv */
@@ -819,24 +812,24 @@ struct resource_resv
 	timed_event *run_event;		   /* run event in calendar */
 	timed_event *end_event;		   /* end event in calendar */
 
-	resource_resv(const char *rname);
+	resource_resv(const std::string& rname);
 	~resource_resv();
 };
 
 struct resource_type
 {
 	/* non consumable - used for selection only (e.g. arch) */
-	unsigned is_non_consumable:1;
-	unsigned is_string:1;
-	unsigned is_boolean:1; /* value == 1 for true and 0 for false */
+	bool is_non_consumable;
+	bool is_string;
+	bool is_boolean; /* value == 1 for true and 0 for false */
 
 	/* consumable - numeric resource which is consumed and may have a max limit */
-	unsigned is_consumable:1;
-	unsigned is_num:1;
-	unsigned is_long:1;
-	unsigned is_float:1;
-	unsigned is_size:1;	/* all sizes are converted into kb */
-	unsigned is_time:1;
+	bool is_consumable;
+	bool is_num;
+	bool is_long;
+	bool is_float;
+	bool is_size;	/* all sizes are converted into kb */
+	bool is_time;
 };
 
 struct schd_resource
@@ -877,14 +870,16 @@ struct resdef
 	unsigned int flags;		/* resource flags (see pbs_ifl.h) */
 };
 
-struct prev_job_info
+class prev_job_info
 {
+	public:
 	const std::string name;	/* name of job */
 	std::string entity_name;	/* fair share entity of job */
 	resource_req *resused;	/* resources used by the job */
 	prev_job_info(const std::string& pname, char *ename, resource_req *rused);
 	prev_job_info(const prev_job_info &);
 	prev_job_info(prev_job_info &&) noexcept;
+	prev_job_info& operator=(const prev_job_info&);
 	~prev_job_info();
 };
 
@@ -956,7 +951,7 @@ struct group_info
  */
 struct resresv_set
 {
-	unsigned can_not_run:1;		/* set can not run */
+	bool can_not_run;		/* set can not run */
 	schd_error *err;		/* reason why set can not run*/
 	char *user;			/* user of set, can be NULL */
 	char *group;			/* group of set, can be NULL */
@@ -969,8 +964,8 @@ struct resresv_set
 
 struct node_partition
 {
-	unsigned int ok_break:1;	/* OK to break up chunks on this node part */
-	unsigned int excl:1;		/* partition should be allocated exclusively */
+	bool ok_break;	/* OK to break up chunks on this node part */
+	bool excl;		/* partition should be allocated exclusively */
 	char *name;			/* res_name=res_val */
 	/* name of resource and value which define the node partition */
 	resdef *def;
@@ -1084,8 +1079,8 @@ struct peer_queue
 
 struct nspec
 {
-	unsigned int end_of_chunk:1; /* used for putting parens into the execvnode */
-	unsigned int go_provision:1; /* used to mark a node to be provisioned */
+	bool end_of_chunk; /* used for putting parens into the execvnode */
+	bool go_provision; /* used to mark a node to be provisioned */
 	int seq_num;			/* sequence number of chunk */
 	int sub_seq_num;		/* sub sequence number for sort stabilization */
 	node_info *ninfo;
@@ -1095,7 +1090,7 @@ struct nspec
 
 struct nameval
 {
-	unsigned int is_set:1;
+	bool is_set;
 	char *str;
 	int value;
 };
@@ -1106,39 +1101,39 @@ struct config
 	 * prime_* is the prime time setting
 	 * non_prime_* is the non-prime setting
 	 */
-	unsigned prime_rr	:1;	/* round robin through queues*/
-	unsigned non_prime_rr	:1;
-	unsigned prime_bq	:1;	/* by queue */
-	unsigned non_prime_bq	:1;
-	unsigned prime_sf	:1;	/* strict fifo */
-	unsigned non_prime_sf	:1;
-	unsigned prime_so	:1;	/* strict ordering */
-	unsigned non_prime_so	:1;
-	unsigned prime_fs	:1;	/* fair share */
-	unsigned non_prime_fs	:1;
-	unsigned prime_hsv	:1;	/* help starving jobs */
-	unsigned non_prime_hsv:1;
-	unsigned prime_bf	:1;	/* back filling */
-	unsigned non_prime_bf	:1;
-	unsigned prime_sn	:1;	/* sort nodes by priority */
-	unsigned non_prime_sn	:1;
-	unsigned prime_bp	:1;	/* backfill around prime time */
-	unsigned non_prime_bp	:1;	/* backfill around non prime time */
-	unsigned prime_pre	:1;	/* preemptive scheduling */
-	unsigned non_prime_pre:1;
-	unsigned update_comments:1;	/* should we update comments or not */
-	unsigned prime_exempt_anytime_queues:1; /* backfill affects anytime queues */
-	unsigned assign_ssinodes:1;	/* assign the ssinodes resource */
-	unsigned preempt_starving:1;	/* once jobs become starving, it can preempt */
-	unsigned preempt_fairshare:1; /* normal jobs can preempt over usage jobs */
-	unsigned dont_preempt_starving:1; /* don't preempt staving jobs */
-	unsigned enforce_no_shares:1;	/* jobs with 0 shares don't run */
-	unsigned node_sort_unused:1;	/* node sorting by unused/assigned is used */
-	unsigned resv_conf_ignore:1;  /* if we want to ignore dedicated time when confirming reservations.  Move to enum if ever expanded */
-	unsigned allow_aoe_calendar:1;        /* allow jobs requesting aoe in calendar*/
+	bool prime_rr;		/* round robin through queues*/
+	bool non_prime_rr;
+	bool prime_bq;		/* by queue */
+	bool non_prime_bq;
+	bool prime_sf;		/* strict fifo */
+	bool non_prime_sf;
+	bool prime_so;		/* strict ordering */
+	bool non_prime_so;
+	bool prime_fs;		/* fair share */
+	bool non_prime_fs;
+	bool prime_hsv;		/* help starving jobs */
+	bool non_prime_hsv;
+	bool prime_bf;		/* back filling */
+	bool non_prime_bf;
+	bool prime_sn;		/* sort nodes by priority */
+	bool non_prime_sn;
+	bool prime_bp;		/* backfill around prime time */
+	bool non_prime_bp;	/* backfill around non prime time */
+	bool prime_pre;		/* preemptive scheduling */
+	bool non_prime_pre;
+	bool update_comments;	/* should we update comments or not */
+	bool prime_exempt_anytime_queues; /* backfill affects anytime queues */
+	bool assign_ssinodes;	/* assign the ssinodes resource */
+	bool preempt_starving;	/* once jobs become starving, it can preempt */
+	bool preempt_fairshare; /* normal jobs can preempt over usage jobs */
+	bool dont_preempt_starving; /* don't preempt staving jobs */
+	bool enforce_no_shares;	/* jobs with 0 shares don't run */
+	bool node_sort_unused;	/* node sorting by unused/assigned is used */
+	bool resv_conf_ignore;  /* if we want to ignore dedicated time when confirming reservations.  Move to enum if ever expanded */
+	bool allow_aoe_calendar;        /* allow jobs requesting aoe in calendar*/
 #ifdef NAS /* localmod 034 */
-	unsigned prime_sto	:1;	/* shares_track_only--no enforce shares */
-	unsigned non_prime_sto:1;
+	bool prime_sto	;	/* shares_track_only--no enforce shares */
+	bool non_prime_sto;
 #endif /* localmod 034 */
 
 	struct sort_info *prime_sort;		/* prime time sort */
@@ -1200,7 +1195,7 @@ struct rescheck
 
 struct event_list
 {
-	unsigned int eol:1;		/* we've reached the end of time */
+	bool eol;		/* we've reached the end of time */
 	timed_event *events;		/* the calendar of events */
 	timed_event *next_event;	/* the next event to be performed */
 	timed_event *first_run_event;	/* The first run event in the calendar */
@@ -1209,7 +1204,7 @@ struct event_list
 
 struct timed_event
 {
-	unsigned int disabled:1;	/* event is disabled - skip it in simulation */
+	bool disabled;	/* event is disabled - skip it in simulation */
 	std::string name;	
 	enum timed_event_types event_type;
 	time_t event_time;

--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -52,6 +52,8 @@
 #ifndef	_DATA_TYPES_H
 #define	_DATA_TYPES_H
 
+#include <vector>
+#include <string>
 
 #include <time.h>
 #include <pbs_ifl.h>
@@ -65,9 +67,12 @@
 #include "site_queue.h"
 #endif
 
+<<<<<<< HEAD
 #include <unordered_map>
 #include <string>
 
+=======
+>>>>>>> 5747272f... Partial C++ refactor of resource_resv and node_info
 struct server_info;
 struct state_count;
 struct queue_info;
@@ -587,12 +592,11 @@ struct job_info
 	unsigned int preempt_status;	/* preempt levels (bitfield) */
 	unsigned int preempt;			/* preempt priority */
 	int peer_sd;			/* connection descriptor to peer server */
-	long long job_id;		/* numeric portion of the job id */
 	resource_req *resused;		/* a list of resources used */
 	group_info *ginfo;		/* the fair share node for the owner */
 
 	/* subjob information */
-	char *array_id;			/* job id of job array if we are a subjob */
+	std::string array_id;		/* job id of job array if we are a subjob */
 	int array_index;		/* array index if we are a subjob */
 	resource_resv *parent_job;	/* pointer to the parent array job */
 
@@ -627,17 +631,6 @@ struct job_info
 #endif
 };
 
-
-struct node_scratch
-{
-	unsigned int visited:1;		/* visited this node for this type of chunk*/
-	unsigned int scattered:1;	/* node allocated to a v/scatter request */
-	unsigned int ineligible:1;	/* node is ineligible for the job */
-	unsigned int to_be_sorted:1;	/* used for sorting of the nodes while
-					 * altering a reservation.
-					 */
-};
-
 struct node_info
 {
 	unsigned is_down:1;		/* node is down */
@@ -652,9 +645,6 @@ struct node_info
 	unsigned is_job_busy:1;	/* ntype = cluster all vp's allocated */
 	unsigned is_stale:1;		/* node is unknown by mom */
 	unsigned is_maintenance:1;	/* node is in maintenance */
-
-	/* node types */
-	unsigned is_pbsnode:1;	/* this is a PBS node */
 
 	/* license types */
 	unsigned lic_lock:1;		/* node has a node locked license */
@@ -682,7 +672,7 @@ struct node_info
 	/* sharing */
 	enum vnode_sharing sharing;	/* deflt or forced sharing/excl of the node */
 
-	char *name;			/* name of the node */
+	const std::string name;		/* name of the node */
 	char *mom;			/* host name on which mom resides */
 
 	char **jobs;			/* the name of the jobs currently on the node */
@@ -737,6 +727,9 @@ struct node_info
 	int node_ind;			/* node's index into sinfo->unordered_nodes */
 	node_partition **np_arr;	/* array of node partitions node is in */
 	char *svr_inst_id;
+
+	node_info(const std::string& name);
+	~node_info();
 };
 
 struct resv_info
@@ -769,22 +762,22 @@ struct resv_info
 };
 
 /* resource reservation - used for both jobs and advanced reservations */
-struct resource_resv
+struct resource_resv 
 {
-	unsigned can_not_run : 1;	/* res resv can not run this cycle */
-	unsigned can_never_run : 1;	/* res resv can never run and will be deleted */
-	unsigned can_not_fit : 1;	/* res resv can not fit into node group */
-	unsigned is_invalid : 1;	/* res resv is invalid and will be ignored */
-	unsigned is_peer_ob : 1;	/* res resv can from a peer server */
+	unsigned can_not_run:1;   /* res resv can not run this cycle */
+	unsigned can_never_run:1; /* res resv can never run and will be deleted */
+	unsigned can_not_fit:1;   /* res resv can not fit into node group */
+	unsigned is_invalid:1;    /* res resv is invalid and will be ignored */
+	unsigned is_peer_ob:1;    /* res resv can from a peer server */
 
-	unsigned is_job : 1;		/* res resv is a job */
-	unsigned is_prov_needed : 1;	/* res resv requires provisioning */
-	unsigned is_shrink_to_fit : 1;	/* res resv is a shrink-to-fit job */
-	unsigned is_resv : 1;		/* res resv is an advanced reservation */
+	unsigned is_job:1;	       /* res resv is a job */
+	unsigned is_prov_needed:1;   /* res resv requires provisioning */
+	unsigned is_shrink_to_fit:1; /* res resv is a shrink-to-fit job */
+	unsigned is_resv:1;	       /* res resv is an advanced reservation */
 
 	unsigned will_use_multinode:1;	/* res resv will use multiple nodes */
 
-	char *name;			/* name of res resv */
+	const std::string name;		/* name of res resv */
 	char *user;			/* username of the owner of the res resv */
 	char *group;			/* exec group of owner of res resv */
 	char *project;			/* exec project of owner of res resv */
@@ -825,6 +818,9 @@ struct resource_resv
 	int resresv_ind;		   /* resource_resv index in all_resresv array */
 	timed_event *run_event;		   /* run event in calendar */
 	timed_event *end_event;		   /* end event in calendar */
+
+	resource_resv(const char *rname);
+	~resource_resv();
 };
 
 struct resource_type
@@ -883,9 +879,13 @@ struct resdef
 
 struct prev_job_info
 {
-	char *name;			/* name of job */
-	char *entity_name;		/* fair share entity of job */
+	const std::string name;	/* name of job */
+	std::string entity_name;	/* fair share entity of job */
 	resource_req *resused;	/* resources used by the job */
+	prev_job_info(const std::string& pname, char *ename, resource_req *rused);
+	prev_job_info(const prev_job_info &);
+	prev_job_info(prev_job_info &&) noexcept;
+	~prev_job_info();
 };
 
 struct counts
@@ -1210,7 +1210,7 @@ struct event_list
 struct timed_event
 {
 	unsigned int disabled:1;	/* event is disabled - skip it in simulation */
-	const char *name;			/* [reference] name of event */
+	std::string name;	
 	enum timed_event_types event_type;
 	time_t event_time;
 	event_ptr_t *event_ptr;

--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -192,7 +192,7 @@ struct th_data_nd_eligible
 
 struct th_data_dup_nd_info
 {
-	bool error;
+	bool error:1;
 	node_info **onodes;
 	node_info **nnodes;
 	server_info *nsinfo;
@@ -203,7 +203,7 @@ struct th_data_dup_nd_info
 
 struct th_data_query_ninfo
 {
-	bool error;
+	bool error:1;
 	struct batch_status *nodes;
 	server_info *sinfo;
 	node_info **oarr;
@@ -220,7 +220,7 @@ struct th_data_free_ninfo
 
 struct th_data_dup_resresv
 {
-	bool error;
+	bool error:1;
 	resource_resv **oresresv_arr;
 	resource_resv **nresresv_arr;
 	server_info *nsinfo;
@@ -231,7 +231,7 @@ struct th_data_dup_resresv
 
 struct th_data_query_jinfo
 {
-	bool error;
+	bool error:1;
 	struct batch_status *jobs;
 	server_info *sinfo;
 	queue_info *qinfo;
@@ -279,13 +279,13 @@ struct state_count
 
 struct place
 {
-	bool free;		/* free placement */
-	bool pack;		/* pack placement */
-	bool scatter;		/* scatter placement */
-	bool vscatter;	/* scatter by vnode */
-	bool excl;		/* need nodes exclusively */
-	bool exclhost;	/* need whole hosts exclusively */
-	bool share;		/* will share nodes */
+	bool free:1;		/* free placement */
+	bool pack:1;		/* pack placement */
+	bool scatter:1;		/* scatter placement */
+	bool vscatter:1;	/* scatter by vnode */
+	bool excl:1;		/* need nodes exclusively */
+	bool exclhost:1;	/* need whole hosts exclusively */
+	bool share:1;		/* will share nodes */
 
 	char *group;			/* resource to node group by */
 };
@@ -309,23 +309,23 @@ struct selspec
 /* for description of these bits, check the PBS admin guide or scheduler IDS */
 struct status
 {
-	bool round_robin;		/* Round robin around queues */
-	bool by_queue;		/* schedule per-queue */
-	bool strict_fifo;		/* deprecated */
-	bool strict_ordering;
-	bool fair_share;
-	bool help_starving_jobs;
-	bool backfill;
-	bool sort_nodes;
-	bool backfill_prime;
-	bool preempting;
+	bool round_robin:1;		/* Round robin around queues */
+	bool by_queue:1;		/* schedule per-queue */
+	bool strict_fifo:1;		/* deprecated */
+	bool strict_ordering:1;
+	bool fair_share:1;
+	bool help_starving_jobs:1;
+	bool backfill:1;
+	bool sort_nodes:1;
+	bool backfill_prime:1;
+	bool preempting:1;
 #ifdef NAS /* localmod 034 */
-	bool shares_track_only;
+	bool shares_track_only:1;
 #endif /* localmod 034 */
 
-	bool is_prime;
-	bool is_ded_time;
-	bool sync_fairshare_files;	/* sync fairshare files to disk */
+	bool is_prime:1;
+	bool is_ded_time:1;
+	bool sync_fairshare_files:1;	/* sync fairshare files to disk */
 
 	struct sort_info *sort_by;		/* job sorting */
 	struct sort_info *node_sort;		/* node sorting */
@@ -362,11 +362,11 @@ struct status
  */
 struct schedattrs
 {
-	bool do_not_span_psets;
-	bool only_explicit_psets;
-	bool preempt_targets_enable;
-	bool sched_preempt_enforce_resumption;
-	bool throughput_mode;
+	bool do_not_span_psets:1;
+	bool only_explicit_psets:1;
+	bool preempt_targets_enable:1;
+	bool sched_preempt_enforce_resumption:1;
+	bool throughput_mode:1;
 	long attr_update_period;
 	char *comment;
 	char *job_sort_formula;
@@ -386,25 +386,27 @@ struct schedattrs
 
 struct server_info
 {
-	bool has_soft_limit;	/* server has a soft user/grp limit set */
-	bool has_hard_limit;	/* server has a hard user/grp limit set */
-	bool has_mult_express;	/* server has multiple express queues */
-	bool has_user_limit;	/* server has user hard or soft limit */
-	bool has_grp_limit;	/* server has group hard or soft limit */
-	bool has_proj_limit;	/* server has project hard or soft limit */
-	bool has_all_limit;	/* server has PBS_ALL limits set on it */
-	bool has_prime_queue;	/* server has a primetime queue */
-	bool has_ded_queue;	/* server has a dedtime queue */
-	bool has_nonprime_queue;	/* server has a non primetime queue */
-	bool node_group_enable;	/* is node grouping enabled */
-	bool has_nodes_assoc_queue; /* nodes are associates with queues */
-	bool has_multi_vnode;	/* server has at least one multi-vnoded MOM  */
-	bool has_runjob_hook;	/* server has at least 1 runjob hook enabled */
-	bool eligible_time_enable;/* controls if we accrue eligible_time  */
-	bool provision_enable;	/* controls if provisioning occurs */
-	bool power_provisioning;	/* controls if power provisioning occurs */
-	bool use_hard_duration;	/* use hard duration when creating the calendar */
-	bool pset_metadata_stale;	/* The placement set meta data is stale and needs to be regenerated before the next use */
+	bool has_soft_limit:1;	/* server has a soft user/grp limit set */
+	bool has_hard_limit:1;	/* server has a hard user/grp limit set */
+	bool has_mult_express:1;	/* server has multiple express queues */
+	bool has_user_limit:1;	/* server has user hard or soft limit */
+	bool has_grp_limit:1;	/* server has group hard or soft limit */
+	bool has_proj_limit:1;	/* server has project hard or soft limit */
+	bool has_all_limit:1;	/* server has PBS_ALL limits set on it */
+	bool has_prime_queue:1;	/* server has a primetime queue */
+	bool has_ded_queue:1;	/* server has a dedtime queue */
+	bool has_nonprime_queue:1;	/* server has a non primetime queue */
+	bool node_group_enable:1;	/* is node grouping enabled */
+	bool has_nodes_assoc_queue:1; /* nodes are associates with queues */
+	bool has_multi_vnode:1;	/* server has at least one multi-vnoded MOM  */
+	bool has_runjob_hook:1;	/* server has at least 1 runjob hook enabled */
+	bool eligible_time_enable:1;/* controls if we accrue eligible_time  */
+	bool provision_enable:1;	/* controls if provisioning occurs */
+	bool power_provisioning:1;	/* controls if power provisioning occurs */
+	bool has_nonCPU_licenses:1;	/* server has non-CPU (e.g. socket-based) licenses */
+	bool use_hard_duration:1;	/* use hard duration when creating the calendar */
+	bool pset_metadata_stale:1;	/* The placement set meta data is stale and needs to be regenerated before the next use */
+	char *name;			/* name of server */
 	struct schd_resource *res;	/* list of resources */
 	void *liminfo;			/* limit storage information */
 	int num_queues;			/* number of queues that reside on the server */
@@ -480,22 +482,22 @@ struct server_info
 
 struct queue_info
 {
-	bool is_started;		/* is queue started */
-	bool is_exec;		/* is the queue an execution queue */
-	bool is_route;		/* is the queue a routing queue */
-	bool is_ok_to_run;	/* is it ok to run jobs in this queue */
-	bool is_ded_queue;	/* only jobs in dedicated time */
-	bool is_prime_queue;	/* only run jobs in primetime */
-	bool is_nonprime_queue;	/* only run jobs in nonprimetime */
-	bool has_nodes;		/* does this queue have nodes assoc with it */
-	bool has_soft_limit;	/* queue has a soft user/grp limit set */
-	bool has_hard_limit;	/* queue has a hard user/grp limit set */
-	bool is_peer_queue;	/* queue is a peer queue */
-	bool has_resav_limit;	/* queue has resources_available limits */
-	bool has_user_limit;	/* queue has user hard or soft limit */
-	bool has_grp_limit;	/* queue has group hard or soft limit */
-	bool has_proj_limit;	/* queue has project hard or soft limit */
-	bool has_all_limit;	/* queue has PBS_ALL limits set on it */
+	bool is_started:1;		/* is queue started */
+	bool is_exec:1;		/* is the queue an execution queue */
+	bool is_route:1;		/* is the queue a routing queue */
+	bool is_ok_to_run:1;	/* is it ok to run jobs in this queue */
+	bool is_ded_queue:1;	/* only jobs in dedicated time */
+	bool is_prime_queue:1;	/* only run jobs in primetime */
+	bool is_nonprime_queue:1;	/* only run jobs in nonprimetime */
+	bool has_nodes:1;		/* does this queue have nodes assoc with it */
+	bool has_soft_limit:1;	/* queue has a soft user/grp limit set */
+	bool has_hard_limit:1;	/* queue has a hard user/grp limit set */
+	bool is_peer_queue:1;	/* queue is a peer queue */
+	bool has_resav_limit:1;	/* queue has resources_available limits */
+	bool has_user_limit:1;	/* queue has user hard or soft limit */
+	bool has_grp_limit:1;	/* queue has group hard or soft limit */
+	bool has_proj_limit:1;	/* queue has project hard or soft limit */
+	bool has_all_limit:1;	/* queue has PBS_ALL limits set on it */
 	struct server_info *server;	/* server where queue resides */
 	char *name;			/* queue name */
 	state_count sc;			/* number of jobs in different states */
@@ -507,9 +509,9 @@ struct queue_info
 	/* localmod 034 */
 	time_t max_borrow;		/* longest job that can borrow CPUs */
 	/* localmod 038 */
-	bool is_topjob_set_aside; /* draws topjobs from per_queues_topjobs */
+	bool is_topjob_set_aside:1; /* draws topjobs from per_queues_topjobs */
 	/* localmod 040 */
-	bool ignore_nodect_sort; /* job_sort_key nodect ignored in this queue */
+	bool ignore_nodect_sort:1; /* job_sort_key nodect ignored in this queue */
 #endif
 	int num_nodes;		/* number of nodes associated with queue */
 	struct schd_resource *qres;	/* list of resources on the queue */
@@ -539,34 +541,35 @@ struct queue_info
 	char *partition;		/* partition to which queue belongs to */
 };
 
-struct job_info
+struct 
+job_info
 {
-	bool is_queued;		/* state booleans */
-	bool is_running;
-	bool is_held;
-	bool is_waiting;
-	bool is_transit;
-	bool is_exiting;
-	bool is_suspended;
-	bool is_susp_sched;	/* job is suspended by scheduler */
-	bool is_userbusy;
-	bool is_begin;		/* job array 'B' state */
-	bool is_expired;		/* 'X' pseudo state for simulated job end */
-	bool is_checkpointed;	/* job has been checkpointed */
+	bool is_queued:1;		/* state booleans */
+	bool is_running:1;
+	bool is_held:1;
+	bool is_waiting:1;
+	bool is_transit:1;
+	bool is_exiting:1;
+	bool is_suspended:1;
+	bool is_susp_sched:1;	/* job is suspended by scheduler */
+	bool is_userbusy:1;
+	bool is_begin:1;		/* job array 'B' state */
+	bool is_expired:1;		/* 'X' pseudo state for simulated job end */
+	bool is_checkpointed:1;	/* job has been checkpointed */
 
-	bool can_not_preempt;	/* this job can not be preempted */
+	bool can_not_preempt:1;	/* this job can not be preempted */
 
-	bool can_checkpoint;	/* this job can be checkpointed */
-	bool can_requeue;	/* this job can be requeued */
-	bool can_suspend;	/* this job can be suspended */
+	bool can_checkpoint:1;	/* this job can be checkpointed */
+	bool can_requeue:1;	/* this job can be requeued */
+	bool can_suspend:1;	/* this job can be suspended */
 
-	bool is_starving;		/* job has waited passed starvation time */
-	bool is_array;		/* is the job a job array object */
-	bool is_subjob;		/* is a subjob of a job array */
+	bool is_starving:1;		/* job has waited passed starvation time */
+	bool is_array:1;		/* is the job a job array object */
+	bool is_subjob:1;		/* is a subjob of a job array */
 
-	bool is_provisioning;	/* job is provisioning */
-	bool is_preempted;	/* job is preempted */
-	bool topjob_ineligible;	/* Job is ineligible to be a top job */
+	bool is_provisioning:1;	/* job is provisioning */
+	bool is_preempted:1;	/* job is preempted */
+	bool topjob_ineligible:1;	/* Job is ineligible to be a top job */
 
 	char *job_name;			/* job name attribute (qsub -N) */
 	char *comment;			/* comment field of job */
@@ -625,29 +628,29 @@ struct job_info
 struct node_info
 {
 	public:
-	bool is_down;		/* node is down */
-	bool is_free;		/* node is free to run a job */
-	bool is_offline;	/* node is off-line */
-	bool is_unknown;	/* node is in an unknown state */
-	bool is_exclusive;	/* node is running in exclusive mode */
-	bool is_job_exclusive;	/* node is running in job-exclusive mode */
-	bool is_resv_exclusive;	/* node is reserved exclusively */
-	bool is_sharing;	/* node is running in job-sharing mode */
-	bool is_busy;		/* load on node is too high to schedule */
-	bool is_job_busy;	/* ntype = cluster all vp's allocated */
-	bool is_stale;		/* node is unknown by mom */
-	bool is_maintenance;	/* node is in maintenance */
+	bool is_down:1;		/* node is down */
+	bool is_free:1;		/* node is free to run a job */
+	bool is_offline:1;	/* node is off-line */
+	bool is_unknown:1;	/* node is in an unknown state */
+	bool is_exclusive:1;	/* node is running in exclusive mode */
+	bool is_job_exclusive:1;	/* node is running in job-exclusive mode */
+	bool is_resv_exclusive:1;	/* node is reserved exclusively */
+	bool is_sharing:1;	/* node is running in job-sharing mode */
+	bool is_busy:1;		/* load on node is too high to schedule */
+	bool is_job_busy:1;	/* ntype = cluster all vp's allocated */
+	bool is_stale:1;		/* node is unknown by mom */
+	bool is_maintenance:1;	/* node is in maintenance */
 
 	/* license types */
-	bool lic_lock;		/* node has a node locked license */
+	bool lic_lock:1;		/* node has a node locked license */
 
-	bool has_hard_limit;	/* node has a hard user/grp limit set */
-	bool no_multinode_jobs;	/* do not run multnode jobs on this node */
+	bool has_hard_limit:1;	/* node has a hard user/grp limit set */
+	bool no_multinode_jobs:1;	/* do not run multnode jobs on this node */
 
-	bool resv_enable;	/* is this node available for reservations */
-	bool provision_enable;	/* is this node available for provisioning */
+	bool resv_enable:1;	/* is this node available for reservations */
+	bool provision_enable:1;	/* is this node available for provisioning */
 
-	bool is_provisioning;	/* node is provisioning */
+	bool is_provisioning:1;	/* node is provisioning */
 	/* node in wait-provision is considered as node in provisioning state
 	 * nodes in provisioning and wait provisioning states cannot run job
 	 * NOTE:
@@ -656,10 +659,10 @@ struct node_info
 	 * since we can't make the other job wait. In another cycle, the node is
 	 * either free or provisioning, then, the case is clear.
 	 */
-	bool is_multivnoded;	/* multi vnode */
-	bool power_provisioning;	/* can this node can power provision */
-	bool is_sleeping;		/* node put to sleep through power on/off or ramp rate limit */
-	bool has_ghost_job;	/* race condition occurred: recalculate resources_assigned */
+	bool is_multivnoded:1;	/* multi vnode */
+	bool power_provisioning:1;	/* can this node can power provision */
+	bool is_sleeping:1;		/* node put to sleep through power on/off or ramp rate limit */
+	bool has_ghost_job:1;	/* race condition occurred: recalculate resources_assigned */
 
 	/* sharing */
 	enum vnode_sharing sharing;	/* deflt or forced sharing/excl of the node */
@@ -726,8 +729,8 @@ struct node_info
 
 struct resv_info
 {
-	bool is_standing;		/* set to 1 for a standing reservation */
-	bool is_running;		/* the reservation is running (not necessarily in the running state) */
+	bool is_standing:1;		/* set to 1 for a standing reservation */
+	bool is_running:1;		/* the reservation is running (not necessarily in the running state) */
 	char *queuename;		/* the name of the queue */
 	char *rrule;			/* recurrence rule for standing reservations */
 	char *execvnodes_seq;		/* sequence of execvnodes for standing resvs */
@@ -757,18 +760,18 @@ struct resv_info
 class resource_resv 
 {
 	public:
-	bool can_not_run;   /* res resv can not run this cycle */
-	bool can_never_run; /* res resv can never run and will be deleted */
-	bool can_not_fit;   /* res resv can not fit into node group */
-	bool is_invalid;    /* res resv is invalid and will be ignored */
-	bool is_peer_ob;    /* res resv can from a peer server */
+	bool can_not_run:1;   /* res resv can not run this cycle */
+	bool can_never_run:1; /* res resv can never run and will be deleted */
+	bool can_not_fit:1;   /* res resv can not fit into node group */
+	bool is_invalid:1;    /* res resv is invalid and will be ignored */
+	bool is_peer_ob:1;    /* res resv can from a peer server */
 
-	bool is_job;	       /* res resv is a job */
-	bool is_prov_needed;   /* res resv requires provisioning */
-	bool is_shrink_to_fit; /* res resv is a shrink-to-fit job */
-	bool is_resv;	       /* res resv is an advanced reservation */
+	bool is_job:1;	       /* res resv is a job */
+	bool is_prov_needed:1;   /* res resv requires provisioning */
+	bool is_shrink_to_fit:1; /* res resv is a shrink-to-fit job */
+	bool is_resv:1;	       /* res resv is an advanced reservation */
 
-	bool will_use_multinode;	/* res resv will use multiple nodes */
+	bool will_use_multinode:1;	/* res resv will use multiple nodes */
 
 	const std::string name;		/* name of res resv */
 	char *user;			/* username of the owner of the res resv */
@@ -819,17 +822,17 @@ class resource_resv
 struct resource_type
 {
 	/* non consumable - used for selection only (e.g. arch) */
-	bool is_non_consumable;
-	bool is_string;
-	bool is_boolean; /* value == 1 for true and 0 for false */
+	bool is_non_consumable:1;
+	bool is_string:1;
+	bool is_boolean:1; /* value == 1 for true and 0 for false */
 
 	/* consumable - numeric resource which is consumed and may have a max limit */
-	bool is_consumable;
-	bool is_num;
-	bool is_long;
-	bool is_float;
-	bool is_size;	/* all sizes are converted into kb */
-	bool is_time;
+	bool is_consumable:1;
+	bool is_num:1;
+	bool is_long:1;
+	bool is_float:1;
+	bool is_size:1;	/* all sizes are converted into kb */
+	bool is_time:1;
 };
 
 struct schd_resource
@@ -951,7 +954,7 @@ struct group_info
  */
 struct resresv_set
 {
-	bool can_not_run;		/* set can not run */
+	bool can_not_run:1;		/* set can not run */
 	schd_error *err;		/* reason why set can not run*/
 	char *user;			/* user of set, can be NULL */
 	char *group;			/* group of set, can be NULL */
@@ -964,8 +967,8 @@ struct resresv_set
 
 struct node_partition
 {
-	bool ok_break;	/* OK to break up chunks on this node part */
-	bool excl;		/* partition should be allocated exclusively */
+	bool ok_break:1;	/* OK to break up chunks on this node part */
+	bool excl:1;		/* partition should be allocated exclusively */
 	char *name;			/* res_name=res_val */
 	/* name of resource and value which define the node partition */
 	resdef *def;
@@ -1079,8 +1082,8 @@ struct peer_queue
 
 struct nspec
 {
-	bool end_of_chunk; /* used for putting parens into the execvnode */
-	bool go_provision; /* used to mark a node to be provisioned */
+	bool end_of_chunk:1; /* used for putting parens into the execvnode */
+	bool go_provision:1; /* used to mark a node to be provisioned */
 	int seq_num;			/* sequence number of chunk */
 	int sub_seq_num;		/* sub sequence number for sort stabilization */
 	node_info *ninfo;
@@ -1090,7 +1093,7 @@ struct nspec
 
 struct nameval
 {
-	bool is_set;
+	bool is_set:1;
 	char *str;
 	int value;
 };
@@ -1101,39 +1104,39 @@ struct config
 	 * prime_* is the prime time setting
 	 * non_prime_* is the non-prime setting
 	 */
-	bool prime_rr;		/* round robin through queues*/
-	bool non_prime_rr;
-	bool prime_bq;		/* by queue */
-	bool non_prime_bq;
-	bool prime_sf;		/* strict fifo */
-	bool non_prime_sf;
-	bool prime_so;		/* strict ordering */
-	bool non_prime_so;
-	bool prime_fs;		/* fair share */
-	bool non_prime_fs;
-	bool prime_hsv;		/* help starving jobs */
-	bool non_prime_hsv;
-	bool prime_bf;		/* back filling */
-	bool non_prime_bf;
-	bool prime_sn;		/* sort nodes by priority */
-	bool non_prime_sn;
-	bool prime_bp;		/* backfill around prime time */
-	bool non_prime_bp;	/* backfill around non prime time */
-	bool prime_pre;		/* preemptive scheduling */
-	bool non_prime_pre;
-	bool update_comments;	/* should we update comments or not */
-	bool prime_exempt_anytime_queues; /* backfill affects anytime queues */
-	bool assign_ssinodes;	/* assign the ssinodes resource */
-	bool preempt_starving;	/* once jobs become starving, it can preempt */
-	bool preempt_fairshare; /* normal jobs can preempt over usage jobs */
-	bool dont_preempt_starving; /* don't preempt staving jobs */
-	bool enforce_no_shares;	/* jobs with 0 shares don't run */
-	bool node_sort_unused;	/* node sorting by unused/assigned is used */
-	bool resv_conf_ignore;  /* if we want to ignore dedicated time when confirming reservations.  Move to enum if ever expanded */
-	bool allow_aoe_calendar;        /* allow jobs requesting aoe in calendar*/
+	bool prime_rr:1;		/* round robin through queues*/
+	bool non_prime_rr:1;
+	bool prime_bq:1;		/* by queue */
+	bool non_prime_bq:1;
+	bool prime_sf:1;		/* strict fifo */
+	bool non_prime_sf:1;
+	bool prime_so:1;		/* strict ordering */
+	bool non_prime_so:1;
+	bool prime_fs:1;		/* fair share */
+	bool non_prime_fs:1;
+	bool prime_hsv:1;		/* help starving jobs */
+	bool non_prime_hsv:1;
+	bool prime_bf:1;		/* back filling */
+	bool non_prime_bf:1;
+	bool prime_sn:1;		/* sort nodes by priority */
+	bool non_prime_sn:1;
+	bool prime_bp:1;		/* backfill around prime time */
+	bool non_prime_bp:1;	/* backfill around non prime time */
+	bool prime_pre:1;		/* preemptive scheduling */
+	bool non_prime_pre:1;
+	bool update_comments:1;	/* should we update comments or not */
+	bool prime_exempt_anytime_queues:1; /* backfill affects anytime queues */
+	bool assign_ssinodes:1;	/* assign the ssinodes resource */
+	bool preempt_starving:1;	/* once jobs become starving, it can preempt */
+	bool preempt_fairshare:1; /* normal jobs can preempt over usage jobs */
+	bool dont_preempt_starving:1; /* don't preempt staving jobs */
+	bool enforce_no_shares:1;	/* jobs with 0 shares don't run */
+	bool node_sort_unused:1;	/* node sorting by unused/assigned is used */
+	bool resv_conf_ignore:1;  /* if we want to ignore dedicated time when confirming reservations.  Move to enum if ever expanded */
+	bool allow_aoe_calendar:1;        /* allow jobs requesting aoe in calendar*/
 #ifdef NAS /* localmod 034 */
-	bool prime_sto	;	/* shares_track_only--no enforce shares */
-	bool non_prime_sto;
+	bool prime_sto	:1;	/* shares_track_only--no enforce shares */
+	bool non_prime_sto:1;
 #endif /* localmod 034 */
 
 	struct sort_info *prime_sort;		/* prime time sort */
@@ -1195,7 +1198,7 @@ struct rescheck
 
 struct event_list
 {
-	bool eol;		/* we've reached the end of time */
+	bool eol:1;		/* we've reached the end of time */
 	timed_event *events;		/* the calendar of events */
 	timed_event *next_event;	/* the next event to be performed */
 	timed_event *first_run_event;	/* The first run event in the calendar */
@@ -1204,7 +1207,7 @@ struct event_list
 
 struct timed_event
 {
-	bool disabled;	/* event is disabled - skip it in simulation */
+	bool disabled:1;	/* event is disabled - skip it in simulation */
 	std::string name;	
 	enum timed_event_types event_type;
 	time_t event_time;

--- a/src/scheduler/fairshare.cpp
+++ b/src/scheduler/fairshare.cpp
@@ -185,7 +185,7 @@ find_group_info(const char *name, group_info *root)
  *
  */
 group_info *
-find_alloc_ginfo(char *name, group_info *root)
+find_alloc_ginfo(const char *name, group_info *root)
 {
 	group_info *ginfo;		/* the found group or allocated group */
 

--- a/src/scheduler/fairshare.h
+++ b/src/scheduler/fairshare.h
@@ -57,7 +57,7 @@ group_info *find_group_info(const char *name, group_info *root);
  *                        can not find the ginfo, then allocate a new one and
  *                        add it to the "unknown" group
  */
-group_info *find_alloc_ginfo(char *name, group_info *root);
+group_info *find_alloc_ginfo(const char *name, group_info *root);
 
 
 /*

--- a/src/scheduler/fifo.cpp
+++ b/src/scheduler/fifo.cpp
@@ -346,7 +346,7 @@ init_scheduling_cycle(status *policy, int pbs_sd, server_info *sinfo)
 			 * one and calculate a new value
 			 */
 
-			for (auto& lj: last_running) {
+			for (const auto& lj: last_running) {
 				user = find_alloc_ginfo(lj.entity_name.c_str(),
 							sinfo->fairshare->root);
 
@@ -1944,7 +1944,7 @@ add_job_to_calendar(int pbs_sd, status *policy, server_info *sinfo,
 		 * Note: We only ever look from now into the future
 		 */
 		nexte = get_next_event(sinfo->calendar);
-		if (find_timed_event(nexte, IGNORE_DISABLED_EVENTS, TIMED_NOEVENT, 0, topjob->name) != NULL)
+		if (find_timed_event(nexte, topjob->name, IGNORE_DISABLED_EVENTS, TIMED_NOEVENT, 0) != NULL)
 			return 1;
 	}
 	if ((nsinfo = dup_server_info(sinfo)) == NULL)

--- a/src/scheduler/fifo.cpp
+++ b/src/scheduler/fifo.cpp
@@ -100,10 +100,6 @@
 #include "site_code.h"
 #endif
 
-/* a list of running jobs from the last scheduling cycle */
-static prev_job_info *last_running = NULL;
-static int last_running_size = 0;
-
 /**
  * @brief
  * 		initialize conf struct and parse conf files
@@ -324,9 +320,8 @@ init_scheduling_cycle(status *policy, int pbs_sd, server_info *sinfo)
 	char decayed = 0;		/* boolean: have we decayed usage? */
 	time_t t;			/* used in decaying fair share */
 	usage_t delta;			/* the usage between last sch cycle and now */
-	struct group_path *gpath;	/* used to update usage with delta */
 	static schd_error *err;
-	int i, j;
+	int i;
 
 	if (err == NULL) {
 		err = new_schd_error();
@@ -346,36 +341,30 @@ init_scheduling_cycle(status *policy, int pbs_sd, server_info *sinfo)
 			remove(USAGE_TOUCH);
 			resort = 1;
 		}
-		if (last_running != NULL && sinfo->running_jobs != NULL) {
+		if (last_running.size() > 0 && sinfo->running_jobs != NULL) {
 			/* add the usage which was accumulated between the last cycle and this
 			 * one and calculate a new value
 			 */
 
-			for (i = 0; i < last_running_size ; i++) {
-				if (last_running[i].name != NULL) {
-					user = find_alloc_ginfo(last_running[i].entity_name,
-								sinfo->fairshare->root);
+			for (auto& lj: last_running) {
+				user = find_alloc_ginfo(lj.entity_name.c_str(),
+							sinfo->fairshare->root);
 
-					if (user != NULL) {
-						for (j = 0; sinfo->running_jobs[j] != NULL &&
-						     strcmp(last_running[i].name, sinfo->running_jobs[j]->name); j++)
-							;
+				if (user != NULL) {
+					auto rj = find_resource_resv(sinfo->running_jobs, lj.name);
 
-						if (sinfo->running_jobs[j] != NULL &&
-							sinfo->running_jobs[j]->job != NULL) {
-							/* just in case the delta is negative just add 0 */
-							delta = formula_evaluate(conf.fairshare_res, sinfo->running_jobs[j], sinfo->running_jobs[j]->job->resused) -
-								formula_evaluate(conf.fairshare_res, sinfo->running_jobs[j], last_running[i].resused);
+					if (rj != NULL && rj->job != NULL) {
+						/* just in case the delta is negative just add 0 */
+						delta = formula_evaluate(conf.fairshare_res, rj, rj->job->resused) -
+							formula_evaluate(conf.fairshare_res, rj, lj.resused);
 
-							delta = IF_NEG_THEN_ZERO(delta);
+						delta = IF_NEG_THEN_ZERO(delta);
 
-							gpath = user->gpath;
-							while (gpath != NULL) {
-								gpath->ginfo->usage += delta;
-								gpath = gpath->next;
-							}
-							resort = 1;
-						}
+						;
+						for (auto gpath = user->gpath; gpath != NULL; gpath = gpath->next)
+							gpath->ginfo->usage += delta;
+
+						resort = 1;
 					}
 				}
 			}
@@ -405,7 +394,7 @@ init_scheduling_cycle(status *policy, int pbs_sd, server_info *sinfo)
 				sinfo->fairshare->last_decay) % conf.decay_time;
 		}
 
-		if (policy->sync_fairshare_files && (decayed || last_running != NULL)) {
+		if (policy->sync_fairshare_files && (decayed || !last_running.empty())) {
 			write_usage(USAGE_FILE, sinfo->fairshare);
 			log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_SERVER, LOG_DEBUG,
 				  "Fairshare", "Usage Sync");
@@ -1184,8 +1173,10 @@ end_cycle_tasks(server_info *sinfo)
 	int i;
 
 	/* keep track of update used resources for fairshare */
-	if (sinfo != NULL && sinfo->policy->fair_share)
-		update_last_running(sinfo);
+	if (sinfo != NULL && sinfo->policy->fair_share) {
+		last_running.clear();
+		last_running = create_prev_job_info(sinfo->running_jobs);
+	}
 
 	/* we copied in conf.fairshare into sinfo at the start of the cycle,
 	 * we don't want to free it now, or we'd lose all fairshare data
@@ -1216,45 +1207,6 @@ end_cycle_tasks(server_info *sinfo)
 
 	log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_REQUEST, LOG_DEBUG,
 		"", "Leaving Scheduling Cycle");
-}
-
-/**
- * @brief
- *		update_last_running - update the last_running job array
- *			      keep the currently running jobs till next
- *			      scheduling cycle
- *
- * @param[in]	sinfo	-	the server of current jobs
- *
- * @return	success/failure
- *
- */
-int
-update_last_running(server_info *sinfo)
-{
-	free_pjobs(last_running, last_running_size);
-
-	last_running = create_prev_job_info(sinfo->running_jobs,
-		sinfo->sc.running);
-	last_running_size = sinfo->sc.running;
-
-	if (last_running == NULL)
-		return 0;
-
-	return 1;
-}
-
-/**
- * @brief clear and free the last running array
- *
- * @return void
- */
-void
-clear_last_running()
-{
-	free_pjobs(last_running, last_running_size);
-	last_running = NULL;
-	last_running_size = 0;
 }
 
 /**
@@ -1362,7 +1314,7 @@ run_job(int pbs_sd, resource_resv *rjob, char *execvnode, int has_runjob_hook, s
 				rjob->server->name);
 		}
 
-		rc = pbs_movejob(rjob->job->peer_sd, rjob->name, buf, NULL);
+		rc = pbs_movejob(rjob->job->peer_sd, const_cast<char *>(rjob->name.c_str()), buf, NULL);
 
 		/*
 		 * After successful transfer of the peer job to local server,
@@ -1515,7 +1467,7 @@ run_update_resresv(status *policy, int pbs_sd, server_info *sinfo,
 	pbs_errno = PBSE_NONE;
 	if (resresv->is_job && resresv->job->is_suspended) {
 		if (pbs_sd != SIMULATE_SD) {
-			pbsrc = pbs_sigjob(get_svr_inst_fd(pbs_sd, resresv->svr_inst_id), resresv->name, const_cast<char *>("resume"), NULL);
+			pbsrc = pbs_sigjob(get_svr_inst_fd(pbs_sd, resresv->svr_inst_id), const_cast<char *>(resresv->name.c_str()), const_cast<char *>("resume"), NULL);
 			if (!pbsrc)
 				ret = 1;
 			else {
@@ -1994,7 +1946,7 @@ add_job_to_calendar(int pbs_sd, status *policy, server_info *sinfo,
 		 * Note: We only ever look from now into the future
 		 */
 		nexte = get_next_event(sinfo->calendar);
-		if (find_timed_event(nexte, IGNORE_DISABLED_EVENTS, topjob->name, TIMED_NOEVENT, 0) != NULL)
+		if (find_timed_event(nexte, IGNORE_DISABLED_EVENTS, TIMED_NOEVENT, 0, topjob->name) != NULL)
 			return 1;
 	}
 	if ((nsinfo = dup_server_info(sinfo)) == NULL)

--- a/src/scheduler/fifo.cpp
+++ b/src/scheduler/fifo.cpp
@@ -1173,10 +1173,8 @@ end_cycle_tasks(server_info *sinfo)
 	int i;
 
 	/* keep track of update used resources for fairshare */
-	if (sinfo != NULL && sinfo->policy->fair_share) {
-		last_running.clear();
-		last_running = create_prev_job_info(sinfo->running_jobs);
-	}
+	if (sinfo != NULL && sinfo->policy->fair_share)
+		create_prev_job_info(sinfo->running_jobs);
 
 	/* we copied in conf.fairshare into sinfo at the start of the cycle,
 	 * we don't want to free it now, or we'd lose all fairshare data

--- a/src/scheduler/fifo.h
+++ b/src/scheduler/fifo.h
@@ -40,6 +40,8 @@
 #ifndef	_FIFO_H
 #define	_FIFO_H
 
+#include <string>
+
 #include  <limits.h>
 #include "data_types.h"
 #include "sched_cmds.h"
@@ -112,11 +114,6 @@ int init_scheduling_cycle(status *policy, int pbs_sd, server_info *sinfo);
  */
 
 resource_resv *next_job(status *policy, server_info *sinfo, int flag);
-
-/*
- *      update_last_running - update the last_running job array
- */
-int update_last_running(server_info *sinfo);
 
 /*
  *      find_runnable_job_ind - find the index of the next runnable job in a job array
@@ -254,9 +251,7 @@ int set_validate_sched_attrs(int);
 
 int validate_running_user(char *exename);
 
-void clear_last_running();
-
-int send_run_job(int virtual_sd, int has_runjob_hook, char *jobid, char *execvnode,
+int send_run_job(int virtual_sd, int has_runjob_hook, const std::string& jobid, char *execvnode,
 		 char *svr_id_node, char *svr_id_job);
 
 #endif	/* _FIFO_H */

--- a/src/scheduler/globals.cpp
+++ b/src/scheduler/globals.cpp
@@ -193,3 +193,6 @@ int clust_primary_sock = -1;
 
 /* secondary socket descriptor to the server pool */
 int clust_secondary_sock = -1;
+
+/* a list of running jobs from the last scheduling cycle */
+std::vector<prev_job_info> last_running;

--- a/src/scheduler/globals.h
+++ b/src/scheduler/globals.h
@@ -118,6 +118,9 @@ extern int clust_primary_sock;
 
 extern int clust_secondary_sock;
 
+/* a list of running jobs from the last scheduling cycle */
+extern std::vector<prev_job_info> last_running;
+
 /**
  * @brief
  * It is used as a placeholder to store aoe name. This aoe name will be

--- a/src/scheduler/job_info.cpp
+++ b/src/scheduler/job_info.cpp
@@ -1227,15 +1227,9 @@ query_job(struct batch_status *job, server_info *sinfo, schd_error *err)
 				resresv->qrank = -1;
 		}
 		else if (!strcmp(attrp->name, ATTR_server_inst_id)) {
-<<<<<<< HEAD
 			resresv->svr_inst_id = string_dup(attrp->value);
 			if (resresv->svr_inst_id == NULL) {
-				free_resource_resv(resresv);
-=======
-			resresv->job->svr_inst_id = string_dup(attrp->value);
-			if (resresv->job->svr_inst_id == NULL) {
 				delete resresv;
->>>>>>> 5747272f... Partial C++ refactor of resource_resv and node_info
 				return NULL;
 			}
 		}

--- a/src/scheduler/job_info.cpp
+++ b/src/scheduler/job_info.cpp
@@ -587,7 +587,7 @@ query_jobs_chunk(th_data_query_jinfo *data)
 			 * header.  We to continue adding valid jobs to our array.  We're
 			 * freeing what we allocated and ignoring this job completely.
 			 */
-			free_resource_resv(resresv);
+			delete resresv;
 			continue;
 		}
 
@@ -596,7 +596,7 @@ query_jobs_chunk(th_data_query_jinfo *data)
 			!resresv->job->is_suspended && !resresv->job->is_provisioning) {
 			log_event(PBSEVENT_SCHED, PBS_EVENTCLASS_RESV, LOG_DEBUG,
 				resresv->name, "Subjob found in undesirable state, ignoring this job");
-			free_resource_resv(resresv);
+			delete resresv;
 			continue;
 		}
 
@@ -1157,15 +1157,14 @@ query_job(struct batch_status *job, server_info *sinfo, schd_error *err)
 	char *endp;			/* used for strtol() */
 	resource_req *resreq;		/* resource_req list for resources requested  */
 
-	if ((resresv = new_resource_resv()) == NULL)
+	if ((resresv = new resource_resv(job->name)) == NULL)
 		return NULL;
 
 	if ((resresv->job = new_job_info()) ==NULL) {
-		free_resource_resv(resresv);
+		delete resresv;
 		return NULL;
 	}
 
-	resresv->name = string_dup(job->name);
 	resresv->rank = get_sched_rank();
 
 	attrp = job->attribs;
@@ -1177,17 +1176,6 @@ query_job(struct batch_status *job, server_info *sinfo, schd_error *err)
 	resresv->job->can_checkpoint = 1;	/* default can be checkpointed */
 	resresv->job->can_requeue = 1;		/* default can be requeued */
 	resresv->job->can_suspend = 1;		/* default can be suspended */
-
-	/* A Job identifier must be of the form <numeric>.<alpha> or
-	 * <numeric>[<numeric>].<alpha> in the case of job arrays, any other
-	 * form is considered malformed
-	 */
-	resresv->job->job_id = strtol(resresv->name, &endp, 10);
-	if ((*endp != '.') && (*endp != '[')) {
-		set_schd_error_codes(err, NEVER_RUN, ERR_SPECIAL);
-		set_schd_error_arg(err, SPECMSG, "Malformed job identifier");
-		resresv->is_invalid = 1;
-	}
 
 	while (attrp != NULL && !resresv->is_invalid) {
 		clear_schd_error(err);
@@ -1239,9 +1227,15 @@ query_job(struct batch_status *job, server_info *sinfo, schd_error *err)
 				resresv->qrank = -1;
 		}
 		else if (!strcmp(attrp->name, ATTR_server_inst_id)) {
+<<<<<<< HEAD
 			resresv->svr_inst_id = string_dup(attrp->value);
 			if (resresv->svr_inst_id == NULL) {
 				free_resource_resv(resresv);
+=======
+			resresv->job->svr_inst_id = string_dup(attrp->value);
+			if (resresv->job->svr_inst_id == NULL) {
+				delete resresv;
+>>>>>>> 5747272f... Partial C++ refactor of resource_resv and node_info
 				return NULL;
 			}
 		}
@@ -1306,7 +1300,7 @@ query_job(struct batch_status *job, server_info *sinfo, schd_error *err)
 		}
 #endif /* localmod 031 */
 		else if (!strcmp(attrp->name, ATTR_array_id))
-			resresv->job->array_id = string_dup(attrp->value);
+			resresv->job->array_id = attrp->value;
 		else if (!strcmp(attrp->name, ATTR_node_set))
 			resresv->node_set_str = break_comma_list(attrp->value);
 		else if (!strcmp(attrp->name, ATTR_array)) { /* array */
@@ -1345,7 +1339,7 @@ query_job(struct batch_status *job, server_info *sinfo, schd_error *err)
 		} else if (!strcmp(attrp->name, ATTR_l)) { /* resources requested*/
 			resreq = find_alloc_resource_req_by_str(resresv->resreq, attrp->resource);
 			if (resreq == NULL) {
-				free_resource_resv(resresv);
+				delete resresv;
 				return NULL;
 			}
 
@@ -1436,7 +1430,7 @@ new_job_info()
 {
 	job_info *jinfo;
 
-	if ((jinfo = static_cast<job_info *>(malloc(sizeof(job_info)))) == NULL) {
+	if ((jinfo = new job_info) == NULL) {
 		log_err(errno, __func__, MEM_ERR_MSG);
 		return NULL;
 	}
@@ -1488,7 +1482,6 @@ new_job_info()
 	jinfo->resused = NULL;
 	jinfo->ginfo = NULL;
 
-	jinfo->array_id = NULL;
 	jinfo->array_index = UNSPECIFIED;
 	jinfo->parent_job = NULL;
 	jinfo->queued_subjobs = NULL;
@@ -1535,6 +1528,9 @@ new_job_info()
 void
 free_job_info(job_info *jinfo)
 {
+	if (jinfo == NULL)
+		return;
+	
 	if (jinfo->comment != NULL)
 		free(jinfo->comment);
 
@@ -1549,9 +1545,6 @@ free_job_info(job_info *jinfo)
 
 	if (jinfo->est_execvnode != NULL)
 		free(jinfo->est_execvnode);
-
-	if (jinfo->array_id != NULL)
-		free(jinfo->array_id);
 
 	if (jinfo->queued_subjobs != NULL)
 		free_range_list(jinfo->queued_subjobs);
@@ -1582,7 +1575,7 @@ free_job_info(job_info *jinfo)
 	if (jinfo->schedsel)
 		free(jinfo->schedsel);
 #endif
-	free(jinfo);
+	delete jinfo;
 }
 
 
@@ -2787,7 +2780,6 @@ dup_job_info(job_info *ojinfo, queue_info *nqinfo, server_info *nsinfo)
 	njinfo->preempt = ojinfo->preempt;
 	njinfo->preempt_status = ojinfo->preempt_status;
 	njinfo->peer_sd = ojinfo->peer_sd;
-	njinfo->job_id = ojinfo->job_id;
 	njinfo->est_start_time = ojinfo->est_start_time;
 	njinfo->formula_value = ojinfo->formula_value;
 	njinfo->est_execvnode = string_dup(ojinfo->est_execvnode);
@@ -2804,7 +2796,7 @@ dup_job_info(job_info *ojinfo, queue_info *nqinfo, server_info *nsinfo)
 	njinfo->resused = dup_resource_req_list(ojinfo->resused);
 
 	njinfo->array_index = ojinfo->array_index;
-	njinfo->array_id = string_dup(ojinfo->array_id);
+	njinfo->array_id = ojinfo->array_id;
 	njinfo->queued_subjobs = dup_range_list(ojinfo->queued_subjobs);
 	njinfo->max_run_subjobs = ojinfo->max_run_subjobs;
 
@@ -2860,7 +2852,7 @@ dup_job_info(job_info *ojinfo, queue_info *nqinfo, server_info *nsinfo)
  * @return	0	: If job dos not fall into any of the preempt_targets
  */
 int
-preempt_job_set_filter(resource_resv *job, void *arg)
+preempt_job_set_filter(resource_resv *job, const void *arg)
 {
 	resource_req *req;
 	char **arglist;
@@ -3040,7 +3032,7 @@ find_and_preempt_jobs(status *policy, int pbs_sd, resource_resv *hjob, server_in
 		for (i = 0; i < no_of_jobs; i++) {
 			job = find_resource_resv_by_indrank(sinfo->running_jobs, -1, jobs[i]);
 			if (job != NULL) {
-				if ((preempt_jobs_list[i] = strdup(job->name)) == NULL) {
+				if ((preempt_jobs_list[i] = string_dup(job->name.c_str())) == NULL) {
 					log_err(errno, __func__, MEM_ERR_MSG);
 					free_string_array(preempt_jobs_list);
 					free(preempt_jobs_list);
@@ -3868,7 +3860,7 @@ set_preempt_prio(resource_resv *job, queue_info *qinfo, server_info *sinfo)
 
 	if (sinfo->qrun_job != NULL) {
 		if (job == sinfo->qrun_job ||
-		    (jinfo->is_subjob && (strcmp(jinfo->array_id, sinfo->qrun_job->name) == 0)))
+		    (jinfo->is_subjob && jinfo->array_id == sinfo->qrun_job->name))
 			jinfo->preempt_status |= PREEMPT_TO_BIT(PREEMPT_QRUN);
 	}
 
@@ -3930,27 +3922,19 @@ set_preempt_prio(resource_resv *job, queue_info *qinfo, server_info *sinfo)
  *
  * @return	created subjob name
  */
-char *
-create_subjob_name(char *array_id, int index)
+std::string
+create_subjob_name(const std::string& array_id, int index)
 {
-	int spn;
-	char *rest;
-	char tmpid[128];		/* hold job id and leading '[' */
-	char buf[1024];		/* buffer to hold new subjob identifer */
+	std::string subjob_id;
+	std::size_t brackets;
 
-	spn = strcspn(array_id, "[");
-	if (spn == 0)
-		return NULL;
+	subjob_id = array_id;
+	brackets = subjob_id.find("[]");
+	if (brackets == std::string::npos)
+		return std::string("");
+	subjob_id.insert(brackets + 1, std::to_string(index));
 
-	rest = array_id + spn + 1;
-
-	if (*rest != ']')
-		return NULL;
-
-	pbs_strncpy(tmpid, array_id, spn+2);
-	sprintf(buf, "%s%d%s", tmpid, index, rest);
-
-	return string_dup(buf);
+	return subjob_id;
 }
 
 /**
@@ -3968,7 +3952,7 @@ create_subjob_name(char *array_id, int index)
  *
  */
 resource_resv *
-create_subjob_from_array(resource_resv *array, int index, char *subjob_name)
+create_subjob_from_array(resource_resv *array, int index, const std::string& subjob_name)
 {
 	resource_resv *subjob;	/* job_info structure for new subjob */
 	range *tmp;			/* a tmp ptr to hold the queued_indices ptr */
@@ -3988,7 +3972,7 @@ create_subjob_from_array(resource_resv *array, int index, char *subjob_name)
 	tmp = array->job->queued_subjobs;
 	array->job->queued_subjobs = NULL;
 
-	subjob = dup_resource_resv(array, array->server, array->job->queue, err);
+	subjob = dup_resource_resv(array, array->server, array->job->queue, subjob_name);
 
 	/* make a copy of dependent jobs */
 	subjob->job->depend_job_str = string_dup(array->job->depend_job_str);
@@ -4007,13 +3991,7 @@ create_subjob_from_array(resource_resv *array, int index, char *subjob_name)
 	subjob->job->is_queued = 1;
 	subjob->job->is_subjob = 1;
 	subjob->job->array_index = index;
-	subjob->job->array_id = string_dup(array->name);
-
-	free(subjob->name);
-	if (subjob_name != NULL)
-		subjob->name = subjob_name;
-	else
-		subjob->name = create_subjob_name(array->name, index);
+	subjob->job->array_id = array->name;
 
 	subjob->rank =  get_sched_rank();
 
@@ -4188,7 +4166,7 @@ queue_subjob(resource_resv *array, server_info *sinfo,
 	queue_info *qinfo)
 {
 	int subjob_index;
-	char *subjob_name;
+	std::string subjob_name;
 	resource_resv *rresv = NULL;
 	resource_resv **tmparr = NULL;
 
@@ -4201,14 +4179,12 @@ queue_subjob(resource_resv *array, server_info *sinfo,
 	subjob_index = range_next_value(array->job->queued_subjobs, -1);
 	if (subjob_index >= 0) {
 		subjob_name = create_subjob_name(array->name, subjob_index);
-		if (subjob_name != NULL) {
+		if (!subjob_name.empty()) {
 			if ((rresv = find_resource_resv(sinfo->jobs, subjob_name)) != NULL) {
-				free(subjob_name);
 				/* Set tmparr to something so we're not considered an error */
 				tmparr = sinfo->jobs;
 			}
-			else if ((rresv = create_subjob_from_array(array, subjob_index,
-				subjob_name)) != NULL) {
+			else if ((rresv = create_subjob_from_array(array, subjob_index, subjob_name)) != NULL) {
 				/* add_resresv_to_array calls realloc, so we need to treat this call
 				 * as a call to realloc.  Put it into a temp variable to check for NULL
 				 */
@@ -4784,7 +4760,7 @@ update_estimated_attrs(int pbs_sd, resource_resv *job,
 	}
 	else {
 		aflags = UPDATE_NOW;
-		if (job->job->array_id !=NULL)
+		if (!job->job->array_id.empty())
 			array = find_resource_resv(job->server->jobs, job->job->array_id);
 	}
 
@@ -5160,7 +5136,7 @@ extend_soft_walltime(resource_resv *resresv, time_t server_time)
  * @retval - 0 if job is not valid for preemption
  * @retval - 1 if the job is valid for preemption
  */
-static int cull_preemptible_jobs(resource_resv *job, void *arg)
+static int cull_preemptible_jobs(resource_resv *job, const void *arg)
 {
 	struct resresv_filter *inp;
 	int index;

--- a/src/scheduler/job_info.cpp
+++ b/src/scheduler/job_info.cpp
@@ -1430,7 +1430,7 @@ new_job_info()
 {
 	job_info *jinfo;
 
-	if ((jinfo = new job_info) == NULL) {
+	if ((jinfo = new job_info()) == NULL) {
 		log_err(errno, __func__, MEM_ERR_MSG);
 		return NULL;
 	}

--- a/src/scheduler/job_info.h
+++ b/src/scheduler/job_info.h
@@ -87,7 +87,7 @@ update_job_attr(int pbs_sd, resource_resv *resresv, const char *attr_name,
 int send_job_updates(int pbs_sd, resource_resv *job);
 
 /* send delayed attributes to the server for a job */
-int send_attr_updates(int job_owner_sd, char *job_name, struct attrl *pattr);
+int send_attr_updates(int job_owner_sd, const std::string& job_name, struct attrl *pattr);
 
 preempt_job_info *send_preempt_jobs(int virtual_sd, char **preempt_jobs_list);
 
@@ -186,7 +186,7 @@ void set_preempt_prio(resource_resv *job, queue_info *qinfo, server_info *sinfo)
  *
  * return created subjob name
  */
-char *create_subjob_name(char *array_id, int index);
+std::string create_subjob_name(const std::string& array_id, int index);
 
 /*
  *	create_subjob_from_array - create a resource_resv structure for a subjob
@@ -194,8 +194,7 @@ char *create_subjob_name(char *array_id, int index);
  *				   will be in state 'Q'
  */
 resource_resv *
-create_subjob_from_array(resource_resv *array, int index, char
-	*subjob_name);
+create_subjob_from_array(resource_resv *array, int index, const std::string& subjob_name);
 
 /*
  *	update_array_on_run - update a job array object when a subjob is run

--- a/src/scheduler/limits.cpp
+++ b/src/scheduler/limits.cpp
@@ -1289,8 +1289,8 @@ check_server_max_user_run(server_info *si, queue_info *qi, resource_resv *rr,
 	/* at this point, we know a generic or individual limit is set */
 	used = find_counts_elm(cts, user, NULL, NULL, NULL);
 	log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, __func__,
-		"%s user %s max_*user_run (%d, %d), used %d",
-		rr->name, user, max_user_run, max_genuser_run, used);
+		"user %s max_*user_run (%d, %d), used %d",
+		user, max_user_run, max_genuser_run, used);
 
 	if (max_user_run != SCHD_INFINITY) {
 		if (max_user_run <= used) {
@@ -1358,9 +1358,9 @@ check_server_max_group_run(server_info *si, queue_info *qi, resource_resv *rr,
 
 	/* at this point, we know a generic or individual limit is set */
 	used = find_counts_elm(cts, group, NULL, NULL, NULL);
-	log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, __func__,
-		"%s group %s max_*group_run (%d, %d), used %d",
-		rr->name, group, max_group_run, max_gengroup_run, used);
+	log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, rr->name,
+		"group %s max_*group_run (%d, %d), used %d",
+		group, max_group_run, max_gengroup_run, used);
 
 	if (max_group_run != SCHD_INFINITY) {
 		if (max_group_run <= used) {
@@ -1413,8 +1413,8 @@ check_server_max_user_res(server_info *si, queue_info *qi, resource_resv *rr,
 	ret = check_max_user_res(rr, cts, &rdef,
 		LI2RESCTX(si->liminfo));
 	if (ret != 0)
-		log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, __func__,
-			   "%s check_max_user_res returned %d", rr->name, ret);
+		log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, rr->name,
+			   "check_max_user_res returned %d", ret);
 	switch (ret) {
 		default:
 		case -1:
@@ -1469,8 +1469,8 @@ check_server_max_group_res(server_info *si, queue_info *qi, resource_resv *rr,
 	ret = check_max_group_res(rr, cts,
 		&rdef, LI2RESCTX(si->liminfo));
 	if (ret != 0)
-		log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, __func__,
-			"%s check_max_group_res returned %d", rr->name, ret);
+		log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, rr->name,
+			"check_max_group_res returned %d", ret);
 	switch (ret) {
 		default:
 		case -1:
@@ -1540,9 +1540,9 @@ check_queue_max_user_run(server_info *si, queue_info *qi, resource_resv *rr,
 
 	/* at this point, we know a generic or individual limit is set */
 	used = find_counts_elm(cts,  user, NULL, NULL, NULL);
-	log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, __func__,
-		"%s user %s max_*user_run (%d, %d), used %d",
-		rr->name, user, max_user_run, max_genuser_run, used);
+	log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, rr->name,
+		"user %s max_*user_run (%d, %d), used %d",
+		user, max_user_run, max_genuser_run, used);
 
 	if (max_user_run != SCHD_INFINITY) {
 		if (max_user_run <= used) {
@@ -1609,9 +1609,9 @@ check_queue_max_group_run(server_info *si, queue_info *qi, resource_resv *rr,
 
 	/* at this point, we know a generic or individual limit is set */
 	used = find_counts_elm(cts, group, NULL, NULL, NULL);
-	log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, __func__,
-		"%s group %s max_*group_run (%d, %d), used %d",
-		rr->name, group, max_group_run, max_gengroup_run, used);
+	log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, rr->name,
+		"group %s max_*group_run (%d, %d), used %d",
+		group, max_group_run, max_gengroup_run, used);
 
 	if (max_group_run != SCHD_INFINITY) {
 		if (max_group_run <= used) {
@@ -1663,8 +1663,8 @@ check_queue_max_user_res(server_info *si, queue_info *qi, resource_resv *rr,
 
 	ret = check_max_user_res(rr, cts, &rdef, LI2RESCTX(qi->liminfo));
 	if (ret != 0)
-		log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, __func__,
-			"%s check_max_user_res returned %d", rr->name, ret);
+		log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, rr->name,
+			"check_max_user_res returned %d", ret);
 
 	switch (ret) {
 		default:
@@ -1720,8 +1720,8 @@ check_queue_max_group_res(server_info *si, queue_info *qi, resource_resv *rr,
 
 	ret = check_max_group_res(rr, cts, &rdef, LI2RESCTX(qi->liminfo));
 	if (ret != 0)
-		log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, __func__,
-			"%s check_max_group_res returned %d", rr->name, ret);
+		log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, rr->name,
+			"check_max_group_res returned %d", ret);
 
 	switch (ret) {
 		default:
@@ -1802,8 +1802,8 @@ check_queue_max_res(server_info *si, queue_info *qi, resource_resv *rr,
 		else
 			used = used_res->amount;
 
-		log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, __func__,
-			"%s max_res.%s %.1lf, used %.1lf", rr->name, res->name, max_res, used);
+		log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, rr->name,
+			"max_res.%s %.1lf, used %.1lf", res->name, max_res, used);
 		if (used + req->amount > max_res) {
 			schderr_args_q_res(qi->name, NULL, NULL, err);
 			err->rdef = res->def;
@@ -1876,8 +1876,8 @@ check_server_max_res(server_info *si, queue_info *qi, resource_resv *rr,
 		else
 			used = used_res->amount;
 
-		log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, __func__,
-			"%s max_res.%s %.1lf, used %.1lf", rr->name, res->name, max_res, used);
+		log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, rr->name,
+			"max_res.%s %.1lf, used %.1lf", res->name, max_res, used);
 		if (used + req->amount > max_res) {
 			err->rdef = res->def;
 			return (SERVER_RESOURCE_LIMIT_REACHED);
@@ -2094,9 +2094,9 @@ check_queue_max_user_run_soft(server_info *si, queue_info *qi, resource_resv *rr
 	/* at this point, we know a generic or individual limit is set */
 	used = find_counts_elm(qi->user_counts, user, NULL, &cnt, NULL);
 
-	log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, __func__,
-		"%s user %s max_*user_run_soft (%d, %d), used %d",
-		rr->name, user, max_user_run_soft, max_genuser_run_soft, used);
+	log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, rr->name,
+		"user %s max_*user_run_soft (%d, %d), used %d",
+		user, max_user_run_soft, max_genuser_run_soft, used);
 
 	if (max_user_run_soft != SCHD_INFINITY) {
 		if (max_user_run_soft < used) {
@@ -2166,9 +2166,9 @@ check_queue_max_group_run_soft(server_info *si, queue_info *qi,
 		return (0);
 
 	used = find_counts_elm(qi->group_counts, group, NULL, &cnt, NULL);
-	log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, __func__,
-		"%s group %s max_*group_run_soft (%d, %d), used %d",
-		rr->name, group, max_group_run_soft, max_gengroup_run_soft, used);
+	log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, rr->name,
+		"group %s max_*group_run_soft (%d, %d), used %d",
+		group, max_group_run_soft, max_gengroup_run_soft, used);
 
 	if (max_group_run_soft != SCHD_INFINITY) {
 		if (max_group_run_soft < used) {
@@ -2347,9 +2347,9 @@ check_server_max_user_run_soft(server_info *si, queue_info *qi,
 
 	/* at this point, we know a generic or individual limit is set */
 	used = find_counts_elm(si->user_counts, user, NULL, &cnt, NULL);
-	log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, __func__,
-		"%s user %s max_*user_run_soft (%d, %d), used %d",
-		rr->name, user, max_user_run_soft, max_genuser_run_soft, used);
+	log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, rr->name,
+		"user %s max_*user_run_soft (%d, %d), used %d",
+		user, max_user_run_soft, max_genuser_run_soft, used);
 
 	if (max_user_run_soft != SCHD_INFINITY) {
 		if (max_user_run_soft < used) {
@@ -2421,9 +2421,9 @@ check_server_max_group_run_soft(server_info *si, queue_info *qi,
 	/* at this point, we know a generic or individual limit is set */
 	used = find_counts_elm(si->group_counts, group, NULL, &cnt, NULL);
 
-	log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, __func__,
-		"%s group %s max_*group_run_soft (%d, %d), used %d",
-		rr->name, group, max_group_run_soft, max_gengroup_run_soft, used);
+	log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, rr->name,
+		"group %s max_*group_run_soft (%d, %d), used %d",
+		group, max_group_run_soft, max_gengroup_run_soft, used);
 
 	if (max_group_run_soft != SCHD_INFINITY) {
 		if (max_group_run_soft < used) {
@@ -2557,9 +2557,9 @@ check_server_max_res_soft(server_info *si, queue_info *qi, resource_resv *rr)
 		else
 			used = used_res->amount;
 
-		log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, __func__,
-			"%s max_res_soft.%s %.1lf, used %.1lf",
-			rr->name, res->name, max_res_soft, used);
+		log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, rr->name,
+			"max_res_soft.%s %.1lf, used %.1lf",
+			res->name, max_res_soft, used);
 
 		if (max_res_soft < used) {
 			if (used_res != NULL)
@@ -2626,9 +2626,9 @@ check_queue_max_res_soft(server_info *si, queue_info *qi, resource_resv *rr)
 		else
 			used = used_res->amount;
 
-		log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, __func__,
-			"%s max_res_soft.%s %.1lf, used %.1lf",
-			rr->name, res->name, max_res_soft, used);
+		log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, rr->name,
+			"max_res_soft.%s %.1lf, used %.1lf",
+			res->name, max_res_soft, used);
 
 		if (max_res_soft < used) {
 			if (used_res != NULL)
@@ -2702,9 +2702,9 @@ check_max_group_res(resource_resv *rr, counts *cts_list,
 		/* at this point, we know a generic or individual limit is set */
 		used = find_counts_elm(cts_list, group, res->def, NULL, NULL);
 
-		log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, __func__,
-			"%s group %s max_*group_res.%s (%.1lf, %.1lf), used %.1lf",
-			rr->name, group, res->name, max_group_res, max_gengroup_res, used);
+		log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, rr->name,
+			"group %s max_*group_res.%s (%.1lf, %.1lf), used %.1lf",
+			group, res->name, max_group_res, max_gengroup_res, used);
 
 		if (max_group_res != SCHD_INFINITY) {
 			if (used + req->amount > max_group_res) {
@@ -2780,9 +2780,9 @@ check_max_group_res_soft(resource_resv *rr, counts *cts_list, void *limitctx, in
 		rescts = NULL;
 		/* at this point, we know a generic or individual limit is set */
 		used = find_counts_elm(cts_list, group, res->def, NULL, &rescts);
-		log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, __func__,
-			"%s group %s max_*group_res_soft.%s (%.1lf, %.1lf), used %.1lf",
-			rr->name, group, res->name, max_group_res_soft, max_gengroup_res_soft, used);
+		log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, rr->name,
+			"group %s max_*group_res_soft.%s (%.1lf, %.1lf), used %.1lf",
+			group, res->name, max_group_res_soft, max_gengroup_res_soft, used);
 
 		if (max_group_res_soft != SCHD_INFINITY) {
 			if (max_group_res_soft < used) {
@@ -2866,9 +2866,9 @@ check_max_user_res(resource_resv *rr, counts *cts_list, resdef **rdef,
 		/* at this point, we know a generic or individual limit is set */
 		used = find_counts_elm(cts_list, user, res->def, NULL, NULL);
 
-		log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, __func__,
-			"%s user %s max_*user_res.%s (%.1lf, %.1lf), used %.1lf",
-			rr->name, user, res->name, max_user_res, max_genuser_res, used);
+		log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, rr->name,
+			"user %s max_*user_res.%s (%.1lf, %.1lf), used %.1lf",
+			user, res->name, max_user_res, max_genuser_res, used);
 
 		if (max_user_res != SCHD_INFINITY) {
 			if (used + req->amount > max_user_res) {
@@ -2947,9 +2947,9 @@ check_max_user_res_soft(resource_resv **rr_arr, resource_resv *rr,
 		/* at this point, we know a generic or individual limit is set */
 		used = find_counts_elm(cts_list, user, res->def, NULL, &rescts);
 
-		log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, __func__,
-			"%s user %s max_*user_res_soft (%.1lf, %.1lf), used %.1lf",
-			rr->name, user, max_user_res_soft, max_genuser_res_soft, used);
+		log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, rr->name,
+			"user %s max_*user_res_soft (%.1lf, %.1lf), used %.1lf",
+			user, max_user_res_soft, max_genuser_res_soft, used);
 
 		if (max_user_res_soft != SCHD_INFINITY) {
 			if (max_user_res_soft < used) {
@@ -3498,9 +3498,9 @@ check_max_project_res(resource_resv *rr, counts *cts_list,
 		/* at this point, we know a generic or individual limit is set */
 		used = find_counts_elm(cts_list, project, res->def, NULL, NULL);
 
-		log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, __func__,
-			"%s project %s max_*project_res.%s (%.1lf, %.1lf), used %.1lf",
-			rr->name, project, res->name, max_project_res, max_genproject_res, used);
+		log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, rr->name,
+			"project %s max_*project_res.%s (%.1lf, %.1lf), used %.1lf",
+			project, res->name, max_project_res, max_genproject_res, used);
 
 		if (max_project_res != SCHD_INFINITY) {
 			if (used + req->amount > max_project_res) {
@@ -3577,9 +3577,9 @@ check_max_project_res_soft(resource_resv *rr, counts *cts_list, void *limitctx, 
 		rescts = NULL;
 		/* at this point, we know a generic or individual limit is set */
 		used = find_counts_elm(cts_list, project, res->def, NULL, &rescts);
-		log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, __func__,
-			"%s project %s max_*project_res_soft.%s (%.1lf, %.1lf), used %.1lf",
-			rr->name, project, res->name, max_project_res_soft, max_genproject_res_soft, used);
+		log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, rr->name,
+			"project %s max_*project_res_soft.%s (%.1lf, %.1lf), used %.1lf",
+			project, res->name, max_project_res_soft, max_genproject_res_soft, used);
 
 		if (max_project_res_soft != SCHD_INFINITY) {
 			if (max_project_res_soft < used){
@@ -3647,8 +3647,8 @@ check_server_max_project_res(server_info *si, queue_info *qi, resource_resv *rr,
 	ret = check_max_project_res(rr, cts,
 		&rdef, LI2RESCTX(si->liminfo));
 	if (ret != 0) {
-		log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, __func__,
-			"%s check_max_project_res returned %d", rr->name, ret);
+		log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, rr->name,
+			"check_max_project_res returned %d", ret);
 	}
 	switch (ret) {
 		default:
@@ -3720,9 +3720,9 @@ check_server_max_project_run_soft(server_info *si, queue_info *qi,
 
 	/* at this point, we know a generic or individual limit is set */
 	used = find_counts_elm(si->project_counts, project, NULL, &cnt, NULL);
-	log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, __func__,
-		"%s project %s max_*project_run_soft (%d, %d), used %d",
-		rr->name, project, max_project_run_soft, max_genproject_run_soft, used);
+	log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, rr->name,
+		"project %s max_*project_run_soft (%d, %d), used %d",
+		project, max_project_run_soft, max_genproject_run_soft, used);
 
 	if (max_project_run_soft != SCHD_INFINITY) {
 		if (max_project_run_soft < used) {
@@ -3815,8 +3815,8 @@ check_queue_max_project_res(server_info *si, queue_info *qi, resource_resv *rr,
 
 	ret = check_max_project_res(rr, cts, &rdef, LI2RESCTX(qi->liminfo));
 	if (ret != 0)
-		log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, __func__,
-			"%s check_max_project_res returned %d", rr->name, ret);
+		log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, rr->name,
+			"check_max_project_res returned %d", ret);
 	switch (ret) {
 		default:
 		case -1:
@@ -3886,9 +3886,9 @@ check_queue_max_project_run_soft(server_info *si, queue_info *qi,
 
 	used = find_counts_elm(qi->project_counts, project, NULL, &cnt, NULL);
 
-	log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, __func__,
+	log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, rr->name,
 		"%s project %s max_*project_run_soft (%d, %d), used %d",
-		rr->name, project, max_project_run_soft, max_genproject_run_soft, used);
+		project, max_project_run_soft, max_genproject_run_soft, used);
 
 	if (max_project_run_soft != SCHD_INFINITY) {
 		if (max_project_run_soft < used) {
@@ -4003,9 +4003,9 @@ check_server_max_project_run(server_info *si, queue_info *qi, resource_resv *rr,
 	/* at this point, we know a generic or individual limit is set */
 	used = find_counts_elm(cts, project, NULL, NULL, NULL);
 
-	log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, __func__,
-		"%s project %s max_*project_run (%d, %d), used %d",
-		rr->name, project, max_project_run, max_genproject_run, used);
+	log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, rr->name,
+		"project %s max_*project_run (%d, %d), used %d",
+		project, max_project_run, max_genproject_run, used);
 
 	if (max_project_run != SCHD_INFINITY) {
 		if (max_project_run <= used) {
@@ -4080,9 +4080,9 @@ check_queue_max_project_run(server_info *si, queue_info *qi, resource_resv *rr,
 	/* at this point, we know a generic or individual limit is set */
 	used = find_counts_elm(cts, project, NULL, NULL, NULL);
 
-	log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, __func__,
-		"%s project %s max_*project_run (%d, %d), used %d",
-		rr->name, project, max_project_run, max_genproject_run, used);
+	log_eventf(PBSEVENT_DEBUG4, PBS_EVENTCLASS_JOB, LOG_DEBUG, rr->name,
+		"project %s max_*project_run (%d, %d), used %d",
+		project, max_project_run, max_genproject_run, used);
 
 	if (max_project_run != SCHD_INFINITY) {
 		if (max_project_run <= used) {

--- a/src/scheduler/misc.cpp
+++ b/src/scheduler/misc.cpp
@@ -45,6 +45,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdarg.h>
 #include <time.h>
 #include <ctype.h>
 #include <string.h>
@@ -316,7 +317,7 @@ skip_line(char *line)
  *	@return nothing
  */
 void
-schdlogerr(int event, int event_class, int sev, const char *name, const char *text,
+schdlogerr(int event, int event_class, int sev, const std::string name, const char *text,
 	schd_error *err)
 {
 	char logbuf[MAX_LOG_SIZE];
@@ -331,6 +332,55 @@ schdlogerr(int event, int event_class, int sev, const char *name, const char *te
 		else
 			log_eventf(event, event_class, sev, name, "%s %s", text, logbuf);
 	}
+}
+
+/**
+ * @brief
+ * 	log_eventf - a combination of log_event() and printf()
+ *
+ * @param[in] eventtype - event type
+ * @param[in] objclass - event object class
+ * @param[in] sev - indication for whether to syslogging enabled or not
+ * @param[in] objname - object name stating log msg related to which object
+ * @param[in] fmt - format string
+ * @param[in] ... - arguments to format string
+ *
+ * @return void
+ */
+void
+log_eventf(int eventtype, int objclass, int sev, const std::string& objname, const char *fmt, ...)
+{
+	va_list args;
+	va_start(args, fmt);
+	do_log_eventf(eventtype, objclass, sev, objname.c_str(), fmt, args);
+	va_end(args);
+}
+
+/**
+ * @brief
+ * 	log_event - log a server event to the log file
+ *
+ *	Checks to see if the event type is being recorded.  If they are,
+ *	pass off to log_record().
+ *
+ *	The caller should ensure proper formating of the message if "text"
+ *	is to contain "continuation lines".
+ *
+ * @param[in] eventtype - event type
+ * @param[in] objclass - event object class
+ * @param[in] sev - indication for whether to syslogging enabled or not
+ * @param[in] objname - object name stating log msg related to which object
+ * @param[in] text - log msg to be logged.
+ *
+ *	Note, "sev" or severity is used only if syslogging is enabled,
+ *	see syslog(3) and log_record.c for details.
+ */
+
+void
+log_event(int eventtype, int objclass, int sev, const std::string& objname, const char *text)
+{
+	if (will_log_event(eventtype))
+		log_record(eventtype, objclass, sev, objname.c_str(), text);
 }
 
 /**
@@ -442,7 +492,7 @@ enum match_string_array_ret match_string_array(const char * const *strarr1, cons
 	strarr2_len = count_array(strarr2);
 
 	for (i = 0; strarr1[i] != NULL; i++) {
-		if (is_string_in_arr(const_cast<char **>(strarr2), const_cast<char *>(strarr1[i])))
+		if (is_string_in_arr(const_cast<char **>(strarr2), strarr1[i]))
 			match++;
 	}
 

--- a/src/scheduler/misc.cpp
+++ b/src/scheduler/misc.cpp
@@ -317,7 +317,7 @@ skip_line(char *line)
  *	@return nothing
  */
 void
-schdlogerr(int event, int event_class, int sev, const std::string name, const char *text,
+schdlogerr(int event, int event_class, int sev, const std::string& name, const char *text,
 	schd_error *err)
 {
 	char logbuf[MAX_LOG_SIZE];

--- a/src/scheduler/misc.h
+++ b/src/scheduler/misc.h
@@ -73,7 +73,7 @@ int skip_line(char *line);
  *                   error will be printed after the message
  */
 void
-schdlogerr(int event, int event_class, int sev, const std::string name, const char *text,
+schdlogerr(int event, int event_class, int sev, const std::string& name, const char *text,
 	schd_error *err);
 
 /*

--- a/src/scheduler/misc.h
+++ b/src/scheduler/misc.h
@@ -40,6 +40,7 @@
 #ifndef	_MISC_H
 #define	_MISC_H
 
+#include <string>
 
 #include "data_types.h"
 #include "server_info.h"
@@ -72,7 +73,7 @@ int skip_line(char *line);
  *                   error will be printed after the message
  */
 void
-schdlogerr(int event, int event_class, int sev, const char *name, const char *text,
+schdlogerr(int event, int event_class, int sev, const std::string name, const char *text,
 	schd_error *err);
 
 /*
@@ -294,6 +295,7 @@ add_str_to_unique_array(char ***str_arr, char *str);
  */
 void free_ptr_array (void *inp);
 
-
+void log_eventf(int eventtype, int objclass, int sev, const std::string& objname, const char *fmt, ...);
+void log_event(int eventtype, int objclass, int sev, const std::string& objname, const char *text);
 
 #endif	/* _MISC_H */

--- a/src/scheduler/node_info.cpp
+++ b/src/scheduler/node_info.cpp
@@ -1090,6 +1090,14 @@ node_filter(node_info **nodes, int size,
 	return new_nodes;
 }
 
+/**
+ * @brief find a node by string
+ * @param[in] ninfo_arr - node array to search
+ * @param[in] nodename - name of node to searh for
+ * @return node_info *
+ * @retval found node
+ * @retval NULL if not found or on error
+ */
 node_info *
 find_node_info(node_info **ninfo_arr, const std::string& nodename)
 {

--- a/src/scheduler/node_info.cpp
+++ b/src/scheduler/node_info.cpp
@@ -3183,8 +3183,7 @@ eval_simple_selspec(status *policy, chunk *chk, node_info **pninfo_arr,
 					if (failerr->status_code == SCHD_UNKWN)
 						copy_schd_error(failerr, err);
 				}
-			}
-			else {
+			} else {
 				ninfo_arr[i]->nscr |= NSCR_VISITED;
 				if (failerr->status_code == SCHD_UNKWN)
 					copy_schd_error(failerr, err);

--- a/src/scheduler/node_info.cpp
+++ b/src/scheduler/node_info.cpp
@@ -657,8 +657,6 @@ node_info::node_info(const std::string& nname): name(nname)
 
 	priority = 0;
 
-	pcpus = 0;
-
 	rank = 0;
 
 	nodesig_ind = -1;

--- a/src/scheduler/node_info.cpp
+++ b/src/scheduler/node_info.cpp
@@ -448,7 +448,7 @@ query_node_info(struct batch_status *node, server_info *sinfo)
 	int check_expiry = 0;
 	time_t expiry = 0;
 
-	if ((ninfo = new node_info(std::string(node->name))) == NULL)
+	if ((ninfo = new node_info(node->name)) == NULL)
 		return NULL;
 
 	attrp = node->attribs;
@@ -1088,32 +1088,6 @@ node_filter(node_info **nodes, int size,
 			new_nodes = new_nodes_tmp;
 	}
 	return new_nodes;
-}
-
-/**
- * @brief
- *		find_node_info - find a node in a node array
- *
- * @param[in]	nodename	-	the node to find
- * @param[in]	ninfo_arr	-	the array of nodes to look in
- *
- * @return	the node
- * @retval	NULL	: if not found
- *
- */
-node_info *
-find_node_info(node_info **ninfo_arr, const char *nodename)
-{
-	int i;
-
-	if (nodename == NULL || ninfo_arr == NULL)
-		return NULL;
-
-	for (i = 0; ninfo_arr[i] != NULL &&
-		strcmp(nodename, ninfo_arr[i]->name.c_str()) ; i++)
-		;
-
-	return ninfo_arr[i];
 }
 
 node_info *

--- a/src/scheduler/node_info.cpp
+++ b/src/scheduler/node_info.cpp
@@ -47,10 +47,7 @@
  * Functions included are:
  * 	query_nodes()
  * 	query_node_info()
- * 	new_node_info()
  * 	free_nodes()
- * 	free_node_info()
- * 	set_node_type()
  * 	set_node_info_state()
  * 	remove_node_state()
  * 	add_node_state()
@@ -201,7 +198,7 @@ query_node_info_chunk(th_data_query_ninfo *data)
 		if (node_in_partition(ninfo, sc_attrs.partition)) {
 			ninfo_arr[nidx++] = ninfo;
 		} else
-			free_node_info(ninfo);
+			delete ninfo;
 	}
 	ninfo_arr[nidx] = NULL;
 
@@ -451,15 +448,10 @@ query_node_info(struct batch_status *node, server_info *sinfo)
 	int check_expiry = 0;
 	time_t expiry = 0;
 
-	if ((ninfo = new_node_info()) == NULL)
+	if ((ninfo = new node_info(std::string(node->name))) == NULL)
 		return NULL;
 
 	attrp = node->attribs;
-
-	if ((ninfo->name = string_dup(node->name)) == NULL) {
-		free_node_info(ninfo);
-		return NULL;
-	}
 
 	ninfo->server = sinfo;
 
@@ -471,7 +463,7 @@ query_node_info(struct batch_status *node, server_info *sinfo)
 		else if (!strcmp(attrp->name, ATTR_server_inst_id)) {
 			ninfo->svr_inst_id = string_dup(attrp->value);
 			if (ninfo->svr_inst_id == NULL) {
-				free_node_info(ninfo);
+				delete ninfo;
 				return NULL;
 			}
 		}
@@ -481,7 +473,7 @@ query_node_info(struct batch_status *node, server_info *sinfo)
 			if (ninfo->mom)
 				free(ninfo->mom);
 			if ((ninfo->mom = string_dup(attrp->value)) == NULL) {
-				free_node_info(ninfo);
+				delete ninfo;
 				return NULL;
 			}
 		}
@@ -494,10 +486,6 @@ query_node_info(struct batch_status *node, server_info *sinfo)
 		}
 		else if (!strcmp(attrp->name, ATTR_NODE_jobs))
 			ninfo->jobs = break_comma_list(attrp->value);
-
-		/* the node type... i.e. a pbs node  */
-		else if (!strcmp(attrp->name, ATTR_NODE_ntype))
-			set_node_type(ninfo, attrp->value);
 		else if (!strcmp(attrp->name, ATTR_maxrun)) {
 			count = strtol(attrp->value, &endp, 10);
 			if (*endp == '\0')
@@ -553,7 +541,7 @@ query_node_info(struct batch_status *node, server_info *sinfo)
 					ninfo->res = res;
 
 				if (set_resource(res, attrp->value, RF_AVAIL) == 0) {
-					free_node_info(ninfo);
+					delete ninfo;
 					ninfo = NULL;
 					break;
 				}
@@ -572,7 +560,7 @@ query_node_info(struct batch_status *node, server_info *sinfo)
 				ninfo->res = res;
 			if (res != NULL) {
 				if (set_resource(res, attrp->value, RF_ASSN) == 0) {
-					free_node_info(ninfo);
+					delete ninfo;
 					ninfo = NULL;
 					break;
 				}
@@ -631,100 +619,87 @@ query_node_info(struct batch_status *node, server_info *sinfo)
 
 /**
  * @brief
- *      new_node_info - allocates a new node_info
- *
- * @return	the new node_info
- *
+ *	node_info constructor
  */
-node_info *
-new_node_info()
+node_info::node_info(const std::string& nname): name(nname)
 {
-	node_info *nnode;
+	svr_inst_id = NULL;
+	is_down = 0;
+	is_free = 0;
+	is_offline = 0;
+	is_unknown = 0;
+	is_exclusive = 0;
+	is_job_exclusive = 0;
+	is_resv_exclusive = 0;
+	is_sharing = 0;
+	is_busy = 0;
+	is_job_busy = 0;
+	is_stale = 0;
+	is_maintenance = 0;
+	is_provisioning = 0;
+	is_sleeping = 0;
+	is_multivnoded = 0;
+	has_ghost_job = 0;
 
-	if ((nnode = static_cast<node_info *>(malloc(sizeof(node_info)))) == NULL) {
-		log_err(errno, __func__, MEM_ERR_MSG);
-		return NULL;
-	}
+	lic_lock = 0;
 
-	nnode->svr_inst_id = NULL;
-	nnode->is_down = 0;
-	nnode->is_free = 0;
-	nnode->is_offline = 0;
-	nnode->is_unknown = 0;
-	nnode->is_exclusive = 0;
-	nnode->is_job_exclusive = 0;
-	nnode->is_resv_exclusive = 0;
-	nnode->is_sharing = 0;
-	nnode->is_pbsnode = 0;
-	nnode->is_busy = 0;
-	nnode->is_job_busy = 0;
-	nnode->is_stale = 0;
-	nnode->is_maintenance = 0;
-	nnode->is_provisioning = 0;
-	nnode->is_sleeping = 0;
-	nnode->is_multivnoded = 0;
-	nnode->has_ghost_job = 0;
+	has_hard_limit = 0;
+	no_multinode_jobs = 0;
+	resv_enable = 0;
+	provision_enable = 0;
+	power_provisioning = 0;
 
-	nnode->lic_lock = 0;
+	sharing = VNS_DFLT_SHARED;
 
-	nnode->has_hard_limit = 0;
-	nnode->no_multinode_jobs = 0;
-	nnode->resv_enable = 0;
-	nnode->provision_enable = 0;
-	nnode->power_provisioning = 0;
+	num_jobs = 0;
+	num_run_resv = 0;
+	num_susp_jobs = 0;
 
-	nnode->sharing = VNS_DFLT_SHARED;
+	priority = 0;
 
-	nnode->num_jobs = 0;
-	nnode->num_run_resv = 0;
-	nnode->num_susp_jobs = 0;
+	pcpus = 0;
 
-	nnode->priority = 0;
+	rank = 0;
 
+	nodesig_ind = -1;
 
-	nnode->rank = 0;
+	mom = NULL;
+	jobs = NULL;
+	resvs = NULL;
+	job_arr = NULL;
+	run_resvs_arr = NULL;
+	res = NULL;
+	server = NULL;
+	queue_name = NULL;
+	group_counts = NULL;
+	user_counts = NULL;
 
-	nnode->nodesig_ind = -1;
+	max_running = SCHD_INFINITY;
+	max_user_run = SCHD_INFINITY;
+	max_group_run = SCHD_INFINITY;
 
-	nnode->name = NULL;
-	nnode->mom = NULL;
-	nnode->jobs = NULL;
-	nnode->resvs = NULL;
-	nnode->job_arr = NULL;
-	nnode->run_resvs_arr = NULL;
-	nnode->res = NULL;
-	nnode->server = NULL;
-	nnode->queue_name = NULL;
-	nnode->group_counts = NULL;
-	nnode->user_counts = NULL;
+	current_aoe = NULL;
+	current_eoe = NULL;
+	nodesig = NULL;
+	last_state_change_time = 0;
+	last_used_time = 0;
 
-	nnode->max_running = SCHD_INFINITY;
-	nnode->max_user_run = SCHD_INFINITY;
-	nnode->max_group_run = SCHD_INFINITY;
+	svr_node = NULL;
+	hostset = NULL;
 
-	nnode->current_aoe = NULL;
-	nnode->current_eoe = NULL;
-	nnode->nodesig = NULL;
-	nnode->last_state_change_time = 0;
-	nnode->last_used_time = 0;
+	node_events = NULL;
+	bucket_ind = -1;
+	node_ind = -1;
 
-	nnode->svr_node = NULL;
-	nnode->hostset = NULL;
-
-	nnode->node_events = NULL;
-	nnode->bucket_ind = -1;
-	nnode->node_ind = -1;
-
-	nnode->nscr = NSCR_NONE;
+	nscr = NSCR_NONE;
 
 #ifdef NAS
 	/* localmod 034 */
-	nnode->sh_type = 0;
-	nnode->sh_cls = 0;
+	sh_type = 0;
+	sh_cls = 0;
 #endif
-	nnode->partition = NULL;
-	nnode->np_arr = NULL;
-	return nnode;
+	partition = NULL;
+	np_arr = NULL;
 }
 
 /**
@@ -747,7 +722,7 @@ free_node_info_chunk(th_data_free_ninfo *data)
 	end = data->eidx;
 
 	for (i = start; i <= end && ninfo_arr[i] != NULL; i++) {
-		free_node_info(ninfo_arr[i]);
+		delete ninfo_arr[i];
 	}
 }
 
@@ -856,96 +831,26 @@ free_nodes(node_info **ninfo_arr)
 
 /**
  * @brief
- *      free_node_info - frees memory used by a node_info
- *
- * @param[in,out]	ninfo	-	the node to free
- *
- * @return	nothing
- *
+ *      node_info destructor
  */
-void
-free_node_info(node_info *ninfo)
+node_info::~node_info()
 {
-	if (ninfo != NULL) {
-		if (ninfo->name != NULL)
-			free(ninfo->name);
-
-		if (ninfo->mom != NULL)
-			free(ninfo->mom);
-
-		if (ninfo->queue_name != NULL)
-			free(ninfo->queue_name);
-
-		if (ninfo->jobs != NULL)
-			free_string_array(ninfo->jobs);
-
-		if (ninfo->resvs != NULL)
-			free_string_array(ninfo->resvs);
-
-		if (ninfo->job_arr != NULL)
-			free(ninfo->job_arr);
-
-		if (ninfo->run_resvs_arr != NULL)
-			free(ninfo->run_resvs_arr);
-
-		if (ninfo->res != NULL)
-			free_resource_list(ninfo->res);
-
-		if (ninfo->group_counts != NULL)
-			free_counts_list(ninfo->group_counts);
-
-		if (ninfo->user_counts != NULL)
-			free_counts_list(ninfo->user_counts);
-
-		if (ninfo->current_aoe != NULL)
-			free(ninfo->current_aoe);
-
-		if (ninfo->current_eoe != NULL)
-			free(ninfo->current_eoe);
-
-		if (ninfo->nodesig != NULL)
-			free(ninfo->nodesig);
-
-		if(ninfo->node_events != NULL)
-			free_te_list(ninfo->node_events);
-
-		if (ninfo->partition != NULL)
-			free(ninfo->partition);
-
-		if (ninfo->np_arr != NULL)
-			free(ninfo->np_arr);
-
-		if (ninfo->svr_inst_id != NULL)
-			free(ninfo->svr_inst_id);
-
-		free(ninfo);
-	}
-}
-
-/**
- * @brief
- *		set_node_type - set the node type bits
- *
- * @param[in,out]	ninfo	-	the node to set the type
- * @param[in]	ntype	-	the type string from the server
- *
- * @return	non-zero	: on error
- *
- */
-int
-set_node_type(node_info *ninfo, char *ntype)
-{
-	if (ntype != NULL && ninfo != NULL) {
-		if (!strcmp(ntype, ND_pbs))
-			ninfo->is_pbsnode = 1;
-		else {
-			log_eventf(PBSEVENT_SCHED, PBS_EVENTCLASS_NODE, LOG_INFO,
-				ninfo->name, "Unknown node type: %s", ntype);
-			return 1;
-		}
-		return 0;
-	}
-	return 1;
+	free(mom);
+	free(queue_name);
+	free_string_array(jobs);
+	free_string_array(resvs);
+	free(job_arr);
+	free(run_resvs_arr);
+	free_resource_list(res);
+	free_counts_list(group_counts);
+	free_counts_list(user_counts);
+	free(current_aoe);
+	free(current_eoe);
+	free(nodesig);
+	free_te_list(node_events);
+	free(partition);
+	free(np_arr);
+	free(svr_inst_id);
 }
 
 /**
@@ -1197,7 +1102,7 @@ node_filter(node_info **nodes, int size,
  *
  */
 node_info *
-find_node_info(node_info **ninfo_arr, char *nodename)
+find_node_info(node_info **ninfo_arr, const char *nodename)
 {
 	int i;
 
@@ -1205,7 +1110,21 @@ find_node_info(node_info **ninfo_arr, char *nodename)
 		return NULL;
 
 	for (i = 0; ninfo_arr[i] != NULL &&
-		strcmp(nodename, ninfo_arr[i]->name) ; i++)
+		strcmp(nodename, ninfo_arr[i]->name.c_str()) ; i++)
+		;
+
+	return ninfo_arr[i];
+}
+
+node_info *
+find_node_info(node_info **ninfo_arr, const std::string& nodename)
+{
+	int i;
+
+	if (ninfo_arr == NULL)
+		return NULL;
+
+	for (i = 0; ninfo_arr[i] != NULL && nodename != ninfo_arr[i]->name ; i++)
 		;
 
 	return ninfo_arr[i];
@@ -1436,7 +1355,7 @@ dup_nodes(node_info **onodes, server_info *nsinfo, unsigned int flags)
 						ninfo = find_node_info(onodes, nnodes[i]->name);
 						ores = find_resource(ninfo->res, nres->def);
 						if (ores->indirect_res != NULL) {
-							sprintf(namebuf, "@%s", nnodes[i]->name);
+							sprintf(namebuf, "@%s", nnodes[i]->name.c_str());
 							for (j = i+1; nnodes[j] != NULL; j++) {
 								tres = find_resource(nnodes[j]->res, nres->def);
 								if (tres != NULL) {
@@ -1484,19 +1403,17 @@ dup_nodes(node_info **onodes, server_info *nsinfo, unsigned int flags)
  *
  */
 node_info *
-dup_node_info(node_info *onode, server_info *nsinfo,
-	unsigned int flags)
+dup_node_info(node_info *onode, server_info *nsinfo, unsigned int flags)
 {
 	node_info *nnode;
 
 	if (onode == NULL)
 		return NULL;
 
-	if ((nnode = new_node_info()) == NULL)
+	if ((nnode = new node_info(onode->name)) == NULL)
 		return NULL;
 
 	nnode->server = nsinfo;
-	nnode->name = string_dup(onode->name);
 	nnode->mom = string_dup(onode->mom);
 	nnode->queue_name = string_dup(onode->queue_name);
 
@@ -1510,7 +1427,6 @@ dup_node_info(node_info *onode, server_info *nsinfo,
 	nnode->is_resv_exclusive = onode->is_resv_exclusive;
 	nnode->is_sharing = onode->is_sharing;
 	nnode->is_busy = onode->is_busy;
-	nnode->is_pbsnode = onode->is_pbsnode;
 	nnode->is_job_busy = onode->is_job_busy;
 	nnode->is_stale = onode->is_stale;
 	nnode->is_maintenance = onode->is_maintenance;
@@ -1582,7 +1498,7 @@ dup_node_info(node_info *onode, server_info *nsinfo,
 	if (onode->partition != NULL) {
 		nnode->partition = string_dup(onode->partition);
 		if (nnode->partition == NULL) {
-			free_node_info(nnode);
+			 delete nnode;
 			return NULL;
 		}
 	}
@@ -1659,7 +1575,7 @@ collect_resvs_on_nodes(node_info **ninfo_arr, resource_resv **resresv_arr, int s
 
 	for (i = 0; ninfo_arr[i] != NULL; i++) {
 		ninfo_arr[i]->run_resvs_arr = resource_resv_filter(resresv_arr, size,
-			check_resv_running_on_node, ninfo_arr[i]->name, 0);
+			check_resv_running_on_node, ninfo_arr[i]->name.c_str(), 0);
 		/* the count of running resvs on the node is set in query_reservations */
 	}
 	return 1;
@@ -1903,43 +1819,39 @@ update_node_on_run(nspec *ns, resource_resv *resresv, const char *job_state)
 		update_counts_on_run(cts, ns->resreq);
 	}
 
-	if (ninfo->is_pbsnode) {
-		/* if we're a cluster node and we have no cpus available, we're job_busy */
-		if (ncpusres == NULL)
-			ncpusres = find_resource(ninfo->res, getallres(RES_NCPUS));
+	/* if we're a cluster node and we have no cpus available, we're job_busy */
+	if (ncpusres == NULL)
+		ncpusres = find_resource(ninfo->res, getallres(RES_NCPUS));
 
-		if (ncpusres != NULL) {
-			if (dynamic_avail(ncpusres) == 0)
-				set_node_info_state(ninfo, ND_jobbusy);
+	if (ncpusres != NULL) {
+		if (dynamic_avail(ncpusres) == 0)
+			set_node_info_state(ninfo, ND_jobbusy);
+	}
+
+	/* if node selected for provisioning, this node is no longer available */
+	if (ns->go_provision == 1) {
+		set_node_info_state(ninfo, ND_prov);
+
+		/* for jobs inside reservation, update the server's node info as well */
+		if (resresv->job != NULL && resresv->job->resv != NULL &&
+		    ninfo->svr_node != NULL) {
+			set_node_info_state(ninfo->svr_node, ND_prov);
 		}
 
-		/* if node selected for provisioning, this node is no longer available */
-		if (ns->go_provision == 1) {
-			set_node_info_state(ninfo, ND_prov);
+		set_current_aoe(ninfo, resresv->aoename);
+	}
 
-			/* for jobs inside reservation, update the server's node info as well */
-			if (resresv->job != NULL && resresv->job->resv != NULL &&
-				ninfo->svr_node != NULL) {
-				set_node_info_state(ninfo->svr_node, ND_prov);
-			}
+	/* if job has eoe setting this node gets current_eoe set */
+	if (resresv->is_job && resresv->eoename != NULL)
+		set_current_eoe(ninfo, resresv->eoename);
 
-
-			set_current_aoe(ninfo, resresv->aoename);
-		}
-
-		/* if job has eoe setting this node gets current_eoe set */
-		if (resresv->is_job && resresv->eoename != NULL)
-			set_current_eoe(ninfo, resresv->eoename);
-
-		if (is_excl(resresv->place_spec, ninfo->sharing)) {
-			if (resresv->is_resv) {
-				add_node_state(ninfo, ND_resv_exclusive);
-			}
-			else {
-				add_node_state(ninfo, ND_job_exclusive);
-				if (ninfo->svr_node != NULL)
-					add_node_state(ninfo->svr_node, ND_job_exclusive);
-			}
+	if (is_excl(resresv->place_spec, ninfo->sharing)) {
+		if (resresv->is_resv) {
+			add_node_state(ninfo, ND_resv_exclusive);
+		} else {
+			add_node_state(ninfo, ND_job_exclusive);
+			if (ninfo->svr_node != NULL)
+				add_node_state(ninfo->svr_node, ND_job_exclusive);
 		}
 	}
 
@@ -3647,7 +3559,7 @@ resources_avail_on_vnode(resource_req *specreq_cons, node_info *node,
 							set_current_aoe(node, resresv->aoename);
 						if (resresv->is_job) {
 							log_eventf(PBSEVENT_DEBUG2, PBS_EVENTCLASS_JOB, LOG_NOTICE, resresv->name,
-								"Vnode %s selected for provisioning with AOE %s", node->name, resresv->aoename);
+								"Vnode %s selected for provisioning with AOE %s", node->name.c_str(), resresv->aoename);
 						}
 					}
 
@@ -3663,7 +3575,7 @@ resources_avail_on_vnode(resource_req *specreq_cons, node_info *node,
 
 						if (resresv->is_job)
 							log_eventf(PBSEVENT_DEBUG2, PBS_EVENTCLASS_JOB, LOG_NOTICE, resresv->name,
-								"Vnode %s selected for power with EOE %s", node->name, resresv->eoename);
+								"Vnode %s selected for power with EOE %s", node->name.c_str(), resresv->eoename);
 					}
 
 					if (num_chunks > num)
@@ -3718,7 +3630,7 @@ resources_avail_on_vnode(resource_req *specreq_cons, node_info *node,
 			}
 
 			if (pl->pack && num_chunks == 1 && cstat.smp_dist == SMP_ROUND_ROBIN)
-				pbs_strncpy(last_node_name, node->name, sizeof(last_node_name));
+				pbs_strncpy(last_node_name, node->name.c_str(), sizeof(last_node_name));
 			return 1;
 		}
 	}
@@ -3764,7 +3676,7 @@ resources_avail_on_vnode(resource_req *specreq_cons, node_info *node,
 			}
 
 			if (pl->pack && cstat.smp_dist == SMP_ROUND_ROBIN)
-				pbs_strncpy(last_node_name, node->name, sizeof(last_node_name));
+				pbs_strncpy(last_node_name, node->name.c_str(), sizeof(last_node_name));
 		}
 		return num_chunks;
 	}
@@ -3887,7 +3799,7 @@ check_resources_for_node(resource_req *resreq, node_info *ninfo,
 				else {
 					ns = NULL;
 					log_eventf(PBSEVENT_SCHED, PBS_EVENTCLASS_SCHED, LOG_WARNING, resresv->name,
-						"Event %s is a run/end event w/o nspec array, ignoring event", event->name);
+						"Event %s is a run/end event w/o nspec array, ignoring event", event->name.c_str());
 				}
 
 				is_run_event = (event->event_type == TIMED_RUN_EVENT);
@@ -4330,7 +4242,7 @@ create_execvnode(nspec **ns)
 				return NULL;
 		}
 
-		if (pbs_strcat(&buf, &bufsize, ns[i]->ninfo->name) ==NULL)
+		if (pbs_strcat(&buf, &bufsize, ns[i]->ninfo->name.c_str()) ==NULL)
 			return NULL;
 
 		end_of_chunk = ns[i]->end_of_chunk;
@@ -4776,7 +4688,7 @@ reorder_nodes(node_info **nodes, resource_resv *resresv)
 
 
 	if (last_node_name[0] == '\0' && nodes[0] != NULL)
-		snprintf(last_node_name, sizeof(last_node_name), "%s", nodes[0]->name);
+		pbs_strncpy(last_node_name, nodes[0]->name.c_str(), sizeof(last_node_name));
 
 	if (resresv != NULL) {
 		if (resresv->aoename != NULL && conf.provision_policy == AVOID_PROVISION) {
@@ -4810,7 +4722,7 @@ reorder_nodes(node_info **nodes, resource_resv *resresv)
 			memcpy(tmparr, nodes, nsize * sizeof(node_info *));
 			qsort(tmparr, nsize, sizeof(node_info *), cmp_node_host);
 
-			for (i = 0; i < nsize && strcmp(last_node_name, tmparr[i]->name); i++)
+			for (i = 0; i < nsize && tmparr[i]->name != last_node_name; i++)
 				;
 
 			if (i < nsize) {
@@ -5396,7 +5308,7 @@ node_in_str(node_info *node, void *strarr)
 	if (node == NULL || strarr == NULL)
 		return 0;
 
-	if (is_string_in_arr((char **)strarr, node->name))
+	if (is_string_in_arr((char **)strarr, node->name.c_str()))
 		return 1;
 
 	return 0;

--- a/src/scheduler/node_info.h
+++ b/src/scheduler/node_info.h
@@ -98,9 +98,7 @@ int is_node_timeshared(node_info *node, void *arg);
 /*
  *      find_node_info - find a node in the node array
  */
-node_info *find_node_info(node_info **ninfo_arr, const char *nodename);
 node_info *find_node_info(node_info **ninfo_arr, const std::string& nodename);
-
 
 /*
  *      dup_node_info - duplicate a node by creating a new one and coping all

--- a/src/scheduler/node_info.h
+++ b/src/scheduler/node_info.h
@@ -67,21 +67,6 @@ free_node_info_chunk(th_data_free_ninfo *data);
  */
 void free_nodes(node_info **ninfo_arr);
 
-
-/*
- *      new_node_info - allocates a new node_info
- */
-#ifdef NAS /* localmod 005 */
-node_info *new_node_info(void);
-#else
-node_info *new_node_info();
-#endif /* localmod 005 */
-
-/*
- *      free_node_info - frees memory used by a node_info
- */
-void free_node_info(node_info *ninfo);
-
 /*
  *      set_node_info_state - set a node state
  */
@@ -113,7 +98,9 @@ int is_node_timeshared(node_info *node, void *arg);
 /*
  *      find_node_info - find a node in the node array
  */
-node_info *find_node_info(node_info **ninfo_arr, char *nodename);
+node_info *find_node_info(node_info **ninfo_arr, const char *nodename);
+node_info *find_node_info(node_info **ninfo_arr, const std::string& nodename);
+
 
 /*
  *      dup_node_info - duplicate a node by creating a new one and coping all
@@ -127,11 +114,6 @@ void dup_node_info_chunk(th_data_dup_nd_info *data);
  *      dup_nodes - duplicate an array of nodes
  */
 node_info **dup_nodes(node_info **onodes, server_info *nsinfo, unsigned int flags);
-
-/*
- *      set_node_type - set the node type bits
- */
-int set_node_type(node_info *ninfo, char *ntype);
 
 /*
  *      collect_jobs_on_nodes - collect all the jobs in the job array on the

--- a/src/scheduler/pbs_sched_bare.cpp
+++ b/src/scheduler/pbs_sched_bare.cpp
@@ -109,7 +109,7 @@ main_sched_loop_bare(int sd, server_info *sinfo)
 			}
 
 			/* Create the exec_node for the job */
-			snprintf(execvnode, sizeof(execvnode), "(%s:ncpus=1)", node->name);
+			snprintf(execvnode, sizeof(execvnode), "(%s:ncpus=1)", node->name.c_str());
 
 			/* Send the run request */
 			send_run_job(sd, 0, jobs[ij]->name, execvnode, node->svr_inst_id,

--- a/src/scheduler/prev_job_info.cpp
+++ b/src/scheduler/prev_job_info.cpp
@@ -102,10 +102,15 @@ prev_job_info::prev_job_info(const prev_job_info& opj): name(opj.name)
 	resused = dup_resource_req_list(opj.resused);
 }
 
-prev_job_info::prev_job_info(prev_job_info&& opj) noexcept: name(std::move(opj.name)), entity_name(std::move(opj.name))
+prev_job_info::prev_job_info(prev_job_info&& opj) noexcept: name(std::move(opj.name)), entity_name(std::move(opj.entity_name))
 {
 	resused = opj.resused;
 	opj.resused = NULL;
+}
+
+prev_job_info& prev_job_info::operator=(const prev_job_info& opj)
+{
+	return *this = prev_job_info(opj);
 }
 
 /**

--- a/src/scheduler/prev_job_info.cpp
+++ b/src/scheduler/prev_job_info.cpp
@@ -59,27 +59,24 @@
 #include "job_info.h"
 #include "misc.h"
 #include "resource_resv.h"
+#include "globals.h"
 
 
 /**
  * @brief
- *		create_prev_job_info - create the prev_job_info array from an array
- *				of jobs
+ *		create_prev_job_info - create the prev_job_info array from an array of jobs
  *
- * @param[in,out]	jobs	-	job array
- * @param[in]	size	-	size of jinfo_arr or UNSPECIFIED if unknown
- *
- * @return	new prev_job_array
- * @retval	NULL	: on error
+ * @param[in]	jobs	-	job array
  *
  * @par	NOTE: jinfo_arr is modified
  *
  */
-std::vector<prev_job_info>
+void
 create_prev_job_info(resource_resv **jobs)
 {
-	std::vector<prev_job_info> npji;	/* new prev_job_info vector */
 	int i;
+
+	last_running.clear();
 
 	for (i = 0; jobs[i] != NULL; i++) {
 		if(jobs[i]->job != NULL) {
@@ -88,11 +85,9 @@ create_prev_job_info(resource_resv **jobs)
 			/* resused is shallow copied, NULL it so it doesn't get freed at the end of the cycle */
 			jobs[i]->job->resused = NULL;
 
-			npji.push_back(pjinfo);
+			last_running.push_back(pjinfo);
 		}
 	}
-
-	return npji;
 }
 
 prev_job_info::prev_job_info(const std::string& pname, char *ename, resource_req *rused): name(pname)

--- a/src/scheduler/prev_job_info.h
+++ b/src/scheduler/prev_job_info.h
@@ -46,6 +46,6 @@
  *      create_prev_job_info - create the prev_job_info array from an array
  *                              of jobs
  */
-std::vector<prev_job_info> create_prev_job_info(resource_resv **resresv_arr);
+void create_prev_job_info(resource_resv **resresv_arr);
 
 #endif	/* _PREV_JOB_INFO_H */

--- a/src/scheduler/prev_job_info.h
+++ b/src/scheduler/prev_job_info.h
@@ -46,15 +46,6 @@
  *      create_prev_job_info - create the prev_job_info array from an array
  *                              of jobs
  */
-prev_job_info *create_prev_job_info(resource_resv **resresv_arr, int size);
+std::vector<prev_job_info> create_prev_job_info(resource_resv **resresv_arr);
 
-/*
- *      free_prev_job_info - free a prev_job_info struct
- */
-void free_prev_job_info(prev_job_info *pjinfo);
-
-/*
- *      free_pjobs - free a list of prev_job_info structs
- */
-void free_pjobs(prev_job_info *pjinfo_arr, int size);
 #endif	/* _PREV_JOB_INFO_H */

--- a/src/scheduler/queue_info.cpp
+++ b/src/scheduler/queue_info.cpp
@@ -970,7 +970,7 @@ dup_queue_info(queue_info *oqinfo, server_info *nsinfo)
 			/* For standing reservations, we need to restore the resv_queue pointers for all occurrences */
 			int i;
 			for(i = 0; nqinfo->server->resvs[i] != NULL; i++) {
-				if (!strcmp(nqinfo->server->resvs[i]->name, nqinfo->resv->name))
+				if (nqinfo->server->resvs[i]->name == nqinfo->resv->name)
 					nqinfo->server->resvs[i]->resv->resv_queue = nqinfo;
 			}
 		}

--- a/src/scheduler/resource.cpp
+++ b/src/scheduler/resource.cpp
@@ -578,7 +578,7 @@ reset_global_resource_ptrs(void)
 	}
 	update_sorting_defs(SD_FREE);
 
-	clear_last_running();
+	last_running.clear();
 
 	/* The above references into this array.  We now free the memory */
 	if (allres != NULL) {

--- a/src/scheduler/resource_resv.cpp
+++ b/src/scheduler/resource_resv.cpp
@@ -337,6 +337,7 @@ resource_resv::~resource_resv()
 
 	if (end_event != NULL)
 		delete_event(server, end_event);
+}
 
 /**
  * @brief	pthread routine for duping a chunk of resresvs

--- a/src/scheduler/resource_resv.cpp
+++ b/src/scheduler/resource_resv.cpp
@@ -46,9 +46,7 @@
  * 	resource_resv.c - This file contains functions related to resource reservations.
  *
  * Functions included are:
- * 	new_resource_resv()
  * 	free_resource_resv_array()
- * 	free_resource_resv()
  * 	dup_resource_resv_array()
  * 	dup_resource_resv()
  * 	find_resource_resv()
@@ -123,80 +121,65 @@
 
 /**
  * @brief
- *		new_resource_resv() - allocate and initialize a resource_resv struct
- *
- * @return	ptr to newly allocated resource_resv struct
- *
+ *		resource_resv constructor
  */
-resource_resv *
-new_resource_resv()
+resource_resv::resource_resv(const char *rname): name(rname) 
 {
-	resource_resv *resresv = NULL;
+	user = NULL;
+	group = NULL;
+	project = NULL;
+	nodepart_name = NULL;
+	select = NULL;
+	execselect = NULL;
 
-	if ((resresv = static_cast<resource_resv *>(malloc(sizeof(resource_resv)))) == NULL) {
-		log_err(errno, __func__, MEM_ERR_MSG);
-		return NULL;
-	}
+	place_spec = NULL;
 
-	resresv->svr_inst_id = NULL;
-	resresv->name = NULL;
-	resresv->user = NULL;
-	resresv->group = NULL;
-	resresv->project = NULL;
-	resresv->nodepart_name = NULL;
-	resresv->select = NULL;
-	resresv->execselect = NULL;
+	is_invalid = 0;
+	can_not_fit = 0;
+	can_not_run = 0;
+	can_never_run = 0;
+	is_peer_ob = 0;
 
-	resresv->place_spec = NULL;
+	is_prov_needed = 0;
+	is_job = 0;
+	is_shrink_to_fit = 0;
+	is_resv = 0;
 
-	resresv->is_invalid = 0;
-	resresv->can_not_fit = 0;
-	resresv->can_not_run = 0;
-	resresv->can_never_run = 0;
-	resresv->is_peer_ob = 0;
+	will_use_multinode = 0;
 
-	resresv->is_prov_needed = 0;
-	resresv->is_job = 0;
-	resresv->is_shrink_to_fit = 0;
-	resresv->is_resv = 0;
+	sch_priority = 0;
+	rank = 0;
+	qtime = 0;
+	qrank = 0;
 
-	resresv->will_use_multinode = 0;
+	ec_index = UNSPECIFIED;
 
-	resresv->sch_priority = 0;
-	resresv->rank = 0;
-	resresv->qtime = 0;
-	resresv->qrank = 0;
+	start = UNSPECIFIED;
+	end = UNSPECIFIED;
+	duration = UNSPECIFIED;
+	hard_duration = UNSPECIFIED;
+	min_duration = UNSPECIFIED;
+	svr_inst_id = NULL;
+	resreq = NULL;
+	server = NULL;
+	ninfo_arr = NULL;
+	nspec_arr = NULL;
 
-	resresv->ec_index = UNSPECIFIED;
+	job = NULL;
+	resv = NULL;
 
-	resresv->start = UNSPECIFIED;
-	resresv->end = UNSPECIFIED;
-	resresv->duration = UNSPECIFIED;
-	resresv->hard_duration = UNSPECIFIED;
-	resresv->min_duration = UNSPECIFIED;
-
-	resresv->resreq = NULL;
-	resresv->server = NULL;
-	resresv->ninfo_arr = NULL;
-	resresv->nspec_arr = NULL;
-
-	resresv->job = NULL;
-	resresv->resv = NULL;
-
-	resresv->aoename = NULL;
-	resresv->eoename = NULL;
+	aoename = NULL;
+	eoename = NULL;
 
 #ifdef NAS /* localmod 034 */
-	resresv->share_type = J_TYPE_ignore;
+	share_type = J_TYPE_ignore;
 #endif /* localmod 034 */
 
-	resresv->node_set_str = NULL;
-	resresv->node_set = NULL;
-	resresv->resresv_ind = -1;
-	resresv->run_event = NULL;
-	resresv->end_event = NULL;
-
-	return resresv;
+	node_set_str = NULL;
+	node_set = NULL;
+	resresv_ind = -1;
+	run_event = NULL;
+	end_event = NULL;
 }
 
 /**
@@ -219,7 +202,7 @@ free_resource_resv_array_chunk(th_data_free_resresv *data)
 	end = data->eidx;
 
 	for (i = start; i <= end && resresv_arr[i] != NULL; i++) {
-		free_resource_resv(resresv_arr[i]);
+		delete resresv_arr[i];
 	}
 }
 
@@ -326,81 +309,34 @@ free_resource_resv_array(resource_resv **resresv_arr)
 
 /**
  * @brief
- *		free_resource_resv - free a resource resv strcture an all of it's ptrs
- *
- * @param[in]	resresv	-	resource_resv to free
- *
- * @return	nothing
+ *		resource_resv destructor
  *
  */
-void
-free_resource_resv(resource_resv *resresv)
+resource_resv::~resource_resv()
 {
-	if (resresv == NULL)
-		return;
-
-	if (resresv->name != NULL)
-		free(resresv->name);
-
-	if (resresv->user != NULL)
-		free(resresv->user);
-
-	if (resresv->group != NULL)
-		free(resresv->group);
-
-	if (resresv->project != NULL)
-		free(resresv->project);
-
-	if (resresv->nodepart_name != NULL)
-		free(resresv->nodepart_name);
-
-	if (resresv->select != NULL)
-		free_selspec(resresv->select);
-
-	if (resresv->execselect != NULL)
-		free_selspec(resresv->execselect);
-
-	if (resresv->place_spec != NULL)
-		free_place(resresv->place_spec);
-
-	if (resresv->resreq != NULL)
-		free_resource_req_list(resresv->resreq);
-
-	if (resresv->ninfo_arr != NULL)
-		free(resresv->ninfo_arr);
-
-	if (resresv->nspec_arr != NULL)
-		free_nspecs(resresv->nspec_arr);
-
-	if (resresv->job != NULL)
-		free_job_info(resresv->job);
-
-	if (resresv->resv != NULL)
-		free_resv_info(resresv->resv);
-
-	if (resresv->aoename != NULL)
-		free(resresv->aoename);
-
-	if (resresv->eoename != NULL)
-		free(resresv->eoename);
-
-	if (resresv->node_set_str != NULL)
-		free_string_array(resresv->node_set_str);
-
-	if (resresv->node_set != NULL)
-		free(resresv->node_set);
-
+	free(user);
+	free(group);
+	free(project);
+	free(nodepart_name);
+	free_selspec(select);
+	free_selspec(execselect);
+	free_place(place_spec);
+	free_resource_req_list(resreq);
+	free(ninfo_arr);
+	free_nspecs(nspec_arr);
+	free_job_info(job);
+	free_resv_info(resv);
+	free(aoename);
+	free(eoename);
+	free_string_array(node_set_str);
+	free(node_set);
+	free(svr_inst_id);
 	/* Avoid dangling pointers inside the calendar */
-	if (resresv->run_event != NULL)
-		delete_event(resresv->server, resresv->run_event);
+	if (run_event != NULL)
+		delete_event(server, run_event);
 
-	if (resresv->end_event != NULL)
-		delete_event(resresv->server, resresv->end_event);
-
-	free(resresv->svr_inst_id);
-
-	free(resresv);
-}
+	if (end_event != NULL)
+		delete_event(server, end_event);
 
 /**
  * @brief	pthread routine for duping a chunk of resresvs
@@ -436,7 +372,7 @@ dup_resource_resv_array_chunk(th_data_dup_resresv *data)
 	end = data->eidx;
 	data->error = 0;
 	for (i = start; i <= end && oresresv_arr[i] != NULL; i++) {
-		if ((nresresv_arr[i] = dup_resource_resv(oresresv_arr[i], nsinfo, nqinfo, err)) == NULL) {
+		if ((nresresv_arr[i] = dup_resource_resv(oresresv_arr[i], nsinfo, nqinfo)) == NULL) {
 			data->error = 1;
 			free_schd_error(err);
 			return;
@@ -592,29 +528,37 @@ dup_resource_resv_array(resource_resv **oresresv_arr,
  *
  */
 resource_resv *
-dup_resource_resv(resource_resv *oresresv, server_info *nsinfo, queue_info *nqinfo, schd_error *err)
+dup_resource_resv(resource_resv *oresresv, server_info *nsinfo, queue_info *nqinfo, const std::string& name)
 {
 	resource_resv *nresresv;
+	schd_error *err;
 
-	if (oresresv == NULL || nsinfo == NULL || err == NULL)
+	if (oresresv == NULL || nsinfo == NULL)
 		return NULL;
 
-	clear_schd_error(err);
+	err = new_schd_error();
+
+	if (err == NULL)
+		return NULL;
 
 	if (!is_resource_resv_valid(oresresv, err)) {
 		schdlogerr(PBSEVENT_DEBUG2, PBS_EVENTCLASS_SCHED, LOG_DEBUG, oresresv->name, "Can't dup resresv", err);
 		return NULL;
 	}
 
-	nresresv = new_resource_resv();
+	if (name.empty())
+		nresresv = new resource_resv(oresresv->name.c_str());
+	else
+		nresresv = new resource_resv(name.c_str());
 
-	if (nresresv == NULL)
+	if (nresresv == NULL) {
+		free_schd_error(err);
 		return NULL;
+	}
 
 	nresresv->server = nsinfo;
 
 	nresresv->svr_inst_id = string_dup(oresresv->svr_inst_id);
-	nresresv->name = string_dup(oresresv->name);
 	nresresv->user = string_dup(oresresv->user);
 	nresresv->group = string_dup(oresresv->group);
 	nresresv->project = string_dup(oresresv->project);
@@ -689,7 +633,8 @@ dup_resource_resv(resource_resv *oresresv, server_info *nsinfo, queue_info *nqin
 		nresresv->nspec_arr = dup_nspecs(oresresv->nspec_arr, nsinfo->nodes, NULL);
 	}
 	else  { /* error */
-		free_resource_resv(nresresv);
+		delete nresresv;
+		free_schd_error(err);
 		return NULL;
 	}
 #ifdef NAS /* localmod 034 */
@@ -698,10 +643,11 @@ dup_resource_resv(resource_resv *oresresv, server_info *nsinfo, queue_info *nqin
 
 	if (!is_resource_resv_valid(nresresv, err)) {
 		schdlogerr(PBSEVENT_DEBUG2, PBS_EVENTCLASS_SCHED, LOG_DEBUG, oresresv->name, "Failed to dup resresv", err);
-		free_resource_resv(nresresv);
+		delete nresresv;
+		free_schd_error(err);
 		return NULL;
 	}
-
+	free_schd_error(err);
 	return nresresv;
 }
 
@@ -718,17 +664,30 @@ dup_resource_resv(resource_resv *oresresv, server_info *nsinfo, queue_info *nqin
  *
  */
 resource_resv *
-find_resource_resv(resource_resv **resresv_arr, char *name)
+find_resource_resv(resource_resv **resresv_arr, const char *name)
 {
 	int i;
 	if (resresv_arr == NULL || name == NULL)
 		return NULL;
 
-	for (i = 0; resresv_arr[i] != NULL && strcmp(resresv_arr[i]->name, name);i++)
+	for (i = 0; resresv_arr[i] != NULL && resresv_arr[i]->name != name;i++)
 		;
 
 	return resresv_arr[i];
 }
+
+resource_resv *find_resource_resv(resource_resv **resresv_arr, const std::string& name)
+{
+	int i;
+	if (resresv_arr == NULL || name.empty())
+		return NULL;
+
+	for (i = 0; resresv_arr[i] != NULL && resresv_arr[i]->name != name;i++)
+		;
+
+	return resresv_arr[i];
+}
+
 
 /**
  * @brief
@@ -774,14 +733,14 @@ find_resource_resv_by_indrank(resource_resv **resresv_arr, int index, int rank)
  *
  */
 resource_resv *
-find_resource_resv_by_time(resource_resv **resresv_arr, char *name, time_t start_time)
+find_resource_resv_by_time(resource_resv **resresv_arr, const std::string& name, time_t start_time)
 {
 	int i;
-	if (resresv_arr == NULL || name == NULL)
+	if (resresv_arr == NULL)
 		return NULL;
 
 	for (i = 0; resresv_arr[i] != NULL;i++) {
-		if ((strcmp(resresv_arr[i]->name, name) == 0) && (resresv_arr[i]->start == start_time))
+		if ((resresv_arr[i]->name == name) && (resresv_arr[i]->start == start_time))
 			break;
 	}
 
@@ -835,10 +794,10 @@ cmp_job_arrays(resource_resv *resresv, void *arg)
 		return 0;
 
 	/* if one is not a subjob = no match */
-	if (resresv->job->array_id == NULL || argresv->job->array_id== NULL)
+	if (resresv->job->array_id.empty() || argresv->job->array_id.empty())
 		return 0;
 
-	if (strcmp(resresv->job->array_id, argresv->job->array_id)== 0)
+	if (resresv->job->array_id == argresv->job->array_id)
 		return 1;
 
 	return 0;
@@ -880,7 +839,7 @@ is_resource_resv_valid(resource_resv *resresv, schd_error *err)
 		return 0;
 	}
 
-	if (resresv->name == NULL) {
+	if (resresv->name.empty()) {
 		set_schd_error_codes(err, NEVER_RUN, ERR_SPECIAL);
 		set_schd_error_arg(err, SPECMSG, "No Name");
 		return 0;
@@ -1821,7 +1780,7 @@ update_resresv_on_end(resource_resv *resresv, const char *job_state)
  */
 resource_resv **
 resource_resv_filter(resource_resv **resresv_arr, int size,
-	int (*filter_func)(resource_resv*, void*), void *arg, int flags)
+	int (*filter_func)(resource_resv *, const void *), const void *arg, int flags)
 {
 	resource_resv **new_resresvs = NULL;			/* new array of jobs */
 	resource_resv **tmp;
@@ -2512,7 +2471,7 @@ create_select_from_nspec(nspec **nspec_array)
 		 */
 		if (nspec_array[i]->resreq != NULL) {
 			if (nspec_array[i]->ninfo != NULL) {
-				snprintf(buf, sizeof(buf), "1:vnode=%s", nspec_array[i]->ninfo->name);
+				snprintf(buf, sizeof(buf), "1:vnode=%s", nspec_array[i]->ninfo->name.c_str());
 				if (pbs_strcat(&select_spec, &selsize, buf) == NULL) {
 					if (selsize > 0)
 						free(select_spec);

--- a/src/scheduler/resource_resv.cpp
+++ b/src/scheduler/resource_resv.cpp
@@ -654,7 +654,7 @@ dup_resource_resv(resource_resv *oresresv, server_info *nsinfo, queue_info *nqin
 	return dup_resource_resv(oresresv, nsinfo, nqinfo, oresresv->name);
 }
 
-	resource_resv *find_resource_resv(resource_resv **resresv_arr, const std::string &name)
+resource_resv *find_resource_resv(resource_resv **resresv_arr, const std::string &name)
 {
 	int i;
 	if (resresv_arr == NULL || name.empty())

--- a/src/scheduler/resource_resv.cpp
+++ b/src/scheduler/resource_resv.cpp
@@ -123,7 +123,7 @@
  * @brief
  *		resource_resv constructor
  */
-resource_resv::resource_resv(const char *rname): name(rname) 
+resource_resv::resource_resv(const std::string& rname): name(rname) 
 {
 	user = NULL;
 	group = NULL;
@@ -543,13 +543,11 @@ dup_resource_resv(resource_resv *oresresv, server_info *nsinfo, queue_info *nqin
 
 	if (!is_resource_resv_valid(oresresv, err)) {
 		schdlogerr(PBSEVENT_DEBUG2, PBS_EVENTCLASS_SCHED, LOG_DEBUG, oresresv->name, "Can't dup resresv", err);
+		free_schd_error(err);
 		return NULL;
 	}
 
-	if (name.empty())
-		nresresv = new resource_resv(oresresv->name.c_str());
-	else
-		nresresv = new resource_resv(name.c_str());
+	nresresv = new resource_resv(name.c_str());
 
 	if (nresresv == NULL) {
 		free_schd_error(err);
@@ -650,39 +648,19 @@ dup_resource_resv(resource_resv *oresresv, server_info *nsinfo, queue_info *nqin
 	free_schd_error(err);
 	return nresresv;
 }
-
-/**
- * @brief
- * 		find a resource_resv by name
- *
- * @param[in]	resresv_arr	-	array of resource_resvs to search
- * @param[in]	name        -	name of resource_resv to find
- *
- * @return	resource_resv *
- * @retval	resource_resv if found
- * @retval	NULL	: if not found or on error
- *
- */
 resource_resv *
-find_resource_resv(resource_resv **resresv_arr, const char *name)
+dup_resource_resv(resource_resv *oresresv, server_info *nsinfo, queue_info *nqinfo)
 {
-	int i;
-	if (resresv_arr == NULL || name == NULL)
-		return NULL;
-
-	for (i = 0; resresv_arr[i] != NULL && resresv_arr[i]->name != name;i++)
-		;
-
-	return resresv_arr[i];
+	return dup_resource_resv(oresresv, nsinfo, nqinfo, oresresv->name);
 }
 
-resource_resv *find_resource_resv(resource_resv **resresv_arr, const std::string& name)
+	resource_resv *find_resource_resv(resource_resv **resresv_arr, const std::string &name)
 {
 	int i;
 	if (resresv_arr == NULL || name.empty())
 		return NULL;
 
-	for (i = 0; resresv_arr[i] != NULL && resresv_arr[i]->name != name;i++)
+	for (i = 0; resresv_arr[i] != NULL && resresv_arr[i]->name != name; i++)
 		;
 
 	return resresv_arr[i];

--- a/src/scheduler/resource_resv.h
+++ b/src/scheduler/resource_resv.h
@@ -80,7 +80,6 @@ int is_resource_resv_valid(resource_resv *resresv, schd_error *err);
 /*
  *      find_resource_resv - find a resource_resv by name
  */
-resource_resv *find_resource_resv(resource_resv **resresv_arr, const char *name);
 resource_resv *find_resource_resv(resource_resv **resresv_arr, const std::string& name);
 
 

--- a/src/scheduler/resource_resv.h
+++ b/src/scheduler/resource_resv.h
@@ -58,8 +58,9 @@ void free_resource_resv_array(resource_resv **resresv);
  *      dup_resource_resv - duplicate a resource resv structure
  */
 resource_resv *dup_resource_resv(resource_resv *oresresv, server_info *nsinfo,
-		queue_info *nqinfo, const std::string& name = {});
+		queue_info *nqinfo, const std::string& name);
 
+resource_resv *dup_resource_resv(resource_resv *oresresv, server_info *nsinfo, queue_info *nqinfo);
 /*
  * pthread routine for duping a chunk of resresvs
  */

--- a/src/scheduler/resource_resv.h
+++ b/src/scheduler/resource_resv.h
@@ -43,20 +43,6 @@
 #include "data_types.h"
 
 /*
- *      new_resource_resv() - allocate and initialize a resource_resv struct
- */
-#ifdef NAS /* localmod 005 */
-resource_resv *new_resource_resv(void);
-#else
-resource_resv *new_resource_resv();
-#endif /* localmod 005 */
-
-/*
- *      free_resource_resv - free a resource resv strcture an all of it's ptrs
- */
-void free_resource_resv(resource_resv *resresv);
-
-/*
  * pthread routine to free resource_resv array chunk
  */
 void
@@ -72,7 +58,7 @@ void free_resource_resv_array(resource_resv **resresv);
  *      dup_resource_resv - duplicate a resource resv structure
  */
 resource_resv *dup_resource_resv(resource_resv *oresresv, server_info *nsinfo,
-		queue_info *nqinfo, schd_error *err);
+		queue_info *nqinfo, const std::string& name = {});
 
 /*
  * pthread routine for duping a chunk of resresvs
@@ -94,7 +80,9 @@ int is_resource_resv_valid(resource_resv *resresv, schd_error *err);
 /*
  *      find_resource_resv - find a resource_resv by name
  */
-resource_resv *find_resource_resv(resource_resv **resresv_arr, char *name);
+resource_resv *find_resource_resv(resource_resv **resresv_arr, const char *name);
+resource_resv *find_resource_resv(resource_resv **resresv_arr, const std::string& name);
+
 
 /*
  * find a resource_resv by unique numeric rank
@@ -105,7 +93,7 @@ resource_resv *find_resource_resv_by_indrank(resource_resv **resresv_arr, int in
 /**
  *  find_resource_resv_by_time - find a resource_resv by name and start time
  */
-resource_resv *find_resource_resv_by_time(resource_resv **resresv_arr, char *name, time_t start_time);
+resource_resv *find_resource_resv_by_time(resource_resv **resresv_arr, const std::string& name, time_t start_time);
 
 /*
  *      find_resource_req - find a resource_req from a resource_req list
@@ -216,7 +204,7 @@ void update_resresv_on_end(resource_resv *resresv, const char *job_state);
  */
 resource_resv **
 resource_resv_filter(resource_resv **resresv_arr, int size,
-	int (*filter_func)(resource_resv*, void*), void *arg, int flags);
+	int (*filter_func)(resource_resv *, const void *), const void *arg, int flags);
 
 
 /*

--- a/src/scheduler/resv_info.cpp
+++ b/src/scheduler/resv_info.cpp
@@ -234,7 +234,7 @@ query_reservations(int pbs_sd, server_info *sinfo, struct batch_status *resvs)
 			ignore_resv = 1;
 		}
 		else if ((resresv->resv->resv_state == RESV_BEING_DELETED) && (resresv->resv->resv_nodes != NULL) &&
-			(!is_string_in_arr(resresv->resv->resv_nodes[0]->resvs, resresv->name))) {
+			(!is_string_in_arr(resresv->resv->resv_nodes[0]->resvs, resresv->name.c_str()))) {
 			log_event(PBSEVENT_SCHED, PBS_EVENTCLASS_RESV, LOG_DEBUG,
 				resresv->name, "Reservation is being deleted and not present on node, ignoring this reservation");
 			ignore_resv = 1;
@@ -252,7 +252,7 @@ query_reservations(int pbs_sd, server_info *sinfo, struct batch_status *resvs)
 					update_jobs_cant_run(pbs_sd, qinfo->jobs, NULL, err, START_WITH_JOB);
 				}
 			}
-			free_resource_resv(resresv);
+			delete resresv;
 			continue;
 		}
 
@@ -434,7 +434,7 @@ query_reservations(int pbs_sd, server_info *sinfo, struct batch_status *resvs)
 					resresv->name, "Error processing standing reservation");
 				free(execvnodes_seq);
 				sinfo->num_resvs--;
-				free_resource_resv(resresv);
+				delete resresv;
 				continue;
 			}
 			/* unroll_execvnode_seq will destroy the first argument that is passed
@@ -468,7 +468,7 @@ query_reservations(int pbs_sd, server_info *sinfo, struct batch_status *resvs)
 				sizeof(resource_resv *) * (sinfo->num_resvs + 1)))) == NULL) {
 				log_err(errno, __func__, MEM_ERR_MSG);
 				free_resource_resv_array(resresv_arr);
-				free_resource_resv(resresv);
+				delete resresv;
 				free_execvnode_seq(tofree);
 				free(execvnodes_seq);
 				free(execvnode_ptr);
@@ -506,11 +506,11 @@ query_reservations(int pbs_sd, server_info *sinfo, struct batch_status *resvs)
 				if (j == 0)
 					resresv_ocr = resresv;
 				else {
-					resresv_ocr = dup_resource_resv(resresv, sinfo, NULL, err);
+					resresv_ocr = dup_resource_resv(resresv, sinfo, NULL);
 					if (resresv_ocr == NULL) {
 						log_err(errno, __func__, "Error duplicating resource reservation");
 						free_resource_resv_array(resresv_arr);
-						free_resource_resv(resresv);
+						delete resresv;
 						free_execvnode_seq(tofree);
 						free(execvnodes_seq);
 						free(execvnode_ptr);
@@ -622,16 +622,15 @@ query_resv(struct batch_status *resv, server_info *sinfo)
 	if (resv == NULL)
 		return NULL;
 
-	if ((advresv = new_resource_resv()) == NULL)
+	if ((advresv = new resource_resv(resv->name)) == NULL)
 		return NULL;
 
 	if ((advresv->resv = new_resv_info()) == NULL) {
-		free_resource_resv(advresv);
+		delete  advresv;
 		return NULL;
 	}
 
 	attrp = resv->attribs;
-	advresv->name = string_dup(resv->name);
 	advresv->server = sinfo;
 	advresv->is_resv = 1;
 
@@ -712,7 +711,7 @@ query_resv(struct batch_status *resv, server_info *sinfo)
 		} else if (!strcmp(attrp->name, ATTR_l)) { /* resources requested*/
 			resreq = find_alloc_resource_req_by_str(advresv->resreq, attrp->resource);
 			if (resreq == NULL) {
-				free_resource_resv(advresv);
+				delete advresv;
 				return NULL;
 			}
 
@@ -898,6 +897,9 @@ new_resv_info()
 void
 free_resv_info(resv_info *rinfo)
 {
+	if (rinfo == NULL)
+		return;
+	
 	if (rinfo->queuename != NULL)
 		free(rinfo->queuename);
 
@@ -1172,7 +1174,7 @@ check_new_reservations(status *policy, int pbs_sd, resource_resv **resvs, server
 							/* For a new, unconfirmed, reservation, we duplicate the parent
 							 * reservation
 							 */
-							nresv_copy = dup_resource_resv(nresv_copy, sinfo, NULL, err);
+							nresv_copy = dup_resource_resv(nresv_copy, sinfo, NULL);
 							if (nresv_copy == NULL)
 								break;
 							if (nresv_copy->resv->select_standing != NULL) {
@@ -1478,7 +1480,7 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 				}
 				nresv = nresv_copy;
 			} else {
-				nresv_copy = dup_resource_resv(nresv, nsinfo, NULL, err);
+				nresv_copy = dup_resource_resv(nresv, nsinfo, NULL);
 
 				if (nresv_copy == NULL) {
 					rconf = RESV_CONFIRM_FAIL;
@@ -1491,7 +1493,7 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 				 */
 				tmp_resresv = add_resresv_to_array(nsinfo->resvs, nresv, NO_FLAGS);
 				if (tmp_resresv == NULL) {
-					free_resource_resv(nresv);
+					delete nresv;
 					rconf = RESV_CONFIRM_FAIL;
 					break;
 				}
@@ -1499,7 +1501,7 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 
 				tmp_resresv = add_resresv_to_array(nsinfo->all_resresv, nresv, SET_RESRESV_INDEX);
 				if (tmp_resresv == NULL) {
-					free_resource_resv(nresv);
+					delete nresv;
 					rconf = RESV_CONFIRM_FAIL;
 					break;
 				}
@@ -1511,7 +1513,7 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 				log_event(PBSEVENT_RESV, PBS_EVENTCLASS_RESV, LOG_INFO, nresv->name,
 					"Error determining if reservation can be confirmed: "
 					"String concatenation failed.");
-				free_resource_resv(nresv);
+				delete nresv;
 				free(tmp);
 				rconf = RESV_CONFIRM_FAIL;
 				break;
@@ -1708,7 +1710,7 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 		snprintf(confirm_msg, LOG_BUF_SIZE, "%s:partition=%s", PBS_RESV_CONFIRM_SUCCESS,
 			 sc_attrs.partition ? sc_attrs.partition : DEFAULT_PARTITION);
 
-		pbsrc = pbs_confirmresv(pbs_sd, nresv_parent->name, short_xc,
+		pbsrc = pbs_confirmresv(pbs_sd, const_cast<char *>(nresv_parent->name.c_str()), short_xc,
 			resv_start_time, confirm_msg);
 	}
 	else {
@@ -1717,7 +1719,7 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 		 * "null" is used satisfy the API but any string would do because we've
 		 * failed to confirm the reservation and no execvnodes were determined
 		 */
-		pbsrc = pbs_confirmresv(pbs_sd, nresv_parent->name, const_cast<char *>("null"),
+		pbsrc = pbs_confirmresv(pbs_sd, const_cast<char *>(nresv_parent->name.c_str()), const_cast<char *>("null"),
 			resv_start_time, const_cast<char *>(PBS_RESV_CONFIRM_FAIL));
 	}
 

--- a/src/scheduler/resv_info.cpp
+++ b/src/scheduler/resv_info.cpp
@@ -752,7 +752,7 @@ query_resv(struct batch_status *resv, server_info *sinfo)
 		} else if (!strcmp(attrp->name, ATTR_server_inst_id)) {
 			advresv->svr_inst_id = string_dup(attrp->value);
 			if (advresv->svr_inst_id == NULL) {
-				free_resource_resv(advresv);
+				delete advresv;
 				return NULL;
 			}
 		}

--- a/src/scheduler/server_info.cpp
+++ b/src/scheduler/server_info.cpp
@@ -120,12 +120,12 @@
 #include <signal.h>
 #include <sys/wait.h>
 
+#include "pbs_entlim.h"
 #include "pbs_ifl.h"
 #include "pbs_error.h"
 #include "log.h"
 #include "pbs_share.h"
 #include "libpbs.h"
-#include "pbs_entlim.h"
 #include "constant.h"
 #include "config.h"
 #include "server_info.h"

--- a/src/scheduler/server_info.cpp
+++ b/src/scheduler/server_info.cpp
@@ -125,12 +125,13 @@
 #include "log.h"
 #include "pbs_share.h"
 #include "libpbs.h"
-#include "server_info.h"
+#include "pbs_entlim.h"
 #include "constant.h"
+#include "config.h"
+#include "server_info.h"
 #include "queue_info.h"
 #include "job_info.h"
 #include "misc.h"
-#include "config.h"
 #include "node_info.h"
 #include "globals.h"
 #include "resv_info.h"
@@ -146,7 +147,6 @@
 #include "simulate.h"
 #include "fairshare.h"
 #include "check.h"
-// #include "pbs_sched.h"
 #include "fifo.h"
 #include "buckets.h"
 #include "parse.h"
@@ -2050,7 +2050,7 @@ create_server_arrays(server_info *sinfo)
  * @retval	1	: job is running
  */
 int
-check_run_job(resource_resv *job, void *arg)
+check_run_job(resource_resv *job, const void *arg)
 {
 	if (job->is_job && job->job != NULL)
 		return job->job->is_running;
@@ -2069,7 +2069,7 @@ check_run_job(resource_resv *job, void *arg)
  * @retval	1	: if job is exiting
  */
 int
-check_exit_job(resource_resv *job, void *arg)
+check_exit_job(resource_resv *job, const void *arg)
 {
 	if (job->is_job && job->job != NULL)
 		return job->job->is_exiting;
@@ -2109,7 +2109,7 @@ check_run_resv(resource_resv *resv, void *arg)
  * @retval	0	: if job is not suspended
  */
 int
-check_susp_job(resource_resv *job, void *arg)
+check_susp_job(resource_resv *job, const void *arg)
 {
 	if (job->is_job && job->job != NULL)
 		return job->job->is_suspended;
@@ -2129,7 +2129,7 @@ check_susp_job(resource_resv *job, void *arg)
  * @retval	0	: if job is not running
  */
 int
-check_job_running(resource_resv *job, void *arg)
+check_job_running(resource_resv *job, const void *arg)
 {
 	if (job->is_job && (job->job->is_running || job->job->is_exiting || job->job->is_userbusy))
 		return 1;
@@ -2149,7 +2149,7 @@ check_job_running(resource_resv *job, void *arg)
  * @retval	0	: if job is not running or not in a reservation
  */
 int
-check_running_job_in_reservation(resource_resv *job, void *arg)
+check_running_job_in_reservation(resource_resv *job, const void *arg)
 {
 	if (job->is_job && job->job != NULL && job->job->resv != NULL &&
 		(check_job_running(job, arg) == 1))
@@ -2170,7 +2170,7 @@ check_running_job_in_reservation(resource_resv *job, void *arg)
  * @retval	0	: if job is not running or in a reservation
  */
 int
-check_running_job_not_in_reservation(resource_resv *job, void *arg)
+check_running_job_not_in_reservation(resource_resv *job, const void *arg)
 {
 	if (job->is_job && job->job != NULL && job->job->resv == NULL &&
 		(check_job_running(job, arg) == 1))
@@ -2191,7 +2191,7 @@ check_running_job_not_in_reservation(resource_resv *job, void *arg)
  * @retval	0	: if reservation is not running on node passed in arg
  */
 int
-check_resv_running_on_node(resource_resv *resv, void *arg)
+check_resv_running_on_node(resource_resv *resv, const void *arg)
 {
 	if (resv->is_resv && resv->resv != NULL) {
 		if (resv->resv->is_running || resv->resv->resv_state == RESV_BEING_DELETED)
@@ -3223,7 +3223,7 @@ find_indirect_resource(schd_resource *res, node_info **nodes)
 				error = 1;
 				log_eventf(PBSEVENT_DEBUG, PBS_EVENTCLASS_NODE, LOG_DEBUG, __func__,
 						"Resource %s is indirect, and does not exist on indirect node %s",
-						res->name, ninfo->name);
+						res->name, ninfo->name.c_str());
 			}
 		} else {
 			error = 1;
@@ -3528,7 +3528,7 @@ free_queue_list(queue_info *** queue_list)
  * @return	void
  */
 void
-create_total_counts(server_info *sinfo, queue_info * qinfo,
+create_total_counts(server_info *sinfo, queue_info *qinfo,
 	resource_resv *resresv, int mode)
 {
 	if (mode == SERVER || mode == ALL) {

--- a/src/scheduler/server_info.h
+++ b/src/scheduler/server_info.h
@@ -46,9 +46,11 @@
 #include "constant.h"
 
 /* Modes passed to update_total_counts_on_run() */
-#define SERVER 1
-#define QUEUE  2
-#define ALL    3
+enum counts_on_run {
+	SERVER,
+	QUEUE,
+	ALL
+};
 /*
  *      query_server - creates a structure of arrays consisting of a server
  *                      and all the queues and jobs that reside in that server
@@ -146,48 +148,48 @@ int copy_server_arrays(server_info *nsinfo, server_info *osinfo);
  *      check_exit_job - function used by job_filter to filter out
  *                       jobs not in the exiting state
  */
-int check_exit_job(resource_resv *job, void *arg);
+int check_exit_job(resource_resv *job, const void *arg);
 
 /*
  *      check_run_resv - function used by resv_filter to filter out
  *                       non-running reservations
  */
-int check_run_resv(resource_resv *resv, void *arg);
+int check_run_resv(resource_resv *resv, const void *arg);
 
 /*
  *
  *	check_susp_job - function used by job_filter to filter out jobs
  *			   which are suspended
  */
-int check_susp_job(resource_resv *job, void *arg);
+int check_susp_job(resource_resv *job, const void *arg);
 
 /*
  *
  *	check_job_running - function used by job_filter to filter out
  *			   jobs that are running
  */
-int check_job_running(resource_resv *job, void *arg);
+int check_job_running(resource_resv *job, const void *arg);
 
 /*
  *
  *	check_running_job_in_reservation - function used by job_filter to filter out
  *			   jobs that are in a reservation
  */
-int check_running_job_in_reservation(resource_resv *job, void *arg);
+int check_running_job_in_reservation(resource_resv *job, const void *arg);
 
 /*
  *
  *	check_running_job_not_in_reservation - function used by job_filter to filter out
  *			   jobs that are not in a reservation
  */
-int check_running_job_not_in_reservation(resource_resv *job, void *arg);
+int check_running_job_not_in_reservation(resource_resv *job, const void *arg);
 
 /*
  *
  *      check_resv_running_on_node - function used by resv_filter to filter out
  *				running reservations
  */
-int check_resv_running_on_node(resource_resv *resv, void *arg);
+int check_resv_running_on_node(resource_resv *resv, const void *arg);
 
 /*
  *      dup_server - duplicate a server_info struct
@@ -309,7 +311,7 @@ counts *counts_max(counts *cmax, counts *ncounts);
  *      check_run_job - function used by resource_resv_filter to filter out
  *                      non-running jobs.
  */
-int check_run_job(resource_resv *job, void *arg);
+int check_run_job(resource_resv *job, const void *arg);
 
 /*
  *      update_universe_on_end - update a pbs universe when a job/resv ends

--- a/src/scheduler/simulate.cpp
+++ b/src/scheduler/simulate.cpp
@@ -1381,7 +1381,7 @@ free_timed_event(timed_event *te)
 			((resource_resv *)te->event_ptr)->end_event = NULL;
 	}
 
-	free(te);
+	delete te;
 }
 
 /**

--- a/src/scheduler/simulate.cpp
+++ b/src/scheduler/simulate.cpp
@@ -499,8 +499,8 @@ set_timed_event_disabled(timed_event *te, int disabled)
  *
  */
 timed_event *
-find_timed_event(timed_event *te_list, int ignore_disabled, const char *name,
-	enum timed_event_types event_type, time_t event_time)
+find_timed_event(timed_event *te_list, int ignore_disabled,
+	enum timed_event_types event_type, time_t event_time, const std::string& name)
 {
 	timed_event *te;
 	int found_name = 0;
@@ -514,7 +514,7 @@ find_timed_event(timed_event *te_list, int ignore_disabled, const char *name,
 		if (ignore_disabled && te->disabled)
 			continue;
 		found_name = found_type = found_time = 0;
-		if (name == NULL || strcmp(te->name, name) == 0)
+		if (name.empty() || te->name == name)
 			found_name = 1;
 
 		if (event_type == te->event_type || event_type == TIMED_NOEVENT)
@@ -699,7 +699,7 @@ exists_resv_event(event_list *calendar, time_t end)
  *
  */
 time_t
-calc_run_time(char *name, server_info *sinfo, int flags)
+calc_run_time(const std::string& name, server_info *sinfo, int flags)
 {
 	time_t event_time = (time_t) 0;	/* time of the simulated event */
 	event_list *calendar;		/* calendar we are simulating in */
@@ -716,7 +716,7 @@ calc_run_time(char *name, server_info *sinfo, int flags)
 	unsigned int ok_flags = NO_ALLPART;
 	queue_info *qinfo = NULL;
 
-	if (name == NULL || sinfo == NULL)
+	if (name.empty() || sinfo == NULL)
 		return (time_t) -1;
 
 	event_time = sinfo->server_time;
@@ -837,7 +837,7 @@ create_event_list(server_info *sinfo)
 	elist->events = create_events(sinfo);
 
 	elist->next_event = elist->events;
-	elist->first_run_event = find_timed_event(elist->events, 0, NULL, TIMED_RUN_EVENT, 0);
+	elist->first_run_event = find_timed_event(elist->events, 0, TIMED_RUN_EVENT, 0);
 	elist->current_time = &sinfo->server_time;
 	add_dedtime_events(elist, sinfo->policy);
 
@@ -994,9 +994,9 @@ dup_event_list(event_list *oelist, server_info *nsinfo)
 
 	if (oelist->next_event != NULL) {
 		nelist->next_event = find_timed_event(nelist->events, 0,
-			oelist->next_event->name,
-			oelist->next_event->event_type,
-			oelist->next_event->event_time);
+						      oelist->next_event->event_type,
+						      oelist->next_event->event_time,
+						      oelist->next_event->name);
 		if (nelist->next_event == NULL) {
 			log_event(PBSEVENT_SCHED, PBS_EVENTCLASS_SCHED, LOG_WARNING,
 			oelist->next_event->name, "can't find next event in duplicated list");
@@ -1007,10 +1007,10 @@ dup_event_list(event_list *oelist, server_info *nsinfo)
 
 	if (oelist->first_run_event != NULL) {
 		nelist->first_run_event =
-		    find_timed_event(nelist->events, 0,
-				     oelist->first_run_event->name,
-				     TIMED_RUN_EVENT,
-				     oelist->first_run_event->event_time);
+			find_timed_event(nelist->events, 0,
+					 TIMED_RUN_EVENT,
+					 oelist->first_run_event->event_time,
+					 oelist->first_run_event->name);
 		if (nelist->first_run_event == NULL) {
 			log_event(PBSEVENT_SCHED, PBS_EVENTCLASS_SCHED, LOG_WARNING, oelist->first_run_event->name,
 				"can't find first run event event in duplicated list");
@@ -1051,13 +1051,12 @@ new_timed_event()
 {
 	timed_event *te;
 
-	if ((te = static_cast<timed_event *>(malloc(sizeof(timed_event)))) == NULL) {
+	if ((te = new timed_event) == NULL) {
 		log_err(errno, __func__, MEM_ERR_MSG);
 		return NULL;
 	}
 
 	te->disabled = 0;
-	te->name = NULL;
 	te->event_type = TIMED_NOEVENT;
 	te->event_time = 0;
 	te->event_ptr = NULL;
@@ -1156,7 +1155,7 @@ dup_te_list(te_list *ote, timed_event *new_timed_event_list)
 	if(nte == NULL)
 		return NULL;
 
-	nte->event = find_timed_event(new_timed_event_list, 0, ote->event->name, ote->event->event_type, ote->event->event_time);
+	nte->event = find_timed_event(new_timed_event_list, 0, ote->event->event_type, ote->event->event_time, ote->event->name);
 
 	return nte;
 }
@@ -1448,8 +1447,7 @@ add_event(event_list *calendar, timed_event *te)
 				calendar->next_event = te;
 			else if (te->event_time == calendar->next_event->event_time) {
 				calendar->next_event =
-					find_timed_event(calendar->events, 0, NULL,
-					TIMED_NOEVENT, te->event_time);
+					find_timed_event(calendar->events, 0, TIMED_NOEVENT, te->event_time);
 			}
 		}
 	}
@@ -1546,7 +1544,7 @@ delete_event(server_info *sinfo, timed_event *e)
 		calendar->next_event = e->next;
 
 	if (calendar->first_run_event == e)
-		calendar->first_run_event = find_timed_event(calendar->events, 0, NULL, TIMED_RUN_EVENT, 0);
+		calendar->first_run_event = find_timed_event(calendar->events, 0, TIMED_RUN_EVENT, 0);
 
 	if (e->prev == NULL)
 		calendar->events = e->next;

--- a/src/scheduler/simulate.h
+++ b/src/scheduler/simulate.h
@@ -132,8 +132,8 @@ void set_timed_event_disabled(timed_event *te, int disabled);
  *
  */
 timed_event *
-find_timed_event(timed_event *te_list, int ignore_disabled, const char *name,
-	enum timed_event_types event_type, time_t event_time);
+find_timed_event(timed_event *te_list, int ignore_disabled,
+	enum timed_event_types event_type, time_t event_time, const std::string& name = {});
 
 
 
@@ -342,7 +342,7 @@ create_event(enum timed_event_types event_type,
  *	returns time_t of when the job will run
  *		or -1 on error
  */
-time_t calc_run_time(char *job_name, server_info *sinfo, int flags);
+time_t calc_run_time(const std::string& name, server_info *sinfo, int flags);
 
 /*
  *

--- a/src/scheduler/simulate.h
+++ b/src/scheduler/simulate.h
@@ -132,11 +132,12 @@ void set_timed_event_disabled(timed_event *te, int disabled);
  *
  */
 timed_event *
-find_timed_event(timed_event *te_list, int ignore_disabled,
-	enum timed_event_types event_type, time_t event_time, const std::string& name = {});
-
-
-
+find_timed_event(timed_event *te_list, const std::string &name, int ignore_disabled,
+		 enum timed_event_types event_type, time_t event_time);
+timed_event *find_timed_event(timed_event *te_list, int ignore_disabled, enum timed_event_types event_type, time_t event_time);
+timed_event *find_timed_event(timed_event *te_list, enum timed_event_types event_type);
+timed_event *find_timed_event(timed_event *te_list, const std::string &name, enum timed_event_types event_type, time_t event_time);
+timed_event *find_timed_event(timed_event *te_list, time_t event_time);
 
 /*
  *      next_event - move an event_list to the next event and return it

--- a/src/scheduler/site_code.cpp
+++ b/src/scheduler/site_code.cpp
@@ -2237,7 +2237,7 @@ count_cpus(node_info **nodes, int ncnt, queue_info **queues, sh_amt *totals)
 		 * Skip nodes in unusable states.
 		 * (Unless jobs are still assigned to them.)
 		 */
-		if ((!node->is_pbsnode || node->is_down || node->is_offline)
+		if ((node->is_down || node->is_offline)
 			&&  (node->jobs == NULL || node->jobs[0] == NULL))
 			continue;
 #if	NAS_DONT_COUNT_EXEMPT


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
For part of the scheduler persistence work for multi-server, some of the scheduler objects needed to be refactored to be more C++ like.  In order to keep the size of the overall scheduler-persistence PR down, this is being done first.

#### Describe Your Change
Refactored resource_resv and node_info to be partial C++ objects.  They now have a full fledged constructor and destructor, but not copy constructor.  I didn't create a copy constructor because the objects are very cross-linked, so it would be difficult to write one.  In the spirit of agile, I did what was required now.

#### Attach Test and Valgrind Logs/Output
Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, WIN2K16
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|5995|3888|5|0|0|1|3882|

Those 5 test failures were a fluke.  I they are in areas of the code I didn't touch.  I did get them to pass in future TH3 runs.