### PR TITLE
multi-svr fixes: Sched crash + PBS_SERVER_INSTANCES bug

### DIFF
--- a/src/lib/Libifl/int_status.c
+++ b/src/lib/Libifl/int_status.c
@@ -187,7 +187,7 @@ aggr_job_ct(struct batch_status *cur, struct batch_status *nxt)
 	long nxt_st_ct[MAX_STATE] = {0};
 	struct attrl *a = NULL;
 	struct attrl *b = NULL;
-	char *tot_jobs_attr = NULL;
+	struct attrl *tot_jobs_attr = NULL;
 	long tot_jobs = 0;
 	char *endp;
 	int found;
@@ -202,7 +202,7 @@ aggr_job_ct(struct batch_status *cur, struct batch_status *nxt)
 			orig_st_ct = &a->value;
 			found++;
 		} else if (a->name && strcmp(a->name, ATTR_total) == 0) {
-			tot_jobs_attr = a->value;
+			tot_jobs_attr = a;
 			tot_jobs += strtol(a->value, &endp, 10);
 			found++;
 		}
@@ -224,8 +224,8 @@ aggr_job_ct(struct batch_status *cur, struct batch_status *nxt)
 	if (orig_st_ct)
 		encode_states(orig_st_ct, cur_st_ct, nxt_st_ct);
 	if (tot_jobs_attr) {
-		free(tot_jobs_attr);
-		pbs_asprintf(&tot_jobs_attr, "%ld", tot_jobs);
+		free(tot_jobs_attr->value);
+		pbs_asprintf(&(tot_jobs_attr->value), "%ld", tot_jobs);
 	}
 }
 

--- a/src/lib/Libifl/pbs_loadconf.c
+++ b/src/lib/Libifl/pbs_loadconf.c
@@ -317,14 +317,17 @@ parse_psi(char *conf_value)
 	}
 	free_string_array(list);
 	pbs_conf.pbs_num_servers = i;
-	pbs_conf.psi_str = strdup(local_conf);
-	free(local_conf);
+	if (conf_value)
+		pbs_conf.psi_str = strdup(local_conf);
+	else
+		pbs_conf.psi_str = local_conf;
 
 	return 0;
 
 err:
 	free_string_array(list);
-	free(local_conf);
+	if (conf_value == NULL)
+		free(local_conf);
 	return -1;
 }
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
- parse_psi was assigning 15001 as the server port for single server scenario, where PBS_SERVER_INSTANCES was missing from pbs.conf.
- Sched was crashing as follows because of an invalid free in aggr_job_ct(), we were freeing the attribute object's value but setting a function local pointer, so 'value' remained free, which meant that when sched free'd it, it crashed as:
```
==1389== Invalid free() / delete / delete[] / realloc()
==1389==    at 0x4C3210C: free (vg_replace_malloc.c:538)
==1389==    by 0x477EF1: __pbs_statfree (pbs_statfree.c:77)
==1389==    by 0x44278B: query_queues(status*, int, server_info*) (queue_info.cpp:322)
==1389==    by 0x44F9A2: query_server(status*, int) (server_info.cpp:268)
==1389==    by 0x4236F8: scheduling_cycle(int, sched_cmd const*) (fifo.cpp:629)
==1389==    by 0x423A46: intermediate_schedule(int, sched_cmd const*) (fifo.cpp:562)
==1389==    by 0x45A556: schedule_wrapper(sched_cmd*, int) (pbs_sched_utils.cpp:1210)
==1389==    by 0x45B522: sched_main(int, char**, int (*)(int, sched_cmd const*)) (pbs_sched_utils.cpp:1156)
==1389==    by 0x679D7B2: (below main) (in /usr/lib64/libc-2.28.so)
==1389==  Address 0xa4fc050 is 0 bytes inside a block of size 2 free'd
==1389==    at 0x4C3210C: free (vg_replace_malloc.c:538)
==1389==    by 0x4770F8: aggr_job_ct (int_status.c:227)
==1389==    by 0x477A9A: aggregate_queue (int_status.c:444)
==1389==    by 0x477A9A: PBSD_status_aggregate (int_status.c:566)
==1389==    by 0x47B4CE: __pbs_statque (pbsD_statque.c:69)
==1389==    by 0x442531: query_queues(status*, int, server_info*) (queue_info.cpp:153)
==1389==    by 0x44F9A2: query_server(status*, int) (server_info.cpp:268)
==1389==    by 0x4236F8: scheduling_cycle(int, sched_cmd const*) (fifo.cpp:629)
==1389==    by 0x423A46: intermediate_schedule(int, sched_cmd const*) (fifo.cpp:562)
==1389==    by 0x45A556: schedule_wrapper(sched_cmd*, int) (pbs_sched_utils.cpp:1210)
==1389==    by 0x45B522: sched_main(int, char**, int (*)(int, sched_cmd const*)) (pbs_sched_utils.cpp:1156)
==1389==    by 0x679D7B2: (below main) (in /usr/lib64/libc-2.28.so)
==1389==  Block was alloc'd at
==1389==    at 0x4C30F0B: malloc (vg_replace_malloc.c:307)
==1389==    by 0x46738D: disrst (disrst.c:99)
==1389==    by 0x485EC6: decode_DIS_attrl (dec_attrl.c:118)
==1389==    by 0x4769C6: read_batch_status (dec_rpyc.c:102)
==1389==    by 0x4769C6: decode_DIS_replyCmd (dec_rpyc.c:385)
==1389==    by 0x46B668: PBSD_rdrpy_sock (int_rdrpy.c:91)
==1389==    by 0x46B712: PBSD_rdrpy (int_rdrpy.c:124)
==1389==    by 0x4775ED: PBSD_status_get (int_status.c:658)
==1389==    by 0x477969: PBSD_status_aggregate (int_status.c:554)
==1389==    by 0x47B4CE: __pbs_statque (pbsD_statque.c:69)
==1389==    by 0x442531: query_queues(status*, int, server_info*) (queue_info.cpp:153)
==1389==    by 0x44F9A2: query_server(status*, int) (server_info.cpp:268)
==1389==    by 0x4236F8: scheduling_cycle(int, sched_cmd const*) (fifo.cpp:629)
```


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
- parse_psi() is now passed NULL when PSI is absent from pbs.conf, and internally uses pbs_conf.batch_service_port along with pbs_default() when it is NULL
- Fixed the sched crash by setting the total count attribute correctly.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Regression results:
Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, WIN2K16
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|6010|3888|1|0|0|1|3886|

The 1 failure is a transient issue, happens on master too, unrelated to my changes


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
