### PR TITLE
updated sleep time for slower machines

### DIFF
--- a/test/tests/functional/pbs_job_dependency.py
+++ b/test/tests/functional/pbs_job_dependency.py
@@ -278,7 +278,6 @@ e.accept()
         job = Job()
         job.set_sleep_time(5)
         j1 = self.server.submit(job)
-        self.server.expect(JOB, {ATTR_state: 'R'}, id=j1)
         self.server.expect(JOB, {ATTR_state: 'F'}, id=j1, extend='x')
         accept_msg = j1 + " Job has finished, dependency satisfied"
         reject_msg = j1 + " Finished job did not satisfy dependency"

--- a/test/tests/functional/pbs_nonprint_characters.py
+++ b/test/tests/functional/pbs_nonprint_characters.py
@@ -191,7 +191,7 @@ sleep 5
                 a = {ATTR_v: "var1=\'A,B,%s,C,D\'" % ch}
             else:
                 a = {ATTR_v: r"var1=\'A\,B\,%s\,C\,D\'" % ch}
-            script = ['sleep 5']
+            script = ['sleep 10']
             script += ['env | grep var1']
             jid = self.create_and_submit_job(attribs=a, content=script)
             # Check if qstat -f output contains the escaped character

--- a/test/tests/functional/pbs_ralter.py
+++ b/test/tests/functional/pbs_ralter.py
@@ -1348,7 +1348,7 @@ class TestPbsResvAlter(TestFunctional):
         This test checks the alter of reservation name.
         """
         duration = 30
-        offset = 10
+        offset = 20
 
         rid1 = self.submit_and_confirm_reservation(
             offset, duration)
@@ -1368,7 +1368,7 @@ class TestPbsResvAlter(TestFunctional):
         This test checks the user permissions for pbs_ralter.
         """
         duration = 30
-        offset = 5
+        offset = 20
         shift = 10
 
         rid1, start1, end1 = self.submit_and_confirm_reservation(

--- a/test/tests/functional/pbs_server_periodic_hook.py
+++ b/test/tests/functional/pbs_server_periodic_hook.py
@@ -384,9 +384,8 @@ pbs.logmsg(pbs.LOG_DEBUG, "periodic hook ended at %%d" %% time.time())
         a = {'Resource_List.select': '1:ncpus=1',
              'Resource_List.walltime': 3}
         j = Job(TEST_USER, attrs=a)
-        j.set_sleep_time(3)
+        j.set_sleep_time(10)
         jid1 = self.server.submit(j)
-        self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
         self.server.expect(JOB, 'queue', id=jid1, op=UNSET, offset=3)
         self.server.log_match(jid1 + ";Exit_status=0")
         j1 = Job(TEST_USER)

--- a/test/tests/functional/pbs_server_periodic_hook.py
+++ b/test/tests/functional/pbs_server_periodic_hook.py
@@ -384,7 +384,7 @@ pbs.logmsg(pbs.LOG_DEBUG, "periodic hook ended at %%d" %% time.time())
         a = {'Resource_List.select': '1:ncpus=1',
              'Resource_List.walltime': 3}
         j = Job(TEST_USER, attrs=a)
-        j.set_sleep_time(10)
+        j.set_sleep_time(3)
         jid1 = self.server.submit(j)
         self.server.expect(JOB, 'queue', id=jid1, op=UNSET, offset=3)
         self.server.log_match(jid1 + ";Exit_status=0")

--- a/test/tests/functional/pbs_trillion_jobid.py
+++ b/test/tests/functional/pbs_trillion_jobid.py
@@ -146,7 +146,7 @@ exit 0
         restart_msg = 'Failed to restart PBS'
         self.assertTrue(self.server.isUp(), restart_msg)
 
-    def submit_job(self, sleep=10, lower=0,
+    def submit_job(self, sleep=100, lower=0,
                    upper=0, job_id=None, job_msg=None, verify=False):
         """
         Helper method to submit a normal/array job


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Fix PTL tests on slower machines


#### Describe Your Change
1. Increase sleep time of job
2. Remove R state check for jobs because in next lie we check for exit_status=0

#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
Id: 6000
Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, WIN2K16
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression

Test Summary: total: 3052, fail: 3, error: 1, timedout: 0, skip: 1, pass: 3047


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
