### PR TITLE
Node buckets does not check for unlicensed nodes

### DIFF
--- a/src/scheduler/buckets.cpp
+++ b/src/scheduler/buckets.cpp
@@ -418,7 +418,7 @@ create_node_buckets(status *policy, node_info **nodes, queue_info **queues, unsi
 		queue_info *qinfo = NULL;
 		int node_ind = nodes[i]->node_ind;
 
-		if (nodes[i]->is_down || nodes[i]->is_offline || node_ind == -1)
+		if (nodes[i]->is_down || nodes[i]->is_offline || node_ind == -1 || nodes[i]->lic_lock == 0)
 			continue;
 
 		if (queues != NULL && nodes[i]->queue_name != NULL)

--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -407,7 +407,6 @@ struct server_info
 	unsigned eligible_time_enable:1;/* controls if we accrue eligible_time  */
 	unsigned provision_enable:1;	/* controls if provisioning occurs */
 	unsigned power_provisioning:1;	/* controls if power provisioning occurs */
-	unsigned has_nonCPU_licenses:1;	/* server has non-CPU (e.g. socket-based) licenses */
 	unsigned use_hard_duration:1;	/* use hard duration when creating the calendar */
 	unsigned pset_metadata_stale:1;	/* The placement set meta data is stale and needs to be regenerated before the next use */
 	char *name;			/* name of server */
@@ -697,8 +696,6 @@ struct node_info
 	char **resvs;			/* the name of the reservations currently on the node */
 	resource_resv **job_arr;	/* ptrs to structs of the jobs on the node */
 	resource_resv **run_resvs_arr;	/* ptrs to structs of resvs holding resources on the node */
-
-	int pcpus;			/* the number of physical cpus */
 
 	/* This element is the server the node is associated with.  In the case
 	 * of a node which is part of an advanced reservation, the nodes are

--- a/src/scheduler/node_info.cpp
+++ b/src/scheduler/node_info.cpp
@@ -280,7 +280,6 @@ query_nodes(int pbs_sd, server_info *sinfo)
 			ATTR_maxuserrun,
 			ATTR_maxgrprun,
 			ATTR_queue,
-			ATTR_NODE_pcpus,
 			ATTR_p,
 			ATTR_NODE_Sharing,
 			ATTR_NODE_License,
@@ -518,11 +517,6 @@ query_node_info(struct batch_status *node, server_info *sinfo)
 		}
 		else if (!strcmp(attrp->name, ATTR_queue))
 			ninfo->queue_name = string_dup(attrp->value);
-		else if (!strcmp(attrp->name, ATTR_NODE_pcpus)) {
-			count = strtol(attrp->value, &endp, 10);
-			if (*endp == '\0')
-				ninfo->pcpus = count;
-		}
 		else if (!strcmp(attrp->name, ATTR_p)) {
 			count = strtol(attrp->value, &endp, 10);
 			if (*endp == '\0')
@@ -540,7 +534,6 @@ query_node_info(struct batch_status *node, server_info *sinfo)
 			switch (attrp->value[0]) {
 				case ND_LIC_TYPE_locked:
 					ninfo->lic_lock = 1;
-					sinfo->has_nonCPU_licenses = 1;
 					break;
 				case ND_LIC_TYPE_cloud:
 					check_expiry = 1;
@@ -630,10 +623,8 @@ query_node_info(struct batch_status *node, server_info *sinfo)
 		attrp = attrp->next;
 	}
 	if (check_expiry) {
-		if (time(NULL) < expiry) {
+		if (time(NULL) < expiry)
 			ninfo->lic_lock = 1;
-			sinfo->has_nonCPU_licenses = 1;
-		}
 	}
 	return ninfo;
 }
@@ -690,7 +681,6 @@ new_node_info()
 
 	nnode->priority = 0;
 
-	nnode->pcpus = 0;
 
 	nnode->rank = 0;
 
@@ -1530,7 +1520,6 @@ dup_node_info(node_info *onode, server_info *nsinfo,
 	nnode->sharing = onode->sharing;
 
 	nnode->lic_lock = onode->lic_lock;
-	nnode->pcpus = onode->pcpus;
 
 	nnode->rank = onode->rank;
 

--- a/src/scheduler/server_info.cpp
+++ b/src/scheduler/server_info.cpp
@@ -1180,7 +1180,6 @@ new_server_info(int limallocflag)
 	sinfo->eligible_time_enable = 0;
 	sinfo->provision_enable = 0;
 	sinfo->power_provisioning = 0;
-	sinfo->has_nonCPU_licenses = 0;
 	sinfo->use_hard_duration = 0;
 	sinfo->pset_metadata_stale = 0;
 	sinfo->num_parts = 0;
@@ -2224,7 +2223,6 @@ dup_server_info(server_info *osinfo)
 	nsinfo->eligible_time_enable = osinfo->eligible_time_enable;
 	nsinfo->provision_enable = osinfo->provision_enable;
 	nsinfo->power_provisioning = osinfo->power_provisioning;
-	nsinfo->has_nonCPU_licenses = osinfo->has_nonCPU_licenses;
 	nsinfo->use_hard_duration = osinfo->use_hard_duration;
 	nsinfo->pset_metadata_stale = osinfo->pset_metadata_stale;
 	nsinfo->name = string_dup(osinfo->name);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
PBS scheduler may not check for the node being licensed when it exercises buckets code.


#### Describe Your Change
Added a check to make sure node is licensed when buckets are created.
Also removed some license-related code that is not relevant anymore.

#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, WIN2K16
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|6008|3888|1|0|0|1|3886|

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
