### PR TITLE
Fix for windows build failure

### DIFF
--- a/src/lib/Libattr/master_node_attr_def.xml
+++ b/src/lib/Libattr/master_node_attr_def.xml
@@ -183,12 +183,14 @@
       <member_at_comp>comp_null</member_at_comp>
       <member_at_free>free_null</member_at_free>
       <member_at_action>
-#ifdef PBS_MOM
-      NULL_FUNC
-#elif PBS_PYTHON
-      NULL_FUNC
-#else
+#ifndef PBS_MOM
+#ifndef PBS_PYTHON
       node_state
+#else
+      NULL_FUNC
+#endif
+#else
+      NULL_FUNC
 #endif
       </member_at_action>
       <member_at_flags>NO_USER_SET | ATR_DFLAG_NOSAVM</member_at_flags>


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Windows build failed because of recent attribute refactor PR. The cause was the way #ifdef is written in master.xml file

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Fixed #ifdef so that build works on windows.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
N/A

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
