### PR TITLE
Fix addtional PTL tests on slower machine

### DIFF
--- a/test/tests/functional/pbs_hook_execjob_end.py
+++ b/test/tests/functional/pbs_hook_execjob_end.py
@@ -424,6 +424,7 @@ class TestPbsExecjobEnd(TestFunctional):
         self.server.expect(JOB, {ATTR_state: 'Q'}, id=jid)
         # run job
         try:
+            now = time.time()
             # qrun will fail as it is discarding the job
             self.server.runjob(jid)
         except PbsRunError as e:
@@ -431,7 +432,6 @@ class TestPbsExecjobEnd(TestFunctional):
             self.assertTrue(
                 'qrun: Request invalid for state of job'
                 in e.msg[0])
-            now = time.time()
             self.mom.log_match("ending hook event EXECJOB_END",
                                starttime=now, interval=2)
             time.sleep(5)

--- a/test/tests/functional/pbs_ralter.py
+++ b/test/tests/functional/pbs_ralter.py
@@ -1348,7 +1348,7 @@ class TestPbsResvAlter(TestFunctional):
         This test checks the alter of reservation name.
         """
         duration = 30
-        offset = 10
+        offset = 20
 
         rid1 = self.submit_and_confirm_reservation(
             offset, duration)
@@ -1368,7 +1368,7 @@ class TestPbsResvAlter(TestFunctional):
         This test checks the user permissions for pbs_ralter.
         """
         duration = 30
-        offset = 5
+        offset = 20
         shift = 10
 
         rid1, start1, end1 = self.submit_and_confirm_reservation(

--- a/test/tests/functional/pbs_reservations.py
+++ b/test/tests/functional/pbs_reservations.py
@@ -407,7 +407,7 @@ class TestReservations(TestFunctional):
         Test that when a running degraded reservation is reconfirmed,
         make sure that only the nodes that unavailable are replaced
         """
-        self.server.manager(MGR_CMD_SET, SERVER, {'reserve_retry_time': 5})
+        self.server.manager(MGR_CMD_SET, SERVER, {'reserve_retry_time': 15})
 
         a = {'resources_available.ncpus': 1}
         self.mom.create_vnodes(a, 5)

--- a/test/tests/functional/pbs_test_run_count.py
+++ b/test/tests/functional/pbs_test_run_count.py
@@ -196,12 +196,14 @@ class Test_run_count(TestFunctional):
         j = Job(TEST_USER, a)
         j.set_sleep_time(10)
         jid = self.server.submit(j)
-        time.sleep(9)
         self.server.expect(JOB, {ATTR_state: "R"},
                            id=j.create_subjob_id(jid, 2))
+        self.server.manager(MGR_CMD_SET, SCHED, {
+                            'scheduling': 'False'}, id=sched)
         # Create an execjob_begin hook that rejects the job
         self.create_reject_begin_hook()
-        time.sleep(8)
+        self.server.manager(MGR_CMD_SET, SCHED, {
+                            'scheduling': 'True'}, id=sched)
         self.server.expect(JOB, {ATTR_state: "X"},
                            id=j.create_subjob_id(jid, 2))
 

--- a/test/tests/functional/pbs_test_run_count.py
+++ b/test/tests/functional/pbs_test_run_count.py
@@ -198,12 +198,10 @@ class Test_run_count(TestFunctional):
         jid = self.server.submit(j)
         self.server.expect(JOB, {ATTR_state: "R"},
                            id=j.create_subjob_id(jid, 2))
-        self.server.manager(MGR_CMD_SET, SCHED, {
-                            'scheduling': 'False'}, id=sched)
+        self.server.manager(MGR_CMD_SET, SCHED, {"scheduling": "false"})
         # Create an execjob_begin hook that rejects the job
         self.create_reject_begin_hook()
-        self.server.manager(MGR_CMD_SET, SCHED, {
-                            'scheduling': 'True'}, id=sched)
+        self.server.manager(MGR_CMD_SET, SCHED, {"scheduling": "true"})
         self.server.expect(JOB, {ATTR_state: "X"},
                            id=j.create_subjob_id(jid, 2))
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Fix addtional PTL tests on slower machine


#### Describe Your Change
1. Adjust reservation submission time
2. Change reservation retry time
3. In case of job array, remove sleep time and instead set scheduling to True & False


#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
Id: 6086
Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, WIN2K16
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression

Test Summary: total: 3154, fail: 2, error: 0, timedout: 0, skip: 0, pass: 3152


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
