### PR TITLE
Fix python mem leaks

### DIFF
--- a/src/lib/Libpython/module_pbs_v1.c
+++ b/src/lib/Libpython/module_pbs_v1.c
@@ -662,8 +662,9 @@ PyObject *
 pbs_v1_module_init(void)
 {
 
-	PyObject *m     = NULL; /* the module object, BORROWED ref */
+	PyObject *m     = NULL; /* the module object, NEW ref */
 	PyObject *mdict = NULL; /* the module object, BORROWED ref */
+	PyObject *py_types_module = NULL;
 
 	m = PyModule_Create(&pbs_v1_module);
 
@@ -676,9 +677,18 @@ pbs_v1_module_init(void)
 
 	mdict = PyModule_GetDict(m);
 
+	/* get svr types */
+	py_types_module = ppsvr_create_types_module();
+	if (py_types_module == NULL)
+		goto ERROR_EXIT;
 	if ((PyDict_SetItemString(mdict, "svr_types",
-		ppsvr_create_types_module())) == -1)
+		py_types_module)) == -1) {
+		Py_XDECREF(py_types_module);
 		return NULL;
+	}
+
+	Py_XDECREF(py_types_module);
+	
 	/* Add all our constants */
 	if (_pv1mod_insert_int_constants(mdict) == -1)
 		return NULL;

--- a/src/lib/Libpython/pbs_python_external.c
+++ b/src/lib/Libpython/pbs_python_external.c
@@ -537,6 +537,7 @@ pbs_python_ext_namespace_init(
 #ifdef PYTHON                        /* --- BEGIN PYTHON BLOCK --- */
 
 	PyObject *namespace_dict = NULL;
+	PyObject *py_v1_module = NULL;
 
 	namespace_dict = PyDict_New(); /* New Refrence MUST Decref */
 	if (!namespace_dict) {
@@ -557,16 +558,22 @@ pbs_python_ext_namespace_init(
 	/*
 	 * Now, add our extension object/module to the namespace.
 	 */
+	py_v1_module = pbs_v1_module_init();
+	if (py_v1_module == NULL)
+		goto ERROR_EXIT;
 	if ((PyDict_SetItemString(namespace_dict,
 		PBS_PYTHON_V1_MODULE_EXTENSION_NAME,
-		pbs_v1_module_init()) == -1)
+		py_v1_module) == -1)
 		) {
+		Py_XDECREF(py_v1_module);
 		snprintf(log_buffer, LOG_BUF_SIZE-1, "%s|adding extension object",
 			__func__);
 		log_buffer[LOG_BUF_SIZE-1] = '\0';
 		pbs_python_write_error_to_log(__func__);
 		goto ERROR_EXIT;
 	}
+
+	Py_XDECREF(py_v1_module);
 
 	return namespace_dict;
 


### PR DESCRIPTION

#### Describe Bug or Feature
memory growth observed during stress/long running testing


#### Describe Your Change
* The cause of the memory growth observed is due to hook environment and further analyzing found that at 2 places missed to decrement the reference count for the value set in a dictionary using PyDict_SetItemString. one in module_pbs_v1.c and another in pbs_python_external.c
* We need to decrement any new reference, in this case in module_pbs_v1.c: ppsvr_create_types_module() will generate new reference and in pbs_python_external.c: pbs_v1_module_init() will generate new reference.



#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
* *[before_fix_stats.txt](https://github.com/openpbs/openpbs/files/5995890/before_fix_stats.txt)*
* *[after_fix_stats.txt](https://github.com/openpbs/openpbs/files/5995893/after_fix_stats.txt)*


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
