### PR TITLE
Join mom and servers hostname sets using update

### DIFF
--- a/test/fw/ptl/utils/plugins/ptl_test_runner.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_runner.py
@@ -1041,7 +1041,7 @@ class PTLTestRunner(Plugin):
         hosts = self.param_dict['moms']
         for server in self.param_dict['servers']:
             if server not in self.param_dict['moms']:
-                hosts.add(self.param_dict['servers'])
+                hosts.update(self.param_dict['servers'])
         for user in PBS_USERS:
             self.logger.info('Cleaning %s\'s home directory' % (str(user)))
             runas = PbsUser.get_user(user)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Merging 2 sets using add was throwing error. When server and mom was not on the same machine, we try to add server and mom hostnames. both are 2 different sets so to merge them add was being used which throws error.


#### Describe Your Change
Merge 2 sets using update.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->


6137 | regression | Tests from given sources on platforms SUSE15, CENTOS8, CENTOS7 | visheshh/pbspro@eo_files | 18th Feb 2021 10:17:16.828 PM +05:30 | 00:03:36.222 | 2 | 0 | 0 | 0 | 0 | 0 | 0 | 2
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
