### PR TITLE
Fixing qdel segfault for remote jobs

### DIFF
--- a/src/lib/Libifl/pbsD_deljoblist.c
+++ b/src/lib/Libifl/pbsD_deljoblist.c
@@ -62,17 +62,21 @@
 /**
  * @brief	Deallocate a svr_jobid_list_t list
  * @param[out]	list - the list to deallocate
+ * @param[in]	shallow - shallow free (don't free the individual jobids in the array)
  * @return	void
  */
 void
-free_svrjobidlist(svr_jobid_list_t *list)
+free_svrjobidlist(svr_jobid_list_t *list, int shallow)
 {
 	svr_jobid_list_t *iter_list = NULL;
 	svr_jobid_list_t *next = NULL;
 
 	for (iter_list = list; iter_list != NULL; iter_list = next) {
 		next = iter_list->next;
-		free(iter_list->jobids);
+		if (shallow)
+			free(iter_list->jobids);
+		else
+			free_str_array(iter_list->jobids);
 		free(iter_list);
 	}
 }
@@ -594,7 +598,7 @@ PBSD_deljoblist(int c, int function, char **jobids, int numjids, char *extend)
 	bcastjids = NULL;
 
 	if (msvr)
-		free_svrjobidlist(svr_jobid_list_hd);
+		free_svrjobidlist(svr_jobid_list_hd, 1);
 	else
 		free(svr_jobid_list_hd);
 
@@ -602,7 +606,7 @@ PBSD_deljoblist(int c, int function, char **jobids, int numjids, char *extend)
 
 err:
 	free(bcastjids);
-	free_svrjobidlist(svr_jobid_list_hd);
+	free_svrjobidlist(svr_jobid_list_hd, 1);
 	pbs_delstatfree(retlist);
 	return NULL;
 }


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
qdel was segfaulting when deleting qmove'd jobs:

```
Program terminated with signal SIGSEGV, Segmentation fault.
#0 process_deljobstat (clusterid=clusterid@entry=0x103dcac "xyz", list=list@entry=0x7ffee6e6f090, rmtlist=rmtlist@entry=0x7ffee6e6f018)
at ../../../src/cmds/qdel.c:100
100 ../../../src/cmds/qdel.c: No such file or directory.
Missing separate debuginfos, use: yum debuginfo-install glibc-2.28-101.el8.x86_64 libxcrypt-4.1.1-4.el8.x86_64
(gdb) bt
#0 process_deljobstat (clusterid=clusterid@entry=0x103dcac "xyz", list=list@entry=0x7ffee6e6f090, rmtlist=rmtlist@entry=0x7ffee6e6f018)
at ../../../src/cmds/qdel.c:100
#1 0x0000000000402cb2 in delete_jobs_for_cluster (warg=0x7ffee6e6f030 "", dfltmail=0, numids=4, jobids=0x103ddd0, clusterid=0x103dcac "xyz")
at ../../../src/cmds/qdel.c:211
#2 main (argc=<optimized out>, argv=<optimized out>, envp=<optimized out>) at ../../../src/cmds/qdel.c:406
```

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
There was a dereference to NULL pointer and accessing free'd memory in qdel.c, I just fixed them.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
```
[ragrawal@m1 ~]$ qsub -lncpus=4 -- /bin/sleep 1000
5.m1     
[ragrawal@m1 ~]$ qsub -lncpus=4 -- /bin/sleep 1000
6.m1
[ragrawal@m1 ~]$ qstat
Job id            Name             User              Time Use S Queue
----------------  ---------------- ----------------  -------- - -----
5.m1              STDIN            ragrawal          00:00:00 R workq           
6.m1              STDIN            ragrawal                 0 Q workq           
[ragrawal@m1 ~]$ qmove workq@m2 6.m1
[ragrawal@m1 ~]$ qstat
Job id            Name             User              Time Use S Queue
----------------  ---------------- ----------------  -------- - -----
5.m1              STDIN            ragrawal          00:00:00 R workq           
[ragrawal@m1 ~]$ qstat @m2
Job id            Name             User              Time Use S Queue
----------------  ---------------- ----------------  -------- - -----
6.m1              STDIN            ragrawal          00:00:00 R workq 

[ragrawal@m1 ~]$ qdel 6.m1
[ragrawal@m1 ~]$ qstat @m2
Job id            Name             User              Time Use S Queue
----------------  ---------------- ----------------  -------- - -----
6.m1              STDIN            ragrawal          00:00:00 E workq   
```


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
