### PR TITLE
Fixing a leak in parse_psi

### DIFF
--- a/src/lib/Libifl/pbs_loadconf.c
+++ b/src/lib/Libifl/pbs_loadconf.c
@@ -1114,7 +1114,7 @@ __pbs_loadconf(int reload)
 
 	if (!reload) {
 		if (parse_psi(psi_value) == -1) {
-			fprintf(stderr, "Couldn't find a valid server instance to connect to\n");
+			fprintf(stderr, "Couldn't parse PBS_SERVER_INSTANCES\n");
 			free(psi_value);
 			goto err;
 		}

--- a/src/lib/Libifl/pbs_loadconf.c
+++ b/src/lib/Libifl/pbs_loadconf.c
@@ -1112,11 +1112,14 @@ __pbs_loadconf(int reload)
 
 	pbs_conf.loaded = 1;
 
-	if (parse_psi(psi_value) == -1) {
-		fprintf(stderr, "Couldn't find a valid server instance to connect to\n");
-		free(psi_value);
-		goto err;
-	}
+	if (!reload) {
+		if (parse_psi(psi_value) == -1) {
+			fprintf(stderr, "Couldn't find a valid server instance to connect to\n");
+			free(psi_value);
+			goto err;
+		}
+	} else
+		fprintf(stderr, "Warning: PBS_SERVER_INSTANCES will not be re-read from pbs.conf, restart to take effect\n");
 
 	if (pbs_client_thread_unlock_conf() != 0)
 		return 0;

--- a/src/lib/Libifl/pbs_loadconf.c
+++ b/src/lib/Libifl/pbs_loadconf.c
@@ -356,7 +356,9 @@ err:
  *	will be void. In that case, access to every pbs_conf.variable has to be
  *	synchronized against the reload of those variables.
  *
- * @param[in] reload		Whether to attempt a reload
+ * @param[in] reload	Whether to attempt a reload
+ * 						Note: The following parameters will not be reloaded:
+ * 						- PBS_SERVER_INSTANCES
  *
  * @return int
  * @retval 1 Success

--- a/src/lib/Libifl/pbs_loadconf.c
+++ b/src/lib/Libifl/pbs_loadconf.c
@@ -1120,8 +1120,7 @@ __pbs_loadconf(int reload)
 			free(psi_value);
 			goto err;
 		}
-	} else if (psi_value && (!pbs_conf.psi_str || strcmp(psi_value, pbs_conf.psi_str)))
-		fprintf(stderr, "Warning: PBS_SERVER_INSTANCES will not be re-read from pbs.conf, restart to take effect\n");
+	}
 
 	if (pbs_client_thread_unlock_conf() != 0)
 		return 0;

--- a/src/lib/Libifl/pbs_loadconf.c
+++ b/src/lib/Libifl/pbs_loadconf.c
@@ -1118,7 +1118,7 @@ __pbs_loadconf(int reload)
 			free(psi_value);
 			goto err;
 		}
-	} else
+	} else if (psi_value && (!pbs_conf.psi_str || strcmp(psi_value, pbs_conf.psi_str)))
 		fprintf(stderr, "Warning: PBS_SERVER_INSTANCES will not be re-read from pbs.conf, restart to take effect\n");
 
 	if (pbs_client_thread_unlock_conf() != 0)

--- a/src/lib/Libifl/pbs_loadconf.c
+++ b/src/lib/Libifl/pbs_loadconf.c
@@ -281,6 +281,9 @@ parse_psi(char *conf_value)
 	free(pbs_conf.psi_str);
 
 	if (conf_value == NULL) {
+		char *dfltsvr = pbs_default();
+		if (dfltsvr == NULL)
+			return -1;
 		pbs_asprintf(&local_conf, "%s:%d", pbs_default(), pbs_conf.batch_service_port);
 		if (local_conf == NULL)
 			return -1;

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -728,12 +728,3 @@
    fun:dis_flush
    ...
 }
-{
-   From PBS - Suppress intentional unfreed memory of psi_str inside pbs_conf
-   Memcheck:Leak
-   fun:malloc
-   ...
-   fun:pbs_asprintf
-   fun:parse_psi
-   ...
-}

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -728,3 +728,12 @@
    fun:dis_flush
    ...
 }
+{
+   From PBS - Suppress intentional unfreed memory of psi_str inside pbs_conf
+   Memcheck:Leak
+   fun:malloc
+   ...
+   fun:pbs_asprintf
+   fun:parse_psi
+   ...
+}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Observed a mem leak for pbs_conf.psi_str, which is allocated inside parse_psi():

13 bytes in 1 blocks are definitely lost in loss record 12 of 39
   at 0x4C28C23: malloc (vg_replace_malloc.c:299)
   by 0x418D12: pbs_asprintf_format (misc_utils.c:529)
   by 0x418E74: pbs_asprintf (misc_utils.c:570)
   by 0x422ED2: parse_psi (pbs_loadconf.c:284)
   by 0x42614E: __pbs_loadconf (pbs_loadconf.c:1112)
   by 0x4275BE: pbs_loadconf (ifl_impl.c:325)
   by 0x405C32: main (pbs_comm.c:606)

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
