### PR TITLE
TestPbsNodeRampDownKeepSelect fails randomly when csh is default shell

### DIFF
--- a/test/tests/functional/pbs_node_rampdown_keep_select.py
+++ b/test/tests/functional/pbs_node_rampdown_keep_select.py
@@ -301,7 +301,8 @@ class TestPbsNodeRampDownKeepSelect(TestFunctional):
         passed using the 'tc' argument
         """
         # 1. submit the job wih select spec
-        job = Job(TEST_USER, attrs={'Resource_List.select': tc.qsub_sel})
+        a = {'Resource_List.select': tc.qsub_sel, ATTR_S: '/bin/bash'}
+        job = Job(TEST_USER, attrs=a)
         if tc.use_script is True:
             job.create_script(self.jobscript)
         else:
@@ -342,6 +343,7 @@ class TestPbsNodeRampDownKeepSelect(TestFunctional):
                                          runas=tc.rel_user)
             self.assertEqual(ret['rc'], 0)
         else:
+            time.sleep(2)
             self.server.sigjob(jid, 'INT')
 
         # 9. verify job state and attributes are as expected
@@ -450,7 +452,7 @@ class TestPbsNodeRampDownKeepSelect(TestFunctional):
         self.jobscript = \
             "#!/bin/sh\n" + \
             "trap 'pbs_release_nodes -k select=ncpus=2+ncpus=3:mpiprocs=2" + \
-            ";sleep 1000;exit 0' 2\n" + \
+            ";sleep 1000;exit 0' INT\n" + \
             "sleep 1000\n" + \
             "exit 0"
         self.test_basic_use_case_ncpus(use_script=True)
@@ -1230,7 +1232,7 @@ class TestPbsNodeRampDownKeepSelect(TestFunctional):
         self.jobscript = \
             "#!/bin/sh\n" + \
             "trap 'pbs_release_nodes -k 2" + \
-            ";sleep 1000;exit 0' 2\n" + \
+            ";sleep 1000;exit 0' INT\n" + \
             "sleep 1000\n" + \
             "exit 0"
         self.test_node_count(use_script=True)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
`test_basic_use_case_ncpus_using_script` and `test_node_count_using_script` of `TestPbsNodeRampDownKeepSelect` Failed with below error:

Issue is seen randomly.. It is not consistent. Out of 10 regressions, it seen 4-5 times.
```
Traceback (most recent call last):
File "/home/pbsroot/TEST/tmp/2021.1.0.20201105141653/lib/python3.6/site-packages/ptl/utils/pbs_testsuite.py", line 184, in wrapper
function(self, *args, **kwargs)
File "/home/pbsroot/TEST/tmp/tests/functional/pbs_node_rampdown_keep_select.py", line 456, in test_basic_use_case_ncpus_using_script
self.test_basic_use_case_ncpus(use_script=True)
File "/home/pbsroot/TEST/tmp/2021.1.0.20201105141653/lib/python3.6/site-packages/ptl/utils/pbs_testsuite.py", line 184, in wrapper
function(self, *args, **kwargs)
File "/home/pbsroot/TEST/tmp/tests/functional/pbs_node_rampdown_keep_select.py", line 431, in test_basic_use_case_ncpus
self.common_tc_flow(tc)
File "/home/pbsroot/TEST/tmp/tests/functional/pbs_node_rampdown_keep_select.py", line 345, in common_tc_flow
self.server.expect(JOB, tc.job_stat_after, id=jid)
File "/home/pbsroot/TEST/tmp/2021.1.0.20201105141653/lib/python3.6/site-packages/ptl/lib/pbs_testlib.py", line 8564, in expect
trigger_sched_cycle=trigger_sched_cycle)
File "/home/pbsroot/TEST/tmp/2021.1.0.20201105141653/lib/python3.6/site-packages/ptl/lib/pbs_testlib.py", line 8564, in expect
trigger_sched_cycle=trigger_sched_cycle)
File "/home/pbsroot/TEST/tmp/2021.1.0.20201105141653/lib/python3.6/site-packages/ptl/lib/pbs_testlib.py", line 8564, in expect
trigger_sched_cycle=trigger_sched_cycle)
[Previous line repeated 177 more times]
File "/home/pbsroot/TEST/tmp/2021.1.0.20201105141653/lib/python3.6/site-packages/ptl/lib/pbs_testlib.py", line 8339, in expect
raise PtlExpectError(rc=1, rv=False, msg=_msg)
ptl.lib.pbs_testlib.PtlExpectError: rc=1, rv=False, msg=expected on server x109-r8: job_state = R && substate = 42 && Resource_List.mpiprocs = 2 && Resource_List.ncpus = 6 && Resource_List.nodect = 3 && Resource_List.select = 1:ncpus=1+1:ncpus=2+1:ncpus=3:mpiprocs=2 && schedselect = 1:ncpus=1+1:ncpus=2+1:ncpus=3:mpiprocs=2 job 2.x109-r8 attempt: 180 got: Resource_List.mpiprocs = 4
```

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
while submitting the job in TC use `ATTR_S` to mention `bash` as the shell


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

[test_basic_use_case_ncpus_using_script_PASS.txt](https://github.com/openpbs/openpbs/files/6033833/test_basic_use_case_ncpus_using_script_PASS.txt)
[test_node_count_using_script_PASS.txt](https://github.com/openpbs/openpbs/files/6033834/test_node_count_using_script_PASS.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
