### PR TITLE
Fix for memory error and schema upgrade

### DIFF
--- a/src/lib/Libdb/pgsql/pbs_schema_upgrade
+++ b/src/lib/Libdb/pgsql/pbs_schema_upgrade
@@ -265,6 +265,12 @@ upgrade_pbs_schema_from_v1_4_0() {
 		ALTER TABLE pbs.resv DROP COLUMN ri_un_type;
 		ALTER TABLE pbs.resv DROP COLUMN ri_fromsock;
 		ALTER TABLE pbs.resv DROP COLUMN ri_fromaddr;
+		ALTER TABLE pbs.server DROP COLUMN sv_numjobs;
+		ALTER TABLE pbs.server DROP COLUMN sv_numque;
+		ALTER TABLE pbs.server DROP COLUMN sv_svraddr;
+		ALTER TABLE pbs.server DROP COLUMN sv_svrport;
+		ALTER TABLE pbs.queue RENAME COLUMN qu_ctime to qu_creattm;
+		ALTER TABLE pbs.queue RENAME COLUMN qu_mtime to qu_savetm;
 		UPDATE pbs.info SET pbs_schema_version = '1.5.0';
 	EOF
 	ret=$?

--- a/src/server/attr_recov_db.c
+++ b/src/server/attr_recov_db.c
@@ -216,7 +216,6 @@ decode_attr_db(void *parent, pbs_db_attr_list_t *db_attr_list, void *padef_idx, 
 			} else {
 				snprintf(log_buffer,LOG_BUF_SIZE, "unknown attribute \"%s\" discarded", pal->al_name);
 				log_err(-1, __func__, log_buffer);
-				(void)free(pal);
 				continue;
 			}
 		}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
1) When pbs_server.bin is recovering an unknown attribute from the database, it gets a SEGV due to a use-after-free error: (https://github.com/openpbs/openpbs/issues/2193)
2) Some of changes are missing from the pbs_schema_upgrade. (https://github.com/openpbs/openpbs/issues/2194)

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
1) Removed additional free.  (https://github.com/openpbs/openpbs/issues/2193)
2) Added the respective sql statements accordingly.  (https://github.com/openpbs/openpbs/issues/2194)

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

[Schema_upgrade_test.txt](https://github.com/openpbs/openpbs/files/6053662/Schema_upgrade_test.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
