### PR TITLE
fix tests from TestExceededResourcesNotification

### DIFF
--- a/test/tests/functional/pbs_exceeded_resources_notification.py
+++ b/test/tests/functional/pbs_exceeded_resources_notification.py
@@ -68,7 +68,7 @@ class TestExceededResourcesNotification(TestFunctional):
                            "Hence this step would be skipped. "
                            "Please check manually." % mailfile)
 
-        ret = self.du.tail(filename=mailfile, sudo=True, option='-n 10')
+        ret = self.du.tail(filename=mailfile, runas=TEST_USER, option='-n 10')
         maillog = [x.strip() for x in ret['out']]
 
         self.assertIn('PBS Job Id: ' + jid, maillog)
@@ -81,8 +81,6 @@ class TestExceededResourcesNotification(TestFunctional):
 
         a = {'Resource_List.walltime': 1}
         j = Job(TEST_USER, a)
-
-        j.set_sleep_time(60)
 
         jid = self.server.submit(j)
         j_comment = '.* and exceeded resource walltime'
@@ -101,17 +99,11 @@ class TestExceededResourcesNotification(TestFunctional):
 
         self.mom.add_config({'$enforce mem': ''})
 
-        self.mom.stop()
-        self.mom.start()
+        self.mom.restart()
 
         a = {'Resource_List.walltime': 3600,
              'Resource_List.select': 'mem=1kb'}
         j = Job(TEST_USER, a)
-
-        test = []
-        test += ['#!/bin/bash']
-        test += ['tail -c 100K /dev/zero']
-        j.create_script(body=test)
 
         jid = self.server.submit(j)
         j_comment = '.* and exceeded resource mem'
@@ -134,8 +126,7 @@ class TestExceededResourcesNotification(TestFunctional):
              '$enforce average_trialperiod': '1',
              '$enforce cpuaverage': ''})
 
-        self.mom.stop()
-        self.mom.start()
+        self.mom.restart()
 
         a = {'Resource_List.walltime': 3600}
         j = Job(TEST_USER, a)
@@ -165,8 +156,7 @@ class TestExceededResourcesNotification(TestFunctional):
              '$enforce delta_cpufactor': '0.1',
              '$enforce cpuburst': ''})
 
-        self.mom.stop()
-        self.mom.start()
+        self.mom.restart()
 
         a = {'Resource_List.walltime': 3600}
         j = Job(TEST_USER, a)

--- a/test/tests/functional/pbs_exceeded_resources_notification.py
+++ b/test/tests/functional/pbs_exceeded_resources_notification.py
@@ -105,6 +105,11 @@ class TestExceededResourcesNotification(TestFunctional):
              'Resource_List.select': 'mem=1kb'}
         j = Job(TEST_USER, a)
 
+        test = []
+        test += ['#!/bin/bash']
+        test += ['tail -c 100K /dev/zero']
+        j.create_script(body=test)
+
         jid = self.server.submit(j)
         j_comment = '.* and exceeded resource mem'
         self.server.expect(JOB, {ATTR_state: "F",


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
fix tests from TestExceededResourcesNotification. Test are failing while verifying mail in respective user due to permission issue.
sometime test 'test_exceeding_mem' got failed because job didn't use specified memory(1kb) and finishes normally due to PTL cannot get expected Exit_status and job comment.

#### Describe Your Change
use runas=TEST_USER instead of sudo=True. 
for test 'test_exceeding_mem' use sleep 100sec. instead of job script so it can consume 1kb.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->

#### Attach Test and Valgrind Logs/Output
Before Fix:
[res_before_fix.txt](https://github.com/openpbs/openpbs/files/6049886/res_before_fix.txt)
for test test_exceeding_mem:
[res_before_fix1.txt](https://github.com/openpbs/openpbs/files/6049891/res_before_fix1.txt)


After Fix:
[res_after_fix.txt](https://github.com/openpbs/openpbs/files/6049895/res_after_fix.txt)
Description: Tests from given sources on platforms SUSE15, CENTOS7, UBUNTU2004
Platforms: SUSE15,CENTOS7,UBUNTU2004
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|6243|15|0|0|0|0|15|


No mom on server:
Description: No_MoM_on_server
Platforms: SUSE15,CENTOS7,UBUNTU2004
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|6244|15|0|0|0|0|15|

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
