### PR TITLE
Test "test_comm_failover_with_isolated_mom_pools" of TestTPP is failing while verifying the job attributes

### DIFF
--- a/test/tests/functional/pbs_test_tpp.py
+++ b/test/tests/functional/pbs_test_tpp.py
@@ -1047,6 +1047,9 @@ class TestTPP(TestFunctional):
         Node 9 : Comm (self.hostI)
         """
         self.common_setup(no_mom_on_comm=True, req_moms=4, req_comms=5)
+        node_attr = {'resources_available.ncpus': '1'}
+        for mom in self.moms.values():
+            self.server.manager(MGR_CMD_SET, NODE, node_attr, id=mom.name)
         a = {'PBS_COMM_ROUTERS': self.hostA}
         comm_hosts = [self.hostF, self.hostG, self.hostH, self.hostI]
         for host in comm_hosts:
@@ -1074,7 +1077,7 @@ class TestTPP(TestFunctional):
         self.comm2.stop('-KILL')
         hosts = [self.hostB, self.hostC]
         for mom in hosts:
-            self.server.expect(NODE, {'state': 'free'}, id=mom)
+            self.server.expect(NODE, {'state': 'job-busy'}, id=mom)
         self.server.expect(JOB, exp_attr, id=jid)
         self.comm2.start()
         self.server.expect(JOB, 'queue', id=jid, op=UNSET, offset=30)
@@ -1093,7 +1096,7 @@ class TestTPP(TestFunctional):
         self.comm4.stop('-KILL')
         hosts = [self.hostD, self.hostE]
         for mom in hosts:
-            self.server.expect(NODE, {'state': 'free'}, id=mom)
+            self.server.expect(NODE, {'state': 'job-busy'}, id=mom)
         self.server.expect(RESV, resv_exp_attrib, rid)
         self.server.expect(JOB, exp_attr, id=jid)
         self.comm4.start()


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature

- Test "test_comm_failover_with_isolated_mom_pools" of TestTPP is failing while verifying the job attributes.
- In the test we are submitting job on 2 moms and kill the primary comm (specified in PBS_LEAF_ROUTERS param) of the first mom. Later the test is verifying the node state of both the moms to be free and job is still in running state.

- In the failed scenario, by the time the test is checking for the job to be in R state job has been completed. This is because while the job is running , the node state would be job-busy but not free. It would be free only when the jobs are completed. In 180 attempts of getting the node state "Free" the job gets completed and the test gets expected node state but fails while verifying job state because job has completed by that time

#### Describe Your Change

- Instead of checking the node state to be "Free", test should check node state to be "Job-busy"
- Also I have updated the test to set resources_available.ncpus to 1 on all the moms because sometimes on the machines where available ncpus is greater than 1, even if the job is running the state would be free instead of job-busy. 


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output

- [TestTPP_5comms_bfr_fix.txt](https://github.com/openpbs/openpbs/files/6049920/TestTPP_5comms_bfr_fix.txt)

- [TestTPP_5comms_after_fix.txt](https://github.com/openpbs/openpbs/files/6049916/TestTPP_5comms_after_fix.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
