### PR TITLE
Implement swap and no-mem/vmem-requested management

### DIFF
--- a/src/hooks/cgroups/pbs_cgroups.CF
+++ b/src/hooks/cgroups/pbs_cgroups.CF
@@ -50,9 +50,9 @@
             "exclude_vntypes"    : [],
             "enforce_default"    : true,
             "exclhost_ignore_default" : false,
-            "default"            : "256MB",
+            "default"            : "0B",
             "reserve_percent"    : 0,
-            "reserve_amount"     : "0MB",
+            "reserve_amount"     : "64MB",
             "manage_cgswap"      : false
         },
         "hugetlb" : {
@@ -61,9 +61,9 @@
             "exclude_vntypes"    : [],
             "enforce_default"    : true,
             "exclhost_ignore_default" : false,
-            "default"            : "0MB",
+            "default"            : "0B",
             "reserve_percent"    : 0,
-            "reserve_amount"     : "0MB"
+            "reserve_amount"     : "0B"
         }
     }
 }

--- a/src/hooks/cgroups/pbs_cgroups.CF
+++ b/src/hooks/cgroups/pbs_cgroups.CF
@@ -20,7 +20,7 @@
             "exclude_cpus"       : [],
             "exclude_hosts"      : [],
             "exclude_vntypes"    : [],
-            "mem_fences"         : true,
+            "mem_fences"         : false,
             "mem_hardwall"       : false,
             "memory_spread_page" : false
         },
@@ -33,30 +33,37 @@
                 "c *:* rwm"
             ]
         },
-        "hugetlb" : {
-            "enabled"            : false,
-            "exclude_hosts"      : [],
-            "exclude_vntypes"    : [],
-            "default"            : "0MB",
-            "reserve_percent"    : 0,
-            "reserve_amount"     : "0MB"
-        },
         "memory" : {
             "enabled"            : true,
             "exclude_hosts"      : [],
             "exclude_vntypes"    : [],
             "soft_limit"         : false,
+            "enforce_default"    : true,
+            "exclhost_ignore_default" : false,
             "default"            : "256MB",
             "reserve_percent"    : 0,
-            "reserve_amount"     : "64MB"
+            "reserve_amount"     : "1GB"
         },
         "memsw" : {
             "enabled"            : false,
             "exclude_hosts"      : [],
             "exclude_vntypes"    : [],
+            "enforce_default"    : true,
+            "exclhost_ignore_default" : false,
             "default"            : "256MB",
             "reserve_percent"    : 0,
-            "reserve_amount"     : "64MB"
+            "reserve_amount"     : "0MB",
+            "manage_cgswap"      : false
+        },
+        "hugetlb" : {
+            "enabled"            : false,
+            "exclude_hosts"      : [],
+            "exclude_vntypes"    : [],
+            "enforce_default"    : true,
+            "exclhost_ignore_default" : false,
+            "default"            : "0MB",
+            "reserve_percent"    : 0,
+            "reserve_amount"     : "0MB"
         }
     }
 }

--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -2444,8 +2444,9 @@ class NodeUtils(object):
                 pbs.size(convert_size(val, 'mb'))
             if (self.cfg['cgroup']['memsw']['enabled']
                     and self.cfg['cgroup']['memsw']['manage_cgswap']):
-                host_resc_avail['cgswap'] = \
-                    host_resc_avail['vmem']-host_resc_avail['mem']
+                host_resc_avail['cgswap'] = max(0,
+                                                host_resc_avail['vmem']
+                                                - host_resc_avail['mem'])
         else:
             # set the value on the host to 0
             host_resc_avail['mem'] = pbs.size('0')
@@ -2585,8 +2586,9 @@ class NodeUtils(object):
                 vnode_resc_avail = vnode_list[vnode_key].resources_available
                 if (self.cfg['cgroup']['memsw']['enabled']
                         and self.cfg['cgroup']['memsw']['manage_cgswap']):
-                    vnode_resc_avail['cgswap'] = (vnode_resc_avail['vmem']
-                                                  - vnode_resc_avail['mem'])
+                    vnode_resc_avail['cgswap'] = max(0,
+                                                     vnode_resc_avail['vmem']
+                                                     - vnode_resc_avail['mem'])
                 pbs.logmsg(pbs.EVENT_DEBUG4, '%s: %s vnode_resc_avail: %s' %
                            (caller_name(), vnode_key, vnode_resc_avail))
         pbs.logmsg(pbs.EVENT_DEBUG4, '%s: host_resc_avail: %s' %

--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -5890,6 +5890,9 @@ def missing_str(memspecs):
             mem_size = pbs.size(memspecs['mem'])
             if mem_size > vmem_size:
                 event.reject("invalid specification: vmem>mem")
+            elif mem_size == vmem_size:
+                # Avoid creating a "0mb" pbs.size
+                return("cgswap=0b")
             else:
                 cgswap_size = vmem_size - mem_size
                 return ("cgswap="
@@ -5913,13 +5916,18 @@ def missing_str(memspecs):
     if 'vmem' in memspecs and 'cgswap' in memspecs:
         try:
             vmem_size = pbs.size(memspecs['vmem'])
-            cgswap_size = pbs.size(memspecs['cgswap'])
-            if cgswap_size >= vmem_size:
-                event.reject("invalid specification: mem<=0")
+            # Woraround for bug: no arithmetic on zero pbs.size
+            # since user may have specified e.g. "0mb" cgswap
+            if size_as_int(memspecs['cgswap']) == 0:
+                mem_size = vmem_size
+                return ("mem=" + str(mem_size))
             else:
-                mem_size = vmem_size - cgswap_size
-                return ("mem="
-                        + str(mem_size))
+                cgswap_size = pbs.size(memspecs['cgswap'])
+                if cgswap_size >= vmem_size:
+                    event.reject("invalid specification: mem<=0")
+                else:
+                    mem_size = vmem_size - cgswap_size
+                    return ("mem=" + str(mem_size))
         except Exception:
             pbs.logmsg(pbs.EVENT_DEBUG4,
                        str(traceback.format_exc().strip().splitlines()))

--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -1061,7 +1061,7 @@ class HookUtils(object):
                                'deleting cpuset cgroup')
 
         # Configure the new cgroup
-        cgroup.configure_job(event.job.id, jobutil.assigned_resources,
+        cgroup.configure_job(event.job, jobutil.assigned_resources,
                              node, cgroup, event.type)
 
         # Write out the assigned resources
@@ -2442,11 +2442,18 @@ class NodeUtils(object):
             val -= val % (1024 * 1024)  # round down to MB
             host_resc_avail['hpmem'] = \
                 pbs.size(convert_size(val, 'mb'))
+            if (self.cfg['cgroup']['memsw']['enabled']
+                    and self.cfg['cgroup']['memsw']['manage_cgswap']):
+                host_resc_avail['cgswap'] = \
+                    host_resc_avail['vmem']-host_resc_avail['mem']
         else:
             # set the value on the host to 0
             host_resc_avail['mem'] = pbs.size('0')
             host_resc_avail['vmem'] = pbs.size('0')
             host_resc_avail['hpmem'] = pbs.size('0')
+            if (self.cfg['cgroup']['memsw']['enabled']
+                    and self.cfg['cgroup']['memsw']['manage_cgswap']):
+                host_resc_avail['cgswap'] = pbs.size('0')
             # Some kernel drivers "reserve" memory on /proc/meminfo
             # and this is not reflected in the node meminfo; if necessary,
             # adjust the values published as resources_available.mem
@@ -2576,6 +2583,10 @@ class NodeUtils(object):
             for nnid in self.numa_nodes:
                 vnode_key = vnode_name + '[%d]' % nnid
                 vnode_resc_avail = vnode_list[vnode_key].resources_available
+                if (self.cfg['cgroup']['memsw']['enabled']
+                        and self.cfg['cgroup']['memsw']['manage_cgswap']):
+                    vnode_resc_avail['cgswap'] = (vnode_resc_avail['vmem']
+                                                  - vnode_resc_avail['mem'])
                 pbs.logmsg(pbs.EVENT_DEBUG4, '%s: %s vnode_resc_avail: %s' %
                            (caller_name(), vnode_key, vnode_resc_avail))
         pbs.logmsg(pbs.EVENT_DEBUG4, '%s: host_resc_avail: %s' %
@@ -2927,7 +2938,7 @@ class CgroupUtils(object):
             if jobid:
                 # Caller wants parent directory of job
                 return os.path.join(subdir, jobid, '')
-            # Caller wants parent directory of subsystem
+            # Caller wants job parent directory for subsystem
             return os.path.join(subdir, '')
         # Caller wants full path to file
         if cgfile == 'tasks':
@@ -3193,20 +3204,14 @@ class CgroupUtils(object):
         defaults['cgroup']['devices']['exclude_hosts'] = []
         defaults['cgroup']['devices']['exclude_vntypes'] = []
         defaults['cgroup']['devices']['allow'] = []
-        defaults['cgroup']['hugetlb'] = {}
-        defaults['cgroup']['hugetlb']['enabled'] = False
-        defaults['cgroup']['hugetlb']['exclude_hosts'] = []
-        defaults['cgroup']['hugetlb']['exclude_vntypes'] = []
-        defaults['cgroup']['hugetlb']['default'] = '0MB'
-        defaults['cgroup']['hugetlb']['reserve_percent'] = 0
-        defaults['cgroup']['hugetlb']['reserve_amount'] = '0MB'
-        defaults['cgroup']['hugetlb']['vnode_hidden_mb'] = 1
         defaults['cgroup']['memory'] = {}
         defaults['cgroup']['memory']['enabled'] = False
         defaults['cgroup']['memory']['exclude_hosts'] = []
         defaults['cgroup']['memory']['exclude_vntypes'] = []
         defaults['cgroup']['memory']['soft_limit'] = False
         defaults['cgroup']['memory']['default'] = '0MB'
+        defaults['cgroup']['memory']['enforce_default'] = True
+        defaults['cgroup']['memory']['exclhost_ignore_default'] = False
         defaults['cgroup']['memory']['reserve_percent'] = 0
         defaults['cgroup']['memory']['reserve_amount'] = '0MB'
         defaults['cgroup']['memory']['vnode_hidden_mb'] = 1
@@ -3216,9 +3221,22 @@ class CgroupUtils(object):
         defaults['cgroup']['memsw']['exclude_hosts'] = []
         defaults['cgroup']['memsw']['exclude_vntypes'] = []
         defaults['cgroup']['memsw']['default'] = '0MB'
+        defaults['cgroup']['memsw']['enforce_default'] = True
+        defaults['cgroup']['memsw']['exclhost_ignore_default'] = False
         defaults['cgroup']['memsw']['reserve_percent'] = 0
         defaults['cgroup']['memsw']['reserve_amount'] = '0MB'
-        defaults['cgroup']['memsw']['vnode_hidden_mb'] = 0
+        defaults['cgroup']['memsw']['vnode_hidden_mb'] = 1
+        defaults['cgroup']['memsw']['manage_cgswap'] = False
+        defaults['cgroup']['hugetlb'] = {}
+        defaults['cgroup']['hugetlb']['enabled'] = False
+        defaults['cgroup']['hugetlb']['exclude_hosts'] = []
+        defaults['cgroup']['hugetlb']['exclude_vntypes'] = []
+        defaults['cgroup']['hugetlb']['default'] = '0MB'
+        defaults['cgroup']['hugetlb']['enforce_defaults'] = True
+        defaults['cgroup']['hugetlb']['exclhost_ignore_default'] = False
+        defaults['cgroup']['hugetlb']['reserve_percent'] = 0
+        defaults['cgroup']['hugetlb']['reserve_amount'] = '0MB'
+        defaults['cgroup']['hugetlb']['vnode_hidden_mb'] = 1
         defaults['cgroup']['net_cls'] = {}
         defaults['cgroup']['net_cls']['enabled'] = False
         defaults['cgroup']['net_prio'] = {}
@@ -3467,6 +3485,29 @@ class CgroupUtils(object):
         """
         pbs.logmsg(pbs.EVENT_DEBUG4, '%s: Method called' % caller_name())
         assigned = {}
+
+        # if jobs have a limit *exactly* equal to the total available limit
+        # then they have no explicit memory req and the limit was set to the
+        # available total -- get totals to compare
+        mem_avail = None
+        filename = self._cgroup_path('memory', 'limit_in_bytes')
+        if filename and os.path.isfile(filename):
+            with open(filename) as desc:
+                mem_avail = int(desc.readline())
+        vmem_avail = None
+        filename = self._cgroup_path('memsw', 'limit_in_bytes')
+        if filename and os.path.isfile(filename):
+            with open(filename) as desc:
+                vmem_avail = int(desc.readline())
+        hpmem_avail = None
+        filename = self._cgroup_path('hugetlb', 'limit_in_bytes')
+        if filename and os.path.isfile(filename):
+            with open(filename) as desc:
+                hpmem_avail = int(desc.readline())
+        pbs.logmsg(pbs.EVENT_DEBUG4, "get_assigned_cgroup_resources:"
+                   " total host avail mem=%s vmem=%s hpmem=%s"
+                   % (mem_avail, vmem_avail, hpmem_avail))
+
         for key in self.paths:
             if key in ('blkio', 'cpu', 'cpuacct', 'freezer', 'systemd'):
                 continue
@@ -3499,18 +3540,24 @@ class CgroupUtils(object):
                                                 jobid)) as desc:
                         assigned[jobid][key]['limit_in_bytes'] = \
                             int(desc.readline())
+                    if assigned[jobid][key]['limit_in_bytes'] == mem_avail:
+                        assigned[jobid][key]['limit_in_bytes'] = 0
                     with open(self._cgroup_path(key, 'soft_limit_in_bytes',
                                                 jobid)) as desc:
                         assigned[jobid][key]['soft_limit_in_bytes'] = \
                             int(desc.readline())
+                    if (assigned[jobid][key]['soft_limit_in_bytes']
+                            == mem_avail):
+                        assigned[jobid][key]['soft_limit_in_bytes'] = 0
                 elif key == 'memsw':
                     filename = self._cgroup_path('memsw', 'limit_in_bytes',
                                                  jobid)
-                    if os.path.isfile(filename):
+                    if filename and os.path.isfile(filename):
                         with open(filename) as desc:
-                            assigned[jobid]['memsw'] = {}
                             assigned[jobid]['memsw']['limit_in_bytes'] = \
                                 int(desc.readline())
+                    if assigned[jobid][key]['limit_in_bytes'] == vmem_avail:
+                        assigned[jobid][key]['limit_in_bytes'] = 0
                     else:
                         pbs.logmsg(pbs.EVENT_DEBUG4, '%s: No such file: %s' %
                                    (caller_name(), filename))
@@ -3519,6 +3566,8 @@ class CgroupUtils(object):
                                                 jobid)) as desc:
                         assigned[jobid][key]['limit_in_bytes'] = \
                             int(desc.readline())
+                    if assigned[jobid][key]['limit_in_bytes'] == hpmem_avail:
+                        assigned[jobid][key]['limit_in_bytes'] == 0
                 elif key == 'devices':
                     path = self._cgroup_path(key, 'list', jobid)
                     pbs.logmsg(pbs.EVENT_DEBUG4, '%s: Devices path is %s' %
@@ -4726,17 +4775,40 @@ class CgroupUtils(object):
             finally:
                 os.umask(old_umask)
 
-    def configure_job(self, jobid, hostresc, node, cgroup, event_type):
+    def configure_job(self, job, hostresc, node, cgroup, event_type):
         """
         Determine the cgroup limits and configure the cgroups
         """
+        jobid = job.id
+
+        # Get available totals for mem, vmem and hpmem from parent cgroup
+        # Calling node.get_memory_on_node etc. may give slightly different
+        # results if kernel drivers have freshly reserved memory since
+        # exechost_startup was called
+        mem_avail = None
+        filename = self._cgroup_path('memory', 'limit_in_bytes')
+        if filename and os.path.isfile(filename):
+            with open(filename) as desc:
+                mem_avail = int(desc.readline())
+        vmem_avail = None
+        filename = self._cgroup_path('memsw', 'limit_in_bytes')
+        if filename and os.path.isfile(filename):
+            with open(filename) as desc:
+                vmem_avail = int(desc.readline())
+        hpmem_avail = None
+        filename = self._cgroup_path('hugetlb', 'limit_in_bytes')
+        if filename and os.path.isfile(filename):
+            with open(filename) as desc:
+                hpmem_avail = int(desc.readline())
+        pbs.logmsg(pbs.EVENT_DEBUG4, "configure_job:"
+                   " total host avail mem=%s vmem=%s hpmem=%s"
+                   % (mem_avail, vmem_avail, hpmem_avail))
+
         pbs.logmsg(pbs.EVENT_DEBUG4, '%s: Method called' % caller_name())
         mem_enabled = 'memory' in self.subsystems
         vmem_enabled = 'memsw' in self.subsystems
         if mem_enabled or vmem_enabled:
             # Initialize mem variables
-            mem_avail = node.get_memory_on_node()
-            pbs.logmsg(pbs.EVENT_DEBUG4, 'mem_avail %s' % mem_avail)
             mem_requested = None
             if 'mem' in hostresc:
                 mem_requested = convert_size(hostresc['mem'], 'kb')
@@ -4744,8 +4816,6 @@ class CgroupUtils(object):
             if mem_enabled:
                 mem_default = self.default('memory')
             # Initialize vmem variables
-            vmem_avail = node.get_vmem_on_node()
-            pbs.logmsg(pbs.EVENT_DEBUG4, 'vmem_avail %s' % vmem_avail)
             vmem_requested = None
             if 'vmem' in hostresc:
                 vmem_requested = convert_size(hostresc['vmem'], 'kb')
@@ -4777,7 +4847,14 @@ class CgroupUtils(object):
                 mem_limit = mem_requested
             else:
                 # mem was not requested
-                if mem_default is None:
+                if (mem_default is None
+                        or not self.cfg['cgroup']['memory']
+                                       ['enforce_default']
+                        or (self.cfg['cgroup']['memory']
+                                    ['exclhost_ignore_default']
+                            and "place" in job.Resource_List
+                            and 'exclhost'
+                                in repr(job.Resource_List['place']))):
                     mem_limit = mem_avail
                 else:
                     mem_limit = mem_default
@@ -4791,10 +4868,20 @@ class CgroupUtils(object):
                 vmem_limit = vmem_requested
             else:
                 # vmem was not requested
-                if vmem_default is None:
+                if (vmem_default is None
+                        or not self.cfg['cgroup']['memsw']
+                                       ['enforce_default']
+                        or (self.cfg['cgroup']['memsw']
+                                    ['exclhost_ignore_default']
+                            and "place" in job.Resource_List
+                            and 'exclhost'
+                                in repr(job.Resource_List['place']))):
+
                     vmem_limit = vmem_avail
                 else:
-                    vmem_limit = vmem_default
+                    vmem_limit = str(min(size_as_int(vmem_avail),
+                                         size_as_int(mem_limit)
+                                         + size_as_int(vmem_default)))
             # Ensure vmem is at least as large as mem
             if size_as_int(vmem_limit) < size_as_int(mem_limit):
                 vmem_limit = mem_limit
@@ -4855,10 +4942,15 @@ class CgroupUtils(object):
         # Initialize hpmem variables
         hpmem_enabled = 'hugetlb' in self.subsystems
         if hpmem_enabled:
-            hpmem_avail = node.get_hpmem_on_node(ignore_reserved=False)
             hpmem_limit = None
             hpmem_default = self.default('hugetlb')
-            if hpmem_default is None:
+            if (hpmem_default is None
+                    or not self.cfg['cgroup']['hugetlb']
+                                   ['enforce_default']
+                    or (self.cfg['cgroup']['hugetlb']
+                                ['exclhost_ignore_default']
+                        and "place" in job.Resource_List
+                        and 'exclhost' in repr(job.Resource_List['place']))):
                 hpmem_default = hpmem_avail
             if 'hpmem' in hostresc:
                 hpmem_limit = convert_size(hostresc['hpmem'], 'kb')
@@ -5767,6 +5859,160 @@ def set_global_vars():
         raise CgroupConfigError('Unable to determine PBS_MOM_HOME')
 
 
+def missing_str(memspecs):
+    if 'vmem' in memspecs and 'mem' in memspecs:
+        try:
+            vmem_size = pbs.size(memspecs['vmem'])
+            mem_size = pbs.size(memspecs['mem'])
+            if mem_size > vmem_size:
+                event.reject("invalid specification: vmem>mem")
+            else:
+                cgswap_size = vmem_size - mem_size
+                return ("cgswap="
+                        + str(cgswap_size))
+        except Exception:
+            pbs.logmsg(pbs.EVENT_DEBUG4,
+                       str(traceback.format_exc().strip().splitlines()))
+            event.reject("Invalid (v)mem size requested")
+
+    if 'mem' in memspecs and 'cgswap' in memspecs:
+        try:
+            vmem_size = (pbs.size(memspecs['mem'])
+                         + pbs.size(memspecs['cgswap']))
+            return ("vmem="
+                    + str(vmem_size))
+        except Exception:
+            pbs.logmsg(pbs.EVENT_DEBUG4,
+                       str(traceback.format_exc().strip().splitlines()))
+            event.reject("Invalid mem or cgswap size requested")
+
+    if 'vmem' in memspecs and 'cgswap' in memspecs:
+        try:
+            vmem_size = pbs.size(memspecs['vmem'])
+            cgswap_size = pbs.size(memspecs['cgswap'])
+            if cgswap_size >= vmem_size:
+                event.reject("invalid specification: mem<=0")
+            else:
+                mem_size = vmem_size - cgswap_size
+                return ("mem="
+                        + str(mem_size))
+        except Exception:
+            pbs.logmsg(pbs.EVENT_DEBUG4,
+                       str(traceback.format_exc().strip().splitlines()))
+            event.reject("Invalid (v)mem size requested")
+    return ""
+
+
+def fill_cgswap():
+    selspec = None
+    event = pbs.event()
+
+    job = event.job
+    job_o = None
+    if event.type == pbs.MODIFYJOB:
+        job_o = event.job_o
+
+    if (hasattr(job, 'Resource_List') and 'select' in job.Resource_List
+            and job.Resource_List.select):
+        # either a submission using -lselect or a qalter specifying -lselect
+        selspec = repr(job.Resource_List["select"])
+        pbs.logmsg(pbs.EVENT_DEBUG3, "fill_cgswap: original selspec is: %s"
+                   % selspec)
+        newspec = []
+        for chunkspec in selspec.split('+'):
+            chunkspec_split = chunkspec.split(':')
+            try:
+                chunkspec_quantity = int(chunkspec_split[0])
+            except Exception:
+                event.reject("Invalid number of chunks in -lselect")
+            newchunk = chunkspec
+            if len(chunkspec_split) == 1:
+                newspec.append(newchunk)
+            else:
+                # more than just a number of chunks
+                # -- get resources specified
+                memspecs = {}
+                for t in chunkspec_split[1:]:
+                    if t.startswith('mem='):
+                        memstr = t.split('=')[1]
+                        memspecs['mem'] = memstr
+                    if t.startswith('vmem='):
+                        vmemstr = t.split('=')[1]
+                        memspecs['vmem'] = vmemstr
+                    if t.startswith('cgswap='):
+                        cgswapstr = t.split('=')[1]
+                        memspecs['cgswap'] = cgswapstr
+                if len(memspecs) > 2:
+                    event.reject("chunk specification overconstrained, "
+                                 "specify only 2 of mem/vmem/cgswap")
+                elif len(memspecs) == 2:
+                    to_add = missing_str(memspecs)
+                    if to_add:
+                        newchunk += ":" + to_add
+                    newspec.append(newchunk)
+                else:
+                    newspec.append(newchunk)
+        newselspec = '+'.join(newspec)
+        pbs.logmsg(pbs.EVENT_DEBUG3, "fill_cgswap: old selspec was: %s, "
+                   "new selspec is %s"
+                   % (selspec, newselspec))
+        job.Resource_List['select'] = pbs.select(newselspec)
+        # need to remove possibly stale "global" cgswap
+        # if there is a select now but if the job was originally submitted
+        # with "old style" per-job resources, as cgswap chunk values are
+        # not summed into Resource_List as for vmem and mem
+        try:
+            job.Resource_List['cgswap'] = None
+        except Exception:
+            pass
+    else:
+        # Old style submission without -lselect
+        # We set 'global' per-job resources; will fail (by design)
+        # if original submission used -lselect.
+        to_add = None
+        memspecs_o = {}
+        memspecs_n = {}
+        memspecs = {}
+        for res in ['vmem', 'mem', 'cgswap']:
+            if (hasattr(job_o, 'Resource_List')
+                    and res in job_o.Resource_List
+                    and job_o.Resource_List[res] is not None):
+                memspecs_o[res] = job_o.Resource_List[res]
+            if (hasattr(job, 'Resource_List')
+                    and res in job.Resource_List
+                    and job.Resource_List[res] is not None):
+                memspecs_n[res] = job.Resource_List[res]
+        memspecs = {**memspecs_o, **memspecs_n}
+        pbs.logmsg(pbs.EVENT_DEBUG3, "memspecs read is: %s"
+                   % str(memspecs))
+
+        if len(memspecs) == 3:
+            # overconstrained -- we have 3 values for mem, vmem and cgswap
+            if (event.type == pbs.QUEUEJOB or len(memspecs_n) > 2):
+                event.reject("chunk specification overconstrained, "
+                             "specify only 2 of mem/vmem/cgswap")
+            else:
+                # modifyjob -- values in the new dictionary are controlling
+                if len(memspecs_n) == 2:
+                    # the two new values determine the third
+                    to_add = missing_str(memspecs_n)
+                elif len(memspecs_n) == 1:
+                    # specified one new value in qalter
+                    # -- pick which old one to keep
+                    # if new value is cgswap, keep old mem and recompute vmem
+                    # if new value is vmem, keep old mem and recompute cgswap
+                    # if new value is mem, keep old vmem and recompute cgswap
+                    if 'cgswap' in memspecs_n:
+                        del memspecs['vmem']
+                    else:
+                        del memspecs['cgswap']
+        if len(memspecs) == 2 and not to_add:
+            to_add = missing_str(memspecs)
+        if to_add:
+            to_add_split = to_add.split('=')
+            job.Resource_List[to_add_split[0]] = pbs.size(to_add_split[1])
+
+
 #
 # FUNCTION main
 #
@@ -5783,6 +6029,11 @@ def main():
     event = pbs.event()
     pbs.logmsg(pbs.EVENT_DEBUG4, '%s: Hook name is %s' %
                (caller_name(), event.hook_name))
+
+    if event.type in [pbs.MODIFYJOB, pbs.QUEUEJOB]:
+        fill_cgswap()
+        event.accept()
+
     try:
         set_global_vars()
     except Exception:

--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -3510,12 +3510,15 @@ class CgroupUtils(object):
         """
         Return a dictionary of currently assigned cgroup resources per job
         """
+        # if jobs have a limit *exactly* equal to the total limit available
+        # for all jobs, then they have no explicit memory req and the
+        # limit is the result of an 'unlimited' default;
+        # in that case, the scheduler assigned 0, so be consistent with it
+
         pbs.logmsg(pbs.EVENT_DEBUG4, '%s: Method called' % caller_name())
         assigned = {}
 
-        # if jobs have a limit *exactly* equal to the total available limit
-        # then they have no explicit memory req and the limit was set to the
-        # available total -- get totals to compare
+        # Get totals available for all jobs to compare with later        
         mem_avail = None
         filename = self._cgroup_path('memory', 'limit_in_bytes')
         if filename and os.path.isfile(filename):
@@ -3568,6 +3571,7 @@ class CgroupUtils(object):
                         assigned[jobid][key]['limit_in_bytes'] = \
                             int(desc.readline())
                     if assigned[jobid][key]['limit_in_bytes'] == mem_avail:
+                        # not explicitly assigned, 'unlimited' raised default
                         assigned[jobid][key]['limit_in_bytes'] = 0
                     with open(self._cgroup_path(key, 'soft_limit_in_bytes',
                                                 jobid)) as desc:
@@ -3575,6 +3579,7 @@ class CgroupUtils(object):
                             int(desc.readline())
                     if (assigned[jobid][key]['soft_limit_in_bytes']
                             == mem_avail):
+                        # not explicitly assigned, 'unlimited' raised default
                         assigned[jobid][key]['soft_limit_in_bytes'] = 0
                 elif key == 'memsw':
                     filename = self._cgroup_path('memsw', 'limit_in_bytes',
@@ -3584,6 +3589,7 @@ class CgroupUtils(object):
                             assigned[jobid]['memsw']['limit_in_bytes'] = \
                                 int(desc.readline())
                     if assigned[jobid][key]['limit_in_bytes'] == vmem_avail:
+                        # not explicitly assigned, 'unlimited' raised default
                         assigned[jobid][key]['limit_in_bytes'] = 0
                     else:
                         pbs.logmsg(pbs.EVENT_DEBUG4, '%s: No such file: %s' %
@@ -3594,6 +3600,7 @@ class CgroupUtils(object):
                         assigned[jobid][key]['limit_in_bytes'] = \
                             int(desc.readline())
                     if assigned[jobid][key]['limit_in_bytes'] == hpmem_avail:
+                        # not explicitly assigned, 'unlimited' raised default
                         assigned[jobid][key]['limit_in_bytes'] = 0
                 elif key == 'devices':
                     path = self._cgroup_path(key, 'list', jobid)

--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -2426,6 +2426,10 @@ class NodeUtils(object):
             if vmem < 0:
                 vmem = 0
             vmem -= vmem % (1024 * 1024)
+            # if there is no swap, trying to subtract vnode_hidden_mb
+            # will lower vmem under mem, do not allow
+            if vmem < mem:
+                vmem = mem
             vmem = pbs.size(convert_size(vmem, 'mb'))
             host_resc_avail['vmem'] = vmem
             pbs.logmsg(pbs.EVENT_DEBUG4, vnode_msg_mem %
@@ -2444,9 +2448,17 @@ class NodeUtils(object):
                 pbs.size(convert_size(val, 'mb'))
             if (self.cfg['cgroup']['memsw']['enabled']
                     and self.cfg['cgroup']['memsw']['manage_cgswap']):
-                host_resc_avail['cgswap'] = max(0,
-                                                host_resc_avail['vmem']
-                                                - host_resc_avail['mem'])
+                # special case 0 cgswap because assigning a "0mb"
+                # pbs.size difference causes a bug
+                if vmem == mem:
+                    host_resc_avail['cgswap'] = pbs.size('0')
+                else:
+                    host_resc_avail['cgswap'] = (host_resc_avail['vmem']
+                                                 - host_resc_avail['mem'])
+            else:
+                # This unsets it if it was defined earlier and needs to
+                # disappear
+                host_resc_avail['cgswap'] = None
         else:
             # set the value on the host to 0
             host_resc_avail['mem'] = pbs.size('0')
@@ -2584,11 +2596,24 @@ class NodeUtils(object):
             for nnid in self.numa_nodes:
                 vnode_key = vnode_name + '[%d]' % nnid
                 vnode_resc_avail = vnode_list[vnode_key].resources_available
+                # vmem can be smaller than mem if there is no swap, since
+                # we try to hide 1MB of swap from the server
+                if vnode_resc_avail['vmem'] < vnode_resc_avail['mem']:
+                    vnode_resc_avail['vmem'] = vnode_resc_avail['mem']
                 if (self.cfg['cgroup']['memsw']['enabled']
                         and self.cfg['cgroup']['memsw']['manage_cgswap']):
-                    vnode_resc_avail['cgswap'] = max(0,
-                                                     vnode_resc_avail['vmem']
-                                                     - vnode_resc_avail['mem'])
+                    # Special case 0 cgswap since a bug creates a crash when
+                    # the "0mb" pbs.size difference is assigned to the resource
+                    if vnode_resc_avail['vmem'] == vnode_resc_avail['mem']:
+                        vnode_resc_avail['cgswap'] = pbs.size('0')
+                    else:
+                        vnode_resc_avail['cgswap'] = \
+                            vnode_resc_avail['vmem'] - vnode_resc_avail['mem']
+                else:
+                    # This unsets it if it was defined earlier and needs to
+                    # disappear
+                    host_resc_avail['cgswap'] = None
+
                 pbs.logmsg(pbs.EVENT_DEBUG4, '%s: %s vnode_resc_avail: %s' %
                            (caller_name(), vnode_key, vnode_resc_avail))
         pbs.logmsg(pbs.EVENT_DEBUG4, '%s: host_resc_avail: %s' %
@@ -4787,17 +4812,17 @@ class CgroupUtils(object):
         # Calling node.get_memory_on_node etc. may give slightly different
         # results if kernel drivers have freshly reserved memory since
         # exechost_startup was called
-        mem_avail = None
+        mem_avail = 0
         filename = self._cgroup_path('memory', 'limit_in_bytes')
         if filename and os.path.isfile(filename):
             with open(filename) as desc:
                 mem_avail = int(desc.readline())
-        vmem_avail = None
+        vmem_avail = 0
         filename = self._cgroup_path('memsw', 'limit_in_bytes')
         if filename and os.path.isfile(filename):
             with open(filename) as desc:
                 vmem_avail = int(desc.readline())
-        hpmem_avail = None
+        hpmem_avail = 0
         filename = self._cgroup_path('hugetlb', 'limit_in_bytes')
         if filename and os.path.isfile(filename):
             with open(filename) as desc:
@@ -4805,6 +4830,9 @@ class CgroupUtils(object):
         pbs.logmsg(pbs.EVENT_DEBUG4, "configure_job:"
                    " total host avail mem=%s vmem=%s hpmem=%s"
                    % (mem_avail, vmem_avail, hpmem_avail))
+
+        # Sanity check vmem_avail > mem_avail unnecessary
+        # -- by construction in exechost_startup
 
         pbs.logmsg(pbs.EVENT_DEBUG4, '%s: Method called' % caller_name())
         mem_enabled = 'memory' in self.subsystems
@@ -4815,37 +4843,29 @@ class CgroupUtils(object):
             if 'mem' in hostresc:
                 mem_requested = convert_size(hostresc['mem'], 'kb')
             mem_default = None
-            if mem_enabled:
-                mem_default = self.default('memory')
+            if mem_enabled and self.default('memory') is not None:
+                mem_default = size_as_int(self.default('memory'))
             # Initialize vmem variables
             vmem_requested = None
             if 'vmem' in hostresc:
                 vmem_requested = convert_size(hostresc['vmem'], 'kb')
             vmem_default = None
-            if vmem_enabled:
-                vmem_default = self.default('memsw')
+            if vmem_enabled and self.default('memsw') is not None:
+                vmem_default = size_as_int(self.default('memsw'))
+                if vmem_default > (vmem_avail - mem_avail):
+                    vmem_default = vmem_avail - mem_avail
             # Initialize softmem variables
             if 'soft_limit' in self.cfg['cgroup']['memory']:
                 softmem_enabled = self.cfg['cgroup']['memory']['soft_limit']
             else:
                 softmem_enabled = False
-            # Sanity check
-            if size_as_int(mem_avail) > size_as_int(vmem_avail):
-                pbs.logmsg(pbs.EVENT_SYSTEM,
-                           '%s: WARNING: mem_avail > vmem_avail' %
-                           caller_name())
-                pbs.logmsg(pbs.EVENT_SYSTEM,
-                           '%s: Check reserve_amount and reserve_percent' %
-                           caller_name())
-                # Increase vmem_avail to match mem_avail
-                vmem_avail = mem_avail
             # Determine the mem limit
             if mem_requested is not None:
                 # mem requested may not exceed available
-                if size_as_int(mem_requested) > size_as_int(mem_avail):
+                if size_as_int(mem_requested) > mem_avail:
                     raise JobValueError(
                         'mem requested (%s) exceeds mem available (%s)' %
-                        (mem_requested, mem_avail))
+                        (mem_requested, str(mem_avail)))
                 mem_limit = mem_requested
             else:
                 # mem was not requested
@@ -4857,16 +4877,16 @@ class CgroupUtils(object):
                             and "place" in job.Resource_List
                             and 'exclhost'
                                 in repr(job.Resource_List['place']))):
-                    mem_limit = mem_avail
+                    mem_limit = str(mem_avail)
                 else:
-                    mem_limit = mem_default
+                    mem_limit = str(mem_default)
             # Determine the vmem limit
             if vmem_requested is not None:
                 # vmem requested may not exceed available
-                if size_as_int(vmem_requested) > size_as_int(vmem_avail):
+                if size_as_int(vmem_requested) > vmem_avail:
                     raise JobValueError(
                         'vmem requested (%s) exceeds vmem available (%s)' %
-                        (vmem_requested, vmem_avail))
+                        (vmem_requested, str(vmem_avail)))
                 vmem_limit = vmem_requested
             else:
                 # vmem was not requested
@@ -4879,11 +4899,11 @@ class CgroupUtils(object):
                             and 'exclhost'
                                 in repr(job.Resource_List['place']))):
 
-                    vmem_limit = vmem_avail
+                    vmem_limit = str(vmem_avail)
                 else:
-                    vmem_limit = str(min(size_as_int(vmem_avail),
+                    vmem_limit = str(min(vmem_avail,
                                          size_as_int(mem_limit)
-                                         + size_as_int(vmem_default)))
+                                         + vmem_default))
             # Ensure vmem is at least as large as mem
             if size_as_int(vmem_limit) < size_as_int(mem_limit):
                 vmem_limit = mem_limit
@@ -4892,30 +4912,30 @@ class CgroupUtils(object):
                 softmem_limit = mem_limit
                 # The hard memory limit is assigned the lesser of the vmem
                 # limit and available memory
-                if size_as_int(vmem_limit) < size_as_int(mem_avail):
+                if size_as_int(vmem_limit) < mem_avail:
                     mem_limit = vmem_limit
                 else:
-                    mem_limit = mem_avail
+                    mem_limit = str(mem_avail)
             # Again, ensure vmem is at least as large as mem
             if size_as_int(vmem_limit) < size_as_int(mem_limit):
                 vmem_limit = mem_limit
             # Sanity checks when both memory and memsw are enabled
             if mem_enabled and vmem_enabled:
                 if vmem_requested is not None:
-                    if size_as_int(vmem_limit) > size_as_int(vmem_requested):
+                    if size_as_int(vmem_requested) < size_as_int(vmem_limit):
                         # The user requested an invalid limit
                         raise JobValueError(
-                            'vmem limit (%s) exceeds vmem requested (%s)' %
-                            (vmem_limit, vmem_requested))
+                            'vmem requested (%s) under minimum possible (%s)'
+                            % (vmem_requested, vmem_limit))
                 if size_as_int(vmem_limit) > size_as_int(mem_limit):
                     # This job may try to utilize swap
-                    if size_as_int(vmem_avail) <= size_as_int(mem_avail):
+                    if vmem_avail <= mem_avail:
                         # No swap available
                         if vmem_requested is not None:
                             raise CgroupLimitError('Job might utilize swap'
                                                    ' and no swap on host')
                         else:
-                            # It got its impossible vmem>mem from a default
+                            # It got an impossible vmem>mem
                             # undo that since there is no swap
                             vmem_limit = mem_limit
             # Assign mem and vmem
@@ -4942,10 +4962,12 @@ class CgroupUtils(object):
                                caller_name())
                     hostresc['vmem'] = pbs.size(vmem_limit)
         # Initialize hpmem variables
+        hpmem_default = None
+        hpmem_limit = None
         hpmem_enabled = 'hugetlb' in self.subsystems
         if hpmem_enabled:
-            hpmem_limit = None
-            hpmem_default = self.default('hugetlb')
+            if self.default('hugetlb') is not None:
+                hpmem_default = size_as_int(self.default('hugetlb'))
             if (hpmem_default is None
                     or not self.cfg['cgroup']['hugetlb']
                                    ['enforce_default']
@@ -4957,11 +4979,11 @@ class CgroupUtils(object):
             if 'hpmem' in hostresc:
                 hpmem_limit = convert_size(hostresc['hpmem'], 'kb')
             else:
-                hpmem_limit = hpmem_default
+                hpmem_limit = str(hpmem_default)
             # Assign hpmem
-            if size_as_int(hpmem_limit) > size_as_int(hpmem_avail):
+            if size_as_int(hpmem_limit) > hpmem_avail:
                 raise JobValueError('hpmem limit (%s) exceeds available (%s)' %
-                                    (hpmem_limit, hpmem_avail))
+                                    (hpmem_limit, str(hpmem_avail)))
             hostresc['hpmem'] = pbs.size(hpmem_limit)
         # Initialize cpuset variables
         cpuset_enabled = 'cpuset' in self.subsystems

--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -5886,8 +5886,14 @@ def set_global_vars():
 def missing_str(memspecs):
     if 'vmem' in memspecs and 'mem' in memspecs:
         try:
-            vmem_size = pbs.size(memspecs['vmem'])
-            mem_size = pbs.size(memspecs['mem'])
+            if size_as_int(memspecs['vmem']) > 0:
+                vmem_size = pbs.size(memspecs['vmem'])
+            else:
+                vmem_size = pbs.size("0b")
+            if size_as_int(memspecs['mem']) > 0:
+                mem_size = pbs.size(memspecs['mem'])
+            else:
+                mem_size = pbs.size("0b")
             if mem_size > vmem_size:
                 event.reject("invalid specification: vmem>mem")
             elif mem_size == vmem_size:
@@ -5904,8 +5910,16 @@ def missing_str(memspecs):
 
     if 'mem' in memspecs and 'cgswap' in memspecs:
         try:
-            vmem_size = (pbs.size(memspecs['mem'])
-                         + pbs.size(memspecs['cgswap']))
+            if size_as_int(memspecs['mem']) > 0:
+                mem_size = pbs.size(memspecs['mem'])
+            else:
+                mem_size = pbs.size("0b")
+            if size_as_int(memspecs['cgswap']) > 0:
+                cgswap_size = pbs.size(memspecs['mem'])
+            else:
+                cgswap_size = pbs.size("0b")
+
+            vmem_size = mem_size + cgswap_size
             return ("vmem="
                     + str(vmem_size))
         except Exception:
@@ -5915,7 +5929,10 @@ def missing_str(memspecs):
 
     if 'vmem' in memspecs and 'cgswap' in memspecs:
         try:
-            vmem_size = pbs.size(memspecs['vmem'])
+            if size_as_int(memspecs['vmem']) > 0:
+                vmem_size = pbs.size(memspecs['vmem'])
+            else:
+                vmem_size = pbs.size("0b")
             # Woraround for bug: no arithmetic on zero pbs.size
             # since user may have specified e.g. "0mb" cgswap
             if size_as_int(memspecs['cgswap']) == 0:

--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -3567,7 +3567,7 @@ class CgroupUtils(object):
                         assigned[jobid][key]['limit_in_bytes'] = \
                             int(desc.readline())
                     if assigned[jobid][key]['limit_in_bytes'] == hpmem_avail:
-                        assigned[jobid][key]['limit_in_bytes'] == 0
+                        assigned[jobid][key]['limit_in_bytes'] = 0
                 elif key == 'devices':
                     path = self._cgroup_path(key, 'list', jobid)
                     pbs.logmsg(pbs.EVENT_DEBUG4, '%s: Devices path is %s' %

--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -5889,16 +5889,16 @@ def missing_str(memspecs):
             if size_as_int(memspecs['vmem']) > 0:
                 vmem_size = pbs.size(memspecs['vmem'])
             else:
-                vmem_size = pbs.size("0b")
+                vmem_size = pbs.size("0B")
             if size_as_int(memspecs['mem']) > 0:
                 mem_size = pbs.size(memspecs['mem'])
             else:
-                mem_size = pbs.size("0b")
+                mem_size = pbs.size("0B")
             if mem_size > vmem_size:
                 event.reject("invalid specification: vmem>mem")
             elif mem_size == vmem_size:
                 # Avoid creating a "0mb" pbs.size
-                return("cgswap=0b")
+                return("cgswap=0B")
             else:
                 cgswap_size = vmem_size - mem_size
                 return ("cgswap="
@@ -5913,13 +5913,12 @@ def missing_str(memspecs):
             if size_as_int(memspecs['mem']) > 0:
                 mem_size = pbs.size(memspecs['mem'])
             else:
-                mem_size = pbs.size("0b")
+                mem_size = pbs.size("0B")
             if size_as_int(memspecs['cgswap']) > 0:
-                cgswap_size = pbs.size(memspecs['mem'])
+                cgswap_size = pbs.size(memspecs['cgswap'])
+                vmem_size = mem_size + cgswap_size
             else:
-                cgswap_size = pbs.size("0b")
-
-            vmem_size = mem_size + cgswap_size
+                vmem_size = mem_size
             return ("vmem="
                     + str(vmem_size))
         except Exception:
@@ -5932,7 +5931,7 @@ def missing_str(memspecs):
             if size_as_int(memspecs['vmem']) > 0:
                 vmem_size = pbs.size(memspecs['vmem'])
             else:
-                vmem_size = pbs.size("0b")
+                vmem_size = pbs.size("0B")
             # Woraround for bug: no arithmetic on zero pbs.size
             # since user may have specified e.g. "0mb" cgswap
             if size_as_int(memspecs['cgswap']) == 0:

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -2292,7 +2292,7 @@ if %s e.job.in_ms_mom():
             self.skipTest('Skipping test since no devices subsystem defined')
         name = 'CGROUP3'
         sleep(2)
-        begin=int(time.time())
+        begin = int(time.time())
         sleep(2)
         self.load_config(self.cfg14 % ('true', 'true'))
 
@@ -2317,7 +2317,7 @@ if %s e.job.in_ms_mom():
             self.skipTest('Skipping test since no devices subsystem defined')
         name = 'CGROUP3'
         sleep(2)
-        begin=int(time.time())
+        begin = int(time.time())
         sleep(2)
         self.load_config(self.cfg14 % ('true', 'false'))
 
@@ -2343,7 +2343,7 @@ if %s e.job.in_ms_mom():
             self.skipTest('Skipping test since no devices subsystem defined')
         name = 'CGROUP3'
         sleep(2)
-        begin=int(time.time())
+        begin = int(time.time())
         sleep(2)
         self.load_config(self.cfg14 % ('false', 'true'))
 

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -1702,8 +1702,16 @@ if %s e.job.in_ms_mom():
             self.assertGreater(count, 0, "pbs_cgroups.CF failed to load")
             # A HUP of each mom ensures update to hook config file is
             # seen by the exechost_startup hook.
+
+            time.sleep(2)
+            stime = int(time.time())
+            time.sleep(2)
             for mom in self.moms_list:
                 mom.signal('-HUP')
+                mom.log_match('Hook handler returned success'
+                              ' for exechost_startup',
+                              starttime=stime, existence=True,
+                              interval=1, n='ALL')
 
     def load_default_config(self, mom_checks=True):
         """
@@ -1990,8 +1998,7 @@ if %s e.job.in_ms_mom():
         self.server.manager(MGR_CMD_SET, HOOK, conf, self.hook_name)
         self.load_config(self.cfg3 % ('', 'false', '', self.mem, '',
                                       self.swapctl, ''))
-        # Restart mom for changes made by cgroups hook to take effect
-        self.mom.restart()
+
         a = {'Resource_List.select': '1:ncpus=1:mem=500mb:host=%s' %
              self.hosts_list[0], ATTR_N: name}
         j = Job(TEST_USER, attrs=a)
@@ -2087,7 +2094,7 @@ if %s e.job.in_ms_mom():
             # try to make next loop match the _next_ updates
             # note: we might still be unlucky and just match an old update,
             # but not next time: the loop's sleep will make 'begin' advance
-            begin=int(time.time())
+            begin = int(time.time())
 
         self.assertGreater(cput_usage, 1.0)
         self.assertGreater(mem_usage, 400000)
@@ -2152,20 +2159,6 @@ if %s e.job.in_ms_mom():
         name = 'CGROUP2'
         self.load_config(self.cfg3 % ('', 'false', '', self.mem, '',
                                       self.swapctl, ''))
-
-        time.sleep(2)
-        begin = int(time.time())
-        # sleep 2s to allow for small time differences and rounding errors
-        time.sleep(2)
-        # Restart mom for changes made by cgroups hook to take effect
-        self.mom.restart()
-
-        # Make sure the MoM is restarted
-        self.moms_list[0].log_match('Hook handler returned success'
-                                    ' for exechost_startup',
-                                    starttime=begin, existence=True,
-                                    interval=1, n='ALL')
-
         a = {'Resource_List.select': '1:ncpus=1:host=%s' %
              self.hosts_list[0], ATTR_N: name}
         j = Job(TEST_USER, attrs=a)
@@ -2299,20 +2292,6 @@ if %s e.job.in_ms_mom():
         name = 'CGROUP3'
         self.load_config(self.cfg14 % ('true', 'true'))
 
-        # sleep 2s: make sure no old log lines will match 'begin' time
-        time.sleep(2)
-        begin = int(time.time())
-        # sleep 2s to allow for small time differences and rounding errors
-        time.sleep(2)
-        # Restart mom for changes made by cgroups hook to take effect
-        self.mom.restart()
-
-        # Make sure the MoM is restarted
-        self.moms_list[0].log_match('Hook handler returned success'
-                                    ' for exechost_startup',
-                                    starttime=begin, existence=True,
-                                    interval=1, n='ALL')
-
         # These will throw an exception if the routines that should not
         # have been called were called.
         # n='ALL' is needed because the cgroup hook is so verbose
@@ -2334,20 +2313,6 @@ if %s e.job.in_ms_mom():
             self.skipTest('Skipping test since no devices subsystem defined')
         name = 'CGROUP3'
         self.load_config(self.cfg14 % ('true', 'false'))
-
-        # sleep 2s: make sure no old log lines will match 'begin' time
-        time.sleep(2)
-        begin = int(time.time())
-        # sleep 2s to allow for small time differences and rounding errors
-        time.sleep(2)
-        # Restart mom for changes made by cgroups hook to take effect
-        self.mom.restart()
-
-        # Make sure the MoM is restarted
-        self.moms_list[0].log_match('Hook handler returned success'
-                                    ' for exechost_startup',
-                                    starttime=begin, existence=True,
-                                    interval=1, n='ALL')
 
         # These will throw an exception if the routines that should not
         # have been called were called.
@@ -2371,20 +2336,6 @@ if %s e.job.in_ms_mom():
             self.skipTest('Skipping test since no devices subsystem defined')
         name = 'CGROUP3'
         self.load_config(self.cfg14 % ('false', 'true'))
-
-        # sleep one second: make sure no old log lines will match 'begin' time
-        time.sleep(2)
-        begin = int(time.time())
-        # sleep 2s to allow for small time differences and rounding errors
-        time.sleep(2)
-        # Restart mom for changes made by cgroups hook to take effect
-        self.mom.restart()
-
-        # Make sure the MoM is restarted
-        self.moms_list[0].log_match('Hook handler returned success'
-                                    ' for exechost_startup',
-                                    starttime=begin, existence=True,
-                                    interval=1, n='ALL')
 
         # These will throw an exception if the routines that should not
         # have been called were called.
@@ -2417,8 +2368,6 @@ if %s e.job.in_ms_mom():
         # occasional trouble seen on TH2
         self.load_config(self.cfg3 % ('', 'false', '', self.mem, '',
                                       self.swapctl, ''))
-        # Restart mom for changes made by cgroups hook to take effect
-        self.mom.restart()
         # Submit two jobs
         a = {'Resource_List.select': '1:ncpus=1:mem=300mb:host=%s' %
              self.hosts_list[0], ATTR_N: name + 'a'}
@@ -2550,8 +2499,6 @@ if %s e.job.in_ms_mom():
         name = 'CGROUP5'
         self.load_config(self.cfg3 % ('', 'false', '', self.mem, '',
                                       self.swapctl, ''))
-        # Restart mom for changes made by cgroups hook to take effect
-        self.mom.restart()
         a = {'Resource_List.select': '1:ncpus=1:mem=300mb:host=%s' %
              self.hosts_list[0], ATTR_N: name}
         j = Job(TEST_USER, attrs=a)
@@ -2587,8 +2534,6 @@ if %s e.job.in_ms_mom():
         name = 'CGROUP6'
         self.load_config(self.cfg3 % ('', 'false', '', self.mem, '',
                                       self.swapctl, ''))
-        # Restart mom for changes made by cgroups hook to take effect
-        self.mom.restart()
         # Make sure output file is gone, otherwise wait and read
         # may pick up stale copy of earlier test
         self.du.rm(runas=TEST_USER, path='~/' + name + '.*', as_script=True)
@@ -2626,8 +2571,6 @@ if %s e.job.in_ms_mom():
         # Configure the hook
         self.load_config(self.cfg3 % ('', vnpernuma, '', self.mem, '',
                                       self.swapctl, ''))
-        # Restart mom for changes made by cgroups hook to take effect
-        self.mom.restart()
         a = {'Resource_List.select': '1:ncpus=1:mem=300mb:host=%s' %
              self.hosts_list[0], 'Resource_List.walltime': 3, ATTR_N: name}
         j = Job(TEST_USER, attrs=a)
@@ -2893,8 +2836,6 @@ if %s e.job.in_ms_mom():
             self.skipTest('Test requires memory subystem mounted')
         self.load_config(self.cfg3 % ('', 'false', '', self.mem, '',
                                       self.swapctl, ''))
-        # Restart mom for changes made by cgroups hook to take effect
-        self.mom.restart()
         self.server.expect(NODE, {'state': 'free'},
                            id=self.nodes_list[0], interval=3, offset=10)
         if self.swapctl == 'true':
@@ -2908,8 +2849,6 @@ if %s e.job.in_ms_mom():
         mem1 = PbsTypeSize(mem[0]['resources_available.mem'])
         self.logger.info('Mem-1: %s' % mem1.value)
         self.load_config(self.cfg4 % (self.mem, self.swapctl))
-        # Restart mom for changes made by cgroups hook to take effect
-        self.mom.restart()
         self.server.expect(NODE, {'state': 'free'},
                            id=self.nodes_list[0], interval=3, offset=10)
         if self.swapctl == 'true':
@@ -2989,8 +2928,6 @@ if %s e.job.in_ms_mom():
             self.skipTest('Test requires memory subystem mounted')
         name = 'CGROUP17'
         self.load_config(self.cfg1 % ('', '', '', '', self.mem, self.swapctl))
-        # Restart mom for cgroups hook changes to take effect
-        self.mom.restart()
         a = {'Resource_List.select': '1:ncpus=1:mem=300mb:host=%s' %
              self.hosts_list[0], ATTR_N: name, ATTR_J: '1-4',
              'Resource_List.place': 'pack:excl'}
@@ -3154,8 +3091,6 @@ if %s e.job.in_ms_mom():
         # Fetch the unmodified value of resources_available.ncpus
         self.load_config(self.cfg5 % ('false', '', 'false', 'false',
                                       'false', self.mem, self.swapctl))
-        # Restart mom for cgroups hook changes to take effect
-        self.mom.restart()
         self.server.expect(NODE, {'state': 'free'},
                            id=self.nodes_list[0], interval=1)
         result = self.server.status(NODE, 'resources_available.ncpus',
@@ -3168,8 +3103,6 @@ if %s e.job.in_ms_mom():
         # Now exclude CPU zero
         self.load_config(self.cfg5 % ('false', '0', 'false', 'false',
                                       'false', self.mem, self.swapctl))
-        # Restart mom for cgroups hook changes to take effect
-        self.mom.restart()
         self.server.expect(NODE, {'state': 'free'},
                            id=self.nodes_list[0], interval=1)
         result = self.server.status(NODE, 'resources_available.ncpus',
@@ -3182,8 +3115,6 @@ if %s e.job.in_ms_mom():
         vnode = '%s[0]' % self.nodes_list[0]
         self.load_config(self.cfg5 % ('true', '', 'false', 'false',
                                       'false', self.mem, self.swapctl))
-        # Restart mom for cgroups hook changes to take effect
-        self.mom.restart()
         self.server.expect(NODE, {'state': 'free'},
                            id=vnode, interval=1)
         result = self.server.status(NODE, 'resources_available.ncpus',
@@ -3194,8 +3125,6 @@ if %s e.job.in_ms_mom():
         # Exclude CPU zero again
         self.load_config(self.cfg5 % ('true', '0', 'false', 'false',
                                       'false', self.mem, self.swapctl))
-        # Restart mom for cgroups hook changes to take effect
-        self.mom.restart()
         self.server.expect(NODE, {'state': 'free'},
                            id=vnode, interval=1)
         result = self.server.status(NODE, 'resources_available.ncpus',
@@ -3219,8 +3148,6 @@ if %s e.job.in_ms_mom():
         # First try with mem_fences set to true (the default)
         self.load_config(self.cfg5 % ('false', '', 'true', 'false',
                                       'false', self.mem, self.swapctl))
-        # Restart mom for cgroups hook changes to take effect
-        self.mom.restart()
         # Do not use node_list -- vnode_per_numa_node is NOW off
         # so use the natural node. Otherwise might 'expect' stale vnode
         self.server.expect(NODE, {'state': 'free'},
@@ -3333,17 +3260,6 @@ if %s e.job.in_ms_mom():
         name = 'CGROUP3'
         self.load_config(self.cfg2)
 
-        # now HUP the MoM and make sure exechost_startup ran
-        time.sleep(2)
-        stime = int(time.time())
-        time.sleep(2)
-        self.moms_list[0].signal('-HUP')
-        self.server.expect(NODE, {'state': 'free'}, id=self.nodes_list[0])
-        self.moms_list[0].log_match('Hook handler returned success'
-                                    ' for exechost_startup',
-                                    starttime=stime, existence=True,
-                                    interval=1, n='ALL')
-
         cmd = ['nvidia-smi', '-L']
         try:
             rv = self.du.run_cmd(hosts=self.moms_list[0].hostname, cmd=cmd)
@@ -3446,15 +3362,6 @@ if %s e.job.in_ms_mom():
         Test that memory.use_hierarchy is enabled by default
         when PBS cgroups hook is instantiated
         """
-        # sleep 2s to avoid matching old log lines
-        # 1s not always enough due to small time jitter between
-        # PTL and daemons
-        time.sleep(2)
-        now = int(time.time())
-        # sleep 2s to be sure that if daemons respond rapidly you
-        # don't skip the lines
-        time.sleep(2)
-
         # Remove PBS directories from memory subsystem
         cpath = None
         if ('memory' in self.paths[self.hosts_list[0]] and
@@ -3469,11 +3376,6 @@ if %s e.job.in_ms_mom():
         self.logger.info("Removing %s" % cpath)
         self.du.run_cmd(cmd=cmd, sudo=True)
         self.load_config(self.cfg6 % (self.mem, self.swapctl))
-        self.moms_list[0].restart()
-        # Wait for exechost_startup hook to run
-        self.moms_list[0].log_match("Hook handler returned success for"
-                                    " exechost_startup event",
-                                    starttime=now, n='ALL')
         # check where cpath is once more
         # since we loaded a new cgroup config file
         cpath = None
@@ -3952,8 +3854,6 @@ event.accept()
         """
         name = 'CGROUP_BIG'
         self.load_config(self.cfg9 % (self.mem, self.mem))
-        # Restart mom for changes made by cgroups hook to take effect
-        self.mom.restart()
 
         vnodes_count = 10
         try:
@@ -4313,8 +4213,6 @@ sleep 300
         cfs_quota_fudge_factor = 1.05
         self.load_config(self.cfg11 % (self.mem, self.mem,
                                        cfs_period_us, cfs_quota_fudge_factor))
-        # Restart mom for changes made by cgroups hook to take effect
-        self.mom.restart()
         self.server.expect(NODE, {'state': 'free'},
                            id=self.nodes_list[0], interval=1)
         result = self.server.status(NODE, 'resources_available.ncpus',
@@ -4505,8 +4403,6 @@ sleep 300
                                        cfs_quota_fudge_factor,
                                        zero_cpus_shares_fraction,
                                        zero_cpus_quota_fraction))
-        # Restart mom for changes made by cgroups hook to take effect
-        self.mom.restart()
         a = {'Resource_List.select': 'ncpus=0',
              ATTR_N: name, ATTR_k: 'oe'}
         j = Job(TEST_USER, attrs=a)
@@ -4570,8 +4466,6 @@ sleep 300
         # set vnode_per_numa=true with use_hyperthreads=true
         self.load_config(self.cfg3 % ('', 'true', '', self.mem, '',
                                       self.swapctl, ''))
-        # Restart mom so vnodes created by cgroups would show
-        self.mom.restart()
         # Submit M*N*P jobs, where M is the number of physical processors,
         # N is the number of 'cpu cores' per M. and P being the
         # number of hyperthreads per core.
@@ -4650,23 +4544,6 @@ sleep 300
 
         self.load_config(self.cfg15
                          % ('true' if vnode_per_numa_node else 'false'))
-
-        # sleep one second: make sure no old log lines will match 'begin' time
-        time.sleep(2)
-        begin = int(time.time())
-        # sleep 2s to allow for small time differences and rounding errors
-        time.sleep(2)
-        # Restart mom for changes made by cgroups hook to take effect
-        self.mom.restart()
-
-        # Make sure the MoM is restarted
-        self.mom.log_match('Hook handler returned success'
-                           ' for exechost_startup',
-                           starttime=begin, existence=True,
-                           interval=1, n='ALL')
-        self.server.expect(NODE, {'state': 'free'},
-                           id=self.mom.shortname, interval=2, offset=1)
-
         vnode_name = self.mom.shortname
         if vnode_per_numa_node:
             vnode_name += "[0]"
@@ -4804,23 +4681,6 @@ sleep 300
 
         self.load_config(self.cfg16
                          % enforce_flags)
-
-        # sleep 2s: make sure no old log lines will match 'begin' time
-        time.sleep(2)
-        begin = int(time.time())
-        # sleep 2s to allow for small time differences and rounding errors
-        time.sleep(2)
-        # Restart mom for changes made by cgroups hook to take effect
-        self.mom.restart()
-
-        # Make sure the MoM is restarted
-        self.mom.log_match('Hook handler returned success'
-                           ' for exechost_startup',
-                           starttime=begin, existence=True,
-                           interval=1, n='ALL')
-        self.server.expect(NODE, {'state': 'free'},
-                           id=self.mom.shortname, interval=2, offset=1)
-
         a = {'Resource_List.select':
              '1:ncpus=1:vnode=%s'
              % self.mom.shortname}

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -2188,7 +2188,25 @@ if %s e.job.in_ms_mom():
                              % vmem_avail_in_bytes)
             self.assertTrue(vmem_avail_in_bytes is not None,
                             "Unable to read total memsw available")
-            MemswLimitExpected = min(201326592, vmem_avail_in_bytes)
+
+            mem_avail = os.path.join(mem_base,
+                                     'memory.limit_in_bytes')
+            result = self.du.cat(hostname=self.mom.hostname,
+                                 filename=mem_avail, sudo=True)
+            mem_avail_in_bytes = None
+            try:
+                mem_avail_in_bytes = int(result['out'][0])
+            except Exception:
+                # None will be seen as a failure, nothing to do
+                pass
+            self.logger.info("total available mem: %d"
+                             % mem_avail_in_bytes)
+            self.assertTrue(mem_avail_in_bytes is not None,
+                            "Unable to read total mem available")
+
+            swap_avail_in_bytes = vmem_avail_in_bytes - mem_avail_in_bytes
+            MemswLimitExpected = (100663296
+                                  + min(100663296, swap_avail_in_bytes))
             self.assertTrue(('MemswLimit=%d' % MemswLimitExpected)
                             in scr_out)
             self.logger.info('MemswLimit check passed')

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -233,17 +233,17 @@ class TestCgroupsHook(TestFunctional):
 
             # Restart MoM
             time.sleep(2)
-            time_before_restart=int(time.time())
+            time_before_restart = int(time.time())
             time.sleep(2)
             mom.restart()
-            
+
             # Make sure that MoM has restarted far enough before reconfiguring
             # as that sends a HUP and may otherwise interfere with the restart
             # We send either a HELLO or a restart to server -- wait for that
             mom.log_match("sent to server",
                           starttime=time_before_restart,
                           n='ALL')
-           
+
             self.logger.info("increase log level for mom and \
                              set polling intervals")
             c = {'$logevent': '0xffffffff', '$clienthost': self.server.name,

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -2014,7 +2014,7 @@ if %s e.job.in_ms_mom():
         # Allow some time to pass for values to be updated
         # sleep 2s: make sure no old log lines will match 'begin' time
         time.sleep(2)
-        begin = time.time()
+        begin = int(time.time())
         # sleep 2s to allow for small time differences and rounding errors
         time.sleep(2)
 

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -4622,7 +4622,7 @@ sleep 300
 
         a = {'Resource_List.select':
              '1:ncpus=1:vnode=%s'
-             % self.mom.hostname}
+             % self.mom.shortname}
         if exclhost:
             a['Resource_List.place'] = 'exclhost'
 

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -2291,9 +2291,9 @@ if %s e.job.in_ms_mom():
         if not self.paths[self.hosts_list[0]]['devices']:
             self.skipTest('Skipping test since no devices subsystem defined')
         name = 'CGROUP3'
-        sleep(2)
+        time.sleep(2)
         begin = int(time.time())
-        sleep(2)
+        time.sleep(2)
         self.load_config(self.cfg14 % ('true', 'true'))
 
         # These will throw an exception if the routines that should not
@@ -2316,9 +2316,9 @@ if %s e.job.in_ms_mom():
         if not self.paths[self.hosts_list[0]]['devices']:
             self.skipTest('Skipping test since no devices subsystem defined')
         name = 'CGROUP3'
-        sleep(2)
+        time.sleep(2)
         begin = int(time.time())
-        sleep(2)
+        time.sleep(2)
         self.load_config(self.cfg14 % ('true', 'false'))
 
         # These will throw an exception if the routines that should not
@@ -2342,9 +2342,9 @@ if %s e.job.in_ms_mom():
         if not self.paths[self.hosts_list[0]]['devices']:
             self.skipTest('Skipping test since no devices subsystem defined')
         name = 'CGROUP3'
-        sleep(2)
+        time.sleep(2)
         begin = int(time.time())
-        sleep(2)
+        time.sleep(2)
         self.load_config(self.cfg14 % ('false', 'true'))
 
         # These will throw an exception if the routines that should not

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -2063,11 +2063,11 @@ if %s e.job.in_ms_mom():
         cput_usage = 0.0
         mem_usage = 0
         vmem_usage = 0
+        # Faster systems might expect to see the usage you finally expect
+        # recorder after 8-10 seconds; on TH it can take up to a minute
         time.sleep(8)
         for count in range(30):
             time.sleep(2)
-            # Faster systems might have expected usage after 8 seconds
-            # TH3 can take up to a minute
             if self.paths[self.hosts_list[0]]['cpuacct'] and cput_usage <= 1.0:
                 # Match last line from the bottom
                 line = self.moms_list[0].log_match(

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -3536,7 +3536,7 @@ event.accept()
             "handling exechost_periodic event: TypeError"
         self.moms_list[0].log_match(err_msg, max_attempts=3,
                                     interval=1, n='ALL',
-                                    starrtime=presubmit,
+                                    starttime=presubmit,
                                     existence=False)
         self.server.log_match(jid2 + ';Exit_status=0', n='ALL',
                               starttime=presubmit)

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -1660,8 +1660,9 @@ if %s e.job.in_ms_mom():
         # copies from setup, node creations, MoM restarts etc.
         # are all finished, so that we don't match a CF copy
         # message in the logs from someone else!
-        time.sleep(5)
-        just_before_import = time.time() - 1
+        time.sleep(2)
+        just_before_import = int(time.time())
+        time.sleep(2)
         self.server.manager(MGR_CMD_IMPORT, HOOK, a, self.hook_name)
         if mom_checks:
             self.moms_list[0].log_match('pbs_cgroups.CF;'
@@ -1682,7 +1683,9 @@ if %s e.job.in_ms_mom():
                 r2 = self.du.run_cmd(cmd=['cat', mom_conf], sudo=True)
                 if r1['out'] != r2['out']:
                     self.logger.info('server & mom pbs_cgroups.CF differ')
-                    just_before_import = time.time() - 1
+                    time.sleep(2)
+                    just_before_import = int(time.time())
+                    time.sleep(2)
                     self.server.manager(MGR_CMD_IMPORT, HOOK, a,
                                         self.hook_name)
                     self.moms_list[0].log_match('pbs_cgroups.CF;'
@@ -1710,8 +1713,9 @@ if %s e.job.in_ms_mom():
                                         'altair',
                                         'pbs_hooks',
                                         'pbs_cgroups.CF')
-
-        now = time.time()
+        time.sleep(2)
+        now = int(time.time())
+        time.sleep(2)
         a = {'content-type': 'application/x-config',
              'content-encoding': 'default',
              'input-file': self.config_file}
@@ -2008,11 +2012,11 @@ if %s e.job.in_ms_mom():
                                     interval=1, n=100, existence=False)
 
         # Allow some time to pass for values to be updated
-        # sleep one second: make sure no old log lines will match 'begin' time
-        time.sleep(1)
+        # sleep 2s: make sure no old log lines will match 'begin' time
+        time.sleep(2)
         begin = time.time()
-        # sleep 1s to allow for small time differences and rounding errors
-        time.sleep(1)
+        # sleep 2s to allow for small time differences and rounding errors
+        time.sleep(2)
 
         self.logger.info('Waiting for periodic hook to update usage data.')
         # loop to check if cput, mem, vmem are expected values
@@ -2220,11 +2224,11 @@ if %s e.job.in_ms_mom():
         name = 'CGROUP3'
         self.load_config(self.cfg14 % ('true', 'true'))
 
-        # sleep one second: make sure no old log lines will match 'begin' time
-        time.sleep(1)
-        begin = time.time()
-        # sleep 1s to allow for small time differences and rounding errors
-        time.sleep(1)
+        # sleep 2s: make sure no old log lines will match 'begin' time
+        time.sleep(2)
+        begin = int(time.time())
+        # sleep 2s to allow for small time differences and rounding errors
+        time.sleep(2)
         # Restart mom for changes made by cgroups hook to take effect
         self.mom.restart()
 
@@ -2256,11 +2260,11 @@ if %s e.job.in_ms_mom():
         name = 'CGROUP3'
         self.load_config(self.cfg14 % ('true', 'false'))
 
-        # sleep one second: make sure no old log lines will match 'begin' time
-        time.sleep(1)
-        begin = time.time()
-        # sleep 1s to allow for small time differences and rounding errors
-        time.sleep(1)
+        # sleep 2s: make sure no old log lines will match 'begin' time
+        time.sleep(2)
+        begin = int(time.time())
+        # sleep 2s to allow for small time differences and rounding errors
+        time.sleep(2)
         # Restart mom for changes made by cgroups hook to take effect
         self.mom.restart()
 
@@ -2294,10 +2298,10 @@ if %s e.job.in_ms_mom():
         self.load_config(self.cfg14 % ('false', 'true'))
 
         # sleep one second: make sure no old log lines will match 'begin' time
-        time.sleep(1)
-        begin = time.time()
-        # sleep 1s to allow for small time differences and rounding errors
-        time.sleep(1)
+        time.sleep(2)
+        begin = int(time.time())
+        # sleep 2s to allow for small time differences and rounding errors
+        time.sleep(2)
         # Restart mom for changes made by cgroups hook to take effect
         self.mom.restart()
 
@@ -3343,7 +3347,15 @@ if %s e.job.in_ms_mom():
         Test that memory.use_hierarchy is enabled by default
         when PBS cgroups hook is instantiated
         """
-        now = time.time()
+        # sleep 2s to avoid matching old log lines
+        # 1s not always enough due to small time jitter between
+        # PTL and daemons
+        time.sleep(2)
+        now = int(time.time())
+        # sleep 2s to be sure that if daemons respond rapidly you
+        # don't skip the lines
+        time.sleep(2)
+
         # Remove PBS directories from memory subsystem
         cpath = None
         if ('memory' in self.paths[self.hosts_list[0]] and
@@ -3478,7 +3490,9 @@ event.accept()
         # Submit a second job and verify that the following message
         # does NOT appear in the mom log:
         # _exechost_periodic_handler: Failed to update jid1
-        presubmit = time.time()
+        time.sleep(2)
+        presubmit = int(time.time())
+        time.sleep(2)
         a = {'Resource_List.select': '1:ncpus=1:mem=100mb:host=%s' %
              self.hosts_list[0]}
         j = Job(TEST_USER, attrs=a)
@@ -3588,7 +3602,9 @@ event.accept()
         j = Job(TEST_USER)
         # Note mother superior is mom[1] not mom[0]
         j.create_script(self.job_scr2 % (self.hosts_list[1]))
-        stime = time.time()
+        time.sleep(2)
+        stime = int(time.time())
+        time.sleep(2)
         jid = self.server.submit(j)
         # Check the exec_vnode while in substate 41
         self.server.expect(JOB, {ATTR_substate: '41'}, id=jid)
@@ -3656,7 +3672,9 @@ event.accept()
         # Submit a job that requires 2 nodes
         j = Job(TEST_USER)
         j.create_script(self.job_scr2 % (self.hosts_list[1]))
-        stime = time.time()
+        time.sleep(2)
+        stime = int(time.time())
+        time.sleep(2)
         jid = self.server.submit(j)
         # Check the exec_vnode while in substate 41
         self.server.expect(JOB, {ATTR_substate: '41'}, id=jid)
@@ -3717,7 +3735,9 @@ event.accept()
         # Submit a job that requires two vnodes
         j = Job(TEST_USER)
         j.create_script(self.job_scr3)
-        stime = time.time()
+        time.sleep(2)
+        stime = int(time.time())
+        time.sleep(2)
         jid = self.server.submit(j)
         # Check the exec_vnode while in substate 41
         self.server.expect(JOB, {ATTR_substate: '41'}, id=jid)
@@ -3774,7 +3794,9 @@ event.accept()
         self.server.expect(JOB, a, jid)
 
         self.logger.info("Killing mom on host %s" % self.hosts_list[1])
-        now = time.time()
+        time.sleep(2)
+        now = int(time.time())
+        time.sleep(2)
         self.moms_list[1].signal('-9')
 
         self.server.expect(NODE, {'state': "down"}, id=self.hosts_list[1])
@@ -4516,10 +4538,10 @@ sleep 300
                          % ('true' if vnode_per_numa_node else 'false'))
 
         # sleep one second: make sure no old log lines will match 'begin' time
-        time.sleep(1)
-        begin = time.time()
-        # sleep 1s to allow for small time differences and rounding errors
-        time.sleep(1)
+        time.sleep(2)
+        begin = int(time.time())
+        # sleep 2s to allow for small time differences and rounding errors
+        time.sleep(2)
         # Restart mom for changes made by cgroups hook to take effect
         self.mom.restart()
 
@@ -4669,11 +4691,11 @@ sleep 300
         self.load_config(self.cfg16
                          % enforce_flags)
 
-        # sleep one second: make sure no old log lines will match 'begin' time
-        time.sleep(1)
-        begin = time.time()
-        # sleep 1s to allow for small time differences and rounding errors
-        time.sleep(1)
+        # sleep 2s: make sure no old log lines will match 'begin' time
+        time.sleep(2)
+        begin = int(time.time())
+        # sleep 2s to allow for small time differences and rounding errors
+        time.sleep(2)
         # Restart mom for changes made by cgroups hook to take effect
         self.mom.restart()
 

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -4001,7 +4001,7 @@ exit 0
         self.server.expect(JOB, {'job_state': 'Q'}, id=jid1)
         err_msg = "%s;.*Failed to assign resources.*" % (jid2,)
         for m in self.moms.values():
-            m.log_match(err_msg, max_attempts=3, interval=1, n='ALL',
+            m.log_match(err_msg, max_attempts=3, interval=1, starttime=stime,
                         regexp=True, existence=False, n='ALL')
 
         self.server.expect(JOB, {'job_state': 'R', 'substate': 42}, id=jid2)

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -1847,7 +1847,7 @@ if %s e.job.in_ms_mom():
         j = Job(TEST_USER, attrs=a)
         j.create_script(self.sleep15_job)
         time.sleep(2)
-        stime=int(time.time())
+        stime = int(time.time())
         time.sleep(2)
         jid = self.server.submit(j)
         a = {'job_state': 'R'}
@@ -1900,7 +1900,7 @@ if %s e.job.in_ms_mom():
         j = Job(TEST_USER, attrs=a)
         j.create_script(self.sleep15_job)
         time.sleep(2)
-        stime=int(time.time())
+        stime = int(time.time())
         time.sleep(2)
         jid = self.server.submit(j)
         a = {'job_state': 'R'}
@@ -1949,7 +1949,7 @@ if %s e.job.in_ms_mom():
         j = Job(TEST_USER, attrs=a)
         j.create_script(self.sleep15_job)
         time.sleep(2)
-        stime=int(time.time())
+        stime = int(time.time())
         time.sleep(2)
         jid = self.server.submit(j)
         a = {'job_state': 'R'}
@@ -1997,7 +1997,7 @@ if %s e.job.in_ms_mom():
         j = Job(TEST_USER, attrs=a)
         j.create_script(self.eatmem_job3)
         time.sleep(2)
-        stime=int(time.time())
+        stime = int(time.time())
         time.sleep(2)
         jid = self.server.submit(j)
         a = {'job_state': 'R'}
@@ -2024,7 +2024,7 @@ if %s e.job.in_ms_mom():
         err_msg = "Unexpected error in pbs_cgroups " + \
             "handling exechost_periodic event: TypeError"
         self.moms_list[0].log_match(err_msg, max_attempts=3,
-                                    interval=1, n='ALL', 
+                                    interval=1, n='ALL',
                                     starttime=stime, existence=False)
 
         # Allow some time to pass for values to be updated
@@ -2498,7 +2498,7 @@ if %s e.job.in_ms_mom():
         j = Job(TEST_USER, attrs=a)
         j.create_script(self.eatmem_job1)
         time.sleep(2)
-        stime=int(time.time())
+        stime = int(time.time())
         time.sleep(2)
         jid = self.server.submit(j)
         a = {'job_state': 'R'}
@@ -2703,7 +2703,7 @@ if %s e.job.in_ms_mom():
         j = Job(TEST_USER, attrs=a)
         j.create_script(self.sleep15_job)
         time.sleep(2)
-        stime=int(time.time())
+        stime = int(time.time())
         time.sleep(2)
         jid = self.server.submit(j)
         a = {'job_state': 'R'}
@@ -2744,7 +2744,7 @@ if %s e.job.in_ms_mom():
         j = Job(TEST_USER, attrs=a)
         j.create_script(self.sleep15_job)
         time.sleep(2)
-        stime=int(time.time())
+        stime = int(time.time())
         time.sleep(2)
         jid = self.server.submit(j)
         a = {'job_state': 'R'}
@@ -3433,7 +3433,7 @@ if %s e.job.in_ms_mom():
         j = Job(TEST_USER, attrs=a)
         j.create_script(self.sleep5_job)
         time.sleep(2)
-        stime=int(time.time())
+        stime = int(time.time())
         time.sleep(2)
         jid1 = self.server.submit(j)
         a = {'job_state': 'R'}
@@ -3995,7 +3995,7 @@ exit 0
         a[ATTR_q] = 'express'
         j2 = Job(TEST_USER, attrs=a)
         time.sleep(2)
-        stime=int(time.time())
+        stime = int(time.time())
         time.sleep(2)
         jid2 = self.server.submit(j2)
         self.server.expect(JOB, {'job_state': 'Q'}, id=jid1)
@@ -4535,7 +4535,7 @@ sleep 300
         j = Job(TEST_USER, attrs=a)
         j.create_script(self.sleep15_job)
         time.sleep(2)
-        stime=int(time.time())
+        stime = int(time.time())
         time.sleep(2)
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, jid)

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -1429,9 +1429,9 @@ sleep 300
 
         # Make sure that by the time we send a HUP and the test
         # actually tinkers with the hooks once more,
-        # MoM will already have gone through its initial setup
-        # after the new hello from the server
-        time.sleep(6)
+        # MoMs will already have gone through their initial setup
+        # and copied the hooks after the new hello from the server
+        time.sleep(10)
 
         # HUP mom so exechost_startup hook is run for each mom...
         for mom in self.moms_list:

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -2138,7 +2138,7 @@ if %s e.job.in_ms_mom():
         using the default memory and vmem
         Check to see that cpuset.cpus=0, cpuset.mems=0 and that
         memory.limit_in_bytes = 100663296
-        memory.memsw.limit_in_bytes = 100663296
+        memory.memsw.limit_in_bytes = 201326592
         """
         if not self.paths[self.hosts_list[0]]['memory']:
             self.skipTest('Test requires memory subystem mounted')
@@ -2167,7 +2167,7 @@ if %s e.job.in_ms_mom():
         self.logger.info('MemorySocket check passed')
         if self.swapctl == 'true':
             self.assertTrue('MemoryLimit=100663296' in scr_out)
-            self.assertTrue('MemswLimit=100663296' in scr_out)
+            self.assertTrue('MemswLimit=201326592' in scr_out)
             self.logger.info('MemoryLimit check passed')
 
     def test_cgroup_prefix_and_devices(self):

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -1708,8 +1708,9 @@ if %s e.job.in_ms_mom():
             time.sleep(2)
             for mom in self.moms_list:
                 mom.signal('-HUP')
-                mom.log_match('Hook handler returned success'
-                              ' for exechost_startup',
+                mom.log_match('hook_perf_stat;label=hook_exechost_startup_'
+                              'pbs_cgroups_.* profile_stop',
+                              regexp=True,
                               starttime=stime, existence=True,
                               interval=1, n='ALL')
 
@@ -2290,6 +2291,9 @@ if %s e.job.in_ms_mom():
         if not self.paths[self.hosts_list[0]]['devices']:
             self.skipTest('Skipping test since no devices subsystem defined')
         name = 'CGROUP3'
+        sleep(2)
+        begin=int(time.time())
+        sleep(2)
         self.load_config(self.cfg14 % ('true', 'true'))
 
         # These will throw an exception if the routines that should not
@@ -2312,6 +2316,9 @@ if %s e.job.in_ms_mom():
         if not self.paths[self.hosts_list[0]]['devices']:
             self.skipTest('Skipping test since no devices subsystem defined')
         name = 'CGROUP3'
+        sleep(2)
+        begin=int(time.time())
+        sleep(2)
         self.load_config(self.cfg14 % ('true', 'false'))
 
         # These will throw an exception if the routines that should not
@@ -2335,6 +2342,9 @@ if %s e.job.in_ms_mom():
         if not self.paths[self.hosts_list[0]]['devices']:
             self.skipTest('Skipping test since no devices subsystem defined')
         name = 'CGROUP3'
+        sleep(2)
+        begin=int(time.time())
+        sleep(2)
         self.load_config(self.cfg14 % ('false', 'true'))
 
         # These will throw an exception if the routines that should not

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -2048,7 +2048,7 @@ if %s e.job.in_ms_mom():
         mem_usage = 0
         vmem_usage = 0
         time.sleep(8)
-        for count in range(10):
+        for count in range(30):
             time.sleep(2)
             # Faster systems might have expected usage after 8 seconds
             # TH3 can take up to a minute

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -3302,6 +3302,7 @@ if %s e.job.in_ms_mom():
         stime = int(time.time())
         time.sleep(2)
         self.moms_list[0].signal('-HUP')
+        self.server.expect(NODE, {'state': 'free'}, id=self.nodes_list[0])
         self.moms_list[0].log_match('Hook handler returned success'
                                     ' for exechost_startup',
                                     starttime=stime, existence=True,
@@ -3326,12 +3327,15 @@ if %s e.job.in_ms_mom():
                 last_gpu_was_physical = False
                 gpus += 1
         if gpus < 1:
-            self.skipTest('Skipping test since no gpus found')
-        self.server.expect(NODE, {'state': 'free'}, id=self.nodes_list[0])
-        ngpus = self.server.status(NODE, id=self.nodes_list[0])[0]
+            self.skipTest('Skipping test since no gpus found on %s'
+                          % (self.nodes_list[0]))
+        ngpus_stat = self.server.status(NODE, id=self.nodes_list[0])[0]
         self.logger.info("pbsnodes for %s reported: %s"
-                         % (self.nodes_list[0], ngpus))
-        ngpus = int(ngpus['resources_available.ngpus'])
+                         % (self.nodes_list[0], ngpus_stat))
+        self.assertTrue('resources_available.ngpus' in ngpus_stat,
+                        "No resources_available.ngpus found on node %s"
+                        % (self.nodes_list[0]))
+        ngpus = int(ngpus_stat['resources_available.ngpus'])
         self.assertEqual(gpus, ngpus, 'ngpus is incorrect')
         a = {'Resource_List.select': '1:ngpus=1', ATTR_N: name}
         j = Job(TEST_USER, attrs=a)

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -1660,7 +1660,7 @@ if %s e.job.in_ms_mom():
         # copies from setup, node creations, MoM restarts etc.
         # are all finished, so that we don't match a CF copy
         # message in the logs from someone else!
-        time.sleep(2)
+        time.sleep(5)
         just_before_import = int(time.time())
         time.sleep(2)
         self.server.manager(MGR_CMD_IMPORT, HOOK, a, self.hook_name)

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -2152,8 +2152,20 @@ if %s e.job.in_ms_mom():
         name = 'CGROUP2'
         self.load_config(self.cfg3 % ('', 'false', '', self.mem, '',
                                       self.swapctl, ''))
+
+        time.sleep(2)
+        begin = int(time.time())
+        # sleep 2s to allow for small time differences and rounding errors
+        time.sleep(2)
         # Restart mom for changes made by cgroups hook to take effect
         self.mom.restart()
+
+        # Make sure the MoM is restarted
+        self.moms_list[0].log_match('Hook handler returned success'
+                                    ' for exechost_startup',
+                                    starttime=begin, existence=True,
+                                    interval=1, n='ALL')
+
         a = {'Resource_List.select': '1:ncpus=1:host=%s' %
              self.hosts_list[0], ATTR_N: name}
         j = Job(TEST_USER, attrs=a)

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -2039,10 +2039,11 @@ if %s e.job.in_ms_mom():
         cput_usage = 0.0
         mem_usage = 0
         vmem_usage = 0
+        time.sleep(8)
         for count in range(10):
+            time.sleep(2)
             # Faster systems might have expected usage after 8 seconds
             # TH3 can take up to a minute
-            time.sleep(8)
             if self.paths[self.hosts_list[0]]['cpuacct'] and cput_usage <= 1.0:
                 lines = self.moms_list[0].log_match(
                     '%s;update_job_usage: CPU usage:' %
@@ -2083,6 +2084,11 @@ if %s e.job.in_ms_mom():
                         break
                 else:
                     break
+            # try to make next loop match the _next_ updates
+            # note: we might still be unlucky and just match an old update,
+            # but not next time: the loop's sleep will make 'begin' advance
+            begin=int(time.time())
+
         self.assertGreater(cput_usage, 1.0)
         self.assertGreater(mem_usage, 400000)
         if self.swapctl == 'true':

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -4552,7 +4552,7 @@ sleep 300
 
     def test_cgroup_cgswap(self, vnode_per_numa_node=False):
         """
-        Test to verify (with vnode_per_numa_node enabled):
+        Test to verify (with vnode_per_numa_node disabled by default):
         - whether queuejob/modifyjob set cgswap to vmem-mem in jobs
         - whether nodes get resources_available.cgswap filled in
         - whether a collection of jobs submitted that do not exceed available
@@ -4888,7 +4888,7 @@ sleep 300
         enforce neither mem nor memsw by enabling flags to ignore
         enforcement for exclhost jobs and submitting an exclhost job:
         job should be able to consume all physical memory
-        fand memsw set as limit for all jobs
+        and memsw set as limit for all jobs
         """
         # enforce flags should both be overrided by exclhost
         self.test_cgroup_enforce_default(enforce_flags=('true', 'true'),

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -1431,13 +1431,13 @@ sleep 300
         # actually tinkers with the hooks once more,
         # MoM will already have gone through its initial setup
         # after the new hello from the server
-        time.sleep(4)
+        time.sleep(6)
 
         # HUP mom so exechost_startup hook is run for each mom...
         for mom in self.moms_list:
             mom.signal('-HUP')
         # ...then wait for exechost_startup updates to propagate to server
-        time.sleep(4)
+        time.sleep(6)
 
         # queuejob hook
         self.qjob_hook_body = """
@@ -2005,8 +2005,14 @@ if %s e.job.in_ms_mom():
             "handling exechost_periodic event: TypeError"
         self.moms_list[0].log_match(err_msg, max_attempts=3,
                                     interval=1, n=100, existence=False)
+
         # Allow some time to pass for values to be updated
+        # sleep one second: make sure no old log lines will match 'begin' time
+        time.sleep(1)
         begin = time.time()
+        # sleep 1s to allow for small time differences and rounding errors
+        time.sleep(1)
+
         self.logger.info('Waiting for periodic hook to update usage data.')
         # loop to check if cput, mem, vmem are expected values
         cput_usage = 0.0
@@ -2213,10 +2219,12 @@ if %s e.job.in_ms_mom():
         name = 'CGROUP3'
         self.load_config(self.cfg14 % ('true', 'true'))
 
-        # Restart mom for changes made by cgroups hook to take effect
+        # sleep one second: make sure no old log lines will match 'begin' time
+        time.sleep(1)
         begin = time.time()
-        # sleep 5s to ensure log matching will not catch older log lines
-        time.sleep(5)
+        # sleep 1s to allow for small time differences and rounding errors
+        time.sleep(1)
+        # Restart mom for changes made by cgroups hook to take effect
         self.mom.restart()
 
         # Make sure the MoM is restarted
@@ -2247,10 +2255,12 @@ if %s e.job.in_ms_mom():
         name = 'CGROUP3'
         self.load_config(self.cfg14 % ('true', 'false'))
 
-        # Restart mom for changes made by cgroups hook to take effect
+        # sleep one second: make sure no old log lines will match 'begin' time
+        time.sleep(1)
         begin = time.time()
-        # sleep 5s to ensure log matching will not catch older log lines
-        time.sleep(5)
+        # sleep 1s to allow for small time differences and rounding errors
+        time.sleep(1)
+        # Restart mom for changes made by cgroups hook to take effect
         self.mom.restart()
 
         # Make sure the MoM is restarted
@@ -2282,10 +2292,12 @@ if %s e.job.in_ms_mom():
         name = 'CGROUP3'
         self.load_config(self.cfg14 % ('false', 'true'))
 
-        # Restart mom for changes made by cgroups hook to take effect
+        # sleep one second: make sure no old log lines will match 'begin' time
+        time.sleep(1)
         begin = time.time()
-        # sleep 5s to ensure log matching will not catch older log lines
-        time.sleep(5)
+        # sleep 1s to allow for small time differences and rounding errors
+        time.sleep(1)
+        # Restart mom for changes made by cgroups hook to take effect
         self.mom.restart()
 
         # Make sure the MoM is restarted
@@ -4494,11 +4506,15 @@ sleep 300
 
         self.load_config(self.cfg15
                          % ('true' if vnode_per_numa_node else 'false'))
-        # Restart mom for changes made by cgroups hook to take effect
+
+        # sleep one second: make sure no old log lines will match 'begin' time
+        time.sleep(1)
         begin = time.time()
-        # sleep 2s to ensure log matching will not catch older log lines
-        time.sleep(2)
+        # sleep 1s to allow for small time differences and rounding errors
+        time.sleep(1)
+        # Restart mom for changes made by cgroups hook to take effect
         self.mom.restart()
+
         # Make sure the MoM is restarted
         self.mom.log_match('Hook handler returned success'
                            ' for exechost_startup',
@@ -4607,11 +4623,15 @@ sleep 300
 
         self.load_config(self.cfg16
                          % enforce_flags)
-        # Restart mom for changes made by cgroups hook to take effect
+
+        # sleep one second: make sure no old log lines will match 'begin' time
+        time.sleep(1)
         begin = time.time()
-        # sleep 2s to ensure log matching will not catch older log lines
-        time.sleep(2)
+        # sleep 1s to allow for small time differences and rounding errors
+        time.sleep(1)
+        # Restart mom for changes made by cgroups hook to take effect
         self.mom.restart()
+
         # Make sure the MoM is restarted
         self.mom.log_match('Hook handler returned success'
                            ' for exechost_startup',
@@ -4649,7 +4669,7 @@ sleep 300
         self.logger.info("total available mem: %d"
                          % mem_avail_in_bytes)
         self.assertTrue(mem_avail_in_bytes is not None,
-                        "Unable to read total memsw available")
+                        "Unable to read total memory available")
 
         # Get total phys+swap memory available
         vmem_avail = os.path.join(mem_base,
@@ -4707,7 +4727,9 @@ sleep 300
                             % (mem_limit_in_bytes, 100 * 1024 * 1024))
         else:
             self.assertTrue(mem_avail_in_bytes == mem_limit_in_bytes,
-                            "job mem limit is not total mem available")
+                            "job mem limit (%d) should be identical to "
+                            "total mem available (%d)"
+                            % (mem_limit_in_bytes, mem_avail_in_bytes))
             self.logger.info("job mem limit is total mem available (%d)"
                              % mem_avail_in_bytes)
         if enforce_flags[1] == 'true' and not exclhost:
@@ -4721,8 +4743,8 @@ sleep 300
         else:
             if swap_avail:
                 self.assertTrue(vmem_avail_in_bytes == vmem_limit_in_bytes,
-                                "job memsw limit (%d) should be total memsw "
-                                "available (%d) but is not"
+                                "job memsw limit (%d) should be identical to "
+                                "total memsw available (%d)"
                                 % (vmem_limit_in_bytes, vmem_avail_in_bytes))
                 self.logger.info("job memsw limit is total memsw available "
                                  " (%d)" % vmem_avail_in_bytes)

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -1668,7 +1668,8 @@ if %s e.job.in_ms_mom():
             self.moms_list[0].log_match('pbs_cgroups.CF;'
                                         'copy hook-related '
                                         'file request received',
-                                        starttime=just_before_import)
+                                        starttime=just_before_import,
+                                        n='ALL')
         pbs_home = self.server.pbs_conf['PBS_HOME']
         svr_conf = os.path.join(
             os.sep, pbs_home, 'server_priv', 'hooks', 'pbs_cgroups.CF')
@@ -1691,7 +1692,8 @@ if %s e.job.in_ms_mom():
                     self.moms_list[0].log_match('pbs_cgroups.CF;'
                                                 'copy hook-related '
                                                 'file request received',
-                                                starttime=just_before_import)
+                                                starttime=just_before_import,
+                                                n='ALL')
                 else:
                     self.logger.info('server & mom pbs_cgroups.CF match')
                     break
@@ -1724,7 +1726,7 @@ if %s e.job.in_ms_mom():
             return
         self.moms_list[0].log_match('pbs_cgroups.CF;copy hook-related '
                                     'file request received',
-                                    starttime=now)
+                                    starttime=now, n='ALL')
 
     def set_vntype(self, host, typestring='myvntype'):
         """
@@ -1844,6 +1846,9 @@ if %s e.job.in_ms_mom():
              self.hosts_list[0], ATTR_N: name}
         j = Job(TEST_USER, attrs=a)
         j.create_script(self.sleep15_job)
+        time.sleep(2)
+        stime=int(time.time())
+        time.sleep(2)
         jid = self.server.submit(j)
         a = {'job_state': 'R'}
         self.server.expect(JOB, a, jid)
@@ -1858,7 +1863,7 @@ if %s e.job.in_ms_mom():
             "%s is in the excluded vnode type list: ['%s']"
             % (self.vntypename[0],
                self.vntypename[0]),
-            starttime=self.server.ctime)
+            starttime=stime, n='ALL')
         self.logger.info('vntypes on both hosts are: %s and %s'
                          % (self.vntypename[0], self.vntypename[1]))
         if self.vntypename[1] == self.vntypename[0]:
@@ -1894,6 +1899,9 @@ if %s e.job.in_ms_mom():
              self.hosts_list[0], ATTR_N: name}
         j = Job(TEST_USER, attrs=a)
         j.create_script(self.sleep15_job)
+        time.sleep(2)
+        stime=int(time.time())
+        time.sleep(2)
         jid = self.server.submit(j)
         a = {'job_state': 'R'}
         self.server.expect(JOB, a, jid)
@@ -1904,7 +1912,8 @@ if %s e.job.in_ms_mom():
         self.assertFalse(self.is_dir(cpath, self.hosts_list[0]))
         host = self.get_hostname(self.hosts_list[0])
         self.moms_list[0].log_match('%s is in the excluded host list: [%s]' %
-                                    (host, log), starttime=self.server.ctime)
+                                    (host, log), starttime=stime,
+                                    n='ALL')
         a = {'Resource_List.select': '1:ncpus=1:mem=300mb:host=%s' %
              self.hosts_list[1], ATTR_N: name}
         j = Job(TEST_USER, attrs=a)
@@ -1939,6 +1948,9 @@ if %s e.job.in_ms_mom():
              % self.hosts_list[0], ATTR_N: name}
         j = Job(TEST_USER, attrs=a)
         j.create_script(self.sleep15_job)
+        time.sleep(2)
+        stime=int(time.time())
+        time.sleep(2)
         jid = self.server.submit(j)
         a = {'job_state': 'R'}
         self.server.expect(JOB, a, jid)
@@ -1947,7 +1959,7 @@ if %s e.job.in_ms_mom():
         self.tempfile.append(o)
         self.moms_list[0].log_match('cgroup excluded for subsystem memory '
                                     'on vnode type %s' % self.vntypename[0],
-                                    starttime=self.server.ctime)
+                                    starttime=stime, n='ALL')
         self.logger.info('vntype values for each hosts are: %s and %s'
                          % (self.vntypename[0], self.vntypename[1]))
         if self.vntypename[0] == self.vntypename[1]:
@@ -1984,6 +1996,9 @@ if %s e.job.in_ms_mom():
              self.hosts_list[0], ATTR_N: name}
         j = Job(TEST_USER, attrs=a)
         j.create_script(self.eatmem_job3)
+        time.sleep(2)
+        stime=int(time.time())
+        time.sleep(2)
         jid = self.server.submit(j)
         a = {'job_state': 'R'}
         self.server.expect(JOB, a, jid)
@@ -2009,7 +2024,8 @@ if %s e.job.in_ms_mom():
         err_msg = "Unexpected error in pbs_cgroups " + \
             "handling exechost_periodic event: TypeError"
         self.moms_list[0].log_match(err_msg, max_attempts=3,
-                                    interval=1, n=100, existence=False)
+                                    interval=1, n='ALL', 
+                                    starttime=stime, existence=False)
 
         # Allow some time to pass for values to be updated
         # sleep 2s: make sure no old log lines will match 'begin' time
@@ -2030,7 +2046,7 @@ if %s e.job.in_ms_mom():
             if self.paths[self.hosts_list[0]]['cpuacct'] and cput_usage <= 1.0:
                 lines = self.moms_list[0].log_match(
                     '%s;update_job_usage: CPU usage:' %
-                    jid, allmatch=True, starttime=begin)
+                    jid, allmatch=True, starttime=begin, n='ALL')
                 for line in lines:
                     match = re.search(r'CPU usage: ([0-9.]+) secs', line[1])
                     if not match:
@@ -2042,7 +2058,7 @@ if %s e.job.in_ms_mom():
                     mem_usage <= 400000):
                 lines = self.moms_list[0].log_match(
                     '%s;update_job_usage: Memory usage: mem=' % jid,
-                    allmatch=True, starttime=begin)
+                    allmatch=True, starttime=begin, n='ALL')
                 for line in lines:
                     match = re.search(r'mem=(\d+)kb', line[1])
                     if not match:
@@ -2053,7 +2069,7 @@ if %s e.job.in_ms_mom():
                 if self.swapctl == 'true' and vmem_usage <= 400000:
                     lines = self.moms_list[0].log_match(
                         '%s;update_job_usage: Memory usage: vmem=' % jid,
-                        allmatch=True, starttime=begin)
+                        allmatch=True, starttime=begin, n='ALL')
                     for line in lines:
                         match = re.search(r'vmem=(\d+)kb', line[1])
                         if not match:
@@ -2236,7 +2252,7 @@ if %s e.job.in_ms_mom():
         self.moms_list[0].log_match('Hook handler returned success'
                                     ' for exechost_startup',
                                     starttime=begin, existence=True,
-                                    interval=1, tail=False)
+                                    interval=1, n='ALL')
 
         # These will throw an exception if the routines that should not
         # have been called were called.
@@ -2244,10 +2260,10 @@ if %s e.job.in_ms_mom():
         # that 50 lines will not suffice
         self.moms_list[0].log_match('_discover_devices', starttime=begin,
                                     existence=True, max_attempts=2,
-                                    interval=1, tail=False, n='ALL')
+                                    interval=1, n='ALL')
         self.moms_list[0].log_match('NVIDIA SMI', starttime=begin,
                                     existence=True, max_attempts=2,
-                                    interval=1, tail=False, n='ALL')
+                                    interval=1, n='ALL')
         self.logger.info('devices_and_gpu_discovery check passed')
 
     def test_suppress_devices_discovery(self):
@@ -2272,7 +2288,7 @@ if %s e.job.in_ms_mom():
         self.moms_list[0].log_match('Hook handler returned success'
                                     ' for exechost_startup',
                                     starttime=begin, existence=True,
-                                    interval=1, tail=False)
+                                    interval=1, n='ALL')
 
         # These will throw an exception if the routines that should not
         # have been called were called.
@@ -2280,10 +2296,10 @@ if %s e.job.in_ms_mom():
         # that 50 lines will not suffice
         self.moms_list[0].log_match('_discover_devices', starttime=begin,
                                     existence=False, max_attempts=2,
-                                    interval=1, tail=False, n='ALL')
+                                    interval=1, n='ALL')
         self.moms_list[0].log_match('_discover_gpus', starttime=begin,
                                     existence=False, max_attempts=2,
-                                    interval=1, tail=False, n='ALL')
+                                    interval=1, n='ALL')
         self.logger.info('suppress_devices_discovery check passed')
 
     def test_suppress_gpu_discovery(self):
@@ -2309,7 +2325,7 @@ if %s e.job.in_ms_mom():
         self.moms_list[0].log_match('Hook handler returned success'
                                     ' for exechost_startup',
                                     starttime=begin, existence=True,
-                                    interval=1, tail=False)
+                                    interval=1, n='ALL')
 
         # These will throw an exception if the routines that should not
         # have been called were called.
@@ -2317,10 +2333,10 @@ if %s e.job.in_ms_mom():
         # that 50 lines will not suffice
         self.moms_list[0].log_match('_discover_devices', starttime=begin,
                                     existence=True, max_attempts=2,
-                                    interval=1, tail=False, n='ALL')
+                                    interval=1, n='ALL')
         self.moms_list[0].log_match('NVIDIA SMI', starttime=begin,
                                     existence=False, max_attempts=2,
-                                    interval=1, tail=False, n='ALL')
+                                    interval=1, n='ALL')
         self.logger.info('suppress_gpu_discovery check passed')
 
     def test_cgroup_cpuset(self):
@@ -2481,6 +2497,9 @@ if %s e.job.in_ms_mom():
              self.hosts_list[0], ATTR_N: name}
         j = Job(TEST_USER, attrs=a)
         j.create_script(self.eatmem_job1)
+        time.sleep(2)
+        stime=int(time.time())
+        time.sleep(2)
         jid = self.server.submit(j)
         a = {'job_state': 'R'}
         self.server.expect(JOB, a, jid)
@@ -2489,7 +2508,7 @@ if %s e.job.in_ms_mom():
         self.tempfile.append(o)
         # mem and vmem limit will both be set, and either could be detected
         self.mom.log_match('%s;Cgroup mem(ory|sw) limit exceeded' % jid,
-                           regexp=True)
+                           regexp=True, n='ALL', starttime=stime)
 
     def test_cgroup_enforce_memsw(self):
         """
@@ -2683,6 +2702,9 @@ if %s e.job.in_ms_mom():
              self.hosts_list[0], ATTR_N: name}
         j = Job(TEST_USER, attrs=a)
         j.create_script(self.sleep15_job)
+        time.sleep(2)
+        stime=int(time.time())
+        time.sleep(2)
         jid = self.server.submit(j)
         a = {'job_state': 'R'}
         self.server.expect(JOB, a, jid)
@@ -2692,7 +2714,7 @@ if %s e.job.in_ms_mom():
         hostn = self.get_hostname(self.hosts_list[0])
         self.moms_list[0].log_match('cgroup excluded for subsystem cpuset '
                                     'on host %s' % hostn,
-                                    starttime=self.server.ctime)
+                                    starttime=stime, n='ALL')
         cpath = self.get_cgroup_job_dir('cpuset', jid, self.hosts_list[0])
         self.assertFalse(self.is_dir(cpath, self.hosts_list[0]))
         # Now try a job on momB
@@ -2721,17 +2743,19 @@ if %s e.job.in_ms_mom():
              self.hosts_list[1], ATTR_N: name}
         j = Job(TEST_USER, attrs=a)
         j.create_script(self.sleep15_job)
+        time.sleep(2)
+        stime=int(time.time())
+        time.sleep(2)
         jid = self.server.submit(j)
         a = {'job_state': 'R'}
         self.server.expect(JOB, a, jid)
         self.server.status(JOB, ATTR_o, jid)
         o = j.attributes[ATTR_o]
         self.tempfile.append(o)
-        time.sleep(1)
         hostn = self.get_hostname(self.hosts_list[1])
         self.moms_list[1].log_match(
             'set enabled to False based on run_only_on_hosts',
-            starttime=self.server.ctime)
+            starttime=stime, n='ALL')
         cpath = self.get_cgroup_job_dir('memory', jid, self.hosts_list[1])
         self.assertFalse(self.is_dir(cpath, self.hosts_list[1]))
         a = {'Resource_List.select': '1:ncpus=1:mem=300mb:host=%s' %
@@ -3374,7 +3398,7 @@ if %s e.job.in_ms_mom():
         # Wait for exechost_startup hook to run
         self.moms_list[0].log_match("Hook handler returned success for"
                                     " exechost_startup event",
-                                    starttime=now)
+                                    starttime=now, n='ALL')
         # check where cpath is once more
         # since we loaded a new cgroup config file
         cpath = None
@@ -3408,6 +3432,9 @@ if %s e.job.in_ms_mom():
              self.hosts_list[0]}
         j = Job(TEST_USER, attrs=a)
         j.create_script(self.sleep5_job)
+        time.sleep(2)
+        stime=int(time.time())
+        time.sleep(2)
         jid1 = self.server.submit(j)
         a = {'job_state': 'R'}
         self.server.expect(JOB, a, jid1)
@@ -3417,9 +3444,11 @@ if %s e.job.in_ms_mom():
         err_msg = "Unexpected error in pbs_cgroups " + \
             "handling exechost_periodic event: TypeError"
         self.moms_list[0].log_match(err_msg, max_attempts=3,
-                                    interval=1, n=100,
+                                    interval=1, n='ALL',
+                                    starttime=stime,
                                     existence=False)
-        self.server.log_match(jid1 + ';Exit_status=0')
+        self.server.log_match(jid1 + ';Exit_status=0', n='ALL',
+                              starttime=stime)
         # Create a periodic hook that runs more frequently than the
         # cgroup hook to prepend jid1 to mom_priv/hooks/hook_data/cgroup_jobs
         hookname = 'prependjob'
@@ -3490,13 +3519,13 @@ event.accept()
         # Submit a second job and verify that the following message
         # does NOT appear in the mom log:
         # _exechost_periodic_handler: Failed to update jid1
-        time.sleep(2)
-        presubmit = int(time.time())
-        time.sleep(2)
         a = {'Resource_List.select': '1:ncpus=1:mem=100mb:host=%s' %
              self.hosts_list[0]}
         j = Job(TEST_USER, attrs=a)
         j.create_script(self.sleep15_job)
+        time.sleep(2)
+        presubmit = int(time.time())
+        time.sleep(2)
         jid2 = self.server.submit(j)
         a = {'job_state': 'R'}
         self.server.expect(JOB, a, jid2)
@@ -3506,9 +3535,11 @@ event.accept()
         err_msg = "Unexpected error in pbs_cgroups " + \
             "handling exechost_periodic event: TypeError"
         self.moms_list[0].log_match(err_msg, max_attempts=3,
-                                    interval=1, n=100,
+                                    interval=1, n='ALL',
+                                    starrtime=presubmit,
                                     existence=False)
-        self.server.log_match(jid2 + ';Exit_status=0')
+        self.server.log_match(jid2 + ';Exit_status=0', n='ALL',
+                              starttime=presubmit)
         self.server.manager(MGR_CMD_DELETE, HOOK, None, hookname)
         command = ['rm', '-rf',
                    os.path.join(self.moms_list[0].pbs_conf['PBS_HOME'],
@@ -3517,7 +3548,7 @@ event.accept()
         self.du.run_cmd(cmd=command, hosts=self.hosts_list[0], sudo=True)
         logmsg = '_exechost_periodic_handler: Failed to update %s' % jid1
         self.moms_list[0].log_match(msg=logmsg, starttime=presubmit,
-                                    max_attempts=1, existence=False)
+                                    n='ALL', max_attempts=1, existence=False)
 
     @requirements(num_moms=3)
     def test_cgroup_release_nodes(self):
@@ -3616,7 +3647,7 @@ event.accept()
         # Check the exec_resize hook reject message in sister mom logs
         self.moms_list[0].log_match(
             "Job;%s;Cannot resize the job" % (jid),
-            starttime=stime, interval=2)
+            starttime=stime, interval=2, n='ALL')
         # Check the exec_vnode after job is in substate 42
         self.server.expect(JOB, {ATTR_substate: '42'}, id=jid)
         # Check for the pruned exec_vnode due to release_nodes() in launch hook
@@ -3629,18 +3660,19 @@ event.accept()
         self.assertEqual(len(pruned_vnodes) + 1, len(initial_vnodes))
         # Check that the exec_vnode got pruned
         self.moms_list[1].log_match("Job;%s;pruned from exec_vnode=%s" % (
-            jid, execvnode1), starttime=stime)
+            jid, execvnode1), starttime=stime, n='ALL')
         self.moms_list[1].log_match("Job;%s;pruned to exec_vnode=%s" % (
-            jid, execvnode2), starttime=stime)
+            jid, execvnode2), starttime=stime, n='ALL')
         # Check that MS saw that the sister mom failed to update the job
         # This message is on MS mom[1] but mentions sismom mom[0]
         self.moms_list[1].log_match(
             "Job;%s;sister node %s.* failed to update job"
             % (jid, self.hosts_list[0]),
-            starttime=stime, interval=2, regexp=True)
+            starttime=stime, interval=2, regexp=True, n='ALL')
         # Because of resize hook reject Mom failed to update the job.
         # Check that job got requeued.
-        self.server.log_match("Job;%s;Job requeued" % (jid), starttime=stime)
+        self.server.log_match("Job;%s;Job requeued" % (jid),
+                              starttime=stime, n='ALL')
 
     @requirements(num_moms=3)
     def test_cgroup_msmom_resize_fail(self):
@@ -3686,7 +3718,7 @@ event.accept()
         # Check the exec_resize hook reject message in MS log
         self.moms_list[1].log_match(
             "Job;%s;Cannot resize the job" % (jid),
-            starttime=stime, interval=2)
+            starttime=stime, interval=2, n='ALL')
         # Check the exec_vnode after job is in substate 42
         self.server.expect(JOB, {ATTR_substate: '42'}, id=jid)
         self.server.expect(JOB, 'exec_vnode', id=jid, op=SET)
@@ -3698,9 +3730,9 @@ event.accept()
         self.assertEqual(len(pruned_vnodes) + 1, len(initial_vnodes))
         # Check that the exec_vnode got pruned
         self.moms_list[1].log_match("Job;%s;pruned from exec_vnode=%s" % (
-            jid, execvnode1), starttime=stime)
+            jid, execvnode1), starttime=stime, n='ALL')
         self.moms_list[1].log_match("Job;%s;pruned to exec_vnode=%s" % (
-            jid, execvnode2), starttime=stime)
+            jid, execvnode2), starttime=stime, n='ALL')
         # Because of resize hook reject Mom failed to update the job.
         # Check that job got requeued
         self.server.log_match("Job;%s;Job requeued" % (jid), starttime=stime)
@@ -3757,9 +3789,9 @@ event.accept()
         self.assertEqual(len(pruned_vnodes) + 1, len(initial_vnodes))
         # Check that the exec_vnode got pruned
         self.moms_list[0].log_match("Job;%s;pruned from exec_vnode=%s" % (
-            jid, execvnode1), starttime=stime)
+            jid, execvnode1), starttime=stime, n='ALL')
         self.moms_list[0].log_match("Job;%s;pruned to exec_vnode=%s" % (
-            jid, execvnode2), starttime=stime)
+            jid, execvnode2), starttime=stime, n='ALL')
         # Find out the released vnode
         if initial_vnodes[0] == execvnode2:
             execvnodeB = initial_vnodes[1]
@@ -3811,15 +3843,16 @@ event.accept()
         cpath = self.get_cgroup_job_dir('memory', jid, self.hosts_list[2])
         self.assertFalse(self.is_dir(cpath, self.hosts_list[2]))
 
-        self.moms_list[0].log_match("job_start_error", starttime=now)
+        self.moms_list[0].log_match("job_start_error",
+                                    starttime=now, n='ALL')
         self.moms_list[0].log_match("Event type is execjob_abort",
-                                    starttime=now)
+                                    starttime=now, n='ALL')
         self.moms_list[0].log_match("Event type is execjob_epilogue",
-                                    starttime=now)
+                                    starttime=now, n='ALL')
         self.moms_list[0].log_match("Event type is execjob_end",
-                                    starttime=now)
+                                    starttime=now, n='ALL')
         self.moms_list[2].log_match("Event type is execjob_abort",
-                                    starttime=now)
+                                    starttime=now, n='ALL')
 
         self.moms_list[1].restart()
 
@@ -3961,12 +3994,15 @@ exit 0
         # Submit an express queue job requesting needing also 2 nodes
         a[ATTR_q] = 'express'
         j2 = Job(TEST_USER, attrs=a)
+        time.sleep(2)
+        stime=int(time.time())
+        time.sleep(2)
         jid2 = self.server.submit(j2)
         self.server.expect(JOB, {'job_state': 'Q'}, id=jid1)
         err_msg = "%s;.*Failed to assign resources.*" % (jid2,)
         for m in self.moms.values():
-            m.log_match(err_msg, max_attempts=3, interval=1, n=100,
-                        regexp=True, existence=False)
+            m.log_match(err_msg, max_attempts=3, interval=1, n='ALL',
+                        regexp=True, existence=False, n='ALL')
 
         self.server.expect(JOB, {'job_state': 'R', 'substate': 42}, id=jid2)
 
@@ -4498,11 +4534,14 @@ sleep 300
         a = {'Resource_List.select': 'ncpus=1:mem=100mb'}
         j = Job(TEST_USER, attrs=a)
         j.create_script(self.sleep15_job)
+        time.sleep(2)
+        stime=int(time.time())
+        time.sleep(2)
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, jid)
         err_msg = "write_value: Permission denied.*%s.*memsw" % (jid)
-        self.mom.log_match(err_msg, max_attempts=3, interval=1, n=100,
-                           regexp=True, existence=False)
+        self.mom.log_match(err_msg, max_attempts=3, interval=1, n='ALL',
+                           starttime=stime, regexp=True, existence=False)
         self.server.status(JOB, ['exec_host'], jid)
         ehost = j.attributes['exec_host']
         ehost1 = ehost.split('/')[0]
@@ -4549,7 +4588,7 @@ sleep 300
         self.mom.log_match('Hook handler returned success'
                            ' for exechost_startup',
                            starttime=begin, existence=True,
-                           interval=1, tail=False)
+                           interval=1, n='ALL')
         self.server.expect(NODE, {'state': 'free'},
                            id=self.mom.shortname, interval=2, offset=1)
 
@@ -4703,7 +4742,7 @@ sleep 300
         self.mom.log_match('Hook handler returned success'
                            ' for exechost_startup',
                            starttime=begin, existence=True,
-                           interval=1, tail=False)
+                           interval=1, n='ALL')
         self.server.expect(NODE, {'state': 'free'},
                            id=self.mom.shortname, interval=2, offset=1)
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
See https://openpbs.atlassian.net/wiki/spaces/PD/pages/2576613377/Improve+memory+swap+management+in+the+cgroup+hook

#### Describe Your Change
-Added queuejob/modifyjob hook to compute "cgswap" from mem and vmem requests
-If "manage_cgswap" is enabled, then resources_available.cgswap is set to the difference between vmem and mem
-Introduce enforce_default and exclhost_ignore_default config parameters in the memory sections (memory/memsw/hugetlb). Since they are boolean, they can be set differently for different cluster hosts.
--enforce_default set to true assigns a default value for mem/swap/hpmem if the job does not explicitly request the resource; enforce_default set to false lets the job use all available resources of that type present on the host and not excluded from use by the job cgroups (cfr. reserved_amount/reserved_percent).
--exclhost_ignore_default enabled will force enforce_default==false behaviour for exclhost placement jobs.
-configure_job and _get_assigned_cgroup_resources will now get the totals available from the parent cgroup set up by exechost_startup, to avoid small changes in reported values due to kernel drivers changing the OS reported totals. exechost_startup will compute the values as before
-memory resources assigned by existing jobs and tallied by the cgroup hook will not include values that have been raised through enforce_default==false or exclhost_ignore_default==true. Since the hook always 'hides' at least one MB from the server/scheduler (and rounds down), the only way for a job to have its cgroup limits identical to the "jobid" parent directory ones is through these mechanisms.
-memsw "default" is now accurately reflecting default extra swap to be added to the memory limit, consistent with the current behaviour of reserved_amount and reserved_percentage. This avoids sites being able to specify nonsensical configurations as well.
-Added default configuration file entries. Changed the default for mem_fences to false, since the combination of mem_fences enabled and vnode_per_numa_node disabled risks erecting fences that may kill jobs. Changed the default reserve_amount for mem to something more appropriate for modern systems with tens of GB (i.e. 1GB) -- the old default is often left as-is by sites and is invariably not enough to protect OS daemons. It's still on the low side but at least sane.

#### Link to Design Doc
See https://openpbs.atlassian.net/wiki/spaces/PD/pages/2576613377/Improve+memory+swap+management+in+the+cgroup+hook


#### Attach Test and Valgrind Logs/Output
@bayucan ran the TH TestCgroupsHook test on  your cgroup_cgswap branch. (http://th.prog.altair.com/results/6401/all) It's all passing now:

Id: 6401
Description: Tests from given sources on platforms CENTOS7, SUSE15
Platforms: CENTOS7,SUSE15
Profile: Cgroups

Test Summary: total: 52, fail: 0, error: 0, timedout: 0, skip: 13, pass: 39


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
