### PR TITLE
Snapshot obfuscate errors out + optimizing obfuscate

### DIFF
--- a/test/fw/ptl/utils/pbs_snaputils.py
+++ b/test/fw/ptl/utils/pbs_snaputils.py
@@ -51,6 +51,7 @@ import tarfile
 import time
 import platform
 from subprocess import STDOUT
+from pathlib import Path
 
 from ptl.lib.pbs_ifl_mock import *
 from ptl.lib.pbs_testlib import (SCHED, BatchUtils, Scheduler, Server,
@@ -423,34 +424,46 @@ class ObfuscateSnapshot(object):
         acct_path = os.path.join(snap_dir, "server_priv", "accounting")
         if not os.path.isdir(acct_path):
             return
-        acct_fnames = self.du.listdir(path=acct_path, sudo=sudo_val)
-        for acct_fname in acct_fnames:
-            acct_fpath = os.path.join(acct_path, acct_fname)
+        acct_fpaths = self.du.listdir(path=acct_path, sudo=sudo_val)
+        for acct_fpath in acct_fpaths:
             self._obfuscate_acct_file(attrs_to_obf, acct_fpath)
         if self.num_bad_acct_records > 0:
             self.logger.info("Total bad records found: " +
                              str(self.num_bad_acct_records))
 
-    def _replace_str_in_file(self, key, val, fpath, sudo=False):
+    def _obfuscate_with_map(self, fpath, sudo=False):
         """
-        Helper function to replace a given string (key) with another (val)
+        Helper function to obfuscate a file with obfuscation map
 
-        :param key - the string to replace
-        :type key - str
-        :param val - the string to replace with
-        :type val - str
         :param filepath - path to the file
         :type filepath - str
+        :param sudo - sudo True/False?
+        :type bool
+
+        :return fpath - possibly updated path to the obfuscated file
         """
         fout = self.du.create_temp_file()
+        pathobj = Path(fpath)
+        fname = pathobj.name
+        fparent = pathobj.parent
         with open(fpath, "r", encoding="latin-1") as fd, \
                 open(fout, "w") as fdout:
             alltext = fd.read()
-            otext = re.sub(r'\b' + key + r'\b', val, alltext)
-            fdout.write(otext)
+            # Obfuscate values from val_obf_map
+            for key, val in self.val_obf_map.items():
+                alltext = re.sub(r'\b' + key + r'\b', val, alltext)
+                if key in fname:
+                    fname = fname.replace(key, val)
+                    fpath = os.path.join(fparent, fname)
+            # Remove the attr values from vals_to_del list
+            for val in self.vals_to_del:
+                alltext = alltext.replace(val, "")
+            fdout.write(alltext)
 
         self.du.rm(path=fpath, sudo=sudo)
         shutil.move(fout, fpath)
+
+        return fpath
 
     def obfuscate_snapshot(self, snap_dir, map_file, sudo_val):
         """
@@ -560,25 +573,7 @@ class ObfuscateSnapshot(object):
         for root, _, fnames in os.walk(snap_dir):
             for fname in fnames:
                 fpath = os.path.join(root, fname)
-                new_fname = None
-
-                # Obfuscate values from val_obf_map
-                for key, val in self.val_obf_map.items():
-                    self._replace_str_in_file(key, val, fpath, sudo=sudo_val)
-                    if key in fname:
-                        new_fname = fname.replace(key, val)
-
-                # Remove the attr values from vals_to_del list
-                fout = self.du.create_temp_file()
-                with open(fpath, "r") as fd, open(fout, "w") as fdout:
-                    data = fd.read()
-                    for val in self.vals_to_del:
-                        data = data.replace(val, "")
-                    fdout.write(data)
-                if new_fname is not None:
-                    os.remove(fpath)
-                    fpath = os.path.join(root, new_fname)
-                shutil.move(fout, fpath)
+                self._obfuscate_with_map(fpath, sudo=sudo_val)
 
         with open(map_file, "w") as fd:
             fd.write("Attributes Obfuscated:\n")

--- a/test/tests/functional/pbs_snapshot_unittest.py
+++ b/test/tests/functional/pbs_snapshot_unittest.py
@@ -258,10 +258,11 @@ class TestPBSSnapshot(TestFunctional):
                     common_path = os.path.commonprefix([file_fullpath,
                                                         svr_fullpath])
                     try:
-                        self.assertEqual(os.path.basename(common_path), "server")
+                        self.assertEqual(os.path.basename(common_path),
+                                         "server")
                     except AssertionError:
-                        # Check if this was a core file, which would explain why it
-                        # it was captured
+                        # Check if this was a core file, which would
+                        # explain why it was captured
                         if CORE_DIR in file_fullpath:
                             continue
                         raise

--- a/test/tests/functional/pbs_snapshot_unittest.py
+++ b/test/tests/functional/pbs_snapshot_unittest.py
@@ -261,9 +261,10 @@ class TestPBSSnapshot(TestFunctional):
                         self.assertEqual(os.path.basename(common_path),
                                          "server")
                     except AssertionError:
-                        # Check if this was a core file, which would
+                        # Check if this was a server core file, which would
                         # explain why it was captured
-                        if CORE_DIR in file_fullpath:
+                        svrcorepath = os.path.join(CORE_DIR, "server_priv")
+                        if svrcorepath in file_fullpath:
                             continue
                         raise
             # Check 3: qstat_Bf.out exists

--- a/test/tests/functional/pbs_snapshot_unittest.py
+++ b/test/tests/functional/pbs_snapshot_unittest.py
@@ -257,7 +257,14 @@ class TestPBSSnapshot(TestFunctional):
                     # Find the common paths between 'server' & the file
                     common_path = os.path.commonprefix([file_fullpath,
                                                         svr_fullpath])
-                    self.assertEqual(os.path.basename(common_path), "server")
+                    try:
+                        self.assertEqual(os.path.basename(common_path), "server")
+                    except AssertionError:
+                        # Check if this was a core file, which would explain why it
+                        # it was captured
+                        if CORE_DIR in file_fullpath:
+                            continue
+                        raise
             # Check 3: qstat_Bf.out exists
             qstat_bf_out = os.path.join(snap_obj.snapdir, QSTAT_BF_PATH)
             self.assertTrue(os.path.isfile(qstat_bf_out))


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Errors out as follows:
  File "/opt/ptl/bin/pbs_snapshot", line 188, in obfuscate_snapshot_wrapper
    obj.obfuscate_snapshot(snap_name, map_file, sudo_val)
  File "/opt/ptl/lib/python3.6/site-packages/ptl/utils/pbs_snaputils.py", line 508, in obfuscate_snapshot
    self.obfuscate_acct_logs(snap_dir, sudo_val)
  File "/opt/ptl/lib/python3.6/site-packages/ptl/utils/pbs_snaputils.py", line 430, in obfuscate_acct_logs
    self._obfuscate_acct_file(attrs_to_obf, acct_fpath)
  File "/opt/ptl/lib/python3.6/site-packages/ptl/utils/pbs_snaputils.py", line 357, in _obfuscate_acct_file
    with open(file_path, "r") as fd, open(fout, "w") as fdout:
FileNotFoundError: [Errno 2] No such file or directory: 'new_snapshot_infra_bigmem/server_priv/accounting/new_snapshot_infra_bigmem/server_priv/accounting/20170617'

- Also, --obfuscate had a performance inefficiency: towards the end, it would open, parse, modify and write all of the files in the snapshot multiple times, once for each key-val pair in the obfuscation map, in order to obfuscate each value. I changed it to open the file, swap all the values in the map and write back, just once.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
DshUtils.listdir returns full paths, not just file names, which is what we were assuming in the obfuscation codepath.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[testsnap.log](https://github.com/openpbs/openpbs/files/6052817/testsnap.log)

[test_capture_server.log](https://github.com/openpbs/openpbs/files/6126788/test_capture_server.log)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
