### PR TITLE
Maintenance resv test fails on cpuset machine

### DIFF
--- a/test/tests/functional/pbs_maintenance_reservations.py
+++ b/test/tests/functional/pbs_maintenance_reservations.py
@@ -652,7 +652,7 @@ class TestMaintenanceReservations(TestFunctional):
         self.server.status(RESV, 'resv_nodes', id=rid1)
         resv_node_list = self.server.reservations[rid1].get_vnodes()
         resv_node = resv_node_list[0]
-        
+
         # On a cpuset machine the resv_node could be a vnode,
         # always pull the hostname from the node attribute
         status = self.server.status(NODE, id=resv_node)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
One of the maintenance tests fails on a cpuset machine where we have vnodes by default.

#### Describe Your Change
Changed the test to use node's resources_available.host value to submit maintenance reservation. This is what pbs_rsub expects too. Also removed the need for specifying multiple moms, the test didn't need it.

#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
[test.txt](https://github.com/openpbs/openpbs/files/6053669/test.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
