### PR TITLE
Fix restarting of MoM in TestMultiNodeJobsRestart

### DIFF
--- a/test/tests/functional/pbs_node_jobs_restart_multinode.py
+++ b/test/tests/functional/pbs_node_jobs_restart_multinode.py
@@ -57,8 +57,10 @@ class TestMultiNodeJobsRestart(TestFunctional):
         momB = self.moms.values()[1]
 
         # Make sure moms are running with -p flag
-        momA.restart(args=['-p'])
-        momB.restart(args=['-p'])
+        momA.stop(sig='-INT')
+        momA.start(args=['-p'])
+        momB.stop(sig='-INT')
+        momB.start(args=['-p'])
 
         pbsdsh_path = os.path.join(self.server.pbs_conf['PBS_EXEC'],
                                    "bin", "pbsdsh")
@@ -70,8 +72,10 @@ class TestMultiNodeJobsRestart(TestFunctional):
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
 
-        momA.restart(args=['-p'])
-        momB.restart(args=['-p'])
+        momA.stop(sig='-INT')
+        momA.start(args=['-p'])
+        momB.stop(sig='-INT')
+        momB.start(args=['-p'])
 
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
 
@@ -105,8 +109,10 @@ class TestMultiNodeJobsRestart(TestFunctional):
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
 
-        momA.restart(args=['-p'])
-        momB.restart(args=['-p'])
+        momA.stop(sig='-INT')
+        momA.start(args=['-p'])
+        momB.stop(sig='-INT')
+        momB.start(args=['-p'])
 
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
"test_restart_hosts_resume" and "test_restart_hosts_resume_withoutp" were failing as it was not able to find the submitted job in the running state after MoM restart with "-p" option. Hence the existing job is not preserved.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
The current PTL framework handles MoM restart by simply stopping the process through init.d script. To preserve the existing job we need to kill the MoM process with -INT option and then start with "-p" option.
Therefore replacing the restart function with stop and start functions with required options.

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Before Fix: [TestMultiNodeJobsRestart.txt](https://github.com/openpbs/openpbs/files/6066465/TestMultiNodeJobsRestart.txt)
After Fix: [TestMultiNodeJobsRestart_pass.txt](https://github.com/openpbs/openpbs/files/6066466/TestMultiNodeJobsRestart_pass.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->