### PR TITLE
Incorrect Job array ids generated for multi-server

### DIFF
--- a/src/include/svrfunc.h
+++ b/src/include/svrfunc.h
@@ -68,6 +68,7 @@ extern int is_compose(int, int);
 extern int is_compose_cmd(int, int, char **);
 extern char *get_servername(unsigned int *);
 extern char *gen_svr_inst_id(void);
+extern int get_server_index(void);
 extern void process_Areply(int);
 extern void process_Dreply(int);
 extern void process_DreplyTPP(int);

--- a/src/server/multi_svr.c
+++ b/src/server/multi_svr.c
@@ -62,6 +62,7 @@ typedef struct peersvr_list {
 static struct peersvr_list *peersvrl;
 extern char server_host[PBS_MAXHOSTNAME + 1];
 extern unsigned int	pbs_server_port_dis;
+static int svridx = -1;
 
 /**
  * @brief
@@ -279,6 +280,18 @@ init_msi()
 {
 	peersvrl = NULL;
 
+	/* Determine the index of the server in PBS_SERVER_INSTANCES list */
+	if (svridx == -1) {
+		int i;
+		for (i = 0; i < get_num_servers(); i++) {
+			if (pbs_conf.psi[i].port == pbs_server_port_dis &&
+			    is_same_host(pbs_conf.psi[i].name, server_host)) {
+				svridx = i;
+				break;
+			}
+		}
+	}
+
 	return 0;
 }
 
@@ -316,23 +329,10 @@ gen_svr_inst_id(void)
  *
  * @return	int
  * @retval	index of the server
- * @retval	-1 if couldn't be determined
+ * @retval	-1 if couldn't be determined (see init_msi)
  */
 int
 get_server_index(void)
 {
-	static int svridx = -1;
-
-	if (svridx == -1) {
-		int i;
-		for (i = 0; i < get_num_servers(); i++) {
-			if (pbs_conf.psi[i].port == pbs_server_port_dis &&
-			    is_same_host(pbs_conf.psi[i].name, server_host)) {
-				svridx = i;
-				break;
-			}
-		}
-	}
-
 	return svridx;
 }

--- a/src/server/multi_svr.c
+++ b/src/server/multi_svr.c
@@ -279,16 +279,14 @@ int
 init_msi()
 {
 	peersvrl = NULL;
+	int i;
 
 	/* Determine the index of the server in PBS_SERVER_INSTANCES list */
-	if (svridx == -1) {
-		int i;
-		for (i = 0; i < get_num_servers(); i++) {
-			if (pbs_conf.psi[i].port == pbs_server_port_dis &&
-			    is_same_host(pbs_conf.psi[i].name, server_host)) {
-				svridx = i;
-				break;
-			}
+	for (i = 0; i < get_num_servers(); i++) {
+		if (pbs_conf.psi[i].port == pbs_server_port_dis &&
+		    is_same_host(pbs_conf.psi[i].name, server_host)) {
+			svridx = i;
+			break;
 		}
 	}
 

--- a/src/server/multi_svr.c
+++ b/src/server/multi_svr.c
@@ -60,6 +60,8 @@ typedef struct peersvr_list {
 } peersvr_list_t;
 
 static struct peersvr_list *peersvrl;
+extern char server_host[PBS_MAXHOSTNAME + 1];
+extern unsigned int	pbs_server_port_dis;
 
 /**
  * @brief
@@ -305,4 +307,32 @@ gen_svr_inst_id(void)
 	}
 
 	return svr_inst_id;
+}
+
+/**
+ * @brief	Calculate the index of the current server
+ *
+ * @param	void
+ *
+ * @return	int
+ * @retval	index of the server
+ * @retval	-1 if couldn't be determined
+ */
+int
+get_server_index(void)
+{
+	static int svridx = -1;
+
+	if (svridx == -1) {
+		int i;
+		for (i = 0; i < get_num_servers(); i++) {
+			if (pbs_conf.psi[i].port == pbs_server_port_dis &&
+			    is_same_host(pbs_conf.psi[i].name, server_host)) {
+				svridx = i;
+				break;
+			}
+		}
+	}
+
+	return svridx;
 }

--- a/src/server/node_func.c
+++ b/src/server/node_func.c
@@ -298,6 +298,7 @@ initialize_pbsnode(struct pbsnode *pnode, char *pname, int ntype)
 	resource_def *prd;
 	resource     *presc;
 	char         *svr_inst_id;
+	static char ndgroupid[PBS_MAXHOSTNAME + 3] = {0};
 
 	pnode->nd_name    = pname;
 	pnode->nd_ntype   = ntype;
@@ -360,19 +361,18 @@ initialize_pbsnode(struct pbsnode *pnode, char *pname, int ntype)
 	prd  = &svr_resc_def[RESC_NCPUS];
 	(void)add_resource_entry(pat1, prd);
 
-	if (get_num_servers() > 1) {
-		resource *svr_nd_grp = NULL;
+    if (get_num_servers() > 1) {
+        resource *svr_nd_grp = NULL;
 
-		/* Set the value of msvr_node_group to "server_id" where
-		 * server_id is the id of the server for the node */
-		prd = &svr_resc_def[RESC_MSVR_ND_GROUP];
-		if ((svr_nd_grp = add_resource_entry(pat1, prd)) != NULL) {
-			char buf[PBS_MAXHOSTNAME];
-
-			snprintf(buf, sizeof(buf), "%s", pbs_server_name);
-			decode_arst(&svr_nd_grp->rs_value, NULL, NULL, buf);
-		}
-	}
+        /* Set the value of msvr_node_group to "server_id" where
+         * server_id is the id of the server for the node */
+        prd = &svr_resc_def[RESC_MSVR_ND_GROUP];
+        if ((svr_nd_grp = add_resource_entry(pat1, prd)) != NULL) {
+            if (ndgroupid[0] == '\0')
+                snprintf(ndgroupid, sizeof(ndgroupid), "%d", get_server_index());
+            decode_arst(&svr_nd_grp->rs_value, NULL, NULL, ndgroupid);
+        }
+    }
 
 	/* add to resources_assigned any resource with ATR_DFLAG_FNASSN */
 	/* or  ATR_DFLAG_ANASSN set in the resource definition          */

--- a/src/server/node_func.c
+++ b/src/server/node_func.c
@@ -361,7 +361,7 @@ initialize_pbsnode(struct pbsnode *pnode, char *pname, int ntype)
 	prd  = &svr_resc_def[RESC_NCPUS];
 	(void)add_resource_entry(pat1, prd);
 
-    if (get_num_servers() > 1) {
+    if (msvr_mode()) {
         resource *svr_nd_grp = NULL;
 
         /* Set the value of msvr_node_group to "server_id" where

--- a/src/server/req_quejob.c
+++ b/src/server/req_quejob.c
@@ -244,27 +244,6 @@ validate_perm_res_in_select(char *val, int val_exist)
 #define SET_RESC_PLACE	2
 
 #ifndef PBS_MOM
-/**
- * @brief	Calculate the index of the current server
- *
- * @param	void
- *
- * @return	int
- * @retval	index of the server
- * @retval	-1 if couldn't be determined
- */
-static int
-get_server_index(void)
-{
-	int i;
-
-	for (i = 0; i < get_num_servers(); i++) {
-		if (pbs_conf.psi[i].port == pbs_server_port_dis && is_same_host(pbs_conf.psi[i].name, server_host))
-			return i;
-	}
-
-	return -1;
-}
 
 /**
  * @brief	Generate and fill jobid of the new job
@@ -303,7 +282,7 @@ generate_jobid(char *jidbuf, char *clusterid, int jtype)
 		if (jtype == 0)
 			sprintf(jidbuf, "%lld%0*d.%s", next_svr_sequence_id, MSVR_JID_NCHARS_SVR, svr_id, clusterid);
 		else
-			sprintf(jidbuf, "%lld[]%0*d.%s", next_svr_sequence_id, MSVR_JID_NCHARS_SVR, svr_id, clusterid);
+			sprintf(jidbuf, "%lld%0*d[].%s", next_svr_sequence_id, MSVR_JID_NCHARS_SVR, svr_id, clusterid);
 	}
 
 	return 0;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
After the jobid namespace redesign change went in, a bug was introduced which caused job array ids to be generated incorrectly: the '[]' came before the numeric portion of server id, leading to jobids such as 0[]00.pbspro.

Also, changed msvr_node_group's value to be set to the position of the server in PBS_SERVER_INSTANCES so that even if PBS_SERVER is the same for all servers, msvr_node_group is set to different values for nodes of each server.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
