### PR TITLE
Automate scenario of verifying the email to non-existent mail recipient

### DIFF
--- a/test/tests/functional/pbs_array_job_mail.py
+++ b/test/tests/functional/pbs_array_job_mail.py
@@ -157,14 +157,14 @@ class Test_array_job_email(TestFunctional):
         # Check stageout file should not be present
         self.assertFalse(os.path.exists(dest_file))
 
-        # Check if mail is deliverd to valid user mail file
-        ret = self.du.cat(filename=pbsuser_mailfile, sudo=True)
-        maillog = [x.strip() for x in ret['out'][-50:]]
+        exp_msg = "PBS Job Id: " + subjid
+        err_msg = "%s msg not found in pbsuser's mail log" % exp_msg
 
-        subjid = j.create_subjob_id(jid, 1)
-        msg = "PBS Job Id: " + subjid
-        err_msg = "%s msg not found in pbsuser's mail log" % msg
-        self.assertIn(msg, maillog, err_msg)
+        # Check if mail is deliverd to valid user mail file
+        ret = self.du.tail(filename=pbsuser_mailfile, runas=TEST_USER,
+                           option="-n 50")
+        maillog = [x.strip() for x in ret['out']]
+        self.assertIn(exp_msg, maillog, err_msg)
 
         # Verify there should not be any email for invalid user
         self.assertFalse(os.path.isfile(non_existent_mailfile))

--- a/test/tests/functional/pbs_array_job_mail.py
+++ b/test/tests/functional/pbs_array_job_mail.py
@@ -121,9 +121,9 @@ class Test_array_job_email(TestFunctional):
         """
         non_existent_user = PbsAttribute.random_str(length=5)
         non_existent_mailfile = os.path.join(os.sep, "var", "mail",
-                                            non_existent_user)
+                                             non_existent_user)
         pbsuser_mailfile = os.path.join(os.sep, "var", "mail",
-                                       str(TEST_USER))
+                                        str(TEST_USER))
 
         # Check mail file should exist for existent user
         if not os.path.isfile(pbsuser_mailfile):
@@ -140,11 +140,12 @@ class Test_array_job_email(TestFunctional):
         if not os.path.isdir(stageout_path) and os.path.exists(src_file):
             os.remove(src_file)
 
-        #Submit job with invalid stageout path
+        # Submit job with invalid stageout path
         usermail_list = str(TEST_USER) + "," + non_existent_user
-        set_attrib =  {ATTR_stageout: stageout_path + '@' +
-                        self.mom.shortname + ':' + dest_file, ATTR_S: '/bin/bash',
-                        ATTR_M: usermail_list, ATTR_J: '1-2'}
+        set_attrib = {ATTR_stageout: stageout_path + '@' +
+                      self.mom.shortname + ':' + dest_file,
+                      ATTR_M: usermail_list, ATTR_J: '1-2',
+                      ATTR_S: '/bin/bash'}
         j = Job()
         j.set_attributes(set_attrib)
         j.set_sleep_time(1)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature

- Automate scenario of verifying the email to non-existent mail recipient

#### Describe Your Change

- Intent of the test: Verify when a job array is submitted with a valid and invalid mail recipients and all file stageout attempts fails then email should get delivered to valid recipient and no email should be sent to invalid recipient.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output

- [Execution_logs_array_job_email.txt.txt](https://github.com/openpbs/openpbs/files/6073889/Execution_logs_array_job_email.txt.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
