### PR TITLE
Fix qdel race condition in test_job_sort_formula_threshold

### DIFF
--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -985,9 +985,12 @@ class SmokeTest(PBSTestSuite):
         msg = "Checking the job state of %s, runs after %s is deleted" % (j3id,
                                                                           j4id)
         self.logger.info(msg)
-        attribs = self.server.status(JOB, 'job_state', id=j4id)
-        if attribs[0]['job_state'] == 'R':
-            self.server.deljob(id=j4id, wait=True)
+        try:
+            self.server.deljob(id=j4id, wait=True, extend='force',
+                               runas=MGR_USER)
+        except PbsDeljobError as e:
+            self.assertIn(
+                'qdel: Unknown Job Id', e.msg[0])
         self.server.expect(JOB, {'job_state': 'R'}, id=j3id, max_attempts=30,
                            interval=2)
         self.server.expect(JOB, {'job_state': 'Q'}, id=j2id, max_attempts=30,
@@ -1022,11 +1025,13 @@ class SmokeTest(PBSTestSuite):
         self.scheduler.log_match(j4id + ";Formula Evaluation = 9",
                                  regexp=True, starttime=self.server.ctime,
                                  max_attempts=10, interval=2)
-
+        try:
+            self.server.deljob(id=j3id, wait=True, extend='force',
+                               runas=MGR_USER)
+        except PbsDeljobError as e:
+            self.assertIn(
+                'qdel: Unknown Job Id', e.msg[0])
         # Make sure we can qrun a job under the threshold
-        attribs = self.server.status(JOB, 'job_state', id=j3id)
-        if attribs[0]['job_state'] == 'R':
-            self.server.deljob(id=j3id, wait=True)
         rv = self.server.expect(SERVER, {'server_state': 'Scheduling'}, op=NE)
         self.server.expect(JOB, {ATTR_state: 'Q'}, id=j1id)
         self.server.runjob(jobid=j1id)

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -985,7 +985,9 @@ class SmokeTest(PBSTestSuite):
         msg = "Checking the job state of %s, runs after %s is deleted" % (j3id,
                                                                           j4id)
         self.logger.info(msg)
-        self.server.deljob(id=j4id, wait=True)
+        attribs = self.server.status(JOB, 'job_state', id=j4id)
+        if attribs[0]['job_state'] == 'R':
+            self.server.deljob(id=j4id, wait=True)
         self.server.expect(JOB, {'job_state': 'R'}, id=j3id, max_attempts=30,
                            interval=2)
         self.server.expect(JOB, {'job_state': 'Q'}, id=j2id, max_attempts=30,
@@ -1022,7 +1024,9 @@ class SmokeTest(PBSTestSuite):
                                  max_attempts=10, interval=2)
 
         # Make sure we can qrun a job under the threshold
-        self.server.deljob(id=j3id, wait=True)
+        attribs = self.server.status(JOB, 'job_state', id=j3id)
+        if attribs[0]['job_state'] == 'R':
+            self.server.deljob(id=j3id, wait=True)
         rv = self.server.expect(SERVER, {'server_state': 'Scheduling'}, op=NE)
         self.server.expect(JOB, {ATTR_state: 'Q'}, id=j1id)
         self.server.runjob(jobid=j1id)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
qdel failed on some machines as the job with walltime 4 was over by the time we delete the job.


#### Describe Your Change
Let the qdel unknown job id error passby and use force delete 


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[smoke_threshold.txt](https://github.com/openpbs/openpbs/files/6092612/smoke_threshold.txt)


Ran smoketest on th3.
Description: Tests from given sources on platforms SUSE15, CENTOS8, CENTOS7
Platforms: SUSE15,CENTOS8,CENTOS7
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|6290|52|0|0|0|0|52|


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
