### PR TITLE
Enhancing pbs_locjob for multi-server

### DIFF
--- a/src/lib/Libifl/int_manager.c
+++ b/src/lib/Libifl/int_manager.c
@@ -166,7 +166,6 @@ PBSD_manager(int c, int rq_type, int command, int objtype, char *objname, struct
 				if (rc == PBSE_NONE || (pbs_errno != PBSE_UNKJOBID && pbs_errno != PBSE_UNKRESVID))
 					break;
 			}
-			
 		}
 
 		return rc;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Right now, pbs_locjob cannot handle a multi-server setup. This leads to unexpected behavior of commands like qdel which use it  to locate jobs which were moved to remote clusters. So, this PR enhances it to handle a multi-server configuration.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
The following shows how qdel was not reporting "unknown job" for an already deleted job, and that gdb showed how locate_job was getting a SIGPIPE
```
[ragrawal@m2 ~]$ qstat
Job id            Name             User              Time Use S Queue
----------------  ---------------- ----------------  -------- - -----
101.m2-3          STDIN            ragrawal          00:00:00 R workq           
201.m2-3          STDIN            ragrawal          00:00:00 R workq           
[ragrawal@m2 ~]$ qdel 900.m2
[ragrawal@m2 ~]$ gdb qdel
GNU gdb (GDB) Red Hat Enterprise Linux 8.2-12.el8
Copyright (C) 2018 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-redhat-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from qdel...
warning: the debug information found in "/usr/lib/debug//opt/pbs/bin/qdel-20.0.0-0.x86_64.debug" does not match "/opt/pbs/bin/qdel" (CRC mismatch).

Missing separate debuginfo for /opt/pbs/bin/qdel
Try: yum --enablerepo='*debug*' install /usr/lib/debug/.build-id/f0/29deed9dc7f8e5b9a6ca220f749c91358bbfad.debug
Reading symbols from .gnu_debugdata for /opt/pbs/bin/qdel...(no debugging symbols found)...done.
(no debugging symbols found)...done.
(gdb) b locate_job
Breakpoint 1 at 0x403860
(gdb) run 900.m2
Starting program: /opt/pbs/bin/qdel 900.m2
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib64/libthread_db.so.1".
warning: Loadable section ".note.gnu.property" outside of ELF segments
warning: Loadable section ".note.gnu.property" outside of ELF segments
[Detaching after fork from child process 38457]
[Detaching after fork from child process 38458]

Breakpoint 1, 0x0000000000403860 in locate_job ()
(gdb) finish
Run till exit from #0  0x0000000000403860 in locate_job ()
[Detaching after fork from child process 38459]
[Detaching after fork from child process 38460]

Program received signal SIGPIPE, Broken pipe.
0x00007ffff7bc5ac5 in write () from /lib64/libpthread.so.0
(gdb) 
```

After fix:
```
[ragrawal@m2 ~]$ qstat
Job id            Name             User              Time Use S Queue
----------------  ---------------- ----------------  -------- - -----
1.m2              STDIN            ragrawal          00:00:00 R workq           
2.m2              STDIN            ragrawal          00:00:00 R workq           
3.m2              STDIN            ragrawal          00:00:00 R workq           
4.m2              STDIN            ragrawal          00:00:00 R workq           
700.m2            STDIN            ragrawal                 0 Q workq           
600.m2            STDIN            ragrawal          00:00:00 R workq           
001.m2-3          STDIN            ragrawal                 0 Q workq           
[ragrawal@m2 ~]$ qdel 700.m2
[ragrawal@m2 ~]$ qdel 700.m2
qdel: Unknown Job Id 700.m2
```

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
