### PR TITLE
Fix interactive test in PTL

### DIFF
--- a/test/fw/ptl/lib/ptl_resourceresv.py
+++ b/test/fw/ptl/lib/ptl_resourceresv.py
@@ -652,7 +652,8 @@ class InteractiveJob(threading.Thread):
             _p.sendline("exit")
             while True:
                 try:
-                    _p.read_nonblocking(timeout=5)
+                    # When -1 (default), use self.timeout
+                    _p.read_nonblocking()
                 except Exception:
                     break
             if _p.isalive():

--- a/test/fw/ptl/lib/ptl_resourceresv.py
+++ b/test/fw/ptl/lib/ptl_resourceresv.py
@@ -642,8 +642,13 @@ class InteractiveJob(threading.Thread):
                 self.job.interactive_handle = None
                 return None
             self.logger.debug(_p.after.decode())
+            _to = 5
             for _l in _sc:
                 (cmd, out) = _l
+                if 'sleep ' in cmd:
+                    timev = cmd.split(' ')[1]
+                    if timev.isnumeric():
+                        _to = int(timev)
                 self.logger.info('sending: ' + cmd)
                 _p.sendline(cmd)
                 self.logger.info('expecting: ' + out)
@@ -652,8 +657,8 @@ class InteractiveJob(threading.Thread):
             _p.sendline("exit")
             while True:
                 try:
-                    # When -1 (default), use self.timeout
-                    _p.read_nonblocking()
+                    # timeout value is same as sleep time of job
+                    _p.read_nonblocking(timeout=_to)
                 except Exception:
                     break
             if _p.isalive():


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Interactive job in PTL executes only for few seconds, irrespective of job's sleep time


#### Describe Your Change
Remove timeout argument from read_nonblocking function call. Instead a default timeout will be used 


#### Attach Test and Valgrind Logs/Output
Added sleep time of 8 secs in test_interactive_job to show changes
[after_fix.txt](https://github.com/openpbs/openpbs/files/6083424/after_fix.txt)
[before_fix.txt](https://github.com/openpbs/openpbs/files/6083425/before_fix.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
