### PR TITLE
Fix race condition in TestAcctlogRescUsedWithTwoMomHooks

### DIFF
--- a/test/tests/functional/pbs_two_mom_hooks_resources_used.py
+++ b/test/tests/functional/pbs_two_mom_hooks_resources_used.py
@@ -96,15 +96,11 @@ class TestAcctlogRescUsedWithTwoMomHooks(TestFunctional):
         resources_used value to be present in the 'R' record.
         """
 
-        test = []
-        test += ['#PBS -N NodeFailRequeueTest\n']
-        test += ['echo Starting test at `date`\n']
-        test += ['sleep 15\n']
-
+        # Submit job
         select = "vnode=" + self.hostA + "+vnode=" + self.hostB
         j1 = Job(TEST_USER, attrs={
-            'Resource_List.select': select})
-        j1.create_script(body=test)
+             ATTR_N: 'NodeFailRequeueTest',
+             'Resource_List.select': select})
         jid1 = self.server.submit(j1)
 
         # Wait for the job to start running.
@@ -126,15 +122,12 @@ class TestAcctlogRescUsedWithTwoMomHooks(TestFunctional):
         resources_used.
         """
 
-        test = []
-        test += ['#PBS -N JobEndTest\n']
-        test += ['echo Starting test at `date`\n']
-        test += ['sleep 15\n']
-
+        # Submit job
         select = "vnode=" + self.hostA + "+vnode=" + self.hostB
         j1 = Job(TEST_USER, attrs={
-            'Resource_List.select': select})
-        j1.create_script(body=test)
+             ATTR_N: 'JobEndTest',
+             'Resource_List.select': select})
+        j1.set_sleep_time(15)
         jid1 = self.server.submit(j1)
 
         # Wait for the job to start running.

--- a/test/tests/functional/pbs_two_mom_hooks_resources_used.py
+++ b/test/tests/functional/pbs_two_mom_hooks_resources_used.py
@@ -99,7 +99,7 @@ class TestAcctlogRescUsedWithTwoMomHooks(TestFunctional):
         test = []
         test += ['#PBS -N NodeFailRequeueTest\n']
         test += ['echo Starting test at `date`\n']
-        test += ['sleep 5\n']
+        test += ['sleep 15\n']
 
         select = "vnode=" + self.hostA + "+vnode=" + self.hostB
         j1 = Job(TEST_USER, attrs={
@@ -129,7 +129,7 @@ class TestAcctlogRescUsedWithTwoMomHooks(TestFunctional):
         test = []
         test += ['#PBS -N JobEndTest\n']
         test += ['echo Starting test at `date`\n']
-        test += ['sleep 1\n']
+        test += ['sleep 15\n']
 
         select = "vnode=" + self.hostA + "+vnode=" + self.hostB
         j1 = Job(TEST_USER, attrs={


### PR DESCRIPTION
#### Describe Bug or Feature
'test_Rrecord'and 'test_Erecord' of 'TestAcctlogRescUsedWithTwoMomHooks' failed on slow machine  some time with below error 

ptl.lib.ptl_error.PtlExpectError: rc=1, rv=False, msg=expected on server x50-xyz:  no data for job_state = R && substate = 42 job 2.xyz attempt: 180

Reason :- Job is of only sleep 5 sec in test_Rrecord and of sleep 1sec in test_Erecord , so there is race condition  on slow machine where some time there is delay of 5 sec to respond in command , in that case job cross the sleep time by the time job test look for job in R state with substate 42 , job is already went into E state  or finished and fail in PTL expect while 

self.server.expect(JOB, {ATTR_state: 'R'}, jid1)

#### Describe Your Change
To avoid the race condition increase sleep time in job script to 15sec


#### Attach Test and Valgrind Logs/Output

Before fix 

[TestAcctlogRescUsedWithTwoMomHooks_before_fix_1.txt](https://github.com/openpbs/openpbs/files/6083470/TestAcctlogRescUsedWithTwoMomHooks_before_fix_1.txt)


After fix 

[TestAcctlogRescUsedWithTwoMomHooks_after_fix_10.txt](https://github.com/openpbs/openpbs/files/6083471/TestAcctlogRescUsedWithTwoMomHooks_after_fix_10.txt)



