### PR TITLE
[WIP]Removing an additional job_save_db call for subjob's run path

### DIFF
--- a/src/include/job.h
+++ b/src/include/job.h
@@ -1012,7 +1012,7 @@ extern int   site_allow_u(char *user, char *host);
 extern void  svr_dequejob(job *);
 extern int   svr_enquejob(job *, char *);
 extern void  svr_evaljobstate(job *, char *, int *, int);
-extern int   svr_setjobstate(job *, char, int);
+extern int   svr_setjobstate(job *, char, int, bool);
 extern int   state_char2int(char);
 extern char	 state_int2char(int);
 extern int   uniq_nameANDfile(char*, char*, char*);

--- a/src/server/array_func.c
+++ b/src/server/array_func.c
@@ -754,7 +754,7 @@ create_subjob(job *parent, char *newjid, int *rc)
 	subj->ji_qs.ji_svrflags &= ~JOB_SVFLG_ArrayJob;
 	subj->ji_qs.ji_svrflags |=  JOB_SVFLG_SubJob;
 	set_job_substate(subj, JOB_SUBSTATE_TRANSICM);
-	svr_setjobstate(subj, JOB_STATE_LTR_QUEUED, JOB_SUBSTATE_QUEUED);
+	svr_setjobstate(subj, JOB_STATE_LTR_QUEUED, JOB_SUBSTATE_QUEUED, true);
 
 	/* subjob needs to borrow eligible time from parent job array.
 	 * expecting only to accrue eligible_time and nothing else.

--- a/src/server/hook_func.c
+++ b/src/server/hook_func.c
@@ -2576,7 +2576,7 @@ set_exec_time(job *pjob, char *new_exec_time_str, char *msg,
 
 		snprintf(msg, msg_len, "'%s' hook set job's %s = %s", hook_name, ATTR_a, exec_time_ctime);
 		svr_evaljobstate(pjob, &newstate, &newsub, 0);
-		svr_setjobstate(pjob, newstate, newsub);
+		svr_setjobstate(pjob, newstate, newsub, true);
 
 		fp_debug_out = pbs_python_get_hook_debug_output_fp();
 		if (fp_debug_out != NULL) {
@@ -2677,7 +2677,7 @@ set_hold_types(job *pjob, char *new_hold_types_str,
 		FILE	*fp_debug_out = NULL;
 		/* indicate attributes changed */
 		svr_evaljobstate(pjob, &newstate, &newsub, 0);
-		svr_setjobstate(pjob, newstate, newsub);
+		svr_setjobstate(pjob, newstate, newsub, true);
 
 		fp_debug_out = pbs_python_get_hook_debug_output_fp();
 		if (fp_debug_out != NULL) {
@@ -3267,7 +3267,7 @@ attribute_jobmap_restore(job *pjob, struct attribute_jobmap *a_map)
 	}
 
 	svr_evaljobstate(pjob, &newstate, &newsub, 0);
-	svr_setjobstate(pjob, newstate, newsub);
+	svr_setjobstate(pjob, newstate, newsub, true);
 }
 
 /*

--- a/src/server/job_func.c
+++ b/src/server/job_func.c
@@ -232,7 +232,7 @@ job_abt(job *pjob, char *text)
 	}
 
 	if ((old_state == JOB_STATE_LTR_RUNNING) && (old_substate != JOB_SUBSTATE_PROVISION)) {
-		svr_setjobstate(pjob, JOB_STATE_LTR_RUNNING, JOB_SUBSTATE_ABORT);
+		svr_setjobstate(pjob, JOB_STATE_LTR_RUNNING, JOB_SUBSTATE_ABORT, true);
 		rc = issue_signal(pjob, "SIGKILL", release_req, 0);
 		if (rc != 0) {
 			(void)sprintf(log_buffer, msg_abt_err,
@@ -255,21 +255,21 @@ job_abt(job *pjob, char *text)
 			pjob->ji_qs.ji_jobid, old_substate);
 		log_err(-1, __func__, log_buffer);
 	} else if (old_substate == JOB_SUBSTATE_PROVISION) {
-		svr_setjobstate(pjob, JOB_STATE_LTR_RUNNING, JOB_SUBSTATE_ABORT);
+		svr_setjobstate(pjob, JOB_STATE_LTR_RUNNING, JOB_SUBSTATE_ABORT, true);
 		/*
 		 * Check if the history of the finished job can be saved or it needs to be purged .
 		 */
 		svr_saveorpurge_finjobhist(pjob);
 	} else if (old_state == JOB_STATE_LTR_HELD && old_substate == JOB_SUBSTATE_DEPNHOLD &&
 		  (is_jattr_set(pjob, JOB_ATR_depend))) {
-		svr_setjobstate(pjob, JOB_STATE_LTR_HELD, JOB_SUBSTATE_ABORT);
+		svr_setjobstate(pjob, JOB_STATE_LTR_HELD, JOB_SUBSTATE_ABORT, true);
 		depend_on_term(pjob);
 		/*
 		 * Check if the history of the finished job can be saved or it needs to be purged .
 		 */
 		svr_saveorpurge_finjobhist(pjob);
 	} else {
-		svr_setjobstate(pjob, JOB_STATE_LTR_EXITING, JOB_SUBSTATE_ABORT);
+		svr_setjobstate(pjob, JOB_STATE_LTR_EXITING, JOB_SUBSTATE_ABORT, true);
 		if ((pjob->ji_qs.ji_svrflags & JOB_SVFLG_HERE) == 0) {
 			/* notify creator that job is exited */
 			issue_track(pjob);

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -2132,7 +2132,7 @@ stat_update(int stream)
 					complete_running(pjob);
 					/* this causes a save of the job */
 					svr_setjobstate(pjob, JOB_STATE_LTR_RUNNING,
-						JOB_SUBSTATE_RUNNING);
+						JOB_SUBSTATE_RUNNING, true);
 					/*
 					 * If JOB_DEPEND_TYPE_BEFORESTART dependency is set for the current job
 					 * then release the after dependency for its childs as the current job

--- a/src/server/pbsd_init.c
+++ b/src/server/pbsd_init.c
@@ -1352,7 +1352,7 @@ pbsd_init_job(job *pjob, int type)
 					/* was sending to Mom, requeue for now */
 
 					svr_evaljobstate(pjob, &newstate, &newsubstate, 1);
-					svr_setjobstate(pjob, newstate, newsubstate);
+					svr_setjobstate(pjob, newstate, newsubstate, true);
 				} else {
 					/* requeue as is - rdy to cmt */
 

--- a/src/server/req_delete.c
+++ b/src/server/req_delete.c
@@ -925,7 +925,7 @@ req_deletejob2(struct batch_request *preq, job *pjob)
 		 * deleted from mom as well.
 		 */
 		if ((rc || is_mgr) && forcedel) {
-			svr_setjobstate(pjob, JOB_STATE_LTR_EXITING, JOB_SUBSTATE_EXITED);
+			svr_setjobstate(pjob, JOB_STATE_LTR_EXITING, JOB_SUBSTATE_EXITED, true);
 			if ((pjob->ji_qs.ji_svrflags & JOB_SVFLG_HERE) == 0)
 				issue_track(pjob);
 			log_event(PBSEVENT_JOB, PBS_EVENTCLASS_JOB, LOG_INFO,
@@ -988,7 +988,7 @@ req_deletejob2(struct batch_request *preq, job *pjob)
 
 		/* job has restart file at mom, do end job processing */
 
-		svr_setjobstate(pjob, JOB_STATE_LTR_EXITING, JOB_SUBSTATE_EXITING);
+		svr_setjobstate(pjob, JOB_STATE_LTR_EXITING, JOB_SUBSTATE_EXITING, true);
 		pjob->ji_momhandle = -1; /* force new connection */
 		pjob->ji_mom_prot = PROT_INVALID;
 		set_task(WORK_Immed, 0, on_job_exit, (void *) pjob);
@@ -1508,7 +1508,7 @@ resend:
 		/* Mom running a site supplied Terminate Job script   */
 		/* Put job into special Exiting state and we are done */
 
-		svr_setjobstate(pjob, JOB_STATE_LTR_EXITING, JOB_SUBSTATE_TERM);
+		svr_setjobstate(pjob, JOB_STATE_LTR_EXITING, JOB_SUBSTATE_TERM, true);
 		return;
 	}
 }

--- a/src/server/req_holdjob.c
+++ b/src/server/req_holdjob.c
@@ -243,7 +243,7 @@ req_holdjob(struct batch_request *preq)
 		if (old_hold != hold_val) {
 			/* indicate attributes changed     */
 			svr_evaljobstate(pjob, &newstate, &newsub, 0);
-			svr_setjobstate(pjob, newstate, newsub);
+			svr_setjobstate(pjob, newstate, newsub, true);
 		}
 		/* Reject preemption because job requested -c n */
 		if (pjob->ji_pmt_preq != NULL)
@@ -318,7 +318,7 @@ req_releasejob(struct batch_request *preq)
 			post_attr_set(etime);
 #endif /* localmod 105 */
 		svr_evaljobstate(pjob, &newstate, &newsub, 0);
-		svr_setjobstate(pjob, newstate, newsub); /* saves job */
+		svr_setjobstate(pjob, newstate, newsub, true); /* saves job */
 
 	}
 
@@ -342,7 +342,7 @@ req_releasejob(struct batch_request *preq)
 					post_attr_set(etime);
 #endif /* localmod 105 */
 					svr_evaljobstate(psubjob, &newstate, &newsub, 0);
-					svr_setjobstate(psubjob, newstate, newsub); /* saves job */
+					svr_setjobstate(psubjob, newstate, newsub, true); /* saves job */
 				}
 				if (get_jattr_long(psubjob, JOB_ATR_hold) == HOLD_n)
 					free_jattr(psubjob, JOB_ATR_Comment);

--- a/src/server/req_jobobit.c
+++ b/src/server/req_jobobit.c
@@ -400,7 +400,7 @@ on_job_exit(struct work_task *ptask)
 			end_job(pjob, 1);
 			return;
 		} else if (rc > 0 && !hs)
-			svr_setjobstate(pjob, JOB_STATE_LTR_EXITING, JOB_SUBSTATE_EXITED);
+			svr_setjobstate(pjob, JOB_STATE_LTR_EXITING, JOB_SUBSTATE_EXITED, true);
 	}
 
 	if (is_jattr_set(pjob, JOB_ATR_relnodes_on_stageout) &&
@@ -425,7 +425,7 @@ on_job_exit(struct work_task *ptask)
 		case JOB_SUBSTATE_ABORT:
 
 
-			svr_setjobstate(pjob, JOB_STATE_LTR_EXITING, JOB_SUBSTATE_STAGEOUT);
+			svr_setjobstate(pjob, JOB_STATE_LTR_EXITING, JOB_SUBSTATE_STAGEOUT, true);
 			ptask->wt_type = WORK_Immed;
 
 			/* Initialize retryok */
@@ -471,7 +471,7 @@ on_job_exit(struct work_task *ptask)
 					}
 
 				} else {		/* no files to copy, any to delete? */
-					svr_setjobstate(pjob, JOB_STATE_LTR_EXITING, JOB_SUBSTATE_STAGEDEL);
+					svr_setjobstate(pjob, JOB_STATE_LTR_EXITING, JOB_SUBSTATE_STAGEDEL, true);
 					ptask = set_task(WORK_Immed, 0, on_job_exit, pjob);
 					append_link(&pjob->ji_svrtask, &ptask->wt_linkobj, ptask);
 					return;
@@ -517,7 +517,7 @@ on_job_exit(struct work_task *ptask)
 
 			free_br(preq);
 			preq = NULL;
-			svr_setjobstate(pjob, JOB_STATE_LTR_EXITING, JOB_SUBSTATE_STAGEDEL);
+			svr_setjobstate(pjob, JOB_STATE_LTR_EXITING, JOB_SUBSTATE_STAGEDEL, true);
 			ptask->wt_type = WORK_Immed;
 
 			/* NO BREAK - FALL INTO THE NEXT CASE */
@@ -559,7 +559,7 @@ on_job_exit(struct work_task *ptask)
 					}
 
 				} else {		/* preq == 0, no files to delete   */
-					svr_setjobstate(pjob, JOB_STATE_LTR_EXITING, JOB_SUBSTATE_EXITED);
+					svr_setjobstate(pjob, JOB_STATE_LTR_EXITING, JOB_SUBSTATE_EXITED, true);
 					ptask = set_task(WORK_Immed, 0, on_job_exit, pjob);
 					append_link(&pjob->ji_svrtask, &ptask->wt_linkobj, ptask);
 					return;
@@ -607,7 +607,7 @@ on_job_exit(struct work_task *ptask)
 			}
 			free_br(preq);
 			preq = NULL;
-			svr_setjobstate(pjob, JOB_STATE_LTR_EXITING, JOB_SUBSTATE_EXITED);
+			svr_setjobstate(pjob, JOB_STATE_LTR_EXITING, JOB_SUBSTATE_EXITED, true);
 
 			ptask->wt_type = WORK_Immed;
 
@@ -826,7 +826,7 @@ on_job_rerun(struct work_task *ptask)
 
 					/* files don`t need to be moved, go to next step */
 
-					svr_setjobstate(pjob, JOB_STATE_LTR_EXITING, JOB_SUBSTATE_RERUN1);
+					svr_setjobstate(pjob, JOB_STATE_LTR_EXITING, JOB_SUBSTATE_RERUN1, true);
 					ptask = set_task(WORK_Immed, 0, on_job_rerun, pjob);
 					append_link(&pjob->ji_svrtask, &ptask->wt_linkobj, ptask);
 					return;
@@ -877,7 +877,7 @@ on_job_rerun(struct work_task *ptask)
 				}
 				on_exitrerun_msg(pjob, msg_obitnocpy);
 			}
-			svr_setjobstate(pjob, JOB_STATE_LTR_EXITING, JOB_SUBSTATE_RERUN1);
+			svr_setjobstate(pjob, JOB_STATE_LTR_EXITING, JOB_SUBSTATE_RERUN1, true);
 			ptask->wt_type = WORK_Immed;
 			free_br(preq);
 			preq = NULL;
@@ -912,7 +912,7 @@ on_job_rerun(struct work_task *ptask)
 					/* we will "fall" into the post reply side */
 
 				} else {		/* no files to copy, any to delete? */
-					svr_setjobstate(pjob, JOB_STATE_LTR_EXITING, JOB_SUBSTATE_RERUN2);
+					svr_setjobstate(pjob, JOB_STATE_LTR_EXITING, JOB_SUBSTATE_RERUN2, true);
 					ptask = set_task(WORK_Immed, 0, on_job_rerun, pjob);
 					append_link(&pjob->ji_svrtask, &ptask->wt_linkobj, ptask);
 					return;
@@ -952,7 +952,7 @@ on_job_rerun(struct work_task *ptask)
 
 			free_br(preq);
 			preq = NULL;
-			svr_setjobstate(pjob, JOB_STATE_LTR_EXITING, JOB_SUBSTATE_RERUN2);
+			svr_setjobstate(pjob, JOB_STATE_LTR_EXITING, JOB_SUBSTATE_RERUN2, true);
 			ptask->wt_type = WORK_Immed;
 
 			/* NO BREAK - FALL INTO THE NEXT CASE */
@@ -980,7 +980,7 @@ on_job_rerun(struct work_task *ptask)
 						/* we will "fall" into the post reply side */
 					}
 				} else {
-					svr_setjobstate(pjob, JOB_STATE_LTR_EXITING, JOB_SUBSTATE_RERUN3);
+					svr_setjobstate(pjob, JOB_STATE_LTR_EXITING, JOB_SUBSTATE_RERUN3, true);
 					ptask = set_task(WORK_Immed, 0, on_job_rerun, pjob);
 					append_link(&pjob->ji_svrtask, &ptask->wt_linkobj, ptask);
 					return;
@@ -1002,7 +1002,7 @@ on_job_rerun(struct work_task *ptask)
 			}
 			free_br(preq);
 			preq = NULL;
-			svr_setjobstate(pjob, JOB_STATE_LTR_EXITING, JOB_SUBSTATE_RERUN3);
+			svr_setjobstate(pjob, JOB_STATE_LTR_EXITING, JOB_SUBSTATE_RERUN3, true);
 			ptask->wt_type = WORK_Immed;
 
 			/* NO BREAK, FALL THROUGH TO NEXT CASE */
@@ -1115,7 +1115,7 @@ on_job_rerun(struct work_task *ptask)
 
 				pjob->ji_qs.ji_svrflags &= ~JOB_SVFLG_StagedIn;
 				svr_evaljobstate(pjob, &newstate, &newsubst, 0);
-				svr_setjobstate(pjob, newstate, newsubst);
+				svr_setjobstate(pjob, newstate, newsubst, true);
 			}
 	}
 }
@@ -1594,7 +1594,7 @@ job_obit(ruu *pruu, int stream)
 
 				set_job_substate(pjob, JOB_SUBSTATE_HELD);
 				svr_evaljobstate(pjob, &newstate, &newsubst, 0);
-				svr_setjobstate(pjob, newstate, newsubst);
+				svr_setjobstate(pjob, newstate, newsubst, true);
 
 				msg = pruu->ru_comment ? pruu->ru_comment : "";
 				mailmsg = (char *) malloc(strlen(msg) + 1 + strlen(msg_bad_password) + 1);
@@ -1659,7 +1659,7 @@ RetryJob:
 				pjob->ji_qs.ji_svrflags |= JOB_SVFLG_HASRUN | JOB_SVFLG_CHKPT;
 
 				svr_evaljobstate(pjob, &newstate, &newsubst, 1);
-				svr_setjobstate(pjob, newstate, newsubst);
+				svr_setjobstate(pjob, newstate, newsubst, true);
 				if (pjob->ji_mom_prot == PROT_TCP)
 					svr_disconnect(pjob->ji_momhandle);
 
@@ -1702,7 +1702,7 @@ RetryJob:
 				set_jattr_str_slim(pjob, JOB_ATR_Comment,
 						"job held due to possible security breach of job tmpdir, failed to start", NULL);
 				rel_resc(pjob);
-				svr_setjobstate(pjob, JOB_STATE_LTR_HELD, JOB_SUBSTATE_HELD);
+				svr_setjobstate(pjob, JOB_STATE_LTR_HELD, JOB_SUBSTATE_HELD, true);
 				free(mailbuf);
 				free(acctbuf);
 				return 0;
@@ -1751,7 +1751,7 @@ RetryJob:
 		(!check_job_substate(pjob, JOB_SUBSTATE_RERUN) && !check_job_substate(pjob, JOB_SUBSTATE_RERUN2))) {
 		DBPRT(("%s: Job %s is terminating and not rerun.\n", __func__, pjob->ji_qs.ji_jobid))
 
-		svr_setjobstate(pjob, JOB_STATE_LTR_EXITING, JOB_SUBSTATE_EXITING);
+		svr_setjobstate(pjob, JOB_STATE_LTR_EXITING, JOB_SUBSTATE_EXITING, true);
 		if (alreadymailed == 0 && mailbuf != NULL)
 			svr_mailowner(pjob, MAIL_END, MAIL_NORMAL, mailbuf);
 	}
@@ -1777,7 +1777,7 @@ RetryJob:
 			pjob->ji_qs.ji_svrflags |= JOB_SVFLG_HASRUN;
 			pjob->ji_qs.ji_svrflags &= ~JOB_SVFLG_HASHOLD;
 			svr_evaljobstate(pjob, &newstate, &newsubst, 1);
-			svr_setjobstate(pjob, newstate, newsubst);
+			svr_setjobstate(pjob, newstate, newsubst, true);
 			if (pjob->ji_mom_prot == PROT_TCP)
 				svr_disconnect(pjob->ji_momhandle);
 			pjob->ji_momhandle = -1;
@@ -1801,7 +1801,7 @@ RetryJob:
 		if ((pjob->ji_qs.ji_svrflags & (JOB_SVFLG_CHKPT | JOB_SVFLG_ChkptMig)) == 0)
 			free_jattr(pjob, JOB_ATR_resc_used);
 
-		svr_setjobstate(pjob, JOB_STATE_LTR_EXITING, get_job_substate(pjob));
+		svr_setjobstate(pjob, JOB_STATE_LTR_EXITING, get_job_substate(pjob), true);
 		ptask = set_task(WORK_Immed, 0, on_job_rerun, (void *) pjob);
 		append_link(&pjob->ji_svrtask, &ptask->wt_linkobj, ptask);
 

--- a/src/server/req_modify.c
+++ b/src/server/req_modify.c
@@ -375,7 +375,7 @@ req_modifyjob(struct batch_request *preq)
 	/* if job is not running, may need to change its state */
 	if (!check_job_state(pjob, JOB_STATE_LTR_RUNNING)) {
 		svr_evaljobstate(pjob, &newstate, &newsubstate, 0);
-		svr_setjobstate(pjob, newstate, newsubstate);
+		svr_setjobstate(pjob, newstate, newsubstate, true);
 	}
 
 	job_save_db(pjob); /* we must save the updates anyway, if any */
@@ -670,7 +670,7 @@ modify_job_attr(job *pjob, svrattrl *plist, int perm, int *bad)
 	}
 
 	if (newstate != -1 && newsubstate != -1) {
-		svr_setjobstate(pjob, newstate, newsubstate);
+		svr_setjobstate(pjob, newstate, newsubstate, true);
 	}
 
 	if (newaccruetype != -1)

--- a/src/server/req_movejob.c
+++ b/src/server/req_movejob.c
@@ -179,7 +179,7 @@ req_movejob(struct batch_request *req)
 				int newsub;
 				/* force re-eval of job state out of Transit */
 				svr_evaljobstate(jobp, &newstate, &newsub, 1);
-				svr_setjobstate(jobp, newstate, newsub);
+				svr_setjobstate(jobp, newstate, newsub, true);
 			}
 			if (jobp && jobp->ji_clterrmsg)
 				reply_text(req, pbs_errno, jobp->ji_clterrmsg);

--- a/src/server/req_preemptjob.c
+++ b/src/server/req_preemptjob.c
@@ -248,7 +248,7 @@ static void clear_preempt_hold(job *pjob)
 
 	if (old_hold != get_jattr_long(pjob, JOB_ATR_hold)) {
 		svr_evaljobstate(pjob, &newstate, &newsub, 0);
-		svr_setjobstate(pjob, newstate, newsub); /* saves job */
+		svr_setjobstate(pjob, newstate, newsub, true); /* saves job */
 	}
 	if (get_jattr_long(pjob, JOB_ATR_hold) == 0)
 		free_jattr(pjob, JOB_ATR_Comment);

--- a/src/server/req_quejob.c
+++ b/src/server/req_quejob.c
@@ -1823,7 +1823,7 @@ req_commit_now(struct batch_request *preq,  job *pj)
 	delete_link(&pj->ji_alljobs);
 
 	svr_evaljobstate(pj, &newstate, &newsub, 1);
-	svr_setjobstate(pj, newstate, newsub);
+	svr_setjobstate(pj, newstate, newsub, true);
 
 	gettimeofday(&tval, NULL);
 	time_msec = (tval.tv_sec * 1000L) + (tval.tv_usec/1000L);

--- a/src/server/req_register.c
+++ b/src/server/req_register.c
@@ -753,7 +753,7 @@ depend_on_que(attribute *pattr, void *pobj, int mode)
 						 check_job_substate(djob, JOB_SUBSTATE_DEPNHOLD))) {
 						/* If the dependent job is running or has system hold, then put this job on hold too*/
 						set_jattr_b_slim(pjob, JOB_ATR_hold, HOLD_s, INCR);
-						svr_setjobstate(pjob, JOB_STATE_LTR_HELD, JOB_SUBSTATE_DEPNHOLD);
+						svr_setjobstate(pjob, JOB_STATE_LTR_HELD, JOB_SUBSTATE_DEPNHOLD, true);
 					}
 				}
 				rc = send_depend_req(pjob, pparent, type,
@@ -967,7 +967,7 @@ int depend_runone_hold_all(job *pjob)
 			d_pjob = find_job(pdj->dc_child);
 			if (d_pjob) {
 				set_jattr_b_slim(d_pjob, JOB_ATR_hold, HOLD_s, INCR);
-				svr_setjobstate(d_pjob, JOB_STATE_LTR_HELD, JOB_SUBSTATE_HELD);
+				svr_setjobstate(d_pjob, JOB_STATE_LTR_HELD, JOB_SUBSTATE_HELD, true);
 			}
 		}
 	}
@@ -1006,7 +1006,7 @@ int depend_runone_release_all(job *pjob)
 			if (d_pjob) {
 				set_jattr_b_slim(d_pjob, JOB_ATR_hold, HOLD_s, DECR);
 				svr_evaljobstate(d_pjob, &newstate, &newsub, 0);
-				svr_setjobstate(d_pjob, newstate, newsub); /* saves job */
+				svr_setjobstate(d_pjob, newstate, newsub, true); /* saves job */
 			}
 		}
 	}
@@ -1157,14 +1157,14 @@ set_depend_hold(job *pjob, attribute *pattr)
 			(check_job_substate(pjob, JOB_SUBSTATE_DEPNHOLD))) {
 			set_jattr_b_slim(pjob, JOB_ATR_hold, HOLD_s, DECR);
 			svr_evaljobstate(pjob, &newstate, &newsubst, 0);
-			svr_setjobstate(pjob, newstate, newsubst);
+			svr_setjobstate(pjob, newstate, newsubst, true);
 		}
 	} else {
 
 		/* there are dependencies, set system hold accordingly */
 
 		set_jattr_b_slim(pjob, JOB_ATR_hold, HOLD_s, INCR);
-		svr_setjobstate(pjob, JOB_STATE_LTR_HELD, substate);
+		svr_setjobstate(pjob, JOB_STATE_LTR_HELD, substate, true);
 	}
 	return;
 }

--- a/src/server/req_rerun.c
+++ b/src/server/req_rerun.c
@@ -184,7 +184,7 @@ force_reque(job *pjob)
 	free_jattr(pjob, JOB_ATR_jobdir);
 	unset_extra_attributes(pjob);
 	svr_evaljobstate(pjob, &newstate, &newsubstate, 1);
-	svr_setjobstate(pjob, newstate, newsubstate);
+	svr_setjobstate(pjob, newstate, newsubstate, true);
 }
 
 /**
@@ -462,7 +462,7 @@ req_rerunjob2(struct batch_request *preq, job *pjob)
 	pjob->ji_qs.ji_svrflags = (pjob->ji_qs.ji_svrflags &
 		~(JOB_SVFLG_CHKPT | JOB_SVFLG_ChkptMig)) |
 	JOB_SVFLG_HASRUN;
-	svr_setjobstate(pjob, JOB_STATE_LTR_RUNNING, JOB_SUBSTATE_RERUN);
+	svr_setjobstate(pjob, JOB_STATE_LTR_RUNNING, JOB_SUBSTATE_RERUN, true);
 
 	sprintf(log_buffer, msg_manager, msg_jobrerun,
 		preq->rq_user, preq->rq_host);

--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -772,7 +772,6 @@ req_runjob2(struct batch_request *preq, job *pjob)
 		reply_ack(preq);
 		if (save_subjob(pjob)) {
 			free_nodes(pjob);
-			req_reject(PBSE_SAVE_ERR, 0, preq);
 			return;
 		}
 	}

--- a/src/server/req_shutdown.c
+++ b/src/server/req_shutdown.c
@@ -339,7 +339,7 @@ shutdown_preempt_chkpt(job *pjob)
 	if (relay_to_mom(pjob, phold, func) == 0) {
 
 		if (check_job_state(pjob, JOB_STATE_LTR_TRANSIT))
-			svr_setjobstate(pjob, JOB_STATE_LTR_RUNNING, JOB_SUBSTATE_RUNNING);
+			svr_setjobstate(pjob, JOB_STATE_LTR_RUNNING, JOB_SUBSTATE_RUNNING, true);
 		pjob->ji_qs.ji_svrflags |= (JOB_SVFLG_HASRUN | JOB_SVFLG_CHKPT | JOB_SVFLG_HASHOLD);
 		(void)job_save_db(pjob);
 		return (0);

--- a/src/server/req_signal.c
+++ b/src/server/req_signal.c
@@ -324,7 +324,7 @@ req_signaljob2(struct batch_request *preq, job *pjob)
 				} else {
 					/* not from scheduler, change substate so the  */
 					/* scheduler will resume the job when possible */
-					svr_setjobstate(pjob, JOB_STATE_LTR_RUNNING, JOB_SUBSTATE_SCHSUSP);
+					svr_setjobstate(pjob, JOB_STATE_LTR_RUNNING, JOB_SUBSTATE_SCHSUSP, true);
 					if (find_assoc_sched_jid(pjob->ji_qs.ji_jobid, &psched))
 						set_scheduler_flag(SCH_SCHEDULE_NEW, psched);
 					else {
@@ -462,7 +462,7 @@ post_signal_req(struct work_task *pwt)
 				}
 				pjob->ji_qs.ji_svrflags |= JOB_SVFLG_Suspend;
 				/* update all released resources */
-				svr_setjobstate(pjob, JOB_STATE_LTR_RUNNING, ss);
+				svr_setjobstate(pjob, JOB_STATE_LTR_RUNNING, ss, true);
 				rel_resc(pjob); /* release resc and nodes */
 				job_save(pjob); /* save released resc and nodes */
 				log_suspend_resume_record(pjob, PBS_ACCT_SUSPEND);
@@ -486,7 +486,7 @@ post_signal_req(struct work_task *pwt)
 			free_jattr(pjob, JOB_ATR_resc_released_list);
 			mark_jattr_not_set(pjob, JOB_ATR_resc_released_list);
 
-			svr_setjobstate(pjob, JOB_STATE_LTR_RUNNING, JOB_SUBSTATE_RUNNING);
+			svr_setjobstate(pjob, JOB_STATE_LTR_RUNNING, JOB_SUBSTATE_RUNNING, true);
 			log_suspend_resume_record(pjob, PBS_ACCT_RESUME);
 
 			set_jattr_generic(pjob, JOB_ATR_Comment,

--- a/src/server/svr_func.c
+++ b/src/server/svr_func.c
@@ -4948,7 +4948,7 @@ fail_vnode_job(struct prov_vnode_info * prov_vnode_info, int hold_or_que)
 		clear_exec_on_run_fail(pjob);
 		set_jattr_b_slim(pjob, JOB_ATR_hold, HOLD_s, INCR);
 		set_jattr_str_slim(pjob, JOB_ATR_Comment, "job held, provisioning failed to start", NULL);
-		svr_setjobstate(pjob, JOB_STATE_LTR_HELD, JOB_SUBSTATE_HELD);
+		svr_setjobstate(pjob, JOB_STATE_LTR_HELD, JOB_SUBSTATE_HELD, true);
 	} else if (hold_or_que == 1) {
 		/* don't purge job, instead requeue */
 		(void)force_reque(pjob);

--- a/src/server/svr_movejob.c
+++ b/src/server/svr_movejob.c
@@ -343,7 +343,7 @@ post_routejob(struct work_task *pwt)
 				/* Job Delete in progress, just set to queued status */
 
 				svr_setjobstate(jobp, JOB_STATE_LTR_QUEUED,
-					JOB_SUBSTATE_ABORT);
+					JOB_SUBSTATE_ABORT, true);
 				return;
 			}
 			add_dest(jobp);		/* else mark destination as bad */
@@ -351,7 +351,7 @@ post_routejob(struct work_task *pwt)
 		default :	/* try routing again */
 			/* force re-eval of job state out of Transit */
 			svr_evaljobstate(jobp, &newstate, &newsub, 1);
-			svr_setjobstate(jobp, newstate, newsub);
+			svr_setjobstate(jobp, newstate, newsub, true);
 			jobp->ji_retryok = 1;
 			if ((r = job_route(jobp)) == PBSE_ROUTEREJ)
 				(void)job_abt(jobp, msg_routebad);
@@ -490,7 +490,7 @@ post_movejob(struct work_task *pwt)
 		if (jobp) {
 			/* force re-eval of job state out of Transit */
 			svr_evaljobstate(jobp, &newstate, &newsub, 1);
-			svr_setjobstate(jobp, newstate, newsub);
+			svr_setjobstate(jobp, newstate, newsub, true);
 		}
 		if (move_type == MOVE_TYPE_Move_Run)
 			r = wstat;
@@ -1101,7 +1101,7 @@ net_move(job *jobp, struct batch_request *req)
 		data      = 0;
 	}
 
-	svr_setjobstate(jobp, JOB_STATE_LTR_TRANSIT, JOB_SUBSTATE_TRNOUT);
+	svr_setjobstate(jobp, JOB_STATE_LTR_TRANSIT, JOB_SUBSTATE_TRNOUT, true);
 	return (send_job(jobp, hostaddr, port, move_type, post_func, data));
 }
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
When running a new subjob, we call job_save_db twice: once from inside req_runjob2->svr_startjob->..->svr_setjobstate, and once inside req_runjob2:
![before](https://user-images.githubusercontent.com/4574875/110030738-16281980-7d04-11eb-85a6-f3e378d920fb.png)

This is redundant, so we'll save some time if we only saved once if possible.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Moved the job_save_db call to after svr_setjobstate(). This causes svr_setjobstate() to skip calling job_save_db as it's a new subjob so that newobj bit is still set. So, we only save the subjob once.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, WIN2K16
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|6471|3990|0|0|0|0|3990|


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
