### PR TITLE
multi-server: init.d/pbs stop kills all servers

### DIFF
--- a/src/cmds/scripts/pbs_init.d.in
+++ b/src/cmds/scripts/pbs_init.d.in
@@ -450,7 +450,7 @@ stop_pbs() {
 					echo "pbs_server evaluating ${PBS_HOME}/server_priv/qmgr_shutdown"
 					${PBS_EXEC}/bin/qmgr <"${PBS_HOME}/server_priv/qmgr_shutdown"
 				fi
-				env -u PBS_SERVER_INSTANCES ${PBS_EXEC}/bin/qterm -t quick
+				PBS_SERVER_INSTANCES= ${PBS_EXEC}/bin/qterm -t quick
 				echo "PBS server - was pid: ${pbs_server_pid}"
 			elif [ ${is_secondary} -eq 1 ]; then
 				echo "This is secondary server, killing process."

--- a/src/lib/Libifl/pbs_loadconf.c
+++ b/src/lib/Libifl/pbs_loadconf.c
@@ -280,7 +280,7 @@ parse_psi(char *conf_value)
 	free(pbs_conf.psi);
 	free(pbs_conf.psi_str);
 
-	if (conf_value == NULL) {
+	if (conf_value == NULL || conf_value[0] == '\0') {
 		char *dfltsvr = pbs_default();
 		if (dfltsvr == NULL)
 			return -1;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
the pbs init script kills all servers with the 'stop' command. This is undesirable and inconsistent with init.d pbs start which only starts one server. We don't want the pbs script to start/stop all servers as multi-server can require special setup that's outside the scope of init.d pbs script, e.g - each server can be on a different host, with/without a HA setup, etc.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
I wasn't sure if we want to restrict qterm to be able to kill all servers, so for now just making init.d pbs script pass an empty PBS_SERVER_INSTANCES to qterm so that it only kills the default server

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Before:
```
[root@pbspro ravi]# ps -ef | grep pbs_server
root     13903     1  0 16:34 ?        00:00:00 /opt/pbs/sbin/pbs_server.bin
root     14420     1  0 16:40 ?        00:00:00 /opt/pbs/sbin/pbs_server.bin
root     14427 14244  0 16:40 pts/0    00:00:00 grep --color=auto pbs_server
[root@pbspro ravi]# /etc/init.d/pbs stop
Stopping PBS
...
[root@pbspro ravi]# ps -ef | grep pbs_server
root     14601 14244  0 16:40 pts/0    00:00:00 grep --color=auto pbs_server
[root@pbspro ravi]#
```

After:
```
[ravi@pbspro ~]$ ps -ef | grep pbs_server
root     89762     1  0 21:35 ?        00:00:00 /opt/pbs/sbin/pbs_server.bin
root     90089     1  0 21:38 ?        00:00:00 /opt/pbs/sbin/pbs_server.bin
ravi     90096    25  0 21:38 pts/0    00:00:00 grep --color=auto pbs_server
[ravi@pbspro ~]$ sudo /etc/init.d/pbs stop
Stopping PBS
...
[ravi@pbspro ~]$ ps -ef | grep pbs_server
root     90089     1  0 21:38 ?        00:00:00 /opt/pbs/sbin/pbs_server.bin
ravi     90403    25  0 21:38 pts/0    00:00:00 grep --color=auto pbs_server
[ravi@pbspro ~]$ 
```


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
