### PR TITLE
Set default shift to 0 in to_size

### DIFF
--- a/src/lib/Libattr/attr_fn_size.c
+++ b/src/lib/Libattr/attr_fn_size.c
@@ -370,6 +370,7 @@ to_size(char *val, struct size_value *psize)
 
 	psize->atsv_units = ATR_SV_BYTESZ;
 	psize->atsv_num = strTouL(val, &pc, 10);
+	psize->atsv_shift = 0;
 	if (pc == val)		/* no numeric part */
 		return (PBSE_BADATVAL);
 


### PR DESCRIPTION
#### Describe Bug or Feature
The size_value struct's atsv_shift member was not being set when using `to_size()`

#### Describe Your Change
Set it to 0 at the beginning.


#### Link to Design Doc
N/A


#### Attach Test and Valgrind Logs/Output
No automated tests, but I can show some code/valgrind output

```
    attribute attr;
    attr.at_flags = ATR_VFLAG_SET;
    attr.at_type = ATR_TYPE_SIZE;

    to_size(value, &attr.at_val.at_size);

(gdb) p value
$2 = 0x164bb02 "100000b"

(gdb) p attr.at_val.at_size 
$3 = {atsv_num = 100000, atsv_shift = 12, atsv_units = 0}
```


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
