### PR TITLE
test_invoke_pbs_tmrsh_from_sister_mom fails with empty output file

### DIFF
--- a/test/tests/functional/pbs_job_task.py
+++ b/test/tests/functional/pbs_job_task.py
@@ -117,15 +117,17 @@ class TestJobTask(TestFunctional):
         mom1 = self.moms.keys()[0]
         mom2 = self.moms.keys()[1]
         mom3 = self.moms.keys()[2]
+        fqdn_mom2 = socket.getfqdn(mom2)
+        fqdn_mom3 = socket.getfqdn(mom3)
         pbstmrsh_cmd = os.path.join(self.server.pbs_conf['PBS_EXEC'],
                                     'bin', 'pbs_tmrsh')
 
         script_mom2 = """#!/bin/bash\n%s %s hostname""" % \
-                      (pbstmrsh_cmd, mom3)
+                      (pbstmrsh_cmd, fqdn_mom3)
         fn = self.du.create_temp_file(hostname=mom2, body=script_mom2)
         self.du.chmod(hostname=mom2, path=fn, mode=0o755)
         a = {ATTR_S: '/bin/bash'}
-        script = ['%s %s %s' % (pbstmrsh_cmd, mom2, fn)]
+        script = ['%s %s %s' % (pbstmrsh_cmd, fqdn_mom2, fn)]
         job = Job(TEST_USER, attrs=a)
         job.set_attributes({'Resource_List.select': '3:ncpus=1',
                             'Resource_List.place': 'scatter'})


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
TestJobTask.test_invoke_pbs_tmrsh_from_sister_mom is failing ,generating error file and empty output file.

test is failing with below error:

Traceback (most recent call last):
  File "/home/pbsroot/TEST/tmp/tests/functional/pbs_job_task.py", line 142, in test_invoke_pbs_tmrsh_from_sister_mom
    self.assertEqual(ret['out'][0], mom3, "pbs_tmrsh invoked from sister"
IndexError: list index out of range

error file has below content:
[pbsroot@x05-c8p1 functional]$ *sudo -H -u pbsuser /opt/tools/wrappers/cat /home/pbsuser/PtlPbsJobScriptpwnfznj5.e2
/opt/pbs/bin/pbs_tmrsh: host "x02-s15" is not a node in job <2.x05-c8p1>*

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
The test scripts need to use FQDNs.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Logs for failed run:
[logfile_ERROR.txt](https://github.com/openpbs/openpbs/files/6116025/logfile_ERROR.txt)

Logs for pass run:
[test_invoke_pbs_tmrsh_from_sister_mom_pass.txt](https://github.com/openpbs/openpbs/files/6116026/test_invoke_pbs_tmrsh_from_sister_mom_pass.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
