### PR TITLE
Changed PTL to use pbs_sleep instead of /bin/sleep

### DIFF
--- a/test/fw/ptl/lib/ptl_mom.py
+++ b/test/fw/ptl/lib/ptl_mom.py
@@ -165,7 +165,10 @@ class MoM(PBSService):
         # This is true by default, but can be set to False if
         # required by a test
         self.revert_to_default = True
-        self.sleep_cmd = '/bin/sleep'
+        pbs_conf = self.du.parse_pbs_config()
+        self.sleep_cmd = os.path.join(pbs_conf['PBS_EXEC'], 'bin', 'pbs_sleep')
+        if not os.path.isfile(self.sleep_cmd):
+            self.sleep_cmd = '/bin/sleep'
 
     def create_and_format_stagein_path(self, storage_info={}, asuser=None):
         """

--- a/test/fw/ptl/lib/ptl_resourceresv.py
+++ b/test/fw/ptl/lib/ptl_resourceresv.py
@@ -354,7 +354,11 @@ class Job(ResourceResv):
         :param duration: The duration, in seconds, to sleep
         :type duration: int
         """
-        self.set_execargs('/bin/sleep', duration)
+        pbs_conf = DshUtils().parse_pbs_config()
+        exe_path = os.path.join(pbs_conf['PBS_EXEC'], 'bin', 'pbs_sleep')
+        if not os.path.isfile(exe_path):
+            exe_path = '/bin/sleep'
+        self.set_execargs(exe_path, duration)
 
     def set_execargs(self, executable, arguments=None):
         """


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Some of the preemption PTL tests have been failing because ptl framework by default submits a /bin/sleep job. Since sleep process cannot really be suspended, it turns out that in some tests job finishes before it can be resumed back.


#### Describe Your Change
Changed the PTL framework to use pbs_sleep binary for all jobs as much as possible. 


#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, WIN2K16
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|6419|3990|1|0|0|8|3981|

Test that failed is a known failure.
[test_smoke.txt](https://github.com/openpbs/openpbs/files/6119168/test_smoke.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
