### PR TITLE
Fixed test_standing_resv_with_multivnode_job_array to request vscatte…

### DIFF
--- a/test/tests/functional/pbs_reservations.py
+++ b/test/tests/functional/pbs_reservations.py
@@ -2104,7 +2104,7 @@ class TestReservations(TestFunctional):
         end = int(time.time()) + 61
         rid = self.submit_reservation(user=PBSROOT_USER,
                                       select='2:ncpus=2',
-                                      place='scatter',
+                                      place='vscatter',
                                       rrule='FREQ=MINUTELY;COUNT=2',
                                       start=start,
                                       end=end)


### PR DESCRIPTION
…r instead of scatter

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
test test_standing_resv_with_multivnode_job_array was recently modified to request scatter instead of vscatter.  The reservation requests 2 chunks.  All the vnodes are on the same host.  It can't be placed on 2 hosts.

#### Describe Your Change
request vscatter instead of scatter.

#### Attach Test and Valgrind Logs/Output
2021-03-10 16:22:15,222 INFO     ===================================
2021-03-10 16:22:15,223 INFO     Completed TestReservations tearDown
2021-03-10 16:22:15,223 INFO     ===================================
2021-03-10 16:22:15,237 INFO     ok

2021-03-10 16:22:15,238 INFO     ================================================================================
run: 1, succeeded: 1, failed: 0, errors: 0, skipped: 0, timedout: 0
