### PR TITLE
preventing child hang from inherited nslookup lock from parent process

### DIFF
--- a/src/lib/Libtpp/tpp_internal.h
+++ b/src/lib/Libtpp/tpp_internal.h
@@ -508,6 +508,17 @@ int tpp_add_fd(int, int, int);
 int tpp_del_fd(int, int);
 int tpp_mod_fd(int, int, int);
 
+/* a new mutex introduced to prevent inheriting lock from tpp thread
+ * from getaddrinfo(nslookup) during fork for periodic hook
+ * set handlers using pthread_atfork.
+ */
+pthread_mutex_t tpp_nslookup_mutex;
+int tpp_nslookup_mutex_lock();
+int tpp_nslookup_mutex_unlock();
+void tpp_nslookup_atfork_prepare();
+void tpp_nslookup_atfork_parent();
+void tpp_nslookup_atfork_child();
+
 int tpp_validate_hdr(int, char *);
 tpp_addr_t *tpp_get_addresses(char *, int *);
 tpp_addr_t *tpp_get_local_host(int);

--- a/src/lib/Libtpp/tpp_internal.h
+++ b/src/lib/Libtpp/tpp_internal.h
@@ -513,8 +513,6 @@ int tpp_mod_fd(int, int, int);
  * set handlers using pthread_atfork.
  */
 pthread_mutex_t tpp_nslookup_mutex;
-int tpp_nslookup_mutex_lock();
-int tpp_nslookup_mutex_unlock();
 void tpp_nslookup_atfork_prepare();
 void tpp_nslookup_atfork_parent();
 void tpp_nslookup_atfork_child();

--- a/src/lib/Libtpp/tpp_platform.c
+++ b/src/lib/Libtpp/tpp_platform.c
@@ -710,10 +710,15 @@ tpp_sock_resolve_host(char *host, int *count)
 	hints.ai_socktype = SOCK_STREAM;
 	hints.ai_protocol = IPPROTO_TCP;
 
+	tpp_nslookup_mutex_lock();
+
 	if ((rc = getaddrinfo(host, NULL, &hints, &pai)) != 0) {
+		tpp_nslookup_mutex_unlock();
 		tpp_log(LOG_CRIT, NULL, "Error %d resolving %s", rc, host);
 		return NULL;
 	}
+	/* unlock nslook up mutex */
+	tpp_nslookup_mutex_unlock();
 
 	*count = 0;
 	for (aip = pai; aip != NULL; aip = aip->ai_next) {

--- a/src/lib/Libtpp/tpp_platform.c
+++ b/src/lib/Libtpp/tpp_platform.c
@@ -710,8 +710,10 @@ tpp_sock_resolve_host(char *host, int *count)
 	hints.ai_socktype = SOCK_STREAM;
 	hints.ai_protocol = IPPROTO_TCP;
 
-	/* introducing a new mutex to prevent child process from 
-	inheriting getaddrinfo mutex using pthread_atfork handlers*/
+	/* 
+	 * introducing a new mutex to prevent child process from 
+	 * inheriting getaddrinfo mutex using pthread_atfork handlers
+	 */
 	tpp_lock(&tpp_nslookup_mutex);
 
 	if ((rc = getaddrinfo(host, NULL, &hints, &pai)) != 0) {

--- a/src/lib/Libtpp/tpp_platform.c
+++ b/src/lib/Libtpp/tpp_platform.c
@@ -710,15 +710,17 @@ tpp_sock_resolve_host(char *host, int *count)
 	hints.ai_socktype = SOCK_STREAM;
 	hints.ai_protocol = IPPROTO_TCP;
 
-	tpp_nslookup_mutex_lock();
+	/* introducing a new mutex to prevent child process from 
+	inheriting getaddrinfo mutex using pthread_atfork handlers*/
+	tpp_lock(&tpp_nslookup_mutex);
 
 	if ((rc = getaddrinfo(host, NULL, &hints, &pai)) != 0) {
-		tpp_nslookup_mutex_unlock();
+		tpp_unlock(&tpp_nslookup_mutex);
 		tpp_log(LOG_CRIT, NULL, "Error %d resolving %s", rc, host);
 		return NULL;
 	}
 	/* unlock nslook up mutex */
-	tpp_nslookup_mutex_unlock();
+	tpp_unlock(&tpp_nslookup_mutex);
 
 	*count = 0;
 	for (aip = pai; aip != NULL; aip = aip->ai_next) {

--- a/src/lib/Libtpp/tpp_transport.c
+++ b/src/lib/Libtpp/tpp_transport.c
@@ -514,8 +514,8 @@ tpp_transport_init(struct tpp_config *conf)
 #ifndef WIN32
 	/* for unix, set a pthread_atfork handler */
 	if (pthread_atfork(tpp_nslookup_atfork_prepare, tpp_nslookup_atfork_parent, tpp_nslookup_atfork_child) != 0) {
-		fprintf(stderr, "tpp nslookup mutex atfork handler failed\n");
-		exit(1);
+		tpp_log(LOG_CRIT, __func__, "tpp nslookup mutex atfork handler failed");
+		return -1;
 	}
 #endif
 

--- a/src/lib/Libtpp/tpp_transport.c
+++ b/src/lib/Libtpp/tpp_transport.c
@@ -505,6 +505,19 @@ tpp_transport_init(struct tpp_config *conf)
 
 	if (tpp_init_rwlock(&cons_array_lock))
 		return -1;
+	
+	if (pthread_mutex_init(&tpp_nslookup_mutex, NULL) != 0) {
+		tpp_log(LOG_CRIT, __func__, "Failed to initialize nslookup mutex");
+		return -1;
+	}
+	
+#ifndef WIN32
+	/* for unix, set a pthread_atfork handler */
+	if (pthread_atfork(tpp_nslookup_atfork_prepare, tpp_nslookup_atfork_parent, tpp_nslookup_atfork_child) != 0) {
+		fprintf(stderr, "tpp nslookup mutex atfork handler failed\n");
+		exit(1);
+	}
+#endif
 
 	tpp_sock_layer_init();
 

--- a/src/lib/Libtpp/tpp_util.c
+++ b/src/lib/Libtpp/tpp_util.c
@@ -2332,6 +2332,89 @@ tpp_set_logmask(long logmask)
 	tpp_log_event_mask = logmask;
 }
 
+/**
+ * @brief
+ *	Lock the mutex associated with tpp nslookup
+ *
+ * @return Error code
+ * @retval -1 - failure
+ * @retval  0 - success
+ *
+ * @par Side Effects:
+ *	None
+ *
+ * @par MT-safe: Yes
+ *
+ */
+int
+tpp_nslookup_mutex_lock()
+{
+
+	if (pthread_mutex_lock(&tpp_nslookup_mutex) != 0)
+		return -1;
+
+	return 0;
+}
+
+/**
+ * @brief
+ *	Unlock the mutex associated with tpp nslookup
+ *
+ * @return Error code
+ * @retval -1 - failure
+ * @retval  0 - success
+ *
+ * @par Side Effects:
+ *	None
+ *
+ * @par MT-safe: Yes
+ *
+ */
+int
+tpp_nslookup_mutex_unlock()
+{
+
+	if (pthread_mutex_unlock(&tpp_nslookup_mutex) != 0)
+		return -1;
+
+	return 0;
+}
+
+#ifndef WIN32
+
+/**
+ * @brief
+ *	wrapper function for tpp_nslookup_mutex_lock().
+ *
+ */
+void
+tpp_nslookup_atfork_prepare()
+{
+	tpp_nslookup_mutex_lock();
+}
+
+/**
+ * @brief
+ *	wrapper function for tpp_nslookup_mutex_unlock().
+ *
+ */
+void
+tpp_nslookup_atfork_parent()
+{
+	tpp_nslookup_mutex_unlock();
+}
+
+/**
+ * @brief
+ *	wrapper function for tpp_nslookup_mutex_unlock().
+ *
+ */
+void
+tpp_nslookup_atfork_child()
+{
+	tpp_nslookup_mutex_unlock();
+}
+#endif
 
 /**
  * @brief encrypt the pkt  with the authdata provided

--- a/src/lib/Libtpp/tpp_util.c
+++ b/src/lib/Libtpp/tpp_util.c
@@ -2332,53 +2332,6 @@ tpp_set_logmask(long logmask)
 	tpp_log_event_mask = logmask;
 }
 
-/**
- * @brief
- *	Lock the mutex associated with tpp nslookup
- *
- * @return Error code
- * @retval -1 - failure
- * @retval  0 - success
- *
- * @par Side Effects:
- *	None
- *
- * @par MT-safe: Yes
- *
- */
-int
-tpp_nslookup_mutex_lock()
-{
-
-	if (pthread_mutex_lock(&tpp_nslookup_mutex) != 0)
-		return -1;
-
-	return 0;
-}
-
-/**
- * @brief
- *	Unlock the mutex associated with tpp nslookup
- *
- * @return Error code
- * @retval -1 - failure
- * @retval  0 - success
- *
- * @par Side Effects:
- *	None
- *
- * @par MT-safe: Yes
- *
- */
-int
-tpp_nslookup_mutex_unlock()
-{
-
-	if (pthread_mutex_unlock(&tpp_nslookup_mutex) != 0)
-		return -1;
-
-	return 0;
-}
 
 #ifndef WIN32
 
@@ -2390,7 +2343,7 @@ tpp_nslookup_mutex_unlock()
 void
 tpp_nslookup_atfork_prepare()
 {
-	tpp_nslookup_mutex_lock();
+	tpp_lock(&tpp_nslookup_mutex);
 }
 
 /**
@@ -2401,7 +2354,7 @@ tpp_nslookup_atfork_prepare()
 void
 tpp_nslookup_atfork_parent()
 {
-	tpp_nslookup_mutex_unlock();
+	tpp_unlock(&tpp_nslookup_mutex);
 }
 
 /**
@@ -2412,7 +2365,7 @@ tpp_nslookup_atfork_parent()
 void
 tpp_nslookup_atfork_child()
 {
-	tpp_nslookup_mutex_unlock();
+	tpp_unlock(&tpp_nslookup_mutex);
 }
 #endif
 


### PR DESCRIPTION

#### Describe Bug or Feature
The periodic hook which used to make http call(will do getaddrinfo sys call), is getting hung permanently even after alarm(timeout) call. 
One possible reason of this hang could be that when the hook process was forked, tpp thread was in getaddrinfo call. Since this library call takes a lock, it is possible that after fork, child inherited this lock but since child was forked by a non-tpp thread it can never release lock.


#### Describe Your Change
Only solution to this problem is to take mutex lock in tpp thread before calling getaddrinfo() and register pthread_atfork handlers to take/release these locks in pre/post handlers respectively.


#### Attach Test and Valgrind Logs/Output
Id: 6455
Description: Rerun All Tests From #6433(without valgrind)
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression

Test Summary: total: 3990, fail: 1, error: 0, timedout: 0, skip: 0, pass: 3989



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
