### PR TITLE
Fix test_cgroups_abort test while restarting mom

### DIFF
--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -3644,7 +3644,7 @@ event.accept()
         self.moms_list[2].log_match("Event type is execjob_abort",
                                     starttime=now)
 
-        self.moms_list[1].restart()
+        self.moms_list[1].pi.restart()
 
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
         self.server.expect(JOB, 'queue', op=UNSET, id=jid, offset=15)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
In test case test_cgroups_abort of TestCgroupsHook mom is killed with -9 signal and then restarted with self.mom.restart method. 
In self.mom.restart method, it keeps checking for mom.lock file for 180 attempts and then restarts the mom, this will timeouts the test case.

#### Describe Your Change
Replace self.mom.restart with self.mom.pi.restart, this will start the mom if it is not up straight away.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
[test_cgroups_abort_after_fix.txt](https://github.com/openpbs/openpbs/files/6128793/test_cgroups_abort_after_fix.txt)
[test_cgroups_abort_before_fix.txt](https://github.com/openpbs/openpbs/files/6128795/test_cgroups_abort_before_fix.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
