### PR TITLE
Fix test_sched_runas_nonroot_pass of TestDaemonServiceUser

### DIFF
--- a/test/tests/functional/pbs_daemon_service_user.py
+++ b/test/tests/functional/pbs_daemon_service_user.py
@@ -69,6 +69,7 @@ class TestDaemonServiceUser(TestFunctional):
                 self.server.hostname,
                 confs='PBS_DAEMON_SERVICE_USER'
             )
+        self.server.restart()
         pbs_conf = self.du.parse_pbs_config(self.server.shortname)
         if setup_sched:
             sched_logs = os.path.join(pbs_conf['PBS_HOME'], 'sched_logs')


### PR DESCRIPTION
#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
The test is failing as the submitted job never goes into running state. Got error saying:
"expect on server x6069-2354-0: job_state = R && substate = 42 job 0.x6069-2354-0 attempt: 180 got: job_state = Q"

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
After adding "PBS_DAEMON_SERVICE_USER" to pbs.conf, we need to restart the server, which was missing in the tests. Hence added server restart.

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

* Test result before fix:

Description: Tests from given sources on platforms SUSE15, CENTOS8, CENTOS7
Platforms: SUSE15,CENTOS8,CENTOS7
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|6439|1|1|0|0|0|0|


* Test result after fix (Ran whole test suite):

Description: Tests from given sources on platforms SUSE15, CENTOS8, CENTOS7
Platforms: SUSE15,CENTOS8,CENTOS7
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|6473|5|0|0|0|0|5|


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
