### PR TITLE
Fixed issue when prime starts at midnight

### DIFF
--- a/src/scheduler/prime.cpp
+++ b/src/scheduler/prime.cpp
@@ -245,7 +245,8 @@ handle_missing_prime_info(void)
 
 	for (d = SUNDAY; d < HIGH_DAY; d++) {
 		if (conf.prime[d][PRIME].all + conf.prime[d][PRIME].none
-				+ conf.prime[d][PRIME].hour + conf.prime[d][PRIME].min == 0) {
+				+ conf.prime[d][PRIME].hour + conf.prime[d][PRIME].min
+				+ conf.prime[d][NON_PRIME].hour + conf.prime[d][NON_PRIME].min == 0) {
 			conf.prime[d][PRIME].all = TRUE;
 			conf.prime[d][PRIME].none = FALSE;
 			conf.prime[d][PRIME].hour = static_cast<unsigned int>(UNSPECIFIED);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
If primetime starts right at midnight, the scheduler will think it is primetime all day

#### Describe Your Change
There is a function that detects if there is a missing day in the scheduler's holidays file.  The prime structure is zeroed by default.  The function works by checking if primeime is zero, but not non-prime.

I check if prime is 0 and non-prime is 0 before considering the day all primetime.

#### Attach Test and Valgrind Logs/Output
This is a pretty esoteric side case.  It really isn't worthwhile to write a test just for this issue.  Any existing test case which runs where primetime starts at midnight will previously fail and now will pass.

Manual Testing:
% sudo grep weekday /var/spool/pbs/sched_priv/holidays
weekday 0000  1730

03/12/2021 15:37:21.194807;0080;pbs_sched;Req;;Starting Scheduling Cycle
03/12/2021 15:37:21.194889;0100;pbs_sched;Svr;;It is primetime.  It will end in 6759 seconds at 03/12/2021 17:30:00
03/12/2021 15:37:21.198152;0080;pbs_sched;Req;;Leaving Scheduling Cycle
