### PR TITLE
Fix test_revert_attributes of TestExpect

### DIFF
--- a/test/fw/ptl/lib/ptl_wrappers.py
+++ b/test/fw/ptl/lib/ptl_wrappers.py
@@ -131,6 +131,7 @@ class Wrappers(PBSService):
                            SCHED: [ATTR_sched_cycle_len, ATTR_scheduling,
                                    ATTR_schedit, ATTR_logevents,
                                    ATTR_sched_server_dyn_res_alarm,
+                                   ATTR_SchedHost,
                                    'preempt_prio', 'preempt_queue_prio',
                                    'throughput_mode', 'job_run_wait',
                                    'partition', 'sched_priv', 'sched_log'],

--- a/test/tests/selftest/pbs_expect.py
+++ b/test/tests/selftest/pbs_expect.py
@@ -94,8 +94,7 @@ class TestExpect(TestSelf):
         self.server.expect(HOOK, 'alarm', op=UNSET, id=hook_name)
 
         a = {'partition': 'P1',
-             'sched_host': self.server.hostname,
-             'sched_port': '15050'}
+             'sched_host': self.server.hostname}
         self.server.manager(MGR_CMD_CREATE, SCHED,
                             a, id="sc1")
         new_sched_home = os.path.join(self.server.pbs_conf['PBS_HOME'],
@@ -106,7 +105,7 @@ class TestExpect(TestSelf):
         self.server.expect(SCHED, 'sched_priv', op=UNSET, id='sc1')
 
         a = {'resources_available.ncpus': 2}
-        self.server.create_vnodes('vn', a, num=2, mom=self.mom)
+        self.mom.create_vnodes(attrib=a, num=2, vname='vn')
         self.server.manager(MGR_CMD_UNSET, VNODE,
                             'resources_available.ncpus', id='vn[1]')
         self.server.expect(VNODE, 'resources_available.ncpus',


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
test_revert_attributes test was failing due to multiple reasons:

1. After unsetting the _sched_host_ attribute of scheduler, it was expecting that attribute to be not present. But the sched_host attribute was still there.
2. It was giving an error saying "Undefined attribute" after trying to create a scheduler partition.
3. Lastly it was throwing an error that the server object didn't have a definition for the "create_vnodes" function.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Following are the changes for the above described failures
1. Since sched_host attribute is set to server's hostname while unsetting it, I added "sched_host" attribute to special attribute list. This would take the default value of sched_host while unsetting it in PTL
2. As "sched_port" attribute has been removed from the scheduler, we don't need to create sched partition using this.
3. "create_vnodes" function was moved to MoM class from server class. So now calling the function using correct object.


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Before the change:
Description: Tests from given build on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES15
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES15
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|6504|1|1|0|0|0|0|

After the change:
Description: Tests from given sources on platforms SUSE15, CENTOS8, CENTOS7
Platforms: SUSE15,CENTOS8,CENTOS7
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|6508|1|0|0|0|0|1|

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
