### PR TITLE
updated expected job output matching method

### DIFF
--- a/test/tests/functional/pbs_reliable_job_startup.py
+++ b/test/tests/functional/pbs_reliable_job_startup.py
@@ -5155,7 +5155,7 @@ pbs_tmrsh %s hostname
         with open(job_output_file, 'r') as fd:
             job_out = fd.read()
 
-        self.assertEqual(job_out, expected_out)
+        self.assertIn(expected_out, job_out, "job output is not present")
 
         # Re-check vnode_list[] parameter in execjob_launch hook
         vnode_list = [self.nAv0, self.nAv1, self.nAv2,
@@ -5241,7 +5241,7 @@ pbs_tmrsh %s hostname
         with open(job_output_file, 'r') as fd:
             job_out = fd.read()
 
-        self.assertEqual(job_out, expected_out)
+        self.assertIn(expected_out, job_out, "job output is not present")
 
     def test_t19(self):
         """


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Test "TestPbsReliableJobStartup.test_t18" is failing because test expects job output file is overwritten after job rerun and only rerun job output is present in job output file. but Job output file is appended and it contains small part of before job rerun and whole part of after job rerun output.


#### Describe Your Change
Test expects job output should present in job output file


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Description: Rerun All Tests From #6510
Platforms: SUSE15,CENTOS8,CENTOS7
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|6514|1|0|0|0|0|1|




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
