### PR TITLE
Added ptl_wrappers.py in test makefile

### DIFF
--- a/test/fw/Makefile.am
+++ b/test/fw/Makefile.am
@@ -106,7 +106,8 @@ dist_ptlmodulelib_PYTHON = \
 	ptl/lib/ptl_entities.py \
 	ptl/lib/ptl_fairshare.py \
 	ptl/lib/ptl_resourceresv.py \
-	ptl/lib/ptl_service.py
+	ptl/lib/ptl_service.py \
+	ptl/lib/ptl_wrappers.py
 
 ptlmoduleutilsdir = $(ptlmoduledir)/utils
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
PBS snapshot is failed because ptl_wappers.py file path is not available in test makefile.


#### Describe Your Change
Added ptl_wrappers.py file path in test makefile.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Before fix
[root@centos openpbs]# /opt/pbs/sbin/pbs_snapshot -H centos --daemon-logs 2 --accounting-logs 2 --with-sudo -o /home/pbsroot
Traceback (most recent call last):
  File "/opt/pbs/unsupported/fw/bin/pbs_snapshot.py", line 54, in <module>
    from ptl.lib.pbs_testlib import PtlConfig
  File "/opt/pbs/unsupported/fw/ptl/lib/pbs_testlib.py", line 49, in <module>
    from ptl.lib.ptl_server import *
  File "/opt/pbs/unsupported/fw/ptl/lib/ptl_server.py", line 84, in <module>
    from ptl.lib.ptl_wrappers import *
ModuleNotFoundError: No module named 'ptl.lib.ptl_wrappers'

After changes
[root@centos openpbs]# /opt/pbs/sbin/pbs_snapshot -H centos --daemon-logs 2 --accounting-logs 2 --with-sudo

Usage: pbs_snapshot -o <path to existing output directory> [OPTION]

    Take snapshot of a PBS system and optionally capture logs for diagnostics

    -H <hostname>                     primary hostname to operate on
                                      Defaults to local host
    -l <loglevel>                     set log level to one of INFO, INFOCLI,
                                      INFOCLI2, DEBUG, DEBUG2, WARNING, ERROR
                                      or FATAL
    -h, --help                        display this usage message
    --basic                           Capture only basic config & state data
    --daemon-logs=<num days>          number of daemon logs to collect
    --accounting-logs=<num days>      number of accounting logs to collect
    --additional-hosts=<hostname>     collect data from additional hosts
                                      'hostname' is a comma separated list
    --map=<file>                      file to store the map of obfuscated data
    --obfuscate                       obfuscates sensitive data
    --with-sudo                       Uses sudo to capture privileged data
    --version                         print version number and exit




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
