### PR TITLE
Increased logging level for cleanup messages

### DIFF
--- a/test/fw/ptl/utils/plugins/ptl_test_runner.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_runner.py
@@ -1043,17 +1043,19 @@ class PTLTestRunner(Plugin):
             if server not in self.param_dict['moms']:
                 hosts.update(self.param_dict['servers'])
         for user in PBS_USERS:
-            self.logger.info('Cleaning %s\'s home directory' % (str(user)))
+            self.logger.debug('Cleaning %s\'s home directory' % (str(user)))
             runas = PbsUser.get_user(user)
             for host in hosts:
                 ret = du.run_cmd(host, cmd=['echo', '$HOME'], sudo=True,
-                                 runas=runas, logerr=False, as_script=True)
+                                 runas=runas, logerr=False, as_script=True,
+                                 level=logging.DEBUG)
                 if ret['rc'] == 0:
                     path = ret['out'][0].strip()
                 else:
                     return None
                 ftd = []
-                files = du.listdir(host, path=path, runas=user)
+                files = du.listdir(host, path=path, runas=user,
+                                   level=logging.DEBUG)
                 bn = os.path.basename
                 ftd.extend([f for f in files if bn(f).startswith('PtlPbs')])
                 ftd.extend([f for f in files if bn(f).startswith('STDIN')])


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
unwanted cleanup messages were appearing on default log level


#### Describe Your Change
Increased log level to DEBUG for unwanted home directory cleanup messages


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
