### PR TITLE
Job array parent is updated with wrong exit status on rerun

### DIFF
--- a/src/server/array_func.c
+++ b/src/server/array_func.c
@@ -295,14 +295,13 @@ update_sj_parent(job *parent, job *sj, char *sjid, char oldstate, char newstate)
 			int pe = 0;
 			if (is_jattr_set(parent, JOB_ATR_exit_status))
 				pe = get_jattr_long(parent, JOB_ATR_exit_status);
-			if (pe != 2) {
-				if (e > 0)
-					pe = 1;
-				else if (e < 0)
-					pe = 2;
-				else
-					pe = 0;
-			}
+			if (e > 0)
+				pe = 1;
+			else if (e < 0)
+				pe = 2;
+			else
+				pe = 0;
+
 			set_jattr_l_slim(parent, JOB_ATR_exit_status, pe, SET);
 		}
 		if (is_jattr_set(sj, JOB_ATR_stageout_status)) {


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Subjob tracking change PR added extra check for parent job's exit status which prevented any update to the job's exit status on a rerun of the array job. This caused PTL test TestResourceUsageLog.test_acclog_job_multiple_qrerun to fail since Array parent had `exit_status=2` but the test was expecting `exit_status=1`

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Removed the check which prevented the update of exit status.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
N/A

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Before change:
ptl.lib.ptl_error.PtlLogMatchError: rc=1, rv=False, msg= x103-c7p5 log match: searching for "E;1\[\]\.pbs\-server.*Exit_status=1.*run_count=0" - using regular expression  - with existence - attempt 180

Accounting logs:
03/01/2021 21:51:01;E;1[].pbs-server;user=pbsuser group=tstgrp00 project=_pbs_project_default jobname=STDIN queue=workq ctime=1614664242 qtime=1614664242 etime=1614664242 start=1614664242 array_indices=1-2 Resource_List.mem=20gb Resource_List.ncpus=1 Resource_List.nodect=1 Resource_List.place=free Resource_List.select=ncpus=1:mem=20gb session=0 end=1614664261 **Exit_status=2 run_count=0**

After change:
2021-03-16 22:54:00,225 INFO      pbs-server log match: searching for "E;243\[\]\.pbs\-server.*Exit_status=1.*run_count=0" - using regular expression  - with existence... OK

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
