### PR TITLE
Short execvnode_seq can crash the scheduler and server

### DIFF
--- a/src/include/libutil.h
+++ b/src/include/libutil.h
@@ -109,7 +109,7 @@ struct map {
 };
 
 /* Compress a delimited string into a dictionary compressed representation */
-char *condense_execvnode_seq(char *);
+char *condense_execvnode_seq(const char *);
 
 /* Decompress a compress string into an array of words (strings) indexed by
  * their associated indices */

--- a/src/lib/Libutil/execvnode_seq_util.c
+++ b/src/lib/Libutil/execvnode_seq_util.c
@@ -81,16 +81,16 @@ static struct map *new_map(int);
 /* Map a sequence of words to a list of indices by which
  * they are represented in the passed string str.
  */
-static void direct_map(dictionary *, char *);
+static int direct_map(dictionary *, char *);
 
 /* find a word in a dictionary */
 static struct word *find_word(dictionary *, char *);
 
 /* Append word to dictionary */
-static void append_to_dict(dictionary *, char *, int);
+static int append_to_dict(dictionary *, char *, int);
 
 /* Append the index of a word in a string to the mapping of the word */
-static void append_to_word(dictionary *, struct word *, int);
+static int append_to_word(dictionary *, struct word *, int);
 
 /* Create a string out of all words in a dictionary and their corresponding mapped indices */
 static char *dict_to_str(dictionary *);
@@ -209,9 +209,11 @@ static struct map *new_map(int val)
  *	If the string exists in the dictionary, its index is appended
  * 	to the word entry. Otherwise it is added as a new word to the dictionary
  *
- * @return Fills the dictionary structure.
+ * @return int
+ * @retval 1 error
+ * @retval 0 success
  */
-static void
+static int
 direct_map(dictionary *dict, char *str)
 {
 	struct word *w;
@@ -220,26 +222,32 @@ direct_map(dictionary *dict, char *str)
 	int i = 0;
 
 	if (dict == NULL || str == NULL)
-		return;
+		return 1;
 
 	if ((str_copy = strdup(str)) == NULL) {
 		DBPRT(("new_word: %s\n", MALLOC_ERR_MSG));
-		return;
+		return 1;
 	}
 
 	str_tok = strtok(str_copy, TOKEN_SEPARATOR);
-	while (str_tok!=NULL) {
+	while (str_tok != NULL) {
 		w = (struct word *)find_word(dict, str_tok);
-		if (w == NULL)
-			append_to_dict(dict, str_tok, i);
-		else
-			append_to_word(dict, w, i);
+		if (w == NULL) {
+			if (append_to_dict(dict, str_tok, i)) {
+				free(str_copy);
+				return 1;
+			}
+		} else
+			if (append_to_word(dict, w, i)) {
+			free(str_copy);
+			return 1;
+			}
 		i++;
 		str_tok = strtok(NULL, TOKEN_SEPARATOR);
 	}
 	dict->max_idx = i;
 	free(str_copy);
-	return;
+	return 0;
 }
 
 /**
@@ -279,21 +287,25 @@ static struct word *find_word(dictionary *dict, char *str)
  * @param[in] dict - The dictionary considered.
  * @param[in] str - The string representation of the word to append
  * @param[in] val - The index at which the string resides in the original string.
+ * 
+ * @return int
+ * @retval 1 error
+ * @retval 0 success
  *
  */
-static void
+static int
 append_to_dict(dictionary *dict, char *str, int val)
 {
 	struct word *nw;
 	struct word *tmp;
 
 	if (dict == NULL || str == NULL || val < 0)
-		return;
+		return 1;
 
 	nw = new_word(str);
 
 	if (nw == NULL)
-		return;
+		return 1;
 
 	if (dict->first == NULL) {
 		dict->first = nw;
@@ -307,14 +319,14 @@ append_to_dict(dictionary *dict, char *str, int val)
 	nw->map = new_map(val);
 
 	if (nw->map == NULL)
-		return;
+		return 1;
 
 	nw->count++;
 	dict->length += strlen(str);
 	dict->length += MAX_INT_LENGTH;
 	dict->count++;
 
-	return;
+	return 0;
 }
 
 /**
@@ -324,16 +336,20 @@ append_to_dict(dictionary *dict, char *str, int val)
  * @param[in] dict - The dictionary considered
  * @param[in] w - The word to append to
  * @param[in] val - The index value to append to the word
+ * 
+ * @return int
+ * @retval 1 error
+ * @retval 0 success
  *
  */
-static void
+static int
 append_to_word(dictionary *dict, struct word *w, int val)
 {
 
 	struct map *m, *tmp;
 
 	if (dict == NULL || w == NULL || val < 0)
-		return;
+		return 1;
 
 	m = w->map;
 	tmp = m;
@@ -341,7 +357,7 @@ append_to_word(dictionary *dict, struct word *w, int val)
 		m = new_map(val);
 
 		if (m == NULL)
-			return;
+			return 1;
 
 		w->map = m;
 	}
@@ -351,14 +367,14 @@ append_to_word(dictionary *dict, struct word *w, int val)
 		}
 		tmp->next = new_map(val);
 
-		if (tmp->next == NULL)
-			return;
+		if (tmp->next == NULL) 
+			return 1;
 	}
 	w->count++;
 	/* MAX_INT_LENGTH is the length of a string representation of an index */
 	dict->length += MAX_INT_LENGTH;
 
-	return;
+	return 0;
 }
 
 /**
@@ -376,7 +392,7 @@ append_to_word(dictionary *dict, struct word *w, int val)
  *
  */
 char *
-condense_execvnode_seq(char *str)
+condense_execvnode_seq(const char *str)
 {
 	dictionary *dict;
 	char *s_tmp;
@@ -396,7 +412,11 @@ condense_execvnode_seq(char *str)
 		free(dict);
 		return NULL;
 	}
-	direct_map(dict, s_tmp);
+	if (direct_map(dict, s_tmp)) {
+		free(s_tmp);
+		free_dict(dict);
+		return NULL;
+	}
 	cp = dict_to_str(dict);
 	/* Free up all memory allocated */
 	free_dict(dict);

--- a/src/lib/Libutil/execvnode_seq_util.c
+++ b/src/lib/Libutil/execvnode_seq_util.c
@@ -367,7 +367,7 @@ append_to_word(dictionary *dict, struct word *w, int val)
 		}
 		tmp->next = new_map(val);
 
-		if (tmp->next == NULL) 
+		if (tmp->next == NULL)
 			return 1;
 	}
 	w->count++;

--- a/src/lib/Libutil/execvnode_seq_util.c
+++ b/src/lib/Libutil/execvnode_seq_util.c
@@ -574,6 +574,9 @@ get_execvnodes_count(char *str)
 	if (str == NULL)
 		return 0;
 
+	if (str[0] == '(')
+		return 1;
+
 	if ((str_copy = strdup(str)) == NULL)
 		return 0;
 	word = strtok(str_copy, COUNT_TOK);

--- a/src/lib/Libutil/execvnode_seq_util.c
+++ b/src/lib/Libutil/execvnode_seq_util.c
@@ -239,8 +239,8 @@ direct_map(dictionary *dict, char *str)
 			}
 		} else
 			if (append_to_word(dict, w, i)) {
-			free(str_copy);
-			return 1;
+				free(str_copy);
+				return 1;
 			}
 		i++;
 		str_tok = strtok(NULL, TOKEN_SEPARATOR);
@@ -556,8 +556,10 @@ unroll_execvnode_seq(char *str, char ***tofree)
  * 	Get the total number of indices represented in the condensed string
  * 	which corresponds to the total number of occurrences in the execvnode string
  *
- * @param[in] str - The condensed execvnode sequence string of which the first token
- * 		    is the total number of tokens.
+ * @param[in] str - Either a condensed execvnode_seq or a single execvnode
+ * 		The format expected is in the form of:
+ * 		execvnode_seq: N#(execvnode){0-N-1} e.g. 10:(mars:ncpus=1){0-9}
+ * 		Single execvnode: (mars:ncpus=1)
  *
  * @return	int
  * @retval	The number of occurrences. If the first token is

--- a/src/server/req_quejob.c
+++ b/src/server/req_quejob.c
@@ -2392,11 +2392,13 @@ req_resvSub(struct batch_request *preq)
 		/* rc is set by check_rrule to report any possible icalendar
 		 * syntax or time problem
 		 */
-		if (rc!=0) {
+		if (rc != 0) {
 			resv_free(presv);
 			req_reject(rc, 0, preq);
 			return;
 		}
+
+		set_rattr_l_slim(presv, RESV_ATR_resv_count, resv_count, SET);
 
 		/* If more than 1 occurrence are requested then alter the
 		 * reservation and queue first character
@@ -2406,7 +2408,8 @@ req_resvSub(struct batch_request *preq)
 			qbuf[0] = PBS_STDNG_RESV_ID_CHAR;
 		} else /* If only 1 occurrence, treat it as an advance reservation */
 			set_rattr_l_slim(presv, RESV_ATR_resv_standing, 0, SET);
-	}
+	} else
+		set_rattr_l_slim(presv, RESV_ATR_resv_count, 1, SET);
 
 	if (is_maintenance)
 		rid[0] = qbuf[0] = PBS_MNTNC_RESV_ID_CHAR;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
If the scheduler reconfirms a degraded reservation with fewer execvnodes than it needs, this reservation can cause the scheduler and server to crash (until the reservation finishes or is deleted).

#### Describe Your Change
I only found two ways this could happen.  

We were calling pbs_asprintf() but only checking for -1 for error.  It returns the return value of vsnprintf().  The man page for vsnprintf() says it returns a negative number on error.  It is possible it was returning a different negative number than -1 and failing.

The other case was in condense_execvnode_seq().  This internally creates a linked list of execvnodes and then condenses them.  When adding an execvnode to the list, if malloc() failed, it would silently not add the execvnode and not detect the error.

The fix for this four fold:
1) The use of pbs_asprintf() was horribly inefficient.  We were having it allocate new memory to concatenate two strings, and then freeing the first.  I converted this to use a std::string which is very efficient concatenating strings.
2) I fixed the internals of condense_execvnode_seq() to detect a memory error and return NULL.
3) I catch if condense_execvnode_seq() returns NULL or if the number of execvnodes does not equal to the number we should have, we exit the cycle and immediately try again
4) The reservation's reserve_count was being set at confirmation time to the number of execvnodes sent over.  I changed this to set it at submission time based on the rrule.  This allows us to check at confirmation time if the incorrect number of execvnodes were sent.


#### Attach Test and Valgrind Logs/Output
This issue showed up once in a weekend valgrind run.  I've never been able to reproduce it outside of the debugger.  Before my fix I was able to crash both the scheduler and server.  I submitted a standing reservation with 10 occurrences, but I only returned 5.  When the daemons tried to access the execvnode_seq, it would use a negative index and crash.

Post fix:
This shows up in the scheduler log:
03/16/2021 16:45:44.172642;0080;pbs_sched;Resv;S2.henke;Invalid execvnode_seq while confirming reservation

and if I bypass the check in the scheduler and send the server an invalid execvnode_seq:
03/16/2021 16:36:49.962786;0200;Server@henke;Resv;S0.henke;Number of execvnodes given does not equal the number of occurrences left



The one failed test is not for reservations (preemption).  I reran it and it passed.

Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, WIN2K16
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|6553|3996|1|0|0|0|3995|