### PR TITLE
fix_test_hook_state_changes_00

### DIFF
--- a/test/tests/functional/pbs_hook_modifyvnode_state_changes.py
+++ b/test/tests/functional/pbs_hook_modifyvnode_state_changes.py
@@ -292,6 +292,9 @@ class TestPbsModifyvnodeStateChanges(TestFunctional):
         Test: induce a variety of vnode state changes with debug turned on
         and inspect the pbs log for expected entries
         """
+        if os.getuid() != 0 or sys.platform in ('cygwin', 'win32'):
+            self.skipTest("Test need to run as root")
+
         self.logger.debug("---- %s TEST STARTED ----" % get_method_name(self))
 
         self.server.manager(MGR_CMD_SET, SERVER, {'log_events': 4095})


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->

Changes done by [PR] (https://github.com/openpbs/openpbs/pull/2105), is causing the test_hook_state_ changes_00 to fail, when it is executed by pbsroot user.

Test is submitting a reservation as a root user and pbs_benchpress is executed by pbsroot, as a result PTL fw is throwing
following error, when it is trying to change its current directory to job owner's home directory (/root).

`Traceback:`

`File "/home/pbsroot/TEST/tmp/tests/functional/pbs_hook_modifyvnode_state_changes.py", line 294, in test_hook_state_changes_00`
`hosts=[mom.shortname]))
File "/home/pbsroot/TEST/tmp/2022.0.0.20201210133919/lib/python3.6/site-packages/ptl/lib/ptl_server.py", line 1630, in submit
os.chdir(submit_dir)
PermissionError: [Errno 13] Permission denied: '/root'`

Running test as root user is successful. 

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Skipping the test if it is not running as a root.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

Running as pbsroot:
[after_fix.txt](https://github.com/openpbs/openpbs/files/6155313/after_fix.txt)
Running as root:
[test_hook_state_changes_00.txt](https://github.com/openpbs/openpbs/files/6155484/test_hook_state_changes_00.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
