### PR TITLE
Fixing the proper server name at connection failure for qstat  in multi-server environement

### DIFF
--- a/src/cmds/qstat.c
+++ b/src/cmds/qstat.c
@@ -2921,7 +2921,7 @@ job_no_args:
 
 				if (conn <= 0) {
 					fprintf(stderr, "qstat: cannot connect to server %s (errno=%d)\n",
-						pbs_server, pbs_errno);
+						def_server, pbs_errno);
 #ifdef NAS /* localmod 071 */
 					(void)tcl_stat(error, NULL, tcl_opt);
 #else
@@ -3106,7 +3106,7 @@ job_no_args:
 que_no_args:
 				conn = cnt2server(server_out);
 				if (conn <= 0) {
-					fprintf(stderr, "qstat: cannot connect to server %s (errno=%d)\n", pbs_server, pbs_errno);
+					fprintf(stderr, "qstat: cannot connect to server %s (errno=%d)\n", def_server, pbs_errno);
 #ifdef NAS /* localmod 071 */
 					(void)tcl_stat(error, NULL, tcl_opt);
 #else
@@ -3154,7 +3154,7 @@ svr_no_args:
 				conn = cnt2server(server_out);
 				if (conn <= 0) {
 					fprintf(stderr, "qstat: cannot connect to server %s (errno=%d)\n",
-						pbs_server, pbs_errno);
+						def_server, pbs_errno);
 #ifdef NAS /* localmod 071 */
 					(void)tcl_stat(error, NULL, tcl_opt);
 #else


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
In a multi-server environment, qstat throws a connection error with the wrong server name.


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Need to print the default server name in case of connection failure. 

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

After fix:

[root@pbs-server pbspro]# cat /etc/pbs.conf 
PBS_SERVER=pbs-server
PBS_START_SERVER=1
PBS_START_SCHED=1
PBS_START_COMM=1
PBS_START_MOM=1
PBS_EXEC=/opt/pbs
PBS_HOME=/var/spool/pbs
PBS_CORE_LIMIT=unlimited
PBS_SCP=/bin/scp
PBS_SERVER_INSTANCES=pbs-server,spark
[root@pbs-server pbspro]# 

[root@pbs-server pbspro]# qstat
Connection refused
qstat: cannot connect to server pbs-server (errno=111)
[root@pbs-server pbspro]# pbsnodes -av
Connection refused
pbsnodes: cannot connect to server pbs-server, error=111
[root@pbs-server pbspro]# 


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
