### PR TITLE
TestPbsExecjobEnd.test_execjob_end_reject_request fails to verify job state

### DIFF
--- a/test/tests/functional/pbs_hook_execjob_end.py
+++ b/test/tests/functional/pbs_hook_execjob_end.py
@@ -321,7 +321,7 @@ class TestPbsExecjobEnd(TestFunctional):
              '1:ncpus=1:host=%s+1:ncpus=1:host=%s' %
              (self.momA.shortname, self.momB.shortname)}
         j = Job(TEST_USER, attrs=a)
-        j.set_sleep_time(30)
+        j.set_sleep_time(60)
         jid = self.server.submit(j)
         self.job_list.append(jid)
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Intermittently TestPbsExecjobEnd.test_execjob_end_reject_request fails to verify job state
By the time we check for job to be in R state after killing the sister mom, the job is already finished as it is only 30 second long.
```
2021-03-13 23:20:58,434 INFO job: executable set to /opt/pbs/bin/pbs_sleep with arguments: 30
2021-03-13 23:20:58,435 INFOCLI x6491-1137-0(run_cmd): sudo -H -u pbsuser /opt/pbs/bin/qsub -l select=1:ncpus=1:host=x6491-1137-0+1:ncpus=1:host=x6491-1137-1 – /opt/pbs/bin/pbs_sleep 30
.
.
.
2021-03-13 23:21:15,584 INFO running init script to stop pbs mom on x6491-1137-1.x6491-1137.th.svc.cluster.local using /etc/pbs.conf init_cmd=['sudo', '-H', 'PBS_START_SERVER=0', 'PBS_START_MOM=1', 'PBS_START_SCHED=0', 'PBS_START_COMM=0', '/opt/pbs/libexec/pbs_init.d', 'stop']
.
.
2021-03-13 23:21:29,987 INFOCLI x6491-1137-0(run_cmd): /opt/pbs/bin/pbsnodes -s x6491-1137-0.x6491-1137.th.svc.cluster.local -v x6491-1137-1
2021-03-13 23:21:30,093 INFO expect on server x6491-1137-0: state ~ down node x6491-1137-1 ... OK
.
.
2021-03-13 23:21:30,175 INFO expect on server x6491-1137-0: job_state = R && substate = 42 job 6.x6491-1137-0 got: job_state = E
```

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Increased the sleep time of the job

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
After fix:
 Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, WIN2K16
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|6563|10|0|0|0|0|10|


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
