### PR TITLE
Fixed possible free of unitialized variable

### DIFF
--- a/src/scheduler/node_info.cpp
+++ b/src/scheduler/node_info.cpp
@@ -4293,7 +4293,7 @@ parse_execvnode(char *execvnode, server_info *sinfo, selspec *sel)
 	char *excvndup;
 	char *node_name;
 	int num_el;
-	struct key_value_pair *kv;
+	struct key_value_pair *kv = NULL;
 
 	nspec **nspec_arr;
 	node_info *ninfo;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
If the server passes execvnode="" to the scheduler, the scheduler will try and free an unitialized value.

It currently isn't possible for the server to pass "" to the scheduler, but it will be possible in the upcoming multi-server persistent scheduler.

#### Describe Your Change
Initialized variable to NULL
