### PR TITLE
Upgrades broken on mom side after job struct refactoring

### DIFF
--- a/src/include/attribute.h
+++ b/src/include/attribute.h
@@ -96,6 +96,7 @@ extern "C" {
 #define RESC_USED_BUF_SIZE 2048
 
 #define MAX_STR_INT 40
+#define ENDATTRIBUTES -711
 
 /*
  * The following structure, svrattrl is used to hold the external form of

--- a/src/include/job.h
+++ b/src/include/job.h
@@ -404,7 +404,7 @@ struct block_job_reply {
 
 #define	JSVERSION_18	800	/* 18 denotes the PBS version and it covers the job structure from >= 13.x to <= 18.x */
 #define	JSVERSION_19	1900	/* 1900 denotes the 19.x.x version */
-#define JSVERSION	2100	/* denotes 21.x and newer */
+#define	JSVERSION	2100	/* denotes 21.x and newer */
 #define	ji_taskid	ji_extended.ji_ext.ji_taskidx
 #define	ji_nodeid	ji_extended.ji_ext.ji_nodeidx
 

--- a/src/include/job.h
+++ b/src/include/job.h
@@ -403,7 +403,8 @@ struct block_job_reply {
 
 
 #define	JSVERSION_18	800	/* 18 denotes the PBS version and it covers the job structure from >= 13.x to <= 18.x */
-#define	JSVERSION	1900	/* 1900 denotes the 19.x.x version */
+#define	JSVERSION_19	1900	/* 1900 denotes the 19.x.x version */
+#define JSVERSION	2100	/* denotes 21.x and newer */
 #define	ji_taskid	ji_extended.ji_ext.ji_taskidx
 #define	ji_nodeid	ji_extended.ji_ext.ji_nodeidx
 
@@ -546,8 +547,6 @@ struct job {
 		int ji_jsversion;   /* job structure version - JSVERSION */
 		int ji_svrflags;    /* server flags */
 		time_t ji_stime;    /* time job started execution */
-		time_t ji_endtBdry; /* estimate upper bound on end time */
-
 		char ji_jobid[PBS_MAXSVRJOBID + 1];   /* job identifier */
 		char ji_fileprefix[PBS_JOBBASE + 1];  /* no longer used */
 		char ji_queue[PBS_MAXQUEUENAME + 1];  /* name of current queue */

--- a/src/include/job.h
+++ b/src/include/job.h
@@ -404,7 +404,7 @@ struct block_job_reply {
 
 #define	JSVERSION_18	800	/* 18 denotes the PBS version and it covers the job structure from >= 13.x to <= 18.x */
 #define	JSVERSION_19	1900	/* 1900 denotes the 19.x.x version */
-#define	JSVERSION	2100	/* denotes 21.x and newer */
+#define	JSVERSION	2200	/* denotes 22.x and newer */
 #define	ji_taskid	ji_extended.ji_ext.ji_taskidx
 #define	ji_nodeid	ji_extended.ji_ext.ji_nodeidx
 

--- a/src/include/libutil.h
+++ b/src/include/libutil.h
@@ -364,7 +364,6 @@ int get_index_from_jid(char *jid);
 char *get_range_from_jid(char *jid);
 char *create_subjob_id(char *parent_jid, int sjidx);
 
-
 #ifdef  __cplusplus
 }
 #endif

--- a/src/lib/Libutil/misc_utils.c
+++ b/src/lib/Libutil/misc_utils.c
@@ -2620,3 +2620,97 @@ create_subjob_id(char *parent_jid, int sjidx)
 	*pcb = '[';
 	return jid;
 }
+
+
+/**
+ * @brief
+ * 		read attributes from file descriptor of a job file
+ *
+ * @param[in]	fd	-	file descriptor.
+ *
+ * @return	int
+ * @return	1	: success
+ * @return	0	: failure
+ */
+static svrattrl *
+read_attr(int fd)
+{
+	int amt;
+	int i;
+	svrattrl *pal;
+	svrattrl tempal;
+
+	i = read(fd, (char *)&tempal, sizeof(tempal));
+	if (i != sizeof(tempal)) {
+		fprintf(stderr, "bad read of attribute\n");
+		return NULL;
+	}
+	if (tempal.al_tsize == ENDATTRIBUTES)
+		return NULL;
+
+	pal = (svrattrl *)malloc(tempal.al_tsize);
+	if (pal == NULL) {
+		fprintf(stderr, "malloc failed\n");
+		exit(1);
+	}
+	*pal = tempal;
+
+	/* read in the actual attribute data */
+
+	amt = pal->al_tsize - sizeof(svrattrl);
+	i = read(fd, (char *)pal + sizeof(svrattrl), amt);
+	if (i != amt) {
+		fprintf(stderr, "short read of attribute\n");
+		exit(2);
+	}
+	pal->al_name = (char *)pal + sizeof(svrattrl);
+	if (pal->al_rescln)
+		pal->al_resc = pal->al_name + pal->al_nameln;
+	else
+		pal->al_resc = NULL;
+	if (pal->al_valln)
+		pal->al_value = pal->al_name + pal->al_nameln + pal->al_rescln;
+	else
+		pal->al_value = NULL;
+
+	return pal;
+}
+
+/**
+ * @brief	Read all job attribute values from a job file
+ *
+ * @param[in]	fd - fd of job file
+ * @param[out]	state - return pointer to state value
+ * @param[out]	substate - return pointer for substate value
+ *
+ * @return	void
+ */
+svrattrl *
+read_all_attrs_from_jbfile(int fd, char **state, char **substate)
+{
+	svrattrl *pal = NULL;
+	svrattrl *pali = NULL;
+
+	while ((pali = read_attr(fd)) != NULL) {
+		if (pal == NULL) {
+			pal = pali;
+			(&pal->al_link)->ll_struct = (void *)(&pal->al_link);
+			(&pal->al_link)->ll_next = NULL;
+			(&pal->al_link)->ll_prior = NULL;
+		} else {
+			pbs_list_link *head = &pal->al_link;
+			pbs_list_link *newp = &pali->al_link;
+			newp->ll_prior = NULL;
+			newp->ll_next  = head;
+			newp->ll_struct = pali;
+			pal = pali;
+		}
+		/* Check if the attribute read is state/substate and store it separately */
+		if (state && strcmp(pali->al_name, ATTR_state) == 0)
+			*state = pali->al_value;
+		else if (substate && strcmp(pali->al_name, ATTR_substate) == 0)
+			*substate = pali->al_value;
+	}
+
+	return pal;
+}

--- a/src/server/attr_recov.c
+++ b/src/server/attr_recov.c
@@ -72,7 +72,6 @@ char  pbs_recov_filename[MAXPATHLEN+1];
 /* data items global to functions in this file */
 
 #define PKBUFSIZE 4096
-#define ENDATTRIBUTES -711
 
 char   pk_buffer[PKBUFSIZE];	/* used to do buffered output */
 static int     pkbfds = -2;	/* descriptor to use for saves */

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -59,13 +59,12 @@ EXTRA_PROGRAMS = \
 	chk_tree \
 	rstester
 
-
 common_cflags = \
 	-I$(top_srcdir)/src/include \
 	@KRB5_CFLAGS@
 
 common_libs = \
-	$(top_builddir)/src/lib/Libpbs/.libs/libpbs.a \
+	$(top_builddir)/src/lib/Libpbs/libpbs.la \
 	$(top_builddir)/src/lib/Libutil/libutil.a \
 	$(top_builddir)/src/lib/Libnet/libnet.a \
 	$(top_builddir)/src/lib/Libsec/libsec.a \

--- a/src/tools/pbs_upgrade_job.c
+++ b/src/tools/pbs_upgrade_job.c
@@ -374,8 +374,8 @@ convert_19ext_to_21(union jobextend_19_20 old_extend)
 	union jobextend je;
 
 	memset(&je, 0, sizeof(je));
-	snprintf(je.fill, sizeof(je.fill), old_extend.fill);
-	snprintf(je.ji_ext.ji_jid, sizeof(je.ji_ext.ji_jid), old_extend.ji_ext.ji_4jid);
+	snprintf(je.fill, sizeof(je.fill), "%s", old_extend.fill);
+	snprintf(je.ji_ext.ji_jid, sizeof(je.ji_ext.ji_jid), "%s", old_extend.ji_ext.ji_4jid);
 	je.ji_ext.ji_credtype = old_extend.ji_ext.ji_credtype;
 #ifdef PBS_MOM
 	je.ji_ext.ji_nodeidx = old_extend.ji_ext.ji_nodeidx;

--- a/src/tools/pbs_upgrade_job.c
+++ b/src/tools/pbs_upgrade_job.c
@@ -90,12 +90,12 @@
 /* From pbs_ifl.h */
 #define PBS_MAXSEQNUM_PRE19	7
 #define PBS_MAXSVRJOBID_PRE19	(PBS_MAXSEQNUM_PRE19 - 1 + PBS_MAXSERVERNAME + PBS_MAXPORTNUM + 2)
-#define PBS_MAXSVRJOBID_19_20	(PBS_MAXSEQNUM - 1 + PBS_MAXSERVERNAME + PBS_MAXPORTNUM + 2)
+#define PBS_MAXSVRJOBID_19_21	(PBS_MAXSEQNUM - 1 + PBS_MAXSERVERNAME + PBS_MAXPORTNUM + 2)
 
 /*
- * Replicate the jobfix structure as it was defined in 19.x and 20.x versions
+ * Replicate the jobfix structure as it was defined in versions 19.x - 21.x
  */
-typedef struct jobfix_19_20 {
+typedef struct jobfix_19_21 {
 	int ji_jsversion;   /* job structure version - JSVERSION */
 	int ji_state;	    /* internal copy of state */
 	int ji_substate;    /* job sub-state */
@@ -106,7 +106,7 @@ typedef struct jobfix_19_20 {
 	time_t ji_stime;    /* time job started execution */
 	time_t ji_endtBdry; /* estimate upper bound on end time */
 
-	char ji_jobid[PBS_MAXSVRJOBID_19_20 + 1]; /* job identifier */
+	char ji_jobid[PBS_MAXSVRJOBID_19_21 + 1]; /* job identifier */
 	char ji_fileprefix[PBS_JOBBASE + 1];	  /* no longer used */
 	char ji_queue[PBS_MAXQUEUENAME + 1];	  /* name of current queue */
 	char ji_destin[PBS_MAXROUTEDEST + 1];	  /* dest from qmove/route */
@@ -135,9 +135,9 @@ typedef struct jobfix_19_20 {
 			gid_t ji_exgid;	      /* execution gid */
 		} ji_momt;
 	} ji_un;
-} jobfix_19_20;
+} jobfix_19_21;
 
-union jobextend_19_20 {
+union jobextend_19_21 {
 	char fill[256]; /* fill to keep same size */
 	struct {
 #if defined(__sgi)
@@ -231,7 +231,7 @@ typedef struct taskfix_PRE19
 #define BUFSZ 4096
 char buf[BUFSZ];
 
-svrattrl *read_all_attrs_from_jbfile(int fd, char **state, char **substate);
+svrattrl *read_all_attrs_from_jbfile(int fd, char **state, char **substate, char **errbuf);
 
 /**
  * @brief
@@ -316,41 +316,49 @@ check_job_file_exit:
  *
  * @param[in]	old_jobfix_pre19 - pre-19 jobfix struct
  *
- * @return	jobfix_19_20
+ * @return	jobfix_19_21
  * @retval	v19 converted jobfix
  */
-jobfix_19_20
-convert_pre18jf_to_19(jobfix_PRE19 old_jobfix_pre19)
+jobfix_19_21
+convert_pre19jf_to_19(jobfix_PRE19 old_jobfix_pre19)
 {
-	jobfix_19_20 jf_19_20;
+	jobfix_19_21 jf_19_21;
 
 	/* Copy the data to the new jobfix structure */
-	memset(&jf_19_20, 0, sizeof(jf_19_20));
-	memcpy(&jf_19_20, &old_jobfix_pre19, sizeof(jf_19_20));
-	snprintf(jf_19_20.ji_jobid, sizeof(jf_19_20.ji_jobid),
+	memset(&jf_19_21, 0, sizeof(jf_19_21));
+	jf_19_21.ji_jsversion = JSVERSION_19;
+	jf_19_21.ji_state = old_jobfix_pre19.ji_state;
+	jf_19_21.ji_substate = old_jobfix_pre19.ji_substate;
+	jf_19_21.ji_svrflags = old_jobfix_pre19.ji_svrflags;
+	jf_19_21.ji_numattr = old_jobfix_pre19.ji_numattr;
+	jf_19_21.ji_ordering = old_jobfix_pre19.ji_ordering;
+	jf_19_21.ji_priority = old_jobfix_pre19.ji_priority;
+	jf_19_21.ji_stime = old_jobfix_pre19.ji_stime;
+	jf_19_21.ji_endtBdry = old_jobfix_pre19.ji_endtBdry;
+	snprintf(jf_19_21.ji_jobid, sizeof(jf_19_21.ji_jobid),
 			"%s", old_jobfix_pre19.ji_jobid);
-	snprintf(jf_19_20.ji_fileprefix, sizeof(jf_19_20.ji_fileprefix),
+	snprintf(jf_19_21.ji_fileprefix, sizeof(jf_19_21.ji_fileprefix),
 			"%s", old_jobfix_pre19.ji_fileprefix);
-	snprintf(jf_19_20.ji_queue, sizeof(jf_19_20.ji_queue),
+	snprintf(jf_19_21.ji_queue, sizeof(jf_19_21.ji_queue),
 			"%s", old_jobfix_pre19.ji_queue);
-	snprintf(jf_19_20.ji_destin, sizeof(jf_19_20.ji_destin),
+	snprintf(jf_19_21.ji_destin, sizeof(jf_19_21.ji_destin),
 			"%s", old_jobfix_pre19.ji_destin);
-	jf_19_20.ji_un_type = old_jobfix_pre19.ji_un_type;
-	memcpy(&jf_19_20.ji_un, &old_jobfix_pre19.ji_un, sizeof(jf_19_20.ji_un));
+	jf_19_21.ji_un_type = old_jobfix_pre19.ji_un_type;
+	memcpy(&jf_19_21.ji_un, &old_jobfix_pre19.ji_un, sizeof(jf_19_21.ji_un));
 
-	return jf_19_20;
+	return jf_19_21;
 }
 
 /**
- * @brief	Upgrade 19-20 jobfix structure to latest
+ * @brief	Upgrade 19-21 jobfix structure to latest
  *
- * @param[in]	old_jf - 19-20 jobfix struct
+ * @param[in]	old_jf - 19-21 jobfix struct
  *
- * @return	jobfix_19_20
- * @retval	v19 converted jobfix
+ * @return	jobfix_19_21
+ * @retval	converted jobfix
  */
 struct jobfix
-convert_19jf_to_21(jobfix_19_20 old_jf)
+convert_19jf_to_22(jobfix_19_21 old_jf)
 {
 	struct jobfix jf;
 
@@ -368,14 +376,24 @@ convert_19jf_to_21(jobfix_19_20 old_jf)
 	return jf;
 }
 
+/**
+ * @brief	Upgrade 19-21 jobextend structure to latest
+ *
+ * @param[in]	old_extend - 19-21 jobextend struct
+ *
+ * @return	jobextend
+ * @retval	converted jobextend
+ */
 union jobextend
-convert_19ext_to_21(union jobextend_19_20 old_extend)
+convert_19ext_to_22(union jobextend_19_21 old_extend)
 {
 	union jobextend je;
 
 	memset(&je, 0, sizeof(je));
 	snprintf(je.fill, sizeof(je.fill), "%s", old_extend.fill);
+#if !defined(__sgi)
 	snprintf(je.ji_ext.ji_jid, sizeof(je.ji_ext.ji_jid), "%s", old_extend.ji_ext.ji_4jid);
+#endif
 	je.ji_ext.ji_credtype = old_extend.ji_ext.ji_credtype;
 #ifdef PBS_MOM
 	je.ji_ext.ji_nodeidx = old_extend.ji_ext.ji_nodeidx;
@@ -405,9 +423,9 @@ upgrade_job_file(int fd, int ver)
 {
 	FILE *tmp = NULL;
 	int tmpfd = -1;
-	jobfix_19_20 qs_19_20;
+	jobfix_19_21 qs_19_20;
 	jobfix_PRE19 old_jobfix_pre19;
-	union jobextend_19_20 old_ji_extended;
+	union jobextend_19_21 old_ji_extended;
 	int ret;
 	off_t pos;
 	job new_job;
@@ -437,7 +455,7 @@ upgrade_job_file(int fd, int ver)
 			return 1;
 		}
 
-		qs_19_20 = convert_pre18jf_to_19(old_jobfix_pre19);
+		qs_19_20 = convert_pre19jf_to_19(old_jobfix_pre19);
 	} else {
 		/* Read in the 19_20 jobfix structure */
 		memset(&qs_19_20, 0, sizeof(qs_19_20));
@@ -453,20 +471,20 @@ upgrade_job_file(int fd, int ver)
 		}
 	}
 	memset(&new_job, 0, sizeof(new_job));
-	new_job.ji_qs = convert_19jf_to_21(qs_19_20);
+	new_job.ji_qs = convert_19jf_to_22(qs_19_20);
 
 	/* Convert old extended data to new */
 	memset(&old_ji_extended, 0, sizeof(old_ji_extended));
-	len = read(fd, (char *)&old_ji_extended, sizeof(union jobextend_19_20));
+	len = read(fd, (char *)&old_ji_extended, sizeof(union jobextend_19_21));
 	if (len < 0) {
 		fprintf(stderr, "Failed to read input file [%s]\n", errno ? strerror(errno) : "No error");
 		return 1;
 	}
-	if (len != sizeof(union jobextend_19_20)) {
+	if (len != sizeof(union jobextend_19_21)) {
 		fprintf(stderr, "Format not recognized, not enough extended data.\n");
 		return 1;
 	}
-	new_job.ji_extended = convert_19ext_to_21(old_ji_extended);
+	new_job.ji_extended = convert_19ext_to_22(old_ji_extended);
 
 	/* previous versions may not have updated values of state and substate in the attribute list
 	 * since we now rely on these attributes instead of the quick save area, it's important
@@ -475,10 +493,19 @@ upgrade_job_file(int fd, int ver)
 	if (statechar != JOB_STATE_LTR_UNKNOWN) {
 		bool stateset = false;
 		bool substateset = false;
+		char *errbuf = malloc(1024);
 
+		if (errbuf == NULL) {
+			fprintf(stderr, "Malloc error\n");
+			return 1;
+		}
 		snprintf(statebuf, sizeof(statebuf), "%c", statechar);
 		snprintf(ssbuf, sizeof(ssbuf), "%d", qs_19_20.ji_substate);
-		pal = read_all_attrs_from_jbfile(fd, NULL, NULL);
+		pal = read_all_attrs_from_jbfile(fd, NULL, NULL, &errbuf);
+		if (pal == NULL && errbuf[0] != '\0') {
+			fprintf(stderr, "%s\n", errbuf);
+			return 1;
+		}
 		pali = pal;
 		while (pali != NULL) {
 			if (strcmp(pali->al_name, ATTR_state) == 0) {
@@ -551,8 +578,8 @@ upgrade_job_file(int fd, int ver)
 				fprintf(stderr, "Failed to write output file [%s]\n", errno ? strerror(errno) : "No error");
 				return 1;
 			}
-			objsize -= copysize;
-			charstrm += copysize;
+			objsize -= len;
+			charstrm += len;
 		}
 		if (pali->al_link.ll_next == NULL)
 			break;

--- a/src/tools/pbs_upgrade_job.c
+++ b/src/tools/pbs_upgrade_job.c
@@ -397,7 +397,7 @@ convert_19ext_to_21(union jobextend_19_20 old_extend)
  * @param[in]	ver		-	Old version
  *
  * @return	int
- * @retval	-1	: failure
+ * @retval	1	: failure
  * @retval	 0	: success
  */
 int

--- a/src/tools/pbs_upgrade_job.c
+++ b/src/tools/pbs_upgrade_job.c
@@ -423,7 +423,7 @@ upgrade_job_file(int fd, int ver)
 {
 	FILE *tmp = NULL;
 	int tmpfd = -1;
-	jobfix_19_21 qs_19_20;
+	jobfix_19_21 qs_19_21;
 	jobfix_PRE19 old_jobfix_pre19;
 	union jobextend_19_21 old_ji_extended;
 	int ret;
@@ -455,23 +455,23 @@ upgrade_job_file(int fd, int ver)
 			return 1;
 		}
 
-		qs_19_20 = convert_pre19jf_to_19(old_jobfix_pre19);
+		qs_19_21 = convert_pre19jf_to_19(old_jobfix_pre19);
 	} else {
-		/* Read in the 19_20 jobfix structure */
-		memset(&qs_19_20, 0, sizeof(qs_19_20));
-		len = read(fd, (char *) &qs_19_20, sizeof(qs_19_20));
+		/* Read in the 19_21 jobfix structure */
+		memset(&qs_19_21, 0, sizeof(qs_19_21));
+		len = read(fd, (char *) &qs_19_21, sizeof(qs_19_21));
 		if (len < 0) {
 			fprintf(stderr, "Failed to read input file [%s]\n",
 				errno ? strerror(errno) : "No error");
 			return 1;
 		}
-		if (len != sizeof(qs_19_20)) {
+		if (len != sizeof(qs_19_21)) {
 			fprintf(stderr, "Format not recognized, not enough fixed data.\n");
 			return 1;
 		}
 	}
 	memset(&new_job, 0, sizeof(new_job));
-	new_job.ji_qs = convert_19jf_to_22(qs_19_20);
+	new_job.ji_qs = convert_19jf_to_22(qs_19_21);
 
 	/* Convert old extended data to new */
 	memset(&old_ji_extended, 0, sizeof(old_ji_extended));
@@ -489,7 +489,7 @@ upgrade_job_file(int fd, int ver)
 	/* previous versions may not have updated values of state and substate in the attribute list
 	 * since we now rely on these attributes instead of the quick save area, it's important
 	 * to make sure that state and substate attributes are set correctly */
-	statechar = state_int2char(qs_19_20.ji_state);
+	statechar = state_int2char(qs_19_21.ji_state);
 	if (statechar != JOB_STATE_LTR_UNKNOWN) {
 		bool stateset = false;
 		bool substateset = false;
@@ -500,7 +500,7 @@ upgrade_job_file(int fd, int ver)
 			return 1;
 		}
 		snprintf(statebuf, sizeof(statebuf), "%c", statechar);
-		snprintf(ssbuf, sizeof(ssbuf), "%d", qs_19_20.ji_substate);
+		snprintf(ssbuf, sizeof(ssbuf), "%d", qs_19_21.ji_substate);
 		pal = read_all_attrs_from_jbfile(fd, NULL, NULL, &errbuf);
 		if (pal == NULL && errbuf[0] != '\0') {
 			fprintf(stderr, "%s\n", errbuf);

--- a/src/tools/pbs_upgrade_job.c
+++ b/src/tools/pbs_upgrade_job.c
@@ -298,7 +298,7 @@ convert_pre18_to_19(jobfix_PRE19 old_jobfix_pre19)
 
 	/* Copy the data to the new jobfix structure */
 	memset(&jobfix_19_20, 0, sizeof(jobfix_19_20));
-	memcpy(&jobfix_19_20, &old_jobfix_pre19, sizeof(old_jobfix_pre19));
+	memcpy(&jobfix_19_20, &old_jobfix_pre19, sizeof(jobfix_19_20));
 	snprintf(jobfix_19_20.ji_jobid, sizeof(jobfix_19_20.ji_jobid),
 			"%s", old_jobfix_pre19.ji_jobid);
 	snprintf(jobfix_19_20.ji_fileprefix, sizeof(jobfix_19_20.ji_fileprefix),
@@ -326,7 +326,7 @@ convert_19_to_21(jobfix_19_20 jobfix_19_20)
 {
 	struct jobfix jf;
 
-	jf.ji_jsversion = jobfix_19_20.ji_jsversion;
+	jf.ji_jsversion = JSVERSION;
 	jf.ji_svrflags = jobfix_19_20.ji_svrflags;
 	jf.ji_stime = jobfix_19_20.ji_stime;
 	snprintf(jf.ji_jobid, sizeof(jf.ji_jobid), "%s", jobfix_19_20.ji_jobid);

--- a/src/tools/pbs_upgrade_job.c
+++ b/src/tools/pbs_upgrade_job.c
@@ -755,7 +755,6 @@ main(int argc, char *argv[])
 	if (!dir) {
 		fprintf(stderr, "Failed to open the task directory [%s]\n",
 				errno ? strerror(errno) : "No error");
-		closedir(dir);
 		return 1;
 	}
 	errno = 0;

--- a/src/tools/pbs_upgrade_job.c
+++ b/src/tools/pbs_upgrade_job.c
@@ -90,6 +90,7 @@
 /* From pbs_ifl.h */
 #define PBS_MAXSEQNUM_PRE19	7
 #define PBS_MAXSVRJOBID_PRE19	(PBS_MAXSEQNUM_PRE19 - 1 + PBS_MAXSERVERNAME + PBS_MAXPORTNUM + 2)
+#define PBS_MAXSVRJOBID_19_20	(PBS_MAXSEQNUM - 1 + PBS_MAXSERVERNAME + PBS_MAXPORTNUM + 2)
 
 /*
  * Replicate the jobfix structure as it was defined in 19.x and 20.x versions
@@ -105,10 +106,10 @@ typedef struct jobfix_19_20 {
 	time_t ji_stime;    /* time job started execution */
 	time_t ji_endtBdry; /* estimate upper bound on end time */
 
-	char ji_jobid[PBS_MAXSVRJOBID + 1];   /* job identifier */
-	char ji_fileprefix[PBS_JOBBASE + 1];  /* no longer used */
-	char ji_queue[PBS_MAXQUEUENAME + 1];  /* name of current queue */
-	char ji_destin[PBS_MAXROUTEDEST + 1]; /* dest from qmove/route */
+	char ji_jobid[PBS_MAXSVRJOBID_19_20 + 1]; /* job identifier */
+	char ji_fileprefix[PBS_JOBBASE + 1];	  /* no longer used */
+	char ji_queue[PBS_MAXQUEUENAME + 1];	  /* name of current queue */
+	char ji_destin[PBS_MAXROUTEDEST + 1];	  /* dest from qmove/route */
 	/* MomS for execution    */
 
 	int ji_un_type;				 /* type of ji_un union */
@@ -321,29 +322,29 @@ check_job_file_exit:
 jobfix_19_20
 convert_pre18jf_to_19(jobfix_PRE19 old_jobfix_pre19)
 {
-	jobfix_19_20 jobfix_19_20;
+	jobfix_19_20 jf_19_20;
 
 	/* Copy the data to the new jobfix structure */
-	memset(&jobfix_19_20, 0, sizeof(jobfix_19_20));
-	memcpy(&jobfix_19_20, &old_jobfix_pre19, sizeof(jobfix_19_20));
-	snprintf(jobfix_19_20.ji_jobid, sizeof(jobfix_19_20.ji_jobid),
+	memset(&jf_19_20, 0, sizeof(jf_19_20));
+	memcpy(&jf_19_20, &old_jobfix_pre19, sizeof(jf_19_20));
+	snprintf(jf_19_20.ji_jobid, sizeof(jf_19_20.ji_jobid),
 			"%s", old_jobfix_pre19.ji_jobid);
-	snprintf(jobfix_19_20.ji_fileprefix, sizeof(jobfix_19_20.ji_fileprefix),
+	snprintf(jf_19_20.ji_fileprefix, sizeof(jf_19_20.ji_fileprefix),
 			"%s", old_jobfix_pre19.ji_fileprefix);
-	snprintf(jobfix_19_20.ji_queue, sizeof(jobfix_19_20.ji_queue),
+	snprintf(jf_19_20.ji_queue, sizeof(jf_19_20.ji_queue),
 			"%s", old_jobfix_pre19.ji_queue);
-	snprintf(jobfix_19_20.ji_destin, sizeof(jobfix_19_20.ji_destin),
+	snprintf(jf_19_20.ji_destin, sizeof(jf_19_20.ji_destin),
 			"%s", old_jobfix_pre19.ji_destin);
-	jobfix_19_20.ji_un_type = old_jobfix_pre19.ji_un_type;
-	memcpy(&jobfix_19_20.ji_un, &old_jobfix_pre19.ji_un, sizeof(jobfix_19_20.ji_un));
+	jf_19_20.ji_un_type = old_jobfix_pre19.ji_un_type;
+	memcpy(&jf_19_20.ji_un, &old_jobfix_pre19.ji_un, sizeof(jf_19_20.ji_un));
 
-	return jobfix_19_20;
+	return jf_19_20;
 }
 
 /**
- * @brief	Upgrade pre 18.x jobfix structure to 19
+ * @brief	Upgrade 19-20 jobfix structure to latest
  *
- * @param[in]	old_jobfix_pre19 - pre-19 jobfix struct
+ * @param[in]	old_jf - 19-20 jobfix struct
  *
  * @return	jobfix_19_20
  * @retval	v19 converted jobfix

--- a/src/tools/printjob.c
+++ b/src/tools/printjob.c
@@ -84,6 +84,9 @@ attribute_def job_attr_def[1] = {{0}};
 
 #define BUF_SIZE 512
 int display_script = 0;	 /* to track if job-script is required or not */
+
+svrattrl *read_all_attrs_from_jbfile(int fd, char **state, char **substate);
+
 /**
  * @brief
  *		Print usage text to stderr and exit.
@@ -217,99 +220,6 @@ print_attr(svrattrl *pal)
 	if (pal->al_value)
 		printf("%s", show_nonprint_chars(pal->al_value));
 	printf("\n");
-}
-
-/**
- * @brief
- * 		read attributes from file descriptor.
- *
- * @param[in]	fd	-	file descriptor.
- *
- * @return	int
- * @return	1	: success
- * @return	0	: failure
- */
-static svrattrl *
-read_attr(int fd)
-{
-	int amt;
-	int i;
-	svrattrl *pal;
-	svrattrl tempal;
-
-	i = read(fd, (char *)&tempal, sizeof(tempal));
-	if (i != sizeof(tempal)) {
-		fprintf(stderr, "bad read of attribute\n");
-		return NULL;
-	}
-	if (tempal.al_tsize == ENDATTRIBUTES)
-		return NULL;
-
-	pal = (svrattrl *)malloc(tempal.al_tsize);
-	if (pal == NULL) {
-		fprintf(stderr, "malloc failed\n");
-		exit(1);
-	}
-	*pal = tempal;
-
-	/* read in the actual attribute data */
-
-	amt = pal->al_tsize - sizeof(svrattrl);
-	i = read(fd, (char *)pal + sizeof(svrattrl), amt);
-	if (i != amt) {
-		fprintf(stderr, "short read of attribute\n");
-		exit(2);
-	}
-	pal->al_name = (char *)pal + sizeof(svrattrl);
-	if (pal->al_rescln)
-		pal->al_resc = pal->al_name + pal->al_nameln;
-	else
-		pal->al_resc = NULL;
-	if (pal->al_valln)
-		pal->al_value = pal->al_name + pal->al_nameln + pal->al_rescln;
-	else
-		pal->al_value = NULL;
-
-	return pal;
-}
-
-/**
- * @brief	Read all job attribute values
- *
- * @param[in]	fd - fd of job file
- * @param[out]	state - return pointer to state value
- * @param[out]	substate - return pointer for substate value
- *
- * @return	void
- */
-static svrattrl *
-read_all_attrs(int fd, char **state, char **substate)
-{
-	svrattrl *pal = NULL;
-	svrattrl *pali = NULL;
-
-	while ((pali = read_attr(fd)) != NULL) {
-		if (pal == NULL) {
-			pal = pali;
-			(&pal->al_link)->ll_struct = (void *)(&pal->al_link);
-			(&pal->al_link)->ll_next = NULL;
-			(&pal->al_link)->ll_prior = NULL;
-		} else {
-			pbs_list_link *head = &pal->al_link;
-			pbs_list_link *newp = &pali->al_link;
-			newp->ll_prior = NULL;
-			newp->ll_next  = head;
-			newp->ll_struct = pali;
-			pal = pali;
-		}
-		/* Check if the attribute read is state/substate and store it separately */
-		if (strcmp(pali->al_name, ATTR_state) == 0)
-			*state = pali->al_value;
-		else if (strcmp(pali->al_name, ATTR_substate) == 0)
-			*substate = pali->al_value;
-	}
-
-	return pal;
 }
 
 /**
@@ -653,7 +563,7 @@ char *argv[];
 				}
 			}
 
-			pal = read_all_attrs(fp, &state, &substate);
+			pal = read_all_attrs_from_jbfile(fp, &state, &substate);
 
 			/* Print the summary first */
 			prt_job_struct(&xjob, state, substate);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
As part of #2016 and #1930 we removed some fields from the quick save area. This was essentially duplicate/obsolete data which just caused the job object to be bloated. But, this broke upgrades: pbs_mom reads the .JB files as follows:
it reads the job's quick save area in a single read(). this means that it will read the previous version's quick save area data into new quick save structure, which doesn't have the same fields as it used to before. So, the quick save structure doesn't get formed properly and it can result in unexpected problems like pbs_mom not recognizing the job.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Modified the pbs_upgrade_job program to handle upgrading quick save area read from v19 and convert it into the latest.

Also removed ji_endtBdry which was accidentally added by https://github.com/openpbs/openpbs/commit/6aff075a30cb46b0bae0e03b400f3b036465875b#diff-c5ce60deecaa37d8fe21cb265cfb0e08cacf6afa94e27779139813086c54f830
#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
**Before fix:**
Mom was not recognizing this v19 job:
```
03/16/2021 00:53:52;0001;pbs_mom;Svr;pbs_mom;job_recov_fs, Job Id  does not match file name for /var/spool/pbs/mom_priv/jobs/0.pbspro.JB
```

**After fix:**
mom logs shows that the job was re-queued and its task restarted
```
[ravi@pbspro mom_logs]$ grep "0.pbspro" *
03/24/2021 03:10:31;0008;pbs_mom;Job;0.pbspro;Started, pid = 14728
03/24/2021 03:10:37;0008;pbs_mom;Job;0.pbspro;kill_job
03/24/2021 03:15:24;0100;pbs_mom;Job;0.pbspro;task 00000001 cput=00:00:00
03/24/2021 03:15:24;0100;pbs_mom;Job;0.pbspro;pbspro cput=00:00:00 mem=0kb
03/24/2021 03:15:24;0100;pbs_mom;Job;0.pbspro;Obit sent
03/24/2021 03:15:24;0008;pbs_mom;Job;0.pbspro;no active process for task 00000001
03/24/2021 03:15:24;0008;pbs_mom;Job;0.pbspro;Terminated
03/24/2021 03:15:24;0100;pbs_mom;Job;0.pbspro;task 00000001 cput=00:00:00
03/24/2021 03:15:24;0100;pbs_mom;Job;0.pbspro;pbspro cput=00:00:00 mem=0kb
03/24/2021 03:15:24;0100;pbs_mom;Job;0.pbspro;Obit sent
03/24/2021 03:15:30;0080;pbs_mom;Job;0.pbspro;delete job request received
03/24/2021 03:15:30;0008;pbs_mom;Job;0.pbspro;kill_job
03/24/2021 03:15:30;0008;pbs_mom;Job;0.pbspro;Started, pid = 60571
[ravi@pbspro mom_logs]$ qstat
Job id            Name             User              Time Use S Queue
----------------  ---------------- ----------------  -------- - -----
0.pbspro          STDIN            ravi              00:00:00 R workq   
[ravi@pbspro mom_logs]$ ps -ef | grep sleep
ravi     60571 60408  0 03:15 ?        00:00:00 /bin/sleep 10000
ravi     60578  7629  0 03:16 pts/2    00:00:00 grep --color=auto sleep
```

**Scenarios tested**:
- job upgrade from v18 to latest
- job upgrade from v19 to latest
- job array upgrade from v19 to latest


**Scenarios pending**:
- job array upgrade from v18 to latest



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
