### PR TITLE
Initialize nslookup mutex before tpp_lock

### DIFF
--- a/src/lib/Libtpp/tpp_internal.h
+++ b/src/lib/Libtpp/tpp_internal.h
@@ -508,14 +508,16 @@ int tpp_add_fd(int, int, int);
 int tpp_del_fd(int, int);
 int tpp_mod_fd(int, int, int);
 
+#ifndef WIN32
 /* a new mutex introduced to prevent inheriting lock from tpp thread
  * from getaddrinfo(nslookup) during fork for periodic hook
  * set handlers using pthread_atfork.
  */
-pthread_mutex_t tpp_nslookup_mutex;
+extern pthread_mutex_t tpp_nslookup_mutex;
 void tpp_nslookup_atfork_prepare();
 void tpp_nslookup_atfork_parent();
 void tpp_nslookup_atfork_child();
+#endif
 
 int tpp_validate_hdr(int, char *);
 tpp_addr_t *tpp_get_addresses(char *, int *);

--- a/src/lib/Libtpp/tpp_platform.c
+++ b/src/lib/Libtpp/tpp_platform.c
@@ -710,19 +710,24 @@ tpp_sock_resolve_host(char *host, int *count)
 	hints.ai_socktype = SOCK_STREAM;
 	hints.ai_protocol = IPPROTO_TCP;
 
+#ifndef WIN32
 	/* 
 	 * introducing a new mutex to prevent child process from 
 	 * inheriting getaddrinfo mutex using pthread_atfork handlers
 	 */
 	tpp_lock(&tpp_nslookup_mutex);
-
+#endif
 	if ((rc = getaddrinfo(host, NULL, &hints, &pai)) != 0) {
+#ifndef WIN32
 		tpp_unlock(&tpp_nslookup_mutex);
+#endif
 		tpp_log(LOG_CRIT, NULL, "Error %d resolving %s", rc, host);
 		return NULL;
 	}
+#ifndef WIN32
 	/* unlock nslook up mutex */
 	tpp_unlock(&tpp_nslookup_mutex);
+#endif
 
 	*count = 0;
 	for (aip = pai; aip != NULL; aip = aip->ai_next) {

--- a/src/lib/Libtpp/tpp_platform.c
+++ b/src/lib/Libtpp/tpp_platform.c
@@ -717,17 +717,15 @@ tpp_sock_resolve_host(char *host, int *count)
 	 */
 	tpp_lock(&tpp_nslookup_mutex);
 #endif
-	if ((rc = getaddrinfo(host, NULL, &hints, &pai)) != 0) {
+	rc = getaddrinfo(host, NULL, &hints, &pai)
+	/* unlock nslookup mutex */
 #ifndef WIN32
 		tpp_unlock(&tpp_nslookup_mutex);
 #endif
+	if (rc != 0) {
 		tpp_log(LOG_CRIT, NULL, "Error %d resolving %s", rc, host);
 		return NULL;
 	}
-#ifndef WIN32
-	/* unlock nslook up mutex */
-	tpp_unlock(&tpp_nslookup_mutex);
-#endif
 
 	*count = 0;
 	for (aip = pai; aip != NULL; aip = aip->ai_next) {

--- a/src/lib/Libtpp/tpp_platform.c
+++ b/src/lib/Libtpp/tpp_platform.c
@@ -717,7 +717,7 @@ tpp_sock_resolve_host(char *host, int *count)
 	 */
 	tpp_lock(&tpp_nslookup_mutex);
 #endif
-	rc = getaddrinfo(host, NULL, &hints, &pai)
+	rc = getaddrinfo(host, NULL, &hints, &pai);
 	/* unlock nslookup mutex */
 #ifndef WIN32
 		tpp_unlock(&tpp_nslookup_mutex);

--- a/src/lib/Libtpp/tpp_transport.c
+++ b/src/lib/Libtpp/tpp_transport.c
@@ -506,11 +506,6 @@ tpp_transport_init(struct tpp_config *conf)
 	if (tpp_init_rwlock(&cons_array_lock))
 		return -1;
 	
-	if (pthread_mutex_init(&tpp_nslookup_mutex, NULL) != 0) {
-		tpp_log(LOG_CRIT, __func__, "Failed to initialize nslookup mutex");
-		return -1;
-	}
-	
 #ifndef WIN32
 	/* for unix, set a pthread_atfork handler */
 	if (pthread_atfork(tpp_nslookup_atfork_prepare, tpp_nslookup_atfork_parent, tpp_nslookup_atfork_child) != 0) {

--- a/src/lib/Libtpp/tpp_util.c
+++ b/src/lib/Libtpp/tpp_util.c
@@ -81,6 +81,10 @@
  *	Global Variables
  */
 
+#ifndef WIN32
+pthread_mutex_t tpp_nslookup_mutex = PTHREAD_MUTEX_INITIALIZER;
+#endif
+
 /* TLS data for each TPP thread */
 static pthread_key_t tpp_key_tls;
 static pthread_once_t tpp_once_ctrl = PTHREAD_ONCE_INIT; /* once ctrl to initialize tls key */


### PR DESCRIPTION


#### Describe Bug or Feature
server, sched processes are exiting after the start with log message "Failed to lock mutex".


#### Describe Your Change
nslookup mutex which introduced in #2299 was acquiring the lock before initializing from tpp_init -> tpp_get_addresses -> tpp_resolv_sock_host. The nslookup mutex is initialized in tpp_transport_init which will be called after tpp_get_addresses.
Solving this issue by initializing nslookup mutex using PTHREAD_MUTEX_INITIALIZER macro(nitializes the static mutex mutex, setting its attributes to default values) And also apply this mutex only to linux platform as fork() API used for linux platforms only.



#### Attach Test and Valgrind Logs/Output
Id: 6593
Description: Tests from given sources on platforms SUSE15, CENTOS8, CENTOS7
Platforms: SUSE15,CENTOS8,CENTOS7
Profile: regression

Test Summary: total: 1956, fail: 0, error: 0, timedout: 0, skip: 0, pass: 1956



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
