### PR TITLE
Remove variable definition from tpp_internal.h

### DIFF
--- a/src/lib/Libtpp/tpp_internal.h
+++ b/src/lib/Libtpp/tpp_internal.h
@@ -512,7 +512,7 @@ int tpp_mod_fd(int, int, int);
  * from getaddrinfo(nslookup) during fork for periodic hook
  * set handlers using pthread_atfork.
  */
-pthread_mutex_t tpp_nslookup_mutex;
+extern pthread_mutex_t tpp_nslookup_mutex;
 void tpp_nslookup_atfork_prepare();
 void tpp_nslookup_atfork_parent();
 void tpp_nslookup_atfork_child();

--- a/src/lib/Libtpp/tpp_transport.c
+++ b/src/lib/Libtpp/tpp_transport.c
@@ -205,6 +205,12 @@ int conns_array_size = 0;                    /* the size of physical connection 
 pthread_rwlock_t cons_array_lock;            /* rwlock used to synchronize array ops */
 pthread_mutex_t thrd_array_lock;             /* mutex used to synchronize thrd assignment */
 
+/*
+ * mutex to prevent child process from inheriting getaddrinfo mutex using
+ * pthread_atfork handlers
+ */
+pthread_mutex_t tpp_nslookup_mutex;
+
 /* function forward declarations */
 static void *work(void *v);
 static int assign_to_worker(int tfd, int delay, thrd_data_t *td);


### PR DESCRIPTION
This PR fixes a _multiple definition of `tpp_nslookup_mutex'_ error by moving the definition into a source file and changing the instance in the header file to a declaration.
