### PR TITLE
errors in sched_config are reported on the wrong lines

### DIFF
--- a/src/lib/Libutil/misc_utils.c
+++ b/src/lib/Libutil/misc_utils.c
@@ -464,14 +464,10 @@ pbs_fgets_extend(char **pbuf, int *pbuf_size, FILE *fp)
 		while (len > 0 && isspace(buf[len-1]))
 			len--;
 
-		if (len > 0) {
-			if (buf[len - 1] != '\\') {
-				break;
-			}
-			else {
-				buf[len - 1] = '\0'; /* remove the backslash (\) */
-			}
-		}
+		if (len > 0 && buf[len - 1] == '\\')
+			buf[len - 1] = '\0'; /* remove the backslash (\) */
+		else /* We're at the end of a non-extended line */
+			break;
 	}
 
 	/* if we read just EOF */

--- a/src/scheduler/parse.cpp
+++ b/src/scheduler/parse.cpp
@@ -193,13 +193,13 @@ parse_config(const char *fname)
 
 #ifdef NAS
 	/* localmod 034 */
-	conf.max_borrow = UNSPECIFIED;
-	conf.per_share_topjobs = 0;
+	tmpconf.max_borrow = UNSPECIFIED;
+	tmpconf.per_share_topjobs = 0;
 	/* localmod 038 */
-	conf.per_queues_topjobs = 0;
+	tmpconf.per_queues_topjobs = 0;
 	/* localmod 030 */
-	conf.min_intrptd_cycle_length = 30;
-	conf.max_intrptd_cycles = 1;
+	tmpconf.min_intrptd_cycle_length = 30;
+	tmpconf.max_intrptd_cycles = 1;
 #endif
 
 	/* auto-set any internally needed config values before reading the file */
@@ -333,7 +333,7 @@ parse_config(const char *fname)
 					}
 				}
 				else if (!strcmp(config_name, PARSE_MAX_STARVE)) {
-					conf.max_starve = res_to_num(config_value, &type);
+					tmpconf.max_starve = res_to_num(config_value, &type);
 					if (!type.is_time) {
 						snprintf(errbuf, sizeof(errbuf), "Invalid time %s", config_value);
 						error = true;
@@ -344,7 +344,7 @@ parse_config(const char *fname)
 						obsolete[0] = PARSE_HALF_LIFE;
 						obsolete[1] = PARSE_FAIRSHARE_DECAY_TIME " and " PARSE_FAIRSHARE_DECAY_FACTOR " instead";
 					}
-					conf.decay_time = res_to_num(config_value, &type);
+					tmpconf.decay_time = res_to_num(config_value, &type);
 					if (!type.is_time) {
 						snprintf(errbuf, sizeof(errbuf), "Invalid time %s", config_value);
 						error = true;
@@ -360,7 +360,7 @@ parse_config(const char *fname)
 							sprintf(errbuf, "%s: Invalid value: %.*f.  Valid values are between 0 and 1.", PARSE_FAIRSHARE_DECAY_FACTOR, float_digits(fnum, 2), fnum);
 							error = true;
 						} else
-							conf.fairshare_decay_factor = fnum;
+							tmpconf.fairshare_decay_factor = fnum;
 					} else {
 						pbs_strncpy(errbuf, "Invalid " PARSE_FAIRSHARE_DECAY_FACTOR, sizeof(errbuf));
 						error = true;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Errors in the sched_config are reported on the wrong lines.  Also, a lot of errors in the sched_config don't report what the error is.

#### Describe Your Change
pbs_fgets_extend() would combine blank lines into the following line.  This means the line number reported would be the current line - number of blank lines above.  

There were also a lot of errors in the sched_config which didn't report what the error was.  This would just report that there was an error on a line number (which was wrong).  I added an error message to all sched_config errors.

#### Attach Test and Valgrind Logs/Output
Here's the errors from the sched_config file in the log:
03/19/2021 12:52:13.537980;0040;pbs_sched;Fil;sched_config;Error reading line 466: Unknown config parameter
03/19/2021 12:52:13.538012;0040;pbs_sched;Fil;sched_config;Error reading line 467: Config line invalid
03/19/2021 12:52:13.538024;0040;pbs_sched;Fil;sched_config;Error reading line 471: Invalid fairshare_decay_factor
03/19/2021 12:52:13.538032;0040;pbs_sched;Fil;sched_config;Error reading line 472: fairshare_entity foo is erroneous (or deprecated).
03/19/2021 12:52:13.538039;0040;pbs_sched;Fil;sched_config;Error reading line 473: resv_confirm_ignore valid values: dedicated_time or none
03/19/2021 12:52:13.538047;0040;pbs_sched;Fil;sched_config;Error reading line 474: Invalid job_sort_key
03/19/2021 12:52:13.538056;0040;pbs_sched;Fil;sched_config;Error reading line 475: Invalid node_sort_key
03/19/2021 12:52:13.538067;0040;pbs_sched;Fil;sched_config;Error reading line 476: server_dyn_res script /foo does not exist
03/19/2021 12:52:13.538074;0040;pbs_sched;Fil;sched_config;Error reading line 477: Invalid server_dyn_res
03/19/2021 12:52:13.538082;0040;pbs_sched;Fil;sched_config;Error reading line 478: Invalid peer queue
