### PR TITLE
fix entity limit tests

### DIFF
--- a/test/tests/functional/pbs_test_entity_limits.py
+++ b/test/tests/functional/pbs_test_entity_limits.py
@@ -107,7 +107,7 @@ class TestEntityLimits(TestFunctional):
         j = Job(TEST_USER, job_attr)
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'B'}, id=jid)
-        subjob1 = jid.replace('[]', '[1]')
+        subjob1 = j.create_subjob_id(jid, 1)
         self.server.expect(JOB, {'job_state': 'R'}, id=subjob1)
 
         del job_attr[ATTR_J]

--- a/test/tests/functional/pbs_test_entity_limits.py
+++ b/test/tests/functional/pbs_test_entity_limits.py
@@ -107,6 +107,8 @@ class TestEntityLimits(TestFunctional):
         j = Job(TEST_USER, job_attr)
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'B'}, id=jid)
+        subjob1 = jid.replace('[]', '[1]')
+        self.server.expect(JOB, {'job_state': 'R'}, id=subjob1)
 
         del job_attr[ATTR_J]
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
test cases from TestEntityLimits testsuite were failing randomly.
For all the test cases - the common error reported was -
Traceback (most recent call last):
  File "/opt/ptl/tests/functional/pbs_test_entity_limits.py", line 272, in test_queue_generic_group_limits_queued
    self.common_limit_test(False, a, attrs, queued=True, exp_err=errmsg)
  File "/opt/ptl/tests/functional/pbs_test_entity_limits.py", line 136, in common_limit_test
    self.assertFalse(True, "Job violating limits got submitted after "
AssertionError: True is not false : Job violating limits got submitted after server restart.

Test setup:
1 ncpu
Relevant steps:
1) All the test cases submit an array job, with subjobs equal to the limit set. expect the parent job to be in 'B' state.
2) Make sure the limit is already hit.
3) restart the server.
4) submit a job and expect the submission to be rejected as the limit is already hit.

Whenever the test case fails - we see the below in the server logs -
03/19/2021 07:09:15.632074;0086;Server@x6588-16-0;Job;76[1].x6588-16-0;Requeueing job, **substate: 41** Requeued in queue: workq

server recovers the job with substate 41.
MoM reports the job to be in substate 42.
because of the substate mismatch, the job is discarded and we see the below in the server logs -
03/19/2021 07:09:16.578465;0800;Server@x6588-16-0;Job;76[1].x6588-16-0;ET_LIM_DBG: set_single_entity_res: kstr **p:p1;ncpus, 1, DECR**, res ncpus, (nil)
03/19/2021 07:09:16.578476;0800;Server@x6588-16-0;Job;76[1].x6588-16-0;ET_LIM_DBG: set_single_entity_res: **usage DECR to 9**

Now, when a new job is submitted, it is allowed to be queued.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
The fix is to confirm that the server has the substate set to 42 before proceeding further, so that on restart, server recovers the job in substate 42 and there is no mismatch.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[logfile_PASS.txt](https://github.com/openpbs/openpbs/files/6176472/logfile_PASS.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->