### PR TITLE
test fixes for TestSchedJobRunWait

### DIFF
--- a/test/tests/functional/pbs_sched_runjobwait.py
+++ b/test/tests/functional/pbs_sched_runjobwait.py
@@ -106,16 +106,9 @@ class TestSchedJobRunWait(TestFunctional):
         # Setting job_run_wait to 'none' should just delete TP
         self.server.manager(MGR_CMD_SET, SCHED,
                             {'job_run_wait': "none"}, id="default")
-        qmgr_path = os.path.join(self.server.pbs_conf['PBS_EXEC'], 'bin',
-                                 'qmgr')
-        qmgr_cmd = [qmgr_path, "-c", "\'print sched throughput_mode\'"]
-        ret = self.du.run_cmd(self.server.hostname,
-                              cmd=qmgr_cmd, as_script=True)
-        self.assertEqual(ret['rc'], 0)
-        self.logger.info(ret['out'])
-        for l in ret['out']:
-            self.assertNotIn('throughput_mode', l,
-                             'throughput_mode displayed when not expected')
+        rt = self.server.status(SCHED)
+        self.assertNotIn('throughput_mode', rt[0].keys(),
+                         'throughput_mode displayed when not expected')
 
         # Setting JRW to runjob/execjob should set TP correctly
         self.server.manager(MGR_CMD_SET, SCHED,


### PR DESCRIPTION


<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
**TestSchedJobRunWait.test_jobrunwait_throughput_clash**
**Issue**: Failed at verification of scheduler attribute 'throughput_mode' to be removed when 'run_job_wait=none'
**Error**: ptl.lib.ptl_error.PtlExpectError: rc=1, rv=False, msg=expected on server x6069-1931-0: throughput_mode = True sched default attempt: 180

**TestSchedJobRunWait.test_multisched_multival**
**Failure**: Failed at create_vnodes() method
**Error**: TypeError: create_vnodes() got multiple values for argument 'additive'

**TestSchedJobRunWait.test_throughput_ok**
**Failure**: Failed due to race condition during log message verification
**Error**: ptl.lib.ptl_error.PtlLogMatchError: rc=1, rv=False, msg=server x6069-1931-0 log match: searching for "Type 15 request received" - with existence - attempt 180


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
**TestSchedJobRunWait.test_jobrunwait_throughput_clash**: 
	Rectified the verification of scheduler attribute 'throughput_mode' to be removed when 'run_job_wait=none'
**TestSchedJobRunWait.test_multisched_multival**:
	Rectified the arguments of create_vnodes() method
**TestSchedJobRunWait.test_throughput_ok**:
	Fixed race condition caused due to log verification from time after job submission


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Before
[logfile_ERROR_multival.txt](https://github.com/openpbs/openpbs/files/6192252/logfile_ERROR_multival.txt)
[logfile_FAIL_clash.txt](https://github.com/openpbs/openpbs/files/6192253/logfile_FAIL_clash.txt)
[logfile_FAIL_thrghput_ok.txt](https://github.com/openpbs/openpbs/files/6192254/logfile_FAIL_thrghput_ok.txt)

After
[jobrunwait_full.txt](https://github.com/openpbs/openpbs/files/6192241/jobrunwait_full.txt)


<!--- Pull Request
 Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
