### PR TITLE
Changed snapshot to capture qstat_tf

### DIFF
--- a/test/fw/ptl/utils/pbs_snaputils.py
+++ b/test/fw/ptl/utils/pbs_snaputils.py
@@ -767,13 +767,13 @@ class _PBSSnapUtils(object):
             # Job information
             value = (QSTAT_F_PATH, [QSTAT_CMD, "-f"])
             self.job_info[QSTAT_F_OUT] = value
+            value = (QSTAT_TF_PATH, [QSTAT_CMD, "-tf"])
+            self.job_info[QSTAT_TF_OUT] = value
             if not self.basic:
                 value = (QSTAT_PATH, [QSTAT_CMD])
                 self.job_info[QSTAT_OUT] = value
                 value = (QSTAT_T_PATH, [QSTAT_CMD, "-t"])
                 self.job_info[QSTAT_T_OUT] = value
-                value = (QSTAT_TF_PATH, [QSTAT_CMD, "-tf"])
-                self.job_info[QSTAT_TF_OUT] = value
                 value = (QSTAT_X_PATH, [QSTAT_CMD, "-x"])
                 self.job_info[QSTAT_X_OUT] = value
                 value = (QSTAT_XF_PATH, [QSTAT_CMD, "-xf"])


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
PBS snapshot does not capture array subjobs info in '--basic' mode.


#### Describe Your Change
Made a change to capture "qstat -tf" output in '--basic' mode.


#### Link to Design Doc
https://community.openpbs.org/t/pbs-snapshot-basic-to-capture-minimal-useful-data/1764
https://openpbs.atlassian.net/wiki/spaces/PD/pages/1351221249/pbs+snapshot+--basic+to+capture+minimal+useful+data

#### Attach Test and Valgrind Logs/Output
```
[root@Nile /tmp]# pbs_snapshot --basic -o /tmp 2> /dev/null
Snapshot available at: /tmp/snapshot_20210323_18_46_30.tgz
[root@Nile /tmp]# tar -tvf snapshot_20210323_18_46_30.tgz | grep qstat_tf.out
-rw-r--r-- root/root     19568 2021-03-23 18:46 snapshot_20210323_18_46_30/job/qstat_tf.out
[root@Nile /tmp]# 

```

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
