### PR TITLE
Fix TestNonprintingCharacters to match qstat output of job

### DIFF
--- a/test/tests/functional/pbs_nonprint_characters.py
+++ b/test/tests/functional/pbs_nonprint_characters.py
@@ -161,9 +161,9 @@ sleep 5
         cmd = [self.qstat_cmd, '-xf', jid]
         ret = self.du.run_cmd(self.server.hostname, cmd=cmd)
         if '\t' in chk_var:
-            job_str = ''.join(ret['out']).replace('\t\t','\t')
+            job_str = ''.join(ret['out']).replace('\t\t', '\t')
         else:
-            job_str = ''.join(ret['out']).replace('\t','')
+            job_str = ''.join(ret['out']).replace('\t', '')
         self.assertIn(chk_var, job_str)
         self.logger.info('qstat -xf output has: %s' % chk_var)
 

--- a/test/tests/functional/pbs_nonprint_characters.py
+++ b/test/tests/functional/pbs_nonprint_characters.py
@@ -160,8 +160,10 @@ sleep 5
         """
         cmd = [self.qstat_cmd, '-xf', jid]
         ret = self.du.run_cmd(self.server.hostname, cmd=cmd)
-        job_str = ""
-        job_str = ''.join(ret['out'])
+        if '\t' in chk_var:
+            job_str = ''.join(ret['out']).replace('\t\t','\t')
+        else:
+            job_str = ''.join(ret['out']).replace('\t','')
         self.assertIn(chk_var, job_str)
         self.logger.info('qstat -xf output has: %s' % chk_var)
 

--- a/test/tests/functional/pbs_nonprint_characters.py
+++ b/test/tests/functional/pbs_nonprint_characters.py
@@ -160,12 +160,8 @@ sleep 5
         """
         cmd = [self.qstat_cmd, '-xf', jid]
         ret = self.du.run_cmd(self.server.hostname, cmd=cmd)
-        k = chk_var.split('=')[0]
-        for elem in ret['out']:
-            if k in elem:
-                i = ret['out'].index(elem)
-                job_str = elem.strip('\t') + ret['out'][i + 1].strip('\t')
-                break
+        job_str = ""
+        job_str = ''.join(ret['out'])
         self.assertIn(chk_var, job_str)
         self.logger.info('qstat -xf output has: %s' % chk_var)
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
1. Fix TestNonprintingCharacters to match qstat output of job
2. Depending on system, qstat command will add /t to job output.
3.e:g: AssertionError: 'NONPRINT_VAR=X\\,\t\\,Y' not found in 'NOSE_TESTMATCH=(^(?:[\\\\w]+|^)Test|pbs_|^test_[\\\\(]*),NONPRINT_VAR=X\\,\\,Y,PBS_O_QUEUE=workq,'
4. In the above example we were stripping /t from string. It resulted in test case failure.


#### Describe Your Change
1. Pass complete qstat output of job to assertIn function.
2. If check string contains '\t' then replace '\t\t' with \t. Else replace '\t' with ''.

#### Link to Design Doc
NA


#### Attach Test and Valgrind Logs/Output


[6675-ALL.zip](https://github.com/openpbs/openpbs/files/6194332/6675-ALL.zip)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
