### PR TITLE
modified ptl json report

### DIFF
--- a/test/fw/ptl/utils/plugins/ptl_report_json.py
+++ b/test/fw/ptl/utils/plugins/ptl_report_json.py
@@ -211,9 +211,6 @@ class PTLJsonData(object):
                 test_status = "PASS"
                 m_avg['testsuites'][tsname]['testcases'][tcname] = []
                 t_sum = []
-                sum_std = []
-                sum_min = []
-                sum_max = []
                 count = 0
                 j_data = data_json['testsuites'][tsname]['testcases'][tcname]
                 measurements_data = []
@@ -227,11 +224,17 @@ class PTLJsonData(object):
                     m_sum = []
                     for i in range(len(m)):
                         sum_mean = 0
+                        sum_std = []
+                        sum_min = []
+                        sum_max = []
                         record = []
                         if "test_measure" in m[i].keys():
                             if len(t_sum) > i:
                                 sum_mean = m[i]["test_data"]['mean'] + \
                                     t_sum[i][0]
+                                sum_std.extend(t_sum[i][1])
+                                sum_min.extend(t_sum[i][2])
+                                sum_max.extend(t_sum[i][3])
                             else:
                                 measurements_data.append(m[i])
                                 sum_mean = m[i]["test_data"]['mean']


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
In avg_measurements , Average values are calculated by using all the measurements data within a test. So within a test all measurements are getting same average value.

**"avg_measurements":** {
    "testsuites": {
      "TestJobPerf": {
        "testcases": {
          "test_job_performance_sched_off": [
            {},
            {
              "test_measure": "job_submission",
              "test_data": {
                "mean": 1315.94,
                "minimum": 1264.01,
                "std_dev": 371.17836164033054,
                "maximum": 2050.46
              },
              "unit": "jobs/sec"
            },
            {
              "test_measure": "job_run_rate",
              "test_data": {
                "mean": 1993.0500000000002,
                "minimum": 1264.01,
                "std_dev": 371.17836164033054,
                "maximum": 2050.46
              },
              "unit": "jobs/sec"
            }
          ]
        }
      }
    }
  },
#### Describe Your Change
Within a test all measurements are getting  individual average values


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[json_report.txt](https://github.com/openpbs/openpbs/files/6194421/json_report.txt)
[json_report_befor_changes.txt](https://github.com/openpbs/openpbs/files/6194470/json_report_befor_changes.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
