### PR TITLE
C++ refactor of resdef structure

### DIFF
--- a/src/scheduler/buckets.cpp
+++ b/src/scheduler/buckets.cpp
@@ -911,9 +911,9 @@ int job_should_use_buckets(resource_resv *resresv) {
 
 	/* Job's requesting specific hosts or vnodes use the standard path */
 	const auto& defs = resresv->select->defs;
-	if (defs.find(getallres(RES_HOST)) != defs.end())
+	if (defs.find(allres["host"]) != defs.end())
 		return 0;
-	if (defs.find(getallres(RES_VNODE)) != defs.end())
+	if (defs.find(allres["vnode"]) != defs.end())
 		return 0;
 	/* If a job has an execselect, it means it's requesting vnode */
 	if (resresv->execselect != NULL)

--- a/src/scheduler/check.cpp
+++ b/src/scheduler/check.cpp
@@ -955,7 +955,7 @@ is_ok_to_run(status *policy, server_info *sinfo,
 #ifdef NAS /* localmod 036 */
 			{
 				if (resresv->job->resv->resv->is_standing) {
-					resource_req *req = find_resource_req(resresv->resreq, getallres(RES_MIN_WALLTIME));
+					resource_req *req = find_resource_req(resresv->resreq, allres["min_walltime"];
 
 					if (req != NULL) {
 						int resv_time_left = calc_time_left(resresv->job->resv, 0);
@@ -1169,7 +1169,7 @@ match_resource(schd_resource *res, resource_req *resreq, unsigned int flags, enu
 				/* Set arg2 for vnode/host resource. In case of preemption, arg2 is used to cull
 				 * the list of running jobs
 				 */
-				if ((res->def == getallres(RES_HOST)) || (res->def == getallres(RES_VNODE)))
+				if (res->def == allres["host"] || (res->def == allres["vnode"]))
 					set_schd_error_arg(err, ARG2, requested);
 			}
 		}

--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -87,7 +87,7 @@ struct schd_error;
 struct np_cache;
 struct chunk;
 class selspec;
-struct resdef;
+class resdef;
 struct event_list;
 struct status;
 struct fairshare_head;
@@ -121,7 +121,6 @@ typedef struct place place;
 typedef struct schd_error schd_error;
 typedef struct np_cache np_cache;
 typedef struct chunk chunk;
-typedef struct resdef resdef;
 typedef struct timed_event timed_event;
 typedef struct event_list event_list;
 typedef struct fairshare_head fairshare_head;
@@ -823,8 +822,9 @@ class resource_resv
 	~resource_resv();
 };
 
-struct resource_type
+class resource_type
 {
+	public:
 	/* non consumable - used for selection only (e.g. arch) */
 	bool is_non_consumable:1;
 	bool is_string:1;
@@ -837,12 +837,13 @@ struct resource_type
 	bool is_float:1;
 	bool is_size:1;	/* all sizes are converted into kb */
 	bool is_time:1;
+	resource_type();
 };
 
 struct schd_resource
 {
 	const char *name;			/* name of the resource - reference to the definition name */
-	struct resource_type type;	/* resource type */
+	resource_type type;	/* resource type */
 
 	char *orig_str_avail;		/* original resources_available string */
 
@@ -861,8 +862,8 @@ struct schd_resource
 
 struct resource_req
 {
-	char *name;			/* name of the resource - reference to the definition name */
-	struct resource_type type;	/* resource type information */
+	const char *name;			/* name of the resource - reference to the definition name */
+	resource_type type;	/* resource type information */
 
 	sch_resource_t amount;		/* numeric value of resource */
 	char *res_str;			/* string value of resource */
@@ -870,11 +871,13 @@ struct resource_req
 	struct resource_req *next;	/* next resource_req in list */
 };
 
-struct resdef
+class resdef
 {
-	char *name;			/* name of resource */
-	struct resource_type type;	/* resource type */
-	unsigned int flags;		/* resource flags (see pbs_ifl.h) */
+	public:
+	const std::string name;	/* name of resource */
+	resource_type type;	/* resource type */
+	unsigned int flags;	/* resource flags (see pbs_ifl.h) */
+	resdef(char *rname, unsigned int rflags, resource_type rtype) : name(rname), type(rtype), flags(rflags) {}
 };
 
 class prev_job_info
@@ -901,7 +904,7 @@ struct counts
 
 struct resource_count
 {
-	char *name;		    /* resource name */
+	const char *name;		    /* resource name */
 	resdef *def;		    /* definition of resource */
 	sch_resource_t amount;	    /* amount of resource used */
 	int soft_limit_preempt_bit; /* Place to store preempt bit if resource of an entity is over limits */

--- a/src/scheduler/fifo.cpp
+++ b/src/scheduler/fifo.cpp
@@ -483,9 +483,9 @@ schedule(int sd, const sched_cmd *cmd)
 		case SCH_SCHEDULE_FIRST:
 			/*
 			 * on the first cycle after the server restarts custom resources
-			 * may have been added.  Dump what we have so we'll requery them.
+			 * may have been added.
 			 */
-			reset_global_resource_ptrs();
+			update_resource_defs(sd);
 
 			/* Get config from the qmgr sched object */
 			if (!set_validate_sched_attrs(sd))
@@ -506,11 +506,11 @@ schedule(int sd, const sched_cmd *cmd)
 		case SCH_CONFIGURE:
 			log_event(PBSEVENT_SCHED, PBS_EVENTCLASS_SCHED, LOG_INFO,
 				  "reconfigure", "Scheduler is reconfiguring");
-			reset_global_resource_ptrs();
-
 			/* Get config from sched_priv/ files */
 			if (schedinit(-1) != 0)
 				return 0;
+
+			update_resource_defs(sd);
 
 			/* Get config from the qmgr sched object */
 			if (!set_validate_sched_attrs(sd))

--- a/src/scheduler/fifo.cpp
+++ b/src/scheduler/fifo.cpp
@@ -2227,7 +2227,7 @@ next_job(status *policy, server_info *sinfo, int flag)
 	int queues_finished = 0;
 	int queue_index_size = 0;
 	int j = 0;
-	int ind;
+	int ind = -1;
 
 	if ((policy == NULL) || (sinfo == NULL))
 		return NULL;

--- a/src/scheduler/globals.cpp
+++ b/src/scheduler/globals.cpp
@@ -114,24 +114,25 @@ const struct enum_conv preempt_prio_info[] =
 	{ PREEMPT_HIGH, "" }
 };
 
-/* Used to create static indexes into allres */
-const struct enum_conv resind[] =
+/* Well known resources: If these aren't queried, we return an error.
+ * Any resource you want to directly index into allres should be in this list
+ */
+const std::vector<std::string> well_known_res
 	{
-	{RES_CPUT, "cput"},
-	{RES_MEM, "mem"},
-	{RES_WALLTIME, "walltime"},
-	{RES_SOFT_WALLTIME, "soft_walltime"},
-	{RES_NCPUS, "ncpus"},
-	{RES_ARCH, "arch"},
-	{RES_HOST, "host"},
-	{RES_VNODE, "vnode"},
-	{RES_AOE, "aoe"},
-	{RES_EOE, "eoe"},
-	{RES_MIN_WALLTIME, "min_walltime"},
-	{RES_MAX_WALLTIME, "max_walltime"},
-	{RES_PREEMPT_TARGETS, "preempt_targets"},
-	{RES_HIGH, ""}
-};
+		"cput",
+		"mem",
+		"walltime",
+		"soft_walltime",
+		"ncpus",
+		"arch",
+		"host",
+		"vnode",
+		"aoe",
+		"eoe",
+		"min_walltime",
+		"max_walltime",
+		"preempt_targets",
+	};
 
 struct config conf;
 struct status cstat;
@@ -165,11 +166,11 @@ pthread_once_t key_once = PTHREAD_ONCE_INIT;
 /* resource definitions from the server */
 
 /* all resources */
-resdef **allres = NULL;
+std::unordered_map<std::string, resdef *> allres;
 /* consumable resources */
-resdef **consres = NULL;
+std::unordered_set<resdef *> consres;
 /* boolean resources*/
-resdef **boolres = NULL;
+std::unordered_set<resdef *> boolres;
 
 /* AOE name used to compare nodes, free when exit cycle */
 char *cmp_aoename = NULL;

--- a/src/scheduler/globals.h
+++ b/src/scheduler/globals.h
@@ -79,9 +79,7 @@ extern const int num_resget;
 /* Variables from pbs_sched code */
 extern int got_sigpipe;
 
-/* static indexes into allres */
-extern const struct enum_conv resind[];
-
+extern const std::vector<std::string> well_known_res;
 /* Stuff needed for multi-threading */
 extern pthread_mutex_t general_lock;
 extern pthread_mutex_t work_lock;
@@ -96,9 +94,9 @@ extern int num_threads;
 extern pthread_key_t th_id_key;
 extern pthread_once_t key_once;
 
-extern resdef **allres;
-extern resdef **consres;
-extern resdef **boolres;
+extern std::unordered_map<std::string, resdef *> allres;
+extern std::unordered_set<resdef *> consres;
+extern std::unordered_set<resdef *> boolres;
 
 extern const char *sc_name;
 extern char *logfile;

--- a/src/scheduler/job_info.cpp
+++ b/src/scheduler/job_info.cpp
@@ -667,12 +667,12 @@ query_jobs_chunk(th_data_query_jinfo *data)
 		/* Find out if it is a shrink-to-fit job.
 		 * If yes, set the duration to max walltime.
 		 */
-		req = find_resource_req(resresv->resreq, getallres(RES_MIN_WALLTIME));
+		req = find_resource_req(resresv->resreq, allres["min_walltime"]);
 		if (req != NULL) {
 			resresv->is_shrink_to_fit = 1;
 			/* Set the min duration */
 			resresv->min_duration = (time_t) req->amount;
-			req = find_resource_req(resresv->resreq, getallres(RES_MAX_WALLTIME));
+			req = find_resource_req(resresv->resreq, allres["max_walltime"]);
 
 #ifdef NAS /* localmod 026 */
 			/* if no max_walltime is set then we want to look at what walltime
@@ -680,19 +680,19 @@ query_jobs_chunk(th_data_query_jinfo *data)
 			 * queue max, or server max.
 			 */
 			if (req == NULL) {
-				req = find_resource_req(resresv->resreq, getallres(RES_WALLTIME));
+				req = find_resource_req(resresv->resreq, allres["walltime"]);
 
 				/* if walltime is set, use it if it's greater than min_walltime */
 				if (req != NULL && resresv->min_duration > req->amount) {
-					req = find_resource_req(resresv->resreq, getallres(RES_MIN_WALLTIME));
+					req = find_resource_req(resresv->resreq, allres["min_walltime"]);
 				}
 			}
 #endif /* localmod 026 */
 		}
 
 		if ((req == NULL) || (resresv->job->is_running == 1)) {
-			soft_walltime_req = find_resource_req(resresv->resreq, getallres(RES_SOFT_WALLTIME));
-			walltime_req = find_resource_req(resresv->resreq, getallres(RES_WALLTIME));
+			soft_walltime_req = find_resource_req(resresv->resreq, allres["soft_walltime"]);
+			walltime_req = find_resource_req(resresv->resreq, allres["walltime"]);
 			if (soft_walltime_req != NULL)
 				req = soft_walltime_req;
 			else
@@ -2094,9 +2094,9 @@ translate_fail_code(schd_error *err, char *comment_msg, char *log_msg)
 		case QUEUE_PROJECT_RES_LIMIT_REACHED:
 		case QUEUE_USER_RES_LIMIT_REACHED:
 			if (comment_msg != NULL && err->rdef != NULL)
-				snprintf(commentbuf, sizeof(commentbuf), ERR2COMMENT(err->error_code), arg1, err->rdef->name);
+				snprintf(commentbuf, sizeof(commentbuf), ERR2COMMENT(err->error_code), arg1, err->rdef->name.c_str());
 			if (log_msg != NULL && err->rdef != NULL)
-				snprintf(log_msg, MAX_LOG_SIZE, ERR2INFO(err->error_code), arg1, err->rdef->name);
+				snprintf(log_msg, MAX_LOG_SIZE, ERR2INFO(err->error_code), arg1, err->rdef->name.c_str());
 			break;
 
 		/* codes using resource definition in error structure */
@@ -2105,9 +2105,9 @@ translate_fail_code(schd_error *err, char *comment_msg, char *log_msg)
 		case SERVER_USER_RES_LIMIT_REACHED:
 		case SERVER_RESOURCE_LIMIT_REACHED:
 			if (comment_msg != NULL && err->rdef != NULL)
-				snprintf(commentbuf, sizeof(commentbuf), ERR2COMMENT(err->error_code), err->rdef->name);
+				snprintf(commentbuf, sizeof(commentbuf), ERR2COMMENT(err->error_code), err->rdef->name.c_str());
 			if (log_msg != NULL && err->rdef != NULL)
-				snprintf(log_msg, MAX_LOG_SIZE, ERR2INFO(err->error_code), err->rdef->name);
+				snprintf(log_msg, MAX_LOG_SIZE, ERR2INFO(err->error_code), err->rdef->name.c_str());
 			break;
 
 		/* codes using a resource definition and arg1 in a different order */
@@ -2116,10 +2116,10 @@ translate_fail_code(schd_error *err, char *comment_msg, char *log_msg)
 		case INSUFFICIENT_SERVER_RESOURCE:
 		case INSUFFICIENT_RESOURCE:
 			if (comment_msg != NULL && err->rdef != NULL)
-				snprintf(commentbuf, sizeof(commentbuf), ERR2COMMENT(err->error_code), err->rdef->name,
+				snprintf(commentbuf, sizeof(commentbuf), ERR2COMMENT(err->error_code), err->rdef->name.c_str(),
 					arg1 == NULL ? "" : arg1);
 			if (log_msg != NULL && err->rdef != NULL)
-				snprintf(log_msg, MAX_LOG_SIZE, ERR2INFO(err->error_code), err->rdef->name,
+				snprintf(log_msg, MAX_LOG_SIZE, ERR2INFO(err->error_code), err->rdef->name.c_str(),
 					arg1 == NULL ? "" : arg1);
 			break;
 
@@ -2128,9 +2128,9 @@ translate_fail_code(schd_error *err, char *comment_msg, char *log_msg)
 		case QUEUE_BYPROJECT_RES_LIMIT_REACHED:
 		case QUEUE_BYUSER_RES_LIMIT_REACHED:
 			if (comment_msg != NULL && err->rdef != NULL)
-				snprintf(commentbuf, sizeof(commentbuf), ERR2COMMENT(err->error_code), arg3, err->rdef->name, arg1);
+				snprintf(commentbuf, sizeof(commentbuf), ERR2COMMENT(err->error_code), arg3, err->rdef->name.c_str(), arg1);
 			if (log_msg != NULL && err->rdef != NULL)
-				snprintf(log_msg, MAX_LOG_SIZE, ERR2INFO(err->error_code), arg3, err->rdef->name, arg1);
+				snprintf(log_msg, MAX_LOG_SIZE, ERR2INFO(err->error_code), arg3, err->rdef->name.c_str(), arg1);
 			break;
 
 		/* codes using resource definition and arg2 */
@@ -2139,10 +2139,10 @@ translate_fail_code(schd_error *err, char *comment_msg, char *log_msg)
 		case SERVER_BYUSER_RES_LIMIT_REACHED:
 			if (comment_msg != NULL && err->rdef != NULL)
 				snprintf(commentbuf, sizeof(commentbuf), ERR2COMMENT(err->error_code), arg2,
-					err->rdef->name);
+					err->rdef->name.c_str());
 			if (log_msg != NULL && err->rdef != NULL)
 				snprintf(log_msg, MAX_LOG_SIZE, ERR2INFO(err->error_code), arg2,
-					err->rdef->name);
+					err->rdef->name.c_str());
 			break;
 
 		case RESERVATION_INTERFERENCE:
@@ -2483,12 +2483,12 @@ create_resresv_sets_resdef(status *policy) {
 	limres = query_limres();
 
 	defs = policy->resdef_to_check;
-	defs.insert(getallres(RES_CPUT));
-	defs.insert(getallres(RES_WALLTIME));
-	defs.insert(getallres(RES_MAX_WALLTIME));
-	defs.insert(getallres(RES_MIN_WALLTIME));
+	defs.insert(allres["cput"]);
+	defs.insert(allres["walltime"]);
+	defs.insert(allres["max_walltime"]);
+	defs.insert(allres["min_walltime"]);
 	if(sc_attrs.preempt_targets_enable)
-		defs.insert(getallres(RES_PREEMPT_TARGETS));
+		defs.insert(allres["preempt_targets"]);
 
 	for (auto cur_res = limres; cur_res != NULL; cur_res = cur_res->next)
 			defs.insert(cur_res->def);
@@ -2892,16 +2892,16 @@ get_job_req_used_time(resource_resv *pjob, int *rtime, int *utime)
 			|| rtime == NULL || utime == NULL)
 		return 1;
 
-	req = find_resource_req(pjob->resreq, getallres(RES_SOFT_WALLTIME));
+	req = find_resource_req(pjob->resreq, allres["soft_walltime"]);
 
 	if (req == NULL)
-		req = find_resource_req(pjob->resreq, getallres(RES_WALLTIME));
+		req = find_resource_req(pjob->resreq, allres["walltime"]);
 
 	if (req == NULL) {
-		req = find_resource_req(pjob->resreq, getallres(RES_CPUT));
-		used = find_resource_req(pjob->job->resused, getallres(RES_CPUT));
+		req = find_resource_req(pjob->resreq, allres["cput"]);
+		used = find_resource_req(pjob->job->resused, allres["cput"]);;
 	} else
-		used = find_resource_req(pjob->job->resused, getallres(RES_WALLTIME));
+		used = find_resource_req(pjob->job->resused, allres["walltime"]);
 
 	if (req != NULL && used != NULL) {
 		*rtime = req->amount;
@@ -3290,7 +3290,7 @@ find_jobs_to_preempt(status *policy, resource_resv *hjob, server_info *sinfo, in
 	pjobs[0] = NULL;
 
 	if (sc_attrs.preempt_targets_enable) {
-		preempt_targets_req = find_resource_req(hjob->resreq, getallres(RES_PREEMPT_TARGETS));
+		preempt_targets_req = find_resource_req(hjob->resreq, allres["preempt_targets"]);
 		if (preempt_targets_req != NULL) {
 
 			preempt_targets_list = break_comma_list(preempt_targets_req->res_str);
@@ -4213,7 +4213,6 @@ formula_evaluate(const char *formula, resource_resv *resresv, resource_req *resr
 	resource_req *req;
 	sch_resource_t ans = 0;
 	const char *str;
-	int i;
 	char *formula_buf;
 	int formula_buf_len;
 
@@ -4222,7 +4221,7 @@ formula_evaluate(const char *formula, resource_resv *resresv, resource_req *resr
 	PyObject *obj;
 
 	if (formula == NULL || resresv == NULL ||
-		resresv->job == NULL || consres == NULL)
+		resresv->job == NULL)
 		return 0;
 
 	formula_buf_len = sizeof(buf) + strlen(formula) + 1;
@@ -4248,14 +4247,14 @@ formula_evaluate(const char *formula, resource_resv *resresv, resource_req *resr
 	}
 
 
-	for (i = 0; consres[i] != NULL; i++) {
-		req = find_resource_req(resreq, consres[i]);
+	for (const auto& cr: consres) {
+		req = find_resource_req(resreq, cr);
 
 		if (req != NULL)
-			sprintf(buf, "\'%s\':%.*f,", consres[i]->name,
+			sprintf(buf, "\'%s\':%.*f,", cr->name.c_str(),
 				float_digits(req->amount, FLOAT_NUM_DIGITS), req->amount);
 		else
-			sprintf(buf, "\'%s\' : 0,", consres[i]->name);
+			sprintf(buf, "\'%s\' : 0,", cr->name.c_str());
 
 		if (pbs_strcat(&globals, &globals_size, buf) == NULL) {
 			free(globals);
@@ -4525,7 +4524,7 @@ getaoename(selspec *select)
 		return NULL;
 
 	for (i = 0; select->chunks[i] != NULL; i++) {
-		req = find_resource_req(select->chunks[i]->req, getallres(RES_AOE));
+		req = find_resource_req(select->chunks[i]->req, allres["aoe"]);
 		if (req != NULL)
 			return string_dup(req->res_str);
 	}
@@ -4564,7 +4563,7 @@ geteoename(selspec *select)
 	/* we only need to look at 1st chunk since either all request eoe
 	 * or none request eoe.
 	 */
-	req = find_resource_req(select->chunks[0]->req, getallres(RES_EOE));
+	req = find_resource_req(select->chunks[0]->req, allres["eoe"]);
 	if (req != NULL)
 		return string_dup(req->res_str);
 
@@ -5072,8 +5071,8 @@ extend_soft_walltime(resource_resv *resresv, time_t server_time)
 	if (resresv == NULL)
 		return UNSPECIFIED;
 
-	soft_walltime_req = find_resource_req(resresv->resreq, getallres(RES_SOFT_WALLTIME));
-	walltime_req = find_resource_req(resresv->resreq, getallres(RES_WALLTIME));
+	soft_walltime_req = find_resource_req(resresv->resreq, allres["soft_walltime"]);
+	walltime_req = find_resource_req(resresv->resreq, allres["walltime"]);
 
 	if (soft_walltime_req == NULL) { /* Nothing to extend */
 		if(walltime_req != NULL)
@@ -5223,10 +5222,10 @@ static int cull_preemptible_jobs(resource_resv *job, const void *arg)
 			 * do not get into chunk level resources. So in such a case we
 			 * compare the resource name with the chunk name
 			 */
-			if (inp->err->rdef == getallres(RES_VNODE)) {
+			if (inp->err->rdef == allres["vnode"]) {
 				if (inp->err->arg2 != NULL && find_node_info(job->ninfo_arr, inp->err->arg2) != NULL)
 					return 1;
-			} else if (inp->err->rdef == getallres(RES_HOST)) {
+			} else if (inp->err->rdef == allres["host"]) {
 				if (inp->err->arg2 != NULL && find_node_by_host(job->ninfo_arr, inp->err->arg2) != NULL)
 					return 1;
 			} else {

--- a/src/scheduler/job_info.cpp
+++ b/src/scheduler/job_info.cpp
@@ -4247,7 +4247,7 @@ formula_evaluate(const char *formula, resource_resv *resresv, resource_req *resr
 	}
 
 
-	for (const auto& cr: consres) {
+	for (const auto& cr : consres) {
 		req = find_resource_req(resreq, cr);
 
 		if (req != NULL)

--- a/src/scheduler/misc.cpp
+++ b/src/scheduler/misc.cpp
@@ -606,7 +606,7 @@ calc_used_walltime(resource_resv *resresv)
 		return 0;
 
 	if (resresv->is_job && resresv->job !=NULL) {
-		used = find_resource_req(resresv->job->resused, getallres(RES_WALLTIME));
+		used = find_resource_req(resresv->job->resused, allres["walltime"]);
 
 		/* If we can't find the used structure, we will just assume no usage */
 		if (used == NULL)
@@ -1383,10 +1383,10 @@ res_to_str_c(sch_resource_t amount, resdef *def, enum resource_fields fld,
 	resource_req req = {0};
 	const char *unknown[] = {"unknown", NULL};
 
-        if (buf == NULL)
-          return const_cast<char *>("");
+	if (buf == NULL)
+		return const_cast<char *>("");
 
-        buf[0] = '\0';
+	buf[0] = '\0';
 
 	if (def == NULL)
 		return const_cast<char *>("");
@@ -1395,7 +1395,7 @@ res_to_str_c(sch_resource_t amount, resdef *def, enum resource_fields fld,
 		case RF_REQUEST:
 			req.amount = amount;
 			req.def = def;
-			req.name = def->name;
+			req.name = def->name.c_str();
 			req.type = def->type;
 			req.res_str = const_cast<char *>("unknown");
 			return res_to_str_re(((void*) &req), fld, &buf, &bufsize, NOEXPAND);
@@ -1405,7 +1405,7 @@ res_to_str_c(sch_resource_t amount, resdef *def, enum resource_fields fld,
 			res.avail = amount;
 			res.assigned = amount;
 			res.def = def;
-			res.name = def->name;
+			res.name = def->name.c_str();
 			res.type = def->type;
 			res.orig_str_avail = const_cast<char *>("unknown");
 			res.str_avail = const_cast<char **>(unknown);
@@ -1465,7 +1465,7 @@ res_to_str_re(void *p, enum resource_fields fld, char **buf,
 
 	char localbuf[1024];
 	char *ret;
-	struct resource_type rtype = {0};
+	resource_type rtype;
 
 	if (buf == NULL || bufsize == NULL)
 		return const_cast<char *>("");

--- a/src/scheduler/node_info.cpp
+++ b/src/scheduler/node_info.cpp
@@ -550,7 +550,7 @@ query_node_info(struct batch_status *node, server_info *sinfo)
 				}
 
 				/* Round memory off to the nearest megabyte */
-				if(res->def == getallres(RES_MEM))
+				if(res->def == allres["mem"])
 					res->avail -= (long) res->avail % 1024;
 #ifdef NAS /* localmod 034 */
 				site_set_node_share(ninfo, res);
@@ -1145,7 +1145,7 @@ find_node_by_host(node_info **ninfo_arr, char *host)
 		return NULL;
 
 	for (i = 0; ninfo_arr[i] != NULL; i++) {
-		res = find_resource(ninfo_arr[i]->res, getallres(RES_HOST));
+		res = find_resource(ninfo_arr[i]->res, allres["host"]);
 		if (res != NULL) {
 			if (compare_res_to_str(res, host, CMP_CASELESS))
 				break;
@@ -1788,7 +1788,7 @@ update_node_on_run(nspec *ns, resource_resv *resresv, const char *job_state)
 
 				res->assigned += resreq->amount;
 
-				if (res->def  == getallres(RES_NCPUS)) {
+				if (res->def == allres["ncpus"]) {
 					ncpusres = res;
 				}
 			}
@@ -1814,7 +1814,7 @@ update_node_on_run(nspec *ns, resource_resv *resresv, const char *job_state)
 
 	/* if we're a cluster node and we have no cpus available, we're job_busy */
 	if (ncpusres == NULL)
-		ncpusres = find_resource(ninfo->res, getallres(RES_NCPUS));
+		ncpusres = find_resource(ninfo->res, allres["ncpus"]);
 
 	if (ncpusres != NULL) {
 		if (dynamic_avail(ncpusres) == 0)
@@ -3074,7 +3074,7 @@ eval_simple_selspec(status *policy, chunk *chk, node_info **pninfo_arr,
 
 	if (resresv->aoename != NULL) {
 		resresv->is_prov_needed = 1;
-		aoereq = find_resource_req(specreq_noncons, getallres(RES_AOE));
+		aoereq = find_resource_req(specreq_noncons, allres["aoe"]);
 		/* Provisionable node needed only if placement=pack or
 		 * subchunk consists aoe resource request.
 		 */
@@ -4701,10 +4701,10 @@ reorder_nodes(node_info **nodes, resource_resv *resresv)
 				/* find the vnode of the next host or the end of the list since the
 				 * beginning will definitely be a different host because of our sort
 				 */
-				hostres = find_resource(tmparr[i]->res, getallres(RES_HOST));
+				hostres = find_resource(tmparr[i]->res, allres["host"]);
 				if (hostres != NULL) {
 					for (; i < nsize; i++) {
-						cur_hostres = find_resource(tmparr[i]->res, getallres(RES_HOST));
+						cur_hostres = find_resource(tmparr[i]->res, allres["host"]);
 						if (cur_hostres != NULL) {
 							if (!compare_res_to_str(cur_hostres, hostres->str_avail[0], CMP_CASELESS))
 								break;
@@ -4757,18 +4757,16 @@ ok_break_chunk(resource_resv *resresv, node_info **nodes)
 
 
 	for (i = 0; nodes[i] != NULL; i++) {
-		res = find_resource(nodes[i]->res, getallres(RES_HOST));
+		res = find_resource(nodes[i]->res, allres["host"]);
 		if (res != NULL) {
 			if (hostres == NULL)
 				hostres = res;
 			else {
-				if (match_string_array(hostres->str_avail, res->str_avail)
-					!= SA_FULL_MATCH) {
+				if (match_string_array(hostres->str_avail, res->str_avail) != SA_FULL_MATCH) {
 					break;
 				}
 			}
-		}
-		else {
+		} else {
 			log_event(PBSEVENT_SCHED, PBS_EVENTCLASS_NODE, LOG_WARNING,
 				nodes[i]->name, "Node has no host resource");
 		}
@@ -4910,7 +4908,7 @@ set_res_on_host(char *res_name, char *res_value,
 
 	for (i = 0; ninfo_arr[i] != NULL && rc; i++) {
 		if (ninfo_arr[i] != exclude) {
-			hostres = find_resource(ninfo_arr[i]->res, getallres(RES_HOST));
+			hostres = find_resource(ninfo_arr[i]->res, allres["host"]);
 
 			if (hostres != NULL) {
 				if (compare_res_to_str(hostres, host, CMP_CASELESS)) {
@@ -5009,7 +5007,7 @@ is_aoe_avail_on_vnode(node_info *ninfo, resource_resv *resresv)
 	if (resresv->aoename == NULL)
 		return 0;
 
-	if ((resp = find_resource(ninfo->res, getallres(RES_AOE))) != NULL)
+	if ((resp = find_resource(ninfo->res, allres["aoe"])) != NULL)
 		return is_string_in_arr(resp->str_avail, resresv->aoename);
 
 	return 0;
@@ -5048,7 +5046,7 @@ is_eoe_avail_on_vnode(node_info *ninfo, resource_resv *resresv)
 	if (resresv->eoename == NULL)
 		return 0;
 
-	if ((resp = find_resource(ninfo->res, getallres(RES_EOE))) != NULL)
+	if ((resp = find_resource(ninfo->res, allres["eoe"])) != NULL)
 		return is_string_in_arr(resp->str_avail, resresv->eoename);
 
 	return 0;

--- a/src/scheduler/node_partition.cpp
+++ b/src/scheduler/node_partition.cpp
@@ -404,7 +404,7 @@ create_node_partitions(status *policy, node_info **nodes, const char * const *re
 	int node_i;		/* index into nodes array */
 	int np_i;		/* index into node partition array we are creating */
 
-	schd_resource *unset_res = NULL;
+	static schd_resource *unset_res = NULL;
 
 	resdef *def;
 

--- a/src/scheduler/parse.cpp
+++ b/src/scheduler/parse.cpp
@@ -181,7 +181,7 @@ parse_config(const char *fname)
 	int i;
 
 	/* resource type for validity checking */
-	struct resource_type type = {0};
+	struct resource_type type;
 
 	struct config tmpconf;
 
@@ -458,6 +458,12 @@ parse_config(const char *fname)
 
 					if (tok != NULL) {
 						si.res_name = tok;
+						auto f = allres.find(tok);
+						if (f != allres.end())
+							si.def = f->second;
+						else
+							si.def = NULL;
+
 						tok = strtok(NULL, DELIM);
 						if (tok != NULL) {
 							if (!strcmp(tok, "high") || !strcmp(tok, "HIGH") ||
@@ -493,6 +499,12 @@ parse_config(const char *fname)
 
 					if (tok != NULL) {
 						si.res_name = tok;
+						auto f = allres.find(tok);
+						if (f != allres.end())
+							si.def = f->second;
+						else
+							si.def = NULL;
+
 						tok = strtok(NULL, DELIM);
 						if (tok != NULL) {
 							if (!strcmp(tok, "high") || !strcmp(tok, "HIGH") ||

--- a/src/scheduler/pbs_sched_bare.cpp
+++ b/src/scheduler/pbs_sched_bare.cpp
@@ -97,7 +97,7 @@ main_sched_loop_bare(int sd, server_info *sinfo)
 			if (node->is_job_busy)
 				continue;
 
-			ncpures = find_resource(node->res, getallres(RES_NCPUS));
+			ncpures = find_resource(node->res, allres["ncpus"]);
 			if (ncpures == NULL)
 				continue;
 
@@ -189,10 +189,10 @@ schedule_bare(int sd, const sched_cmd *cmd)
 
 	case SCH_SCHEDULE_FIRST:
 		/*
-			 * on the first cycle after the server restarts custom resources
-			 * may have been added.  Dump what we have so we'll requery them.
-			 */
-		reset_global_resource_ptrs();
+		 * on the first cycle after the server restarts custom resources
+		 * may have been added.  Dump what we have so we'll requery them.
+		 */
+		update_resource_defs(sd);
 
 		/* Get config from the qmgr sched object */
 		if (!set_validate_sched_attrs(sd))
@@ -213,7 +213,7 @@ schedule_bare(int sd, const sched_cmd *cmd)
 	case SCH_CONFIGURE:
 		log_event(PBSEVENT_SCHED, PBS_EVENTCLASS_SCHED, LOG_INFO,
 			  "reconfigure", "Scheduler is reconfiguring");
-		reset_global_resource_ptrs();
+		update_resource_defs(sd);
 
 		/* Get config from sched_priv/ files */
 		if (schedinit(-1) != 0)

--- a/src/scheduler/resource.cpp
+++ b/src/scheduler/resource.cpp
@@ -369,6 +369,7 @@ update_resource_defs(int pbs_sd)
 				ru = tru;
 			} else {
 				ru->def = f->second;
+				ru->name = ru->def->name.c_str();
 				prev_res = ru;
 				ru = ru->next;
 			}

--- a/src/scheduler/resource.cpp
+++ b/src/scheduler/resource.cpp
@@ -379,6 +379,9 @@ update_resource_defs(int pbs_sd)
 		}
 	}
 
+	for (auto& d: allres)
+		delete d.second;
+
 	allres = tmpres;
 
 	consres.clear();

--- a/src/scheduler/resource.cpp
+++ b/src/scheduler/resource.cpp
@@ -116,7 +116,7 @@ query_resources(int pbs_sd)
 	}
 
 	for (cur_bs = bs; cur_bs != NULL; cur_bs = cur_bs->next) {
-		int flags;
+		int flags = NO_FLAGS;
 		resource_type rtype;
 		char *endp;
 		resdef *def;

--- a/src/scheduler/resource.cpp
+++ b/src/scheduler/resource.cpp
@@ -92,10 +92,7 @@
  *
  * @param[in]	pbs_sd	-	communication descriptor to pbs server
  *
- * @return	bool
- * @retval	true success
- * @retval	false failure
- *
+ * @return unordered_map of resource defs
  */
 std::unordered_map<std::string, resdef *>
 query_resources(int pbs_sd)
@@ -145,7 +142,7 @@ query_resources(int pbs_sd)
 	// Make sure most used resources were sent to us
 	for (const auto& r: well_known_res) {
 		if (tmpres.find(r) == allres.end()) {
-			for (auto &d : tmpres)
+			for (auto& d : tmpres)
 				delete d.second;
 			return {};
 		}
@@ -352,7 +349,6 @@ create_resource_signature(schd_resource *reslist, std::unordered_set<resdef *>& 
 bool
 update_resource_defs(int pbs_sd)
 {
-	clear_limres();
 	auto tmpres = query_resources(pbs_sd);
 
 	if (tmpres.empty())
@@ -401,6 +397,8 @@ update_resource_defs(int pbs_sd)
 		conf.resdef_to_check = resstr_to_resdef(conf.res_to_check);
 	}
 	update_sorting_defs();
+
+	clear_limres();
 
 	return true;
 }

--- a/src/scheduler/resource.cpp
+++ b/src/scheduler/resource.cpp
@@ -124,8 +124,7 @@ query_resources(int pbs_sd)
 			if (!strcmp(attrp->name, ATTR_RESC_TYPE)) {
 				int num = strtol(attrp->value, &endp, 10);
 				rtype = conv_rsc_type(num);
-			}
-			else if (!strcmp(attrp->name, ATTR_RESC_FLAG)) {
+			} else if (!strcmp(attrp->name, ATTR_RESC_FLAG)) {
 				flags = strtol(attrp->value, &endp, 10);
 			}
 			attrp = attrp->next;
@@ -141,7 +140,7 @@ query_resources(int pbs_sd)
 
 	// Make sure most used resources were sent to us
 	for (const auto& r: well_known_res) {
-		if (tmpres.find(r) == allres.end()) {
+		if (tmpres.find(r) == tmpres.end()) {
 			for (auto& d : tmpres)
 				delete d.second;
 			return {};

--- a/src/scheduler/resource.cpp
+++ b/src/scheduler/resource.cpp
@@ -131,7 +131,7 @@ query_resources(int pbs_sd)
 		}
 		def = new resdef(cur_bs->name, flags, rtype);
 		if (def == NULL) {
-			for (auto& d: tmpres)
+			for (auto& d : tmpres)
 				delete d.second;
 			return {};
 		}
@@ -143,7 +143,7 @@ query_resources(int pbs_sd)
 	 *      This is to allow us to directly index into the allres umap.
 	 *      Do not directly index into the allres umap for non-well known resources.  Use find_resdef()
 	 */
-	for (const auto& r: well_known_res) {
+	for (const auto& r : well_known_res) {
 		if (tmpres.find(r) == tmpres.end()) {
 			for (auto& d : tmpres)
 				delete d.second;
@@ -389,13 +389,13 @@ update_resource_defs(int pbs_sd)
 		}
 	}
 
-	for (auto& d: allres)
+	for (auto& d : allres)
 		delete d.second;
 
 	allres = tmpres;
 
 	consres.clear();
-	for (const auto& def: allres) {
+	for (const auto& def : allres) {
 		if (def.second->type.is_consumable)
 			consres.insert(def.second);
 	}

--- a/src/scheduler/resource.cpp
+++ b/src/scheduler/resource.cpp
@@ -138,7 +138,11 @@ query_resources(int pbs_sd)
 		tmpres[def->name] = def;
 	}
 
-	// Make sure most used resources were sent to us
+	/**
+	 * @par Make sure all the well known resources are sent to us.
+	 *      This is to allow us to directly index into the allres umap.
+	 *      Do not directly index into the allres umap for non-well known resources.  Use find_resdef()
+	 */
 	for (const auto& r: well_known_res) {
 		if (tmpres.find(r) == tmpres.end()) {
 			for (auto& d : tmpres)
@@ -197,6 +201,16 @@ conv_rsc_type(int type)
 	return rtype;
 }
 
+/**
+ * @brief find a resdef in the global allres
+ * 	  This function should be used if not finding a well known resource
+ *
+ * @param name - the name of the resdef to find
+ *
+ * @return resdef *
+ * @retval found resdef
+ * @retval NULL if not found
+ */
 resdef *
 find_resdef(const std::string& name)
 {

--- a/src/scheduler/resource.h
+++ b/src/scheduler/resource.h
@@ -49,7 +49,7 @@
  *
  *	returns resdef list of resources
  */
-resdef **query_resources(int pbs_sd);
+std::unordered_map<std::string, resdef *> query_resources(int pbs_sd);
 
 /*
  *	conv_rsc_type - convert server type number into resource_type struct
@@ -57,24 +57,10 @@ resdef **query_resources(int pbs_sd);
  *	  OUT: rtype - resource type structure
  *	returns nothing
  */
-void conv_rsc_type(int type, struct resource_type *rtype);
-
-/* used with filter_array*/
-int def_is_consumable(void *vdef, void *n);
-int def_is_bool(void *vdef, void *n);
-int filter_noncons(void *v, void *arg);
-
-
-/* constructors and destructors for resdef list object */
-resdef *new_resdef(void);				/* constructor */
-resdef *dup_resdef(resdef *olddef);		/* copy constructor */
-resdef **dup_resdef_array(resdef **);	/* list copy constructor */
-void free_resdef(resdef *def);		/* destructor */
-void free_resdef_array(resdef **deflist);
+resource_type conv_rsc_type(int type);
 
 /* find and return a resdef entry by name */
-resdef *find_resdef(resdef **deflist, const char *name);
-resdef *find_resdef(resdef **deflist, const std::string& name);
+resdef *find_resdef(const std::string& name);
 
 /*
  *  create resdef array based on a str array of resource names
@@ -82,20 +68,10 @@ resdef *find_resdef(resdef **deflist, const std::string& name);
 resdef** resdef_arr_from_str_arr(resdef **deflist, char **strarr);
 
 /*
- *  safely access allres by index.  This can be used if allres is NULL
- */
-resdef *getallres(enum resource_index ind);
-
-/*
  * query the resource definition from the server and create derived
  * data structures.  Only query if required.
  */
-int update_resource_defs(int pbs_sd);
-
-/*
- * free and clear global resource definition pointers
- */
-void reset_global_resource_ptrs(void);
+bool update_resource_defs(int pbs_sd);
 
 /* checks if a resource avail is set. */
 int is_res_avail_set(schd_resource *res);
@@ -122,6 +98,6 @@ int add_resdef_to_array(resdef ***resdef_arr, resdef *def);
 resdef **copy_resdef_array(resdef **deflist);
 
 /* update the def member in sort_info structures in conf */
-void update_sorting_defs(int op);
+void update_sorting_defs(void);
 
 #endif /* _RESOURCE_H */

--- a/src/scheduler/resource_resv.cpp
+++ b/src/scheduler/resource_resv.cpp
@@ -1018,7 +1018,7 @@ dup_resource_req(resource_req *oreq)
 
 	nreq->def = oreq->def;
 	if(nreq->def)
-		nreq->name = nreq->def->name;
+		nreq->name = nreq->def->name.c_str();
 
 	memcpy(&(nreq->type), &(oreq->type), sizeof(struct resource_type));
 	nreq->res_str = string_dup(oreq->res_str);
@@ -1048,7 +1048,7 @@ resource_count *dup_resource_count(resource_count *orcount)
 
 	nrcount->def = orcount->def;
 	if(nrcount->def)
-		nrcount->name = nrcount->def->name;
+		nrcount->name = nrcount->def->name.c_str();
 
 	nrcount->amount = orcount->amount;
 	nrcount->soft_limit_preempt_bit = orcount->soft_limit_preempt_bit;
@@ -1130,12 +1130,12 @@ create_resource_req(const char *name, const char *value)
 		return NULL;
 
 
-	rdef = find_resdef(allres, name);
+	rdef = find_resdef(name);
 
 	if (rdef != NULL) {
 		if ((resreq = new_resource_req()) != NULL) {
 			resreq->def = rdef;
-			resreq->name = rdef->name;
+			resreq->name = rdef->name.c_str();
 			resreq->type = rdef->type;
 
 			if (value != NULL) {
@@ -1185,7 +1185,7 @@ find_alloc_resource_req(resource_req *reqlist, resdef *def)
 
 		req->def = def;
 		req->type = req->def->type;
-		req->name = def->name;
+		req->name = def->name.c_str();
 		if (prev != NULL)
 			prev->next = req;
 	}
@@ -1222,7 +1222,7 @@ resource_count *find_alloc_resource_count(resource_count *rcountlist, resdef *de
 			return NULL;
 
 		rcount->def = def;
-		rcount->name = def->name;
+		rcount->name = def->name.c_str();
 		if (prev != NULL)
 			prev->next = rcount;
 	}
@@ -1365,7 +1365,7 @@ set_resource_req(resource_req *req, const char *val)
 	if (req->def != NULL)
 		rdef = req->def;
 	else {
-		rdef = find_resdef(allres, req->name);
+		rdef = find_resdef(req->name);
 		req->def = rdef;
 	}
 	if (rdef != NULL)

--- a/src/scheduler/server_info.cpp
+++ b/src/scheduler/server_info.cpp
@@ -196,13 +196,11 @@ query_server(status *pol, int pbs_sd)
 	if (pol == NULL)
 		return NULL;
 
-	if (update_resource_defs(pbs_sd) == 0) {
-		log_event(PBSEVENT_SCHED, PBS_EVENTCLASS_SCHED, LOG_WARNING, "resources",
-			"Failed to update global resource definition arrays");
-		return NULL;
-	}
-
 	PBSD_server_ready(pbs_sd);
+
+	if (allres.empty())
+		if (update_resource_defs(pbs_sd) == false)
+			return NULL;
 
 	/* get server information from pbs server */
 	if ((server = pbs_statserver(pbs_sd, NULL, NULL)) == NULL) {
@@ -210,7 +208,7 @@ query_server(status *pol, int pbs_sd)
 		if (errmsg == NULL)
 			errmsg = "";
 		log_eventf(PBSEVENT_SCHED, PBS_EVENTCLASS_SERVER, LOG_NOTICE, "server_info",
-			"pbs_statserver failed: %s (%d)", errmsg, pbs_errno);
+			   "pbs_statserver failed: %s (%d)", errmsg, pbs_errno);
 		return NULL;
 	}
 
@@ -337,7 +335,7 @@ query_server(status *pol, int pbs_sd)
 	/* create res_to_check arrays based on current jobs/resvs */
 	policy->resdef_to_check = collect_resources_from_requests(sinfo->all_resresv);
 	for (const auto& rd : policy->resdef_to_check) {
-		if (!(rd == getallres(RES_HOST) || rd == getallres(RES_VNODE)))
+		if (!(rd == allres["host"] || rd == allres["vnode"]))
 			policy->resdef_to_check_no_hostvnode.insert(rd);
 		
 		if (rd->flags & ATR_DFLAG_RASSN)
@@ -869,7 +867,7 @@ find_alloc_resource(schd_resource *resplist, resdef *def)
 
 		resp->def = def;
 		resp->type = def->type;
-		resp->name = def->name;
+		resp->name = def->name.c_str();
 
 		if (prev != NULL)
 			prev->next = resp;
@@ -1326,12 +1324,12 @@ create_resource(const char *name, const char *value, enum resource_fields field)
 	if(value == NULL && field != RF_NONE)
 		return NULL;
 
-	rdef = find_resdef(allres, name);
+	rdef = find_resdef(name);
 
 	if (rdef != NULL) {
 		if ((nres = new_resource()) != NULL) {
 			nres->def = rdef;
-			nres->name = rdef->name;
+			nres->name = rdef->name.c_str();
 			nres->type = rdef->type;
 
 			if (value != NULL) {
@@ -1424,7 +1422,6 @@ add_resource_list(status *policy, schd_resource *r1, schd_resource *r2, unsigned
 	schd_resource *end_r1 = NULL;
 	schd_resource *nres;
 	sch_resource_t assn;
-	int i;
 
 	if (r1 == NULL || r2 == NULL)
 		return 0;
@@ -1464,7 +1461,7 @@ add_resource_list(status *policy, schd_resource *r1, schd_resource *r2, unsigned
 		} else {
 			if (!(flags & NO_UPDATE_NON_CONSUMABLE)) {
 				if (cur_r1->type.is_string) {
-					if (cur_r1->def == getallres(RES_VNODE))
+					if (cur_r1->def == allres["vnode"])
 						add_resource_str_arr(cur_r1, cur_r2->str_avail, 1);
 					else
 						add_resource_str_arr(cur_r1, cur_r2->str_avail, 0);
@@ -1475,27 +1472,25 @@ add_resource_list(status *policy, schd_resource *r1, schd_resource *r2, unsigned
 	}
 
 	if (flags & ADD_UNSET_BOOLS_FALSE) {
-		if (boolres != NULL) {
-			for (i = 0; boolres[i] != NULL; i++) {
-				if (find_resource(r2, boolres[i]) == NULL) {
-					cur_r1 = find_resource(r1, boolres[i]);
-					if (cur_r1 == NULL) {
-						nres = create_resource(boolres[i]->name, ATR_FALSE, RF_AVAIL);
-						if (nres == NULL)
-							return 0;
+		for (const auto &br : boolres) {
+			if (find_resource(r2, br) == NULL) {
+				cur_r1 = find_resource(r1, br);
+				if (cur_r1 == NULL) {
+					nres = create_resource(br->name.c_str(), ATR_FALSE, RF_AVAIL);
+					if (nres == NULL)
+						return 0;
 
-						if (end_r1 == NULL)
-							for (end_r1 = r1; end_r1->next != NULL; end_r1 = end_r1->next)
-								;
-						end_r1->next = nres;
-						end_r1 = nres;
-					} else {
-						nres = false_res();
-						if (nres == NULL)
-							return 0;
-						nres->name = boolres[i]->name;
-						(void)add_resource_bool(cur_r1, nres);
-					}
+					if (end_r1 == NULL)
+						for (end_r1 = r1; end_r1->next != NULL; end_r1 = end_r1->next)
+							;
+					end_r1->next = nres;
+					end_r1 = nres;
+				} else {
+					nres = false_res();
+					if (nres == NULL)
+						return 0;
+					nres->name = br->name.c_str();
+					(void) add_resource_bool(cur_r1, nres);
 				}
 			}
 		}
@@ -2485,7 +2480,6 @@ dup_selective_resource_list(schd_resource *res, std::unordered_set<resdef *>& de
 	schd_resource *nres;
 	schd_resource *prev = NULL;
 	schd_resource *head = NULL;
-	int i;
 
 	for (pres = res; pres != NULL; pres = pres->next) {
 		if (((flags & ADD_ALL_BOOL) && pres->type.is_boolean) ||
@@ -2509,10 +2503,10 @@ dup_selective_resource_list(schd_resource *res, std::unordered_set<resdef *>& de
 		}
 	}
 	/* add on any booleans which are unset (i.e.,  false) */
-	if (boolres != NULL && (flags & ADD_UNSET_BOOLS_FALSE)) {
-		for (i = 0; boolres[i] != NULL; i++) {
-			if (find_resource(res, boolres[i]) == NULL) {
-				nres = create_resource(boolres[i]->name, ATR_FALSE, RF_AVAIL);
+	if (flags & ADD_UNSET_BOOLS_FALSE) {
+		for (const auto& br : boolres) {
+			if (find_resource(res, br) == NULL) {
+				nres = create_resource(br->name.c_str(), ATR_FALSE, RF_AVAIL);
 				if (nres == NULL) {
 					free_resource_list(head);
 					return NULL;
@@ -2591,7 +2585,7 @@ dup_resource(schd_resource *res)
 
 	nres->def = res->def;
 	if (nres->def != NULL)
-		nres->name = nres->def->name;
+		nres->name = nres->def->name.c_str();
 
 
 	if (res->indirect_vnode_name != NULL)
@@ -3122,6 +3116,15 @@ set_resource(schd_resource *res, const char *val, enum resource_fields field)
 	if (res == NULL || val == NULL)
 		return 0;
 
+	if (res->def != NULL)
+		rdef = res->def;
+	else {
+		rdef = find_resdef(res->name);
+		res->def = rdef;
+	}
+	if (rdef != NULL)
+		res->type = rdef->type;
+
 	if (field == RF_AVAIL) {
 		/* if this resource is being re-set, lets free the memory we previously
 		 * allocated in the last call to this function.  We NULL the values just
@@ -3153,12 +3156,8 @@ set_resource(schd_resource *res, const char *val, enum resource_fields field)
 			if (res->indirect_vnode_name == NULL)
 				return 0;
 		} else {
-			/* if the resource type is already set, clear it so we can set it here */
-			if (res->type.is_consumable != 0 || res->type.is_non_consumable !=0)
-				memset(&(res->type), 0, sizeof(struct resource_type));
-
 			/* if val is a string, avail will be set to SCHD_INFINITY_RES */
-			res->avail = res_to_num(val, &(res->type));
+			res->avail = res_to_num(val, NULL);
 			if (res->avail == SCHD_INFINITY_RES) {
 				/* Verify that this is a string type resource */
 				if (!res->def->type.is_string)
@@ -3182,15 +3181,6 @@ set_resource(schd_resource *res, const char *val, enum resource_fields field)
 		if (res->str_assigned == NULL)
 			return 0;
 	}
-
-	if(res->def != NULL)
-		rdef = res->def;
-	else {
-		rdef = find_resdef(allres, res->name);
-		res->def = rdef;
-	}
-	if (rdef != NULL)
-		res->type = rdef->type;
 
 	return 1;
 }
@@ -3834,7 +3824,7 @@ create_resource_assn_for_node(node_info *ninfo)
 	for (r = ninfo->res; r != NULL; r = r->next)
 		if(r->type.is_consumable) {
 			r->assigned = 0;
-			if (r->def == getallres(RES_NCPUS))
+			if (r->def == allres["ncpus"])
 				ncpus_res = r;
 		}
 

--- a/src/scheduler/site_code.cpp
+++ b/src/scheduler/site_code.cpp
@@ -2091,7 +2091,7 @@ site_vnode_inherit(node_info ** nodes)
 		/*
 		 * Is this a natural node?
 		 */
-		res = find_resource(ninfo->res, getallres(RES_HOST));
+		res = find_resource(ninfo->res, allres["host"]);
 		if (res == NULL)
 			continue;
 		if (compare_res_to_str(res, ninfo->name, CMP_CASELESS)) {
@@ -2255,7 +2255,7 @@ count_cpus(node_info **nodes, int ncnt, queue_info **queues, sh_amt *totals)
 		 * counted against running jobs.
 		 */
 #if 0 /* XXX HACK until SBUrate available, localmod 126 */
-		res = find_resource(node->res, getallres(RES_NCPUS));
+		res = find_resource(node->res, allres["ncpus"]);
 		if (res != NULL && res->avail != SCHD_INFINITY) {
 			if (node->is_down || node->is_offline)
 				/*

--- a/src/scheduler/sort.cpp
+++ b/src/scheduler/sort.cpp
@@ -167,15 +167,15 @@ cmp_placement_sets(const void *v1, const void *v2)
 	np1 = *((node_partition **) v1);
 	np2 = *((node_partition **) v2);
 
-	ncpus1 = find_resource(np1->res, getallres(RES_NCPUS));
-	ncpus2 = find_resource(np2->res, getallres(RES_NCPUS));
+	ncpus1 = find_resource(np1->res, allres["ncpus"]);
+	ncpus2 = find_resource(np2->res, allres["ncpus"]);
 
 	if (ncpus1 != NULL && ncpus2 != NULL)
 		rc = cmpres(ncpus1->avail, ncpus2->avail);
 
 	if (!rc) {
-		mem1 = find_resource(np1->res, getallres(RES_MEM));
-		mem2 = find_resource(np2->res, getallres(RES_MEM));
+		mem1 = find_resource(np1->res, allres["mem"]);
+		mem2 = find_resource(np2->res, allres["mem"]);
 
 		if (mem1 != NULL && mem2 != NULL)
 			rc = cmpres(mem1->avail, mem2->avail);
@@ -1032,8 +1032,8 @@ cmp_node_host(const void *v1, const void *v2)
 	n1 = (node_info **) v1;
 	n2 = (node_info **) v2;
 
-	res1 = find_resource((*n1)->res, getallres(RES_HOST));
-	res2 = find_resource((*n2)->res, getallres(RES_HOST));
+	res1 = find_resource((*n1)->res, allres["host"]);
+	res2 = find_resource((*n2)->res, allres["host"]);
 
 	if (res1 != NULL && res2 != NULL)
 		rc = strcmp(res1->orig_str_avail, res2->orig_str_avail);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
The scheduler uses a resdef structure to store resource definitions it gets from the server.  It used to store this in a NULL terminated array.  It was semi-sorted so some definitions appeared in well known locations.  This was so you could directly index  into the array for often used definitions.  Other than that, finding a definition was an O(N) search.

#### Describe Your Change
I replaced the NULL terminated array with a std::unordered_map.  This allows for O(1) searches for all elements.
I did 2 performance tests (they're in TestSchedPerf).  The calendar test showed no difference.  The test which runs 10k 1 cpu jobs was was about 5s faster.  Master ran in about 45s.  The new code ran in about 40s.

#### Attach Test and Valgrind Logs/Output
The 3 failed tests were hook tests which I reran and they passed.

Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, WIN2K16
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|6696|3999|3|0|0|0|3996|