### PR TITLE
Implement manage_rlimit_as; add PTL test

### DIFF
--- a/src/hooks/cgroups/pbs_cgroups.CF
+++ b/src/hooks/cgroups/pbs_cgroups.CF
@@ -9,6 +9,7 @@
     "use_hyperthreads"      : false,
     "ncpus_are_cores"       : false,
     "discover_gpus"         : true,
+    "manage_rlimit_as"      : true,
     "cgroup" : {
         "cpuacct" : {
             "enabled"            : true,

--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -2846,6 +2846,29 @@ class CgroupUtils(object):
         else:
             self.subsystems = self._target_subsystems()
 
+        # Check if memsw is enabled despite lack of kernel support
+        # if so disable memsw
+        if 'memsw' in self.subsystems:
+            memsw_limit_file = (self.paths['memsw']
+                                + 'limit_in_bytes')
+            if not os.path.isfile(memsw_limit_file):
+                pbs.logmsg(pbs.EVENT_ERROR,
+                           'CONFIG ERROR: CF enables memsw '
+                           'but %s is missing'
+                           % memsw_limit_file)
+                pbs.logmsg(pbs.EVENT_ERROR,
+                           'CONFIG ERROR: kernel swapaccount parameter is 0, '
+                           'disabling memsw subsystem')
+                pbs.logmsg(pbs.EVENT_ERROR,
+                           'CONFIG ERROR: to fix this, either add '
+                           'swapaccount=1 to kernel command line '
+                           'or disable memsw')
+                self.cfg['cgroup']['memsw']['enabled'] = False
+                self.subsystems.remove('memsw')
+                pbs.logmsg(pbs.EVENT_DEBUG4,
+                           'remaining enabled subsystems: '
+                           + repr(self.subsystems))
+
         # Return now if nothing is enabled
         if not self.subsystems:
             pbs.logmsg(pbs.EVENT_DEBUG2, '%s: No cgroups enabled' %

--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -2889,13 +2889,23 @@ class CgroupUtils(object):
         Write a message to the job stderr file
         """
         pbs.logmsg(pbs.EVENT_DEBUG4, '%s: Method called' % caller_name())
+        filename = None
         try:
-            filename = job.stderr_file()
+            if str(job.Join_Path) == 'oe':
+                # If we write in stderr we might do it after the join!
+                # so write in stdout instead
+                filename = job.stdout_file()
+            else:
+                filename = job.stderr_file()
+            pbs.logmsg(pbs.EVENT_DEBUG4,"Message to be written to %s: %s"
+                       % (str(filename), msg.strip()))
             if filename is None:
                 return
             with open(filename, 'a') as desc:
                 desc.write(msg)
         except Exception:
+            # tough luck for user, but not fatal to system
+            # Note: sometimes normal (e.g. interactive jobs)
             pass
 
     def _target_subsystems(self):
@@ -4751,7 +4761,7 @@ class CgroupUtils(object):
                                 and pbs.event().job.in_ms_mom()):
                             self.write_to_stderr(pbs.event().job,
                                                  "Cgroup mem limit "
-                                                 "exceeded: %s" % (err_msg))
+                                                 "exceeded: %s\n" % (err_msg))
             elif subsys == 'memsw':
                 max_vmem = self._get_max_memsw_usage(jobid)
                 if max_vmem is None:
@@ -4771,7 +4781,7 @@ class CgroupUtils(object):
                     if vmem_failcnt > 0:
                         err_msg = self._get_error_msg(jobid)
                         pbs.logjobmsg(jobid,
-                                      'Cgroup memsw limit exceeded: %s' %
+                                      'Cgroup memsw limit exceeded: %s\n' %
                                       (err_msg))
                         if (pbs.event().type == pbs.EXECJOB_EPILOGUE
                                 and pbs.event().job.in_ms_mom()):
@@ -5703,6 +5713,16 @@ class CgroupUtils(object):
             if job_start < 0:
                 continue
             return kill_line
+
+        # Found nothing -- more recent kernels have different messages
+        for line in out_split:
+            start = line.find('oom-kill')
+            kill_line = line[start:]
+            job_start = line.find(jobid)
+            if job_start < 0:
+                continue
+            return kill_line
+
         return ''
 
     def write_job_env_file(self, jobid, env_list):

--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -1153,6 +1153,53 @@ class HookUtils(object):
                            'Error removing file: %s' % (filename))
         return True
 
+    def manage_rlimit_as(self, job):
+        """
+        Sets rlimit_as according to pvmem (if present)
+        if pvmem is not present, sets it to unlimited
+        (since we know vmem specifies memory+swap usage limit,
+         not address space limit)
+        """
+        import resource
+        rlimit_as = None
+        parent_pid = os.getppid()
+        if 'pvmem' in job.Resource_List and job.Resource_List['pvmem']:
+            rlimit_as = size_as_int(job.Resource_List['pvmem'])
+        else:
+            rlimit_as = resource.RLIM_INFINITY
+
+        prlimit_command = None
+        if hasattr(resource, 'prlimit'):
+            # No need to call command -- Python has direct support
+            prlimit_command = ''
+            pbs.logmsg(pbs.EVENT_DEBUG3,
+                       'Calling resource.prlimit(%s, resource.RLIMIT_AS, %s)'
+                       % (parent_pid, str((rlimit_as, rlimit_as))))
+            resource.prlimit(parent_pid, resource.RLIMIT_AS,
+                             (rlimit_as, rlimit_as))
+        elif os.path.isfile('/usr/bin/prlimit'):
+            prlimit_command = '/usr/bin/prlimit'
+        elif os.path.isfile('/bin/prlimit'):
+            prlimit_command = '/bin/prlimit'
+
+        if prlimit_command is None:
+            pbs.logmsg(pbs.EVENT_ERROR, "cannot set rlimit_as for task: "
+                       "prlimit command not found")
+        elif prlimit_command != '':
+            cmd = [prlimit_command,
+                   '--as=' + str(rlimit_as) + ':' + str(rlimit_as),
+                   '--pid=' + str(parent_pid)]
+            pbs.logmsg(pbs.EVENT_DEBUG3, 'Running: ' + ' '.join(cmd))
+            try:
+                # Try running the prlimit command
+                process = subprocess.Popen(cmd, shell=False,
+                                           stdout=subprocess.PIPE,
+                                           stderr=subprocess.PIPE)
+                out = process.communicate()[0]
+            except Exception:
+                pbs.logmsg(pbs.EVENT_DEBUG4, 'Failed to execute: %s' %
+                           ' '.join(cmd))
+
     def _execjob_launch_handler(self, event, cgroup, jobutil):
         """
         Handler for execjob_launch events.
@@ -1173,6 +1220,13 @@ class HookUtils(object):
                        (cgroup.assigned_resources))
             if "gpu" in node.devices:
                 cgroup.setup_job_devices_env(node.devices['gpu'])
+
+        # If vmem was requested, set per process address space limit
+        # or clear the one MoM has set,
+        # if possible (requires prlimit support)
+        if (cgroup.cfg['manage_rlimit_as']
+                and cgroup.cfg['cgroup']['memsw']['enabled']):
+            self.manage_rlimit_as(pbs.event().job)
         return True
 
     def _exechost_periodic_handler(self, event, cgroup, jobutil):
@@ -3199,6 +3253,7 @@ class CgroupUtils(object):
         defaults['job_setup_timeout'] = 30
         defaults['placement_type'] = 'load_balanced'
         defaults['propagate_vntype_to_server'] = True
+        defaults['manage_rlimit_as'] = True
         defaults['cgroup'] = {}
         defaults['cgroup']['cpu'] = {}
         defaults['cgroup']['cpu']['enabled'] = False
@@ -3518,7 +3573,7 @@ class CgroupUtils(object):
         pbs.logmsg(pbs.EVENT_DEBUG4, '%s: Method called' % caller_name())
         assigned = {}
 
-        # Get totals available for all jobs to compare with later        
+        # Get totals available for all jobs to compare with later
         mem_avail = None
         filename = self._cgroup_path('memory', 'limit_in_bytes')
         if filename and os.path.isfile(filename):
@@ -4968,6 +5023,7 @@ class CgroupUtils(object):
                                'scheduler configuration file' %
                                caller_name())
                     hostresc['vmem'] = pbs.size(vmem_limit)
+
         # Initialize hpmem variables
         hpmem_default = None
         hpmem_limit = None

--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -1183,7 +1183,7 @@ class HookUtils(object):
             prlimit_command = '/bin/prlimit'
 
         if prlimit_command is None:
-            pbs.logmsg(pbs.EVENT_ERROR, "cannot set rlimit_as for task: "
+            pbs.logmsg(pbs.EVENT_DEBUG, "cannot set rlimit_as for task: "
                        "prlimit command not found")
         elif prlimit_command != '':
             cmd = [prlimit_command,
@@ -1197,7 +1197,8 @@ class HookUtils(object):
                                            stderr=subprocess.PIPE)
                 out = process.communicate()[0]
             except Exception:
-                pbs.logmsg(pbs.EVENT_DEBUG4, 'Failed to execute: %s' %
+                pbs.logmsg(pbs.EVENT_ERROR,
+                           'Found but to failed to execute: %s' %
                            ' '.join(cmd))
 
     def _execjob_launch_handler(self, event, cgroup, jobutil):
@@ -2897,7 +2898,7 @@ class CgroupUtils(object):
                 filename = job.stdout_file()
             else:
                 filename = job.stderr_file()
-            pbs.logmsg(pbs.EVENT_DEBUG4,"Message to be written to %s: %s"
+            pbs.logmsg(pbs.EVENT_DEBUG4, "Message to be written to %s: %s"
                        % (str(filename), msg.strip()))
             if filename is None:
                 return

--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -2203,8 +2203,15 @@ class NodeUtils(object):
                        caller_name())
         cpuinfo['physical_cpus'] = int(cpuinfo['logical_cpus']
                                        // cpuinfo['hyperthreads_per_core'])
-        pbs.logmsg(pbs.EVENT_DEBUG4, '%s returning: %s' %
-                   (caller_name(), cpuinfo))
+        wanted_keys = ['physical_cpus', 'logical_cpus','hyperthreads_per_core',
+                       'hyperthreads']
+        cpuinfo_short = dict((k, cpuinfo[k])
+                             for k in wanted_keys if k in cpuinfo)
+        pbs.logmsg(pbs.EVENT_DEBUG4, "%s returning: %s"
+                   % (caller_name(), cpuinfo_short))
+        if 0 in cpuinfo['cpu']:
+            pbs.logmsg(pbs.EVENT_DEBUG4, "%s For CPU 0: cpuinfo['cpu'][0]: %s"
+                       % (caller_name(), cpuinfo['cpu'][0]))
         return cpuinfo
 
     def gather_jobs_on_node(self, cgroup):

--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -344,7 +344,13 @@ def size_as_int(value):
     """
     Convert a size string to an integer representation of size in bytes
     """
-    return int(convert_size(value).rstrip(string.ascii_lowercase))
+    in_bytes = convert_size(value, units='b')
+    if in_bytes is not None:
+        return int(convert_size(value).rstrip(string.ascii_lowercase))
+    else:
+        pbs.logmsg(pbs.EVENT_ERROR, "size_as_int: Value %s "
+                   "does not convert to int, returning None" % value)
+        return None
 
 
 #
@@ -3632,56 +3638,64 @@ class CgroupUtils(object):
                         assigned[jobid][key]['mems'] = \
                             expand_list(desc.readline())
                 elif key == 'memory':
-                    with open(self._cgroup_path(key, 'limit_in_bytes',
-                                                jobid)) as desc:
-                        assigned[jobid][key]['limit_in_bytes'] = \
-                            int(desc.readline())
-                    if assigned[jobid][key]['limit_in_bytes'] == mem_avail:
-                        # not explicitly assigned, 'unlimited' raised default
-                        assigned[jobid][key]['limit_in_bytes'] = 0
-                    with open(self._cgroup_path(key, 'soft_limit_in_bytes',
-                                                jobid)) as desc:
-                        assigned[jobid][key]['soft_limit_in_bytes'] = \
-                            int(desc.readline())
-                    if (assigned[jobid][key]['soft_limit_in_bytes']
-                            == mem_avail):
-                        # not explicitly assigned, 'unlimited' raised default
-                        assigned[jobid][key]['soft_limit_in_bytes'] = 0
-                elif key == 'memsw':
-                    filename = self._cgroup_path('memsw', 'limit_in_bytes',
-                                                 jobid)
+                    filename = self._cgroup_path(key, 'limit_in_bytes', jobid)
                     if filename and os.path.isfile(filename):
                         with open(filename) as desc:
-                            assigned[jobid]['memsw']['limit_in_bytes'] = \
+                            assigned[jobid][key]['limit_in_bytes'] = \
                                 int(desc.readline())
-                    if assigned[jobid][key]['limit_in_bytes'] == vmem_avail:
-                        # not explicitly assigned, 'unlimited' raised default
-                        assigned[jobid][key]['limit_in_bytes'] = 0
+                        if assigned[jobid][key]['limit_in_bytes'] == mem_avail:
+                            # not explicitly assigned, 'unlimited' raised dflt
+                            assigned[jobid][key]['limit_in_bytes'] = 0
+                    filename = self._cgroup_path(key,
+                                                 'soft_limit_in_bytes', jobid)
+                    if filename and os.path.isfile(filename):
+                        with open(filename) as desc:
+                            assigned[jobid][key]['soft_limit_in_bytes'] = \
+                                int(desc.readline())
+                        if (assigned[jobid][key]['soft_limit_in_bytes']
+                                == mem_avail):
+                            # not explicitly assigned, 'unlimited' raised dflt
+                            assigned[jobid][key]['soft_limit_in_bytes'] = 0
+                elif key == 'memsw':
+                    filename = self._cgroup_path(key, 'limit_in_bytes', jobid)
+                    if filename and os.path.isfile(filename):
+                        with open(filename) as desc:
+                            assigned[jobid][key]['limit_in_bytes'] = \
+                                int(desc.readline())
+                        if (assigned[jobid][key]['limit_in_bytes']
+                                == vmem_avail):
+                            # not explicitly assigned, 'unlimited' raised dflt
+                            assigned[jobid][key]['limit_in_bytes'] = 0
                     else:
                         pbs.logmsg(pbs.EVENT_DEBUG4, '%s: No such file: %s' %
                                    (caller_name(), filename))
                 elif key == 'hugetlb':
-                    with open(self._cgroup_path(key, 'limit_in_bytes',
-                                                jobid)) as desc:
-                        assigned[jobid][key]['limit_in_bytes'] = \
-                            int(desc.readline())
-                    if assigned[jobid][key]['limit_in_bytes'] == hpmem_avail:
-                        # not explicitly assigned, 'unlimited' raised default
-                        assigned[jobid][key]['limit_in_bytes'] = 0
+                    filename = self._cgroup_path(key, 'limit_in_bytes', jobid)
+                    if filename and os.path.isfile(filename):
+                        with open(filename) as desc:
+                            assigned[jobid][key]['limit_in_bytes'] = \
+                                int(desc.readline())
+                        if (assigned[jobid][key]['limit_in_bytes']
+                                == hpmem_avail):
+                            # not explicitly assigned, 'unlimited' raised dflt
+                            assigned[jobid][key]['limit_in_bytes'] = 0
                 elif key == 'devices':
                     path = self._cgroup_path(key, 'list', jobid)
                     pbs.logmsg(pbs.EVENT_DEBUG4, '%s: Devices path is %s' %
                                (caller_name(), path))
-                    with open(path) as desc:
-                        assigned[jobid][key]['list'] = []
-                        for line in desc:
-                            pbs.logmsg(pbs.EVENT_DEBUG4, '%s: Appending %s' %
-                                       (caller_name(), line))
-                            assigned[jobid][key]['list'].append(line)
-                            pbs.logmsg(pbs.EVENT_DEBUG4,
-                                       '%s: assigned[%s][%s][list] = %s' %
-                                       (caller_name(), jobid, key,
-                                        assigned[jobid][key]['list']))
+                    if path and os.path.isfile(path):
+                        with open(path) as desc:
+                            assigned[jobid][key]['list'] = []
+                            for line in desc:
+                                pbs.logmsg(pbs.EVENT_DEBUG4, '%s: '
+                                           'Appending %s'
+                                           % (caller_name(), line))
+                                assigned[jobid][key]['list'].append(line)
+                                pbs.logmsg(pbs.EVENT_DEBUG4,
+                                           '%s: assigned[%s][%s][list] '
+                                           '= %s'
+                                           % (caller_name(), jobid, key,
+                                              assigned[jobid][key]['list']))
                 elif key == 'pids':
                     pbs.logmsg(pbs.EVENT_DEBUG4, '%s: subsystem %s' %
                                (caller_name(), key))
@@ -4405,8 +4419,13 @@ class CgroupUtils(object):
                 myname = 'socket %d' % socket
                 req = requested
             pbs.logmsg(pbs.EVENT_DEBUG4, 'Current target is %s' % myname)
-            new = self._assign_resources(req, available[socket],
-                                         [socket], node)
+            new = None
+            if socket in available:
+                new = self._assign_resources(req, available[socket],
+                                             [socket], node)
+            else:
+                pbs.logmsg(pbs.EVENT_ERROR, 'Attempt to allocate resources '
+                           'on non-existing socket #' + str(socket))
             if new:
                 new['cpuset.mems'].append(socket)
                 # Add the memory-only NUMA nodes
@@ -4879,6 +4898,7 @@ class CgroupUtils(object):
         """
         Determine the cgroup limits and configure the cgroups
         """
+        pbs.logmsg(pbs.EVENT_DEBUG4, '%s: Method called' % caller_name())
         jobid = job.id
 
         # Get available totals for mem, vmem and hpmem from parent cgroup
@@ -4900,14 +4920,17 @@ class CgroupUtils(object):
         if filename and os.path.isfile(filename):
             with open(filename) as desc:
                 hpmem_avail = int(desc.readline())
+
+        # Sanity check vmem_avail >= mem_avail
+        # -- unnecessary by construction in exechost_startup
+        # but memsw may be disabled or swap accounting disabled
+        if vmem_avail < mem_avail:
+            vmem_avail = mem_avail
+
         pbs.logmsg(pbs.EVENT_DEBUG4, "configure_job:"
                    " total host avail mem=%s vmem=%s hpmem=%s"
                    % (mem_avail, vmem_avail, hpmem_avail))
 
-        # Sanity check vmem_avail > mem_avail unnecessary
-        # -- by construction in exechost_startup
-
-        pbs.logmsg(pbs.EVENT_DEBUG4, '%s: Method called' % caller_name())
         mem_enabled = 'memory' in self.subsystems
         vmem_enabled = 'memsw' in self.subsystems
         if mem_enabled or vmem_enabled:
@@ -4922,8 +4945,9 @@ class CgroupUtils(object):
             vmem_requested = None
             if 'vmem' in hostresc:
                 vmem_requested = convert_size(hostresc['vmem'], 'kb')
-            vmem_default = None
-            if vmem_enabled and self.default('memsw') is not None:
+            vmem_default = 0
+            if (vmem_enabled and (self.default('memsw') is not None)
+                    and (vmem_avail > mem_avail)):
                 vmem_default = size_as_int(self.default('memsw'))
                 if vmem_default > (vmem_avail - mem_avail):
                     vmem_default = vmem_avail - mem_avail
@@ -4954,7 +4978,10 @@ class CgroupUtils(object):
                 else:
                     mem_limit = str(mem_default)
             # Determine the vmem limit
-            if vmem_requested is not None:
+            if not vmem_enabled:
+                # set as equal, but will not be used to set cgroup limit
+                vmem_limit = mem_limit
+            elif vmem_requested is not None:
                 # vmem requested may not exceed available
                 if size_as_int(vmem_requested) > vmem_avail:
                     raise JobValueError(
@@ -4968,15 +4995,17 @@ class CgroupUtils(object):
                                        ['enforce_default']
                         or (self.cfg['cgroup']['memsw']
                                     ['exclhost_ignore_default']
-                            and "place" in job.Resource_List
+                            and 'place' in job.Resource_List
                             and 'exclhost'
                                 in repr(job.Resource_List['place']))):
-
                     vmem_limit = str(vmem_avail)
                 else:
                     vmem_limit = str(min(vmem_avail,
                                          size_as_int(mem_limit)
                                          + vmem_default))
+            pbs.logmsg(pbs.EVENT_DEBUG4,
+                       "Limits computed from requests/defaults: "
+                       "mem: %s vmem: %s" % (mem_limit, vmem_limit))
             # Ensure vmem is at least as large as mem
             if size_as_int(vmem_limit) < size_as_int(mem_limit):
                 vmem_limit = mem_limit

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -259,13 +259,6 @@ class TestCgroupsHook(TestFunctional):
             self.nodes_list.append(node)
             self.vntypename.append(vntype)
 
-            # Tell the MoM's kernel to flush the buffer cache:
-            # when we run a job we want less dirty page cache
-            # which might slow down memory allocations
-            flush_cmd = ["echo 3 >/proc/sys/vm/drop_caches"]
-            self.du.run_cmd(hosts=mom.hostname, cmd=flush_cmd,
-                            as_script=True, sudo=True)
-
         # Setting self.mom defaults to primary mom as some of
         # library methods assume that
         self.mom = self.moms_list[0]
@@ -1929,10 +1922,11 @@ if %s e.job.in_ms_mom():
         self.load_config(a)
         for m in self.moms.values():
             m.restart()
+
         a = {'Resource_List.select': '1:ncpus=1:mem=300mb:host=%s' %
              self.hosts_list[0], ATTR_N: name}
         j = Job(TEST_USER, attrs=a)
-        j.create_script(self.sleep15_job)
+        j.create_script(self.sleep100_job)
         time.sleep(2)
         stime = int(time.time())
         time.sleep(2)
@@ -1957,10 +1951,11 @@ if %s e.job.in_ms_mom():
             self.logger.info('Skipping the second part of this test '
                              'since hostB also has same vntype value')
             return
+
         a = {'Resource_List.select': '1:ncpus=1:mem=300mb:host=%s' %
              self.hosts_list[1], ATTR_N: name}
         j1 = Job(TEST_USER, attrs=a)
-        j1.create_script(self.sleep15_job)
+        j1.create_script(self.sleep100_job)
         jid2 = self.server.submit(j1)
         a = {'job_state': 'R'}
         self.server.expect(JOB, a, jid2)
@@ -1982,10 +1977,11 @@ if %s e.job.in_ms_mom():
                                       self.mem, self.swapctl))
         for m in self.moms.values():
             m.restart()
+
         a = {'Resource_List.select': '1:ncpus=1:mem=300mb:host=%s' %
              self.hosts_list[0], ATTR_N: name}
         j = Job(TEST_USER, attrs=a)
-        j.create_script(self.sleep15_job)
+        j.create_script(self.sleep100_job)
         time.sleep(2)
         stime = int(time.time())
         time.sleep(2)
@@ -2001,10 +1997,12 @@ if %s e.job.in_ms_mom():
         self.moms_list[0].log_match('%s is in the excluded host list: [%s]' %
                                     (host, log), starttime=stime,
                                     n='ALL')
+        self.server.delete(jid, wait=True)
+
         a = {'Resource_List.select': '1:ncpus=1:mem=300mb:host=%s' %
              self.hosts_list[1], ATTR_N: name}
         j = Job(TEST_USER, attrs=a)
-        j.create_script(self.sleep15_job)
+        j.create_script(self.sleep100_job)
         jid2 = self.server.submit(j)
         a = {'job_state': 'R'}
         self.server.expect(JOB, a, jid2)
@@ -2031,10 +2029,11 @@ if %s e.job.in_ms_mom():
                                       '"' + self.vntypename[0] + '"'))
         for m in self.moms.values():
             m.restart()
+
         a = {'Resource_List.select': '1:ncpus=1:mem=100mb:host=%s'
              % self.hosts_list[0], ATTR_N: name}
         j = Job(TEST_USER, attrs=a)
-        j.create_script(self.sleep15_job)
+        j.create_script(self.sleep100_job)
         time.sleep(2)
         stime = int(time.time())
         time.sleep(2)
@@ -2053,10 +2052,11 @@ if %s e.job.in_ms_mom():
             self.logger.info('Skipping the second part of this test '
                              'since hostB also has same vntype value')
             return
+
         a = {'Resource_List.select': '1:ncpus=1:mem=100mb:host=%s' %
              self.hosts_list[1], ATTR_N: name}
         j1 = Job(TEST_USER, attrs=a)
-        j1.create_script(self.sleep15_job)
+        j1.create_script(self.sleep100_job)
         jid2 = self.server.submit(j1)
         a = {'job_state': 'R'}
         self.server.expect(JOB, a, jid2)
@@ -2195,7 +2195,7 @@ if %s e.job.in_ms_mom():
              '1:ncpus=1:mem=300mb:host=%s' % self.hosts_list[0],
              ATTR_N: name, ATTR_k: 'oe'}
         j = Job(TEST_USER, attrs=a)
-        j.create_script(self.sleep15_job)
+        j.create_script(self.sleep100_job)
         jid = self.server.submit(j)
         a = {'job_state': 'R'}
         self.server.expect(JOB, a, jid)
@@ -2233,7 +2233,7 @@ if %s e.job.in_ms_mom():
         a = {'Resource_List.select': '1:ncpus=1:host=%s' %
              self.hosts_list[0], ATTR_N: name}
         j = Job(TEST_USER, attrs=a)
-        j.create_script(self.sleep15_job)
+        j.create_script(self.sleep100_job)
         jid = self.server.submit(j)
         a = {'job_state': 'R'}
         self.server.expect(JOB, a, jid)
@@ -2452,12 +2452,12 @@ if %s e.job.in_ms_mom():
         a = {'Resource_List.select': '1:ncpus=1:mem=300mb:host=%s' %
              self.hosts_list[0], ATTR_N: name + 'a'}
         j1 = Job(TEST_USER, attrs=a)
-        j1.create_script(self.sleep15_job)
+        j1.create_script(self.sleep100_job)
         jid1 = self.server.submit(j1)
         b = {'Resource_List.select': '1:ncpus=1:mem=300mb:host=%s' %
              self.hosts_list[0], ATTR_N: name + 'b'}
         j2 = Job(TEST_USER, attrs=b)
-        j2.create_script(self.sleep15_job)
+        j2.create_script(self.sleep100_job)
         jid2 = self.server.submit(j2)
         a = {'job_state': 'R'}
         # Make sure they are both running
@@ -2937,7 +2937,7 @@ if %s e.job.in_ms_mom():
         a = {'Resource_List.select': '1:ncpus=1:mem=300mb:host=%s' %
              self.hosts_list[0], ATTR_N: name}
         j = Job(TEST_USER, attrs=a)
-        j.create_script(self.sleep15_job)
+        j.create_script(self.sleep100_job)
         time.sleep(2)
         stime = int(time.time())
         time.sleep(2)
@@ -2957,7 +2957,7 @@ if %s e.job.in_ms_mom():
         a = {'Resource_List.select': '1:ncpus=1:mem=300mb:host=%s' %
              self.hosts_list[1], ATTR_N: name}
         j = Job(TEST_USER, attrs=a)
-        j.create_script(self.sleep15_job)
+        j.create_script(self.sleep100_job)
         jid2 = self.server.submit(j)
         a = {'job_state': 'R'}
         self.server.expect(JOB, a, jid2)
@@ -2978,7 +2978,7 @@ if %s e.job.in_ms_mom():
         a = {'Resource_List.select': '1:ncpus=1:mem=300mb:host=%s' %
              self.hosts_list[1], ATTR_N: name}
         j = Job(TEST_USER, attrs=a)
-        j.create_script(self.sleep15_job)
+        j.create_script(self.sleep100_job)
         time.sleep(2)
         stime = int(time.time())
         time.sleep(2)
@@ -2997,7 +2997,7 @@ if %s e.job.in_ms_mom():
         a = {'Resource_List.select': '1:ncpus=1:mem=300mb:host=%s' %
              self.hosts_list[0], ATTR_N: name}
         j = Job(TEST_USER, attrs=a)
-        j.create_script(self.sleep15_job)
+        j.create_script(self.sleep100_job)
         jid2 = self.server.submit(j)
         a = {'job_state': 'R'}
         self.server.expect(JOB, a, jid2)
@@ -3222,7 +3222,7 @@ if %s e.job.in_ms_mom():
         a = {'Resource_List.select': '2:ncpus=1:mem=100mb',
              'Resource_List.place': 'scatter'}
         j = Job(TEST_USER, attrs=a)
-        j.create_script(self.sleep15_job)
+        j.create_script(self.sleep100_job)
         jid = self.server.submit(j)
         a = {'job_state': 'R'}
         self.server.expect(JOB, a, jid)
@@ -3413,7 +3413,7 @@ if %s e.job.in_ms_mom():
         a = {'Resource_List.select': '1:ncpus=1:mem=100mb:host=%s' %
              self.hosts_list[0]}
         j = Job(TEST_USER, attrs=a)
-        j.create_script(self.sleep15_job)
+        j.create_script(self.sleep100_job)
         jid = self.server.submit(j)
         a = {'job_state': 'R'}
         self.server.expect(JOB, a, jid)
@@ -3427,6 +3427,8 @@ if %s e.job.in_ms_mom():
         self.assertEqual(result['rc'], 0)
         value_mem_fences = result['out'][0]
         self.logger.info("value with mem_fences: %s" % value_mem_fences)
+        self.server.delete(jid, wait=True)
+
         # Now try with mem_fences set to false
         self.load_config(self.cfg5 % ('false', '', 'false', 'false',
                                       'false', self.mem, self.swapctl))
@@ -3435,7 +3437,7 @@ if %s e.job.in_ms_mom():
         a = {'Resource_List.select': '1:ncpus=1:mem=100mb:host=%s' %
              self.hosts_list[0]}
         j = Job(TEST_USER, attrs=a)
-        j.create_script(self.sleep15_job)
+        j.create_script(self.sleep100_job)
         jid = self.server.submit(j)
         a = {'job_state': 'R'}
         self.server.expect(JOB, a, jid)
@@ -3458,6 +3460,7 @@ if %s e.job.in_ms_mom():
         """
         if not self.paths[self.hosts_list[0]]['memory']:
             self.skipTest('Test requires memory subystem mounted')
+
         self.load_config(self.cfg5 % ('false', '', 'true', 'false',
                                       'false', self.mem, self.swapctl))
         self.server.expect(NODE, {'state': 'free'},
@@ -3465,7 +3468,7 @@ if %s e.job.in_ms_mom():
         a = {'Resource_List.select': '1:ncpus=1:mem=100mb:host=%s' %
              self.hosts_list[0]}
         j = Job(TEST_USER, attrs=a)
-        j.create_script(self.sleep15_job)
+        j.create_script(self.sleep100_job)
         jid = self.server.submit(j)
         a = {'job_state': 'R'}
         self.server.expect(JOB, a, jid)
@@ -3484,6 +3487,8 @@ if %s e.job.in_ms_mom():
                              filename=fn, sudo=True)
         self.assertEqual(result['rc'], 0)
         self.assertEqual(result['out'][0], '0')
+        self.server.delete(jid, wait=True)
+
         self.load_config(self.cfg5 % ('false', '', 'true', 'true',
                                       'false', self.mem, self.swapctl))
         self.server.expect(NODE, {'state': 'free'},
@@ -3491,7 +3496,7 @@ if %s e.job.in_ms_mom():
         a = {'Resource_List.select': '1:ncpus=1:mem=100mb:host=%s' %
              self.hosts_list[0]}
         j = Job(TEST_USER, attrs=a)
-        j.create_script(self.sleep15_job)
+        j.create_script(self.sleep100_job)
         jid = self.server.submit(j)
         a = {'job_state': 'R'}
         self.server.expect(JOB, a, jid)
@@ -3572,6 +3577,7 @@ if %s e.job.in_ms_mom():
         """
         if not self.paths[self.hosts_list[0]]['memory']:
             self.skipTest('Test requires memory subystem mounted')
+
         self.load_config(self.cfg5 % ('false', '', 'true', 'false',
                                       'false', self.mem, self.swapctl))
         nid = self.nodes_list[0]
@@ -3580,7 +3586,7 @@ if %s e.job.in_ms_mom():
         hostn = self.hosts_list[0]
         a = {'Resource_List.select': '1:ncpus=1:mem=100mb:host=%s' % hostn}
         j = Job(TEST_USER, attrs=a)
-        j.create_script(self.sleep15_job)
+        j.create_script(self.sleep100_job)
         jid = self.server.submit(j)
         a = {'job_state': 'R'}
         self.server.expect(JOB, a, jid)
@@ -3596,13 +3602,15 @@ if %s e.job.in_ms_mom():
         result = self.du.cat(hostname=hostn, filename=fn, sudo=True)
         self.assertEqual(result['rc'], 0)
         self.assertEqual(result['out'][0], '0')
+        self.server.delete(jid, wait=True)
+
         self.load_config(self.cfg5 % ('false', '', 'true', 'false',
                                       'true', self.mem, self.swapctl))
         self.server.expect(NODE, {'state': 'free'}, id=nid,
                            interval=3, offset=10)
         a = {'Resource_List.select': '1:ncpus=1:mem=100mb:host=%s' % hostn}
         j = Job(TEST_USER, attrs=a)
-        j.create_script(self.sleep15_job)
+        j.create_script(self.sleep100_job)
         jid = self.server.submit(j)
         a = {'job_state': 'R'}
         self.server.expect(JOB, a, jid)
@@ -3757,7 +3765,8 @@ event.accept()
         a = {'Resource_List.select': '1:ncpus=1:mem=100mb:host=%s' %
              self.hosts_list[0]}
         j = Job(TEST_USER, attrs=a)
-        j.create_script(self.sleep15_job)
+        # Here a short job is OK, since we are waiting for it to end
+        j.create_script(self.sleep30_job)
         time.sleep(2)
         presubmit = int(time.time())
         time.sleep(2)
@@ -4055,7 +4064,7 @@ event.accept()
              '1:ncpus=1:host=%s+1:ncpus=1:host=%s+1:ncpus=1:host=%s' %
              (self.hosts_list[0], self.hosts_list[1], self.hosts_list[2])}
         j = Job(TEST_USER, attrs=a)
-        j.create_script(self.sleep15_job)
+        j.create_script(self.sleep100_job)
         jid = self.server.submit(j)
         a = {'job_state': 'R', 'substate': '41'}
         self.server.expect(JOB, a, jid)
@@ -4097,7 +4106,7 @@ event.accept()
         a = {'Resource_List.select': '3:ncpus=1:mem=100mb',
              'Resource_List.place': 'scatter'}
         j = Job(TEST_USER, attrs=a)
-        j.create_script(self.sleep15_job)
+        j.create_script(self.sleep100_job)
         jid = self.server.submit(j)
         a = {'job_state': 'R'}
         self.server.expect(JOB, a, jid)
@@ -4139,7 +4148,7 @@ event.accept()
         select_spec = "%d:ncpus=%d" % (vnodes_count, cpus_per_vnode)
         a = {'Resource_List.select': select_spec, ATTR_N: name + 'a'}
         j1 = Job(TEST_USER, attrs=a)
-        j1.create_script(self.sleep15_job)
+        j1.create_script(self.sleep100_job)
         jid1 = self.server.submit(j1)
         a = {'job_state': 'R'}
         # Make sure job is running
@@ -4389,7 +4398,7 @@ sleep 300
              "ncpus=%d" % ncpus_req,
              ATTR_N: name, ATTR_k: 'oe'}
         j = Job(TEST_USER, attrs=a)
-        j.create_script(self.sleep15_job)
+        j.create_script(self.sleep100_job)
         jid = self.server.submit(j)
         a = {'job_state': 'R'}
         self.server.expect(JOB, a, jid)
@@ -4486,7 +4495,7 @@ sleep 300
              "ncpus=%d" % ncpus_req,
              ATTR_N: name, ATTR_k: 'oe'}
         j = Job(TEST_USER, attrs=a)
-        j.create_script(self.sleep15_job)
+        j.create_script(self.sleep100_job)
         jid = self.server.submit(j)
         a = {'job_state': 'R'}
         self.server.expect(JOB, a, jid)
@@ -4574,7 +4583,7 @@ sleep 300
         a = {'Resource_List.select': 'ncpus=0',
              ATTR_N: name, ATTR_k: 'oe'}
         j = Job(TEST_USER, attrs=a)
-        j.create_script(self.sleep15_job)
+        j.create_script(self.sleep100_job)
         jid = self.server.submit(j)
         a = {'job_state': 'R'}
         self.server.expect(JOB, a, jid)
@@ -4664,7 +4673,7 @@ sleep 300
         a = {'Resource_List.select': 'ncpus=0',
              ATTR_N: name, ATTR_k: 'oe'}
         j = Job(TEST_USER, attrs=a)
-        j.create_script(self.sleep15_job)
+        j.create_script(self.sleep100_job)
         jid = self.server.submit(j)
         a = {'job_state': 'R'}
         self.server.expect(JOB, a, jid)
@@ -4760,7 +4769,7 @@ sleep 300
         self.mom.add_config(c)
         a = {'Resource_List.select': 'ncpus=1:mem=100mb'}
         j = Job(TEST_USER, attrs=a)
-        j.create_script(self.sleep15_job)
+        j.create_script(self.sleep100_job)
         time.sleep(2)
         stime = int(time.time())
         time.sleep(2)

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -2751,7 +2751,6 @@ if %s e.job.in_ms_mom():
             if ret['rc'] != 0:
                 self.logger.info("Cannot confirm freezer state"
                                  "sleeping 30 seconds instead")
-                confirmed_frozen = True
                 time.sleep(30)
                 break
             if ret['out'][0] == 'FROZEN':
@@ -2764,7 +2763,7 @@ if %s e.job.in_ms_mom():
                 time.sleep(1)
 
         if not confirmed_frozen:
-            self.logger.info("Freezer did not work -- skip test")
+            self.logger.info("Freezer did not work; skip test after cleanup")
 
         # Catch any exception so we can thaw the cgroup or the jobs
         # will remain frozen and impact subsequent tests

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -183,7 +183,7 @@ class TestCgroupsHook(TestFunctional):
 
         self.hook_name = 'pbs_cgroups'
         # Cleanup previous pbs_cgroup hook so as to not interfere with test
-        c_hook = self.server.filter(HOOK, 
+        c_hook = self.server.filter(HOOK,
                                     {'enabled': True}, id=self.hook_name)
         if c_hook:
             self.server.manager(MGR_CMD_DELETE, HOOK, id=self.hook_name)

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -3328,10 +3328,12 @@ if %s e.job.in_ms_mom():
         j3 = Job(TEST_USER, attrs=a)
         j3.create_script('date')
         jid3 = self.server.submit(j3)
+        # Will either start with "Can Never Run" or "Not Running"
+        # Don't match only one
         a = {'job_state': 'Q',
              'comment':
              (MATCH_RE,
-              '.*Can Never Run: Insufficient amount of resource: mem.*')}
+              '.*: Insufficient amount of resource: mem.*')}
         self.server.expect(JOB, a, attrop=PTL_AND, id=jid3, offset=10,
                            interval=1)
 

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -259,6 +259,13 @@ class TestCgroupsHook(TestFunctional):
             self.nodes_list.append(node)
             self.vntypename.append(vntype)
 
+            # Tell the MoM's kernel to flush the buffer cache:
+            # when we run a job we want less dirty page cache
+            # which might slow down memory allocations
+            flush_cmd = ["echo 3 >/proc/sys/vm/drop_caches"]
+            self.du.run_cmd(hosts=mom.hostname, cmd=flush_cmd,
+                            as_script=True, sudo=True)
+
         # Setting self.mom defaults to primary mom as some of
         # library methods assume that
         self.mom = self.moms_list[0]
@@ -372,7 +379,6 @@ if sleeptime2 > 0 and (end_time2 - start_time2) < sleeptime2 :
         self.eatmem_job1 = \
             '#PBS -joe\n' \
             '#PBS -S /bin/bash\n' \
-            'timeout -s KILL 60 sync\n' \
             'sleep 10\n' \
             'python_path=`which python 2>/dev/null`\n' \
             'python3_path=`which python3 2>/dev/null`\n' \
@@ -393,7 +399,6 @@ if sleeptime2 > 0 and (end_time2 - start_time2) < sleeptime2 :
         self.eatmem_job2 = \
             '#PBS -joe\n' \
             '#PBS -S /bin/bash\n' \
-            'timeout -s KILL 60 sync\n' \
             'python_path=`which python 2>/dev/null`\n' \
             'python3_path=`which python3 2>/dev/null`\n' \
             'python2_path=`which python2 2>/dev/null`\n' \
@@ -419,7 +424,6 @@ if sleeptime2 > 0 and (end_time2 - start_time2) < sleeptime2 :
         self.eatmem_job3 = \
             '#PBS -joe\n' \
             '#PBS -S /bin/bash\n' \
-            'timeout -s KILL 60 sync\n' \
             'python_path=`which python 2>/dev/null`\n' \
             'python3_path=`which python3 2>/dev/null`\n' \
             'python2_path=`which python2 2>/dev/null`\n' \

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -2721,8 +2721,8 @@ if %s e.job.in_ms_mom():
                                       as_script=True)
                 if ret['rc'] != 0:
                     success = False
-                    self.logger.info('Failed to copy %s to %s on %s' %
-                                     (fn, task_file, self.hosts_list[0]))
+                    self.logger.info('Failed to put %s into %s on %s' %
+                                     (pidstr, task_file, self.hosts_list[0]))
                     self.logger.info('rc = %d', ret['rc'])
                     self.logger.info('stdout = %s', ret['out'])
                     self.logger.info('stderr = %s', ret['err'])

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -5132,8 +5132,9 @@ sleep 300
                              filename=job_output_file,
                              sudo=True)
         self.assertTrue('out' in result, "Nothing in job output file?")
-        self.logger.info("job_out=%s" % result['out'][0])
-        self.assertTrue('unlimited' in result['out'][0])
+        job_out = '\n'.join(result['out'])
+        self.logger.info("job_out=%s" % job_out)
+        self.assertTrue('unlimited' in job_out)
         self.logger.info("Job that requests vmem "
                          "but no pvmem correctly has unlimited RLIMIT_AS")
 
@@ -5156,9 +5157,10 @@ sleep 300
                              filename=job_output_file,
                              sudo=True)
         self.assertTrue('out' in result, "Nothing in job output file?")
-        self.logger.info("job_out=%s" % result['out'][0])
+        job_out = '\n'.join(result['out'])
+        self.logger.info("job_out=%s" % job_out)
         # ulimit reports kb, not bytes
-        self.assertTrue(str(300 * 1024) in result['out'][0])
+        self.assertTrue(str(300 * 1024) in job_out)
         self.logger.info("Job that requests 300mb pvmem "
                          "correctly has 300mb RLIMIT_AS")
 

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -2631,7 +2631,7 @@ if %s e.job.in_ms_mom():
         tmp_file = filename.split(':')[1]
         tmp_host = ehost.split('/')[0]
         tmp_out = self.wait_and_read_file(filename=tmp_file, host=tmp_host)
-        self.tempfile.append(tmp_out)
+        self.tempfile.append(tmp_file)
         success = False
         foundstr = ''
         if tmp_out == []:


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
When enabling the "memsw" functionality in the cgroup hook, the semantics of "vmem" change.

Without it "vmem" is managed by MoM and denotes the sum of the address spaces used by all processes on the mother superior node, and MoM sets a per process limit for RLIMIT_AS (since clearly a single process cannot use less address space than the sum for all processes).

But when the cgroup hook "memsw" functionality is enabled, "vmem" requests instead specify the sum of physical memory plus swap usage for the job, which is often smaller than the address space limit.

Indeed, it is doubtful that in the face of kernel limits on real memory plus swap usage anyone would care about the address space limits, especially on 64-bit systems (which have an 8 Exabyte positive address address space). Address space limits were used in the past when there were no physical memory and swap limits enforced by the kernel, but cgroups make these unnecessary.

But on most current versions of PBSPro, the MoM does not know about this change in semantics for vmem, and it still sets a RLIMIT_AS limit for all processes in the job. Since many applications allocate much more address space than they actually use memory, that can make applications fail even though they are staying well within the memory+swap usage corresponding to their vmem requests.

Even MoM itself can be a victim for small vmem limits: when the job starter child forks to run the execjob_launch hook, the fork and exec of pbs_python can make it use up to 150mb-200mb of address space, so setting a small RLIMIT_AS limit can make either the job starter or the hooks fail.

Furthermore, a per-job 'pvmem' resource request unambiguously requests exactly a RLIMIT_AS, so there is no real need to use vmem to specify this limit if one is desired.

To summarise: when enabling the "memsw" functionality in the cgroup hook, RLIMIT_AS should be unlimited, unless the job also requests "pvmem" (which is an unambiguous request to set RLIMIT_AS).

Note: this really is a MoM bug; ideally it should be possible to enable or disable automatic setting of the RLIMIT_AS limit when 'vmem' is requested in the MoM config file. But until such a mechanism exists, at least the cgroup hook can mitigate the effect for values of 'vmem' large enough to allow the job starter and the hooks to run.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
A new parameter is introduced to the cgroup configuration file, manage_rlimit_as, which by default is true.

If enabled, then the cgroup hook will reset the RLIMIT_AS process limit for task processes to either unlimited (if pvmem is not specified) or the value of pvmem requested for the job.

This functionality requires a kernel that supports the prlimit system call (i.e. Linux kernel 2.6.36 and above).

If hooks use Python 3, i.e. for PBS versions 2020 and above, that is the only requirement.

For older versions of PBS, the 'prlimit' command should be present. This command is available in util-linux versions 2.21 and above on:
-CentOS7/RedHat from version 7.0
-SLES from version 12 onward,
-Ubuntu from version Ubuntu 16.04 onward
-Debian versions from version 8.0 onward
(i.e. most OS versions with a kernel that supports the prlimit system call and have a version of util-linux >= 2.21).

If the support for changing process limits of other processes is not present, then limits set by MoM are never changed (i.e. the hook behaves as before, and as if manage_rlimit_as were disabled).

When the flag is disabled, limits set by MoM will not be changed. It is unlikely anyone would want this behaviour, except on MoMs where it is possible to disable enforcement of 'vmem' as an RLIMIT_AS limit set on processes.
#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
https://openpbs.atlassian.net/wiki/spaces/PD/pages/2668199965/Fix+incorrect+MoM+RLIMIT+AS+when+vmem+is+used+for+the+group+hook+s+memsw+functionality

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
A PTL test was added, test_manage_rlimit_as. 

A job requests -lselect=1:ncpus=0:mem=300mb:vmem=300mb and the test checks that ulimit -v in a job returns 'unlimited'. A job requests -lselect=1:ncpus=0:mem=300mb:vmem=300mb,pvmem=300mb, and then ulimit -v should return 307200 (since ulimit -v output is in kb units).

Relevant portion of test_manage_rlimit_as output:
```
2021-03-26 13:08:54,255 INFO     manager on dragon: set server {'job_history_enable': 'True'}
2021-03-26 13:08:54,255 INFOCLI  dragon: /opt/pbs/bin/qmgr -c set server job_history_enable=True
2021-03-26 13:08:54,283 INFOCLI  dragon: /opt/pbs/bin/qstat -Bf dragon
2021-03-26 13:08:54,294 INFO     expect on server dragon: job_history_enable = True server dragon ...  OK
2021-03-26 13:08:54,294 INFO     Current config: {
    "cgroup_prefix"         : "pbs_jobs",
    "exclude_hosts"         : [],
    "exclude_vntypes"       : ["no_cgroups"],
    "run_only_on_hosts"     : [],
    "periodic_resc_update"  : true,
    "vnode_per_numa_node"   : false,
    "online_offlined_nodes" : true,
    "use_hyperthreads"      : false,
    "ncpus_are_cores"       : false,
    "manage_rlimit_as"      : true,
    "cgroup" : {
        "cpuacct" : {
            "enabled"            : true,
            "exclude_hosts"      : [],
            "exclude_vntypes"    : []
        },
        "cpuset" : {
            "enabled"            : true,
            "exclude_cpus"       : [],
            "exclude_hosts"      : [],
            "exclude_vntypes"    : [],
            "mem_fences"         : true,
            "mem_hardwall"       : false,
            "memory_spread_page" : false
        },
        "devices" : {
            "enabled"            : true,
            "exclude_hosts"      : [],
            "exclude_vntypes"    : [],
            "allow"              : [
                "b *:* rwm",
                "c *:* rwm"
            ]
        },
        "hugetlb" : {
            "enabled"            : false,
            "exclude_hosts"      : [],
            "exclude_vntypes"    : [],
            "default"            : "0MB",
            "reserve_percent"    : 0,
            "reserve_amount"     : "0MB"
        },
        "memory" : {
            "enabled"            : true,
            "exclude_hosts"      : [],
            "exclude_vntypes"    : [],
            "soft_limit"         : false,
            "default"            : "100MB",
            "reserve_percent"    : 0,
            "swappiness"         : 0,
            "reserve_amount"     : "2GB",
            "enforce_default"    : true,
            "exclhost_ignore_default" : true
        },
        "memsw" : {
            "enabled"            : true,
            "exclude_hosts"      : [],
            "exclude_vntypes"    : [],
            "default"            : "100MB",
            "reserve_percent"    : 0,
            "reserve_amount"     : "10GB",
            "manage_cgswap"      : true,
            "enforce_default"    : true,
            "exclhost_ignore_default" : true
        }
    }
}

2021-03-26 13:09:01,301 INFO     manager on dragon: import hook pbs_cgroups {'content-type': 'application/x-config', 'content-encoding': 'default', 'input-file': '/tmp/PtlPbs9u4sidjl'}
2021-03-26 13:09:01,302 INFOCLI  dragon: sudo -H /opt/pbs/bin/qmgr -c import hook pbs_cgroups application/x-config default /tmp/PtlPbs9u4sidjl
2021-03-26 13:09:01,326 ERROR    err: ["hook 'pbs_cgroups' contents overwritten"]
2021-03-26 13:09:04,892 INFO     mom dragon log match: searching for "pbs_cgroups.CF;copy hook-related file request received" - with existence... OK
2021-03-26 13:09:04,903 INFOCLI2 dragon: sudo -H cat /var/spool/PBS/server_priv/hooks/pbs_cgroups.CF
2021-03-26 13:09:04,923 INFOCLI2 dragon: sudo -H cat /var/spool/PBS/mom_priv/hooks/pbs_cgroups.CF
2021-03-26 13:09:04,941 INFO     server & mom pbs_cgroups.CF match
2021-03-26 13:09:08,945 INFO     mom dragon: sent signal -HUP
2021-03-26 13:09:08,945 INFOCLI2 dragon: sudo -H /usr/bin/cat /var/spool/PBS/mom_priv/mom.lock
2021-03-26 13:09:08,964 INFOCLI2 dragon: sudo -H kill -HUP 554166
2021-03-26 13:09:12,543 INFO     mom dragon log match: searching for "hook_perf_stat;label=hook_exechost_startup_pbs_cgroups_.* profile_stop" - using regular expression  - with existence - No match
2021-03-26 13:09:17,143 INFO     mom dragon log match: searching for "hook_perf_stat;label=hook_exechost_startup_pbs_cgroups_.* profile_stop" - using regular expression  - with existence... OK
2021-03-26 13:09:17,153 INFO     job: executable set to /bin/sleep with arguments: 100
2021-03-26 13:09:17,154 INFOCLI2 dragon: which chmod
2021-03-26 13:09:17,163 INFOCLI2 dragon: /usr/bin/chmod 755 /tmp/PtlPbsJobScript_fdaldlg
2021-03-26 13:09:17,168 INFOCLI  dragon: sudo -H -u pbsuser /opt/pbs/bin/qsub -l select=1:ncpus=0:mem=300mb:vmem=300mb:vnode=dragon /tmp/PtlPbsJobScript_fdaldlg
2021-03-26 13:09:17,203 INFO     submit to dragon as pbsuser: job 4424.dragon OrderedDict([('Resource_List.select', '1:ncpus=0:mem=300mb:vmem=300mb:vnode=dragon')])
2021-03-26 13:09:17,203 INFOCLI  job script /tmp/PtlPbsJobScript_fdaldlg
---
#!/bin/bash
ulimit -v
---
2021-03-26 13:09:17,203 INFO     server dragon: expect offset set to 1
2021-03-26 13:09:18,204 INFOCLI  dragon: /opt/pbs/bin/qstat -x -f 4424.dragon
2021-03-26 13:09:18,218 INFO     expect on server dragon: job_state = F job 4424.dragon  got: job_state = R
2021-03-26 13:09:18,719 INFOCLI  dragon: /opt/pbs/bin/qmgr -c set server scheduling=True
2021-03-26 13:09:18,738 INFOCLI  dragon: /opt/pbs/bin/qstat -x -f 4424.dragon
2021-03-26 13:09:18,950 INFO     expect on server dragon: job_state = F job 4424.dragon attempt: 2  got: job_state = E
2021-03-26 13:09:19,451 INFOCLI  dragon: /opt/pbs/bin/qmgr -c set server scheduling=True
2021-03-26 13:09:19,470 INFOCLI  dragon: /opt/pbs/bin/qstat -x -f 4424.dragon
2021-03-26 13:09:19,482 INFO     expect on server dragon: job_state = F job 4424.dragon attempt: 3 ...  OK
2021-03-26 13:09:19,482 INFO     status on dragon: job 4424.dragon
2021-03-26 13:09:19,482 INFOCLI  dragon: /opt/pbs/bin/qstat -x -f 4424.dragon
2021-03-26 13:09:19,693 INFOCLI2 dragon: sudo -H /usr/bin/cat /home/pbsuser/PtlPbsJobScript_fdaldlg.o4424
2021-03-26 13:09:19,714 INFO     job_out=unlimited
2021-03-26 13:09:19,714 INFO     Job that requests vmem but no pvmem correctly has unlimited RLIMIT_AS
2021-03-26 13:09:19,714 INFO     job: executable set to /bin/sleep with arguments: 100
2021-03-26 13:09:19,715 INFOCLI2 dragon: /usr/bin/chmod 755 /tmp/PtlPbsJobScriptld59nol_
2021-03-26 13:09:19,723 INFOCLI  dragon: sudo -H -u pbsuser /opt/pbs/bin/qsub -l select=1:ncpus=0:mem=300mb:vmem=300mb:vnode=dragon -l pvmem=300mb /tmp/PtlPbsJobScriptld59nol_
2021-03-26 13:09:19,745 INFO     submit to dragon as pbsuser: job 4425.dragon OrderedDict([('Resource_List.select', '1:ncpus=0:mem=300mb:vmem=300mb:vnode=dragon'), ('Resource_List.pvmem', '300mb')])
2021-03-26 13:09:19,745 INFOCLI  job script /tmp/PtlPbsJobScriptld59nol_
---
#!/bin/bash
ulimit -v
---
2021-03-26 13:09:19,745 INFO     server dragon: expect offset set to 1
2021-03-26 13:09:20,746 INFOCLI  dragon: /opt/pbs/bin/qstat -x -f 4425.dragon
2021-03-26 13:09:20,761 INFO     expect on server dragon: job_state = F job 4425.dragon  got: job_state = E
2021-03-26 13:09:21,261 INFOCLI  dragon: /opt/pbs/bin/qmgr -c set server scheduling=True
2021-03-26 13:09:21,281 INFOCLI  dragon: /opt/pbs/bin/qstat -x -f 4425.dragon
2021-03-26 13:09:21,293 INFO     expect on server dragon: job_state = F job 4425.dragon attempt: 2  got: job_state = E
2021-03-26 13:09:21,794 INFOCLI  dragon: /opt/pbs/bin/qmgr -c set server scheduling=True
2021-03-26 13:09:21,811 INFOCLI  dragon: /opt/pbs/bin/qstat -x -f 4425.dragon
2021-03-26 13:09:22,023 INFO     expect on server dragon: job_state = F job 4425.dragon attempt: 3 ...  OK
2021-03-26 13:09:22,024 INFO     status on dragon: job 4425.dragon
2021-03-26 13:09:22,024 INFOCLI  dragon: /opt/pbs/bin/qstat -x -f 4425.dragon
2021-03-26 13:09:22,237 INFOCLI2 dragon: sudo -H /usr/bin/cat /home/pbsuser/PtlPbsJobScriptld59nol_.o4425
2021-03-26 13:09:22,257 INFO     job_out=307200
2021-03-26 13:09:22,257 INFO     Job that requests 300mb pvmem correctly has 300mb RLIMIT_AS
```
<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
