### PR TITLE
Fix race condition in TestQueRescUsage

### DIFF
--- a/test/tests/functional/pbs_que_resc_usage.py
+++ b/test/tests/functional/pbs_que_resc_usage.py
@@ -39,6 +39,7 @@
 
 
 from tests.functional import *
+from time import time
 
 
 class TestQueRescUsage(TestFunctional):
@@ -90,12 +91,11 @@ class TestQueRescUsage(TestFunctional):
         self.assertEqual(
             int(q_status[0]['resources_available.ncpus']), 8, self.err_msg)
         # job submission
+        t1 = time()
         j_attr = {'Resource_List.ncpus': '3'}
         j1 = Job(attrs=j_attr)
-        j1.set_sleep_time(30)
         jid_1 = self.server.submit(j1)
         j2 = Job(attrs=j_attr)
-        j2.set_sleep_time(30)
         jid_2 = self.server.submit(j2)
         self.server.expect(JOB, {'job_state': 'R'}, jid_1)
         self.server.expect(JOB, {'job_state': 'R'}, jid_2)
@@ -121,8 +121,9 @@ class TestQueRescUsage(TestFunctional):
         self.assertEqual(
             int(q_status[0]['resources_assigned.ncpus']), 6, self.err_msg)
         # If no jobs are running at the time of restart the server
-        self.server.expect(JOB, 'queue', op=UNSET, id=jid_1)
-        self.server.expect(JOB, 'queue', op=UNSET, id=jid_2)
+        delta = time() - t1
+        self.server.expect(JOB, 'queue', op=UNSET, id=jid_1, offset=delta)
+        self.server.expect(JOB, 'queue', op=UNSET, id=jid_2, offset=delta)
         self.server.restart()
         q_status = self.server.status(QUEUE, id='workq')
         self.assertNotIn('resources_available.ncpus',
@@ -141,15 +142,14 @@ class TestQueRescUsage(TestFunctional):
         # create a resource
         self.create_custom_resc()
 
+        t1 = time()
         # resources_assigned is zero but still jobs are in the system
         j1_attr = {'Resource_List.foo': '3'}
         j1 = Job(attrs=j1_attr)
-        j1.set_sleep_time(30)
         jid_1 = self.server.submit(j1)
         # requesting negative resource here
         j2_attr = {'Resource_List.foo': '-3'}
         j2 = Job(attrs=j2_attr)
-        j2.set_sleep_time(30)
         jid_2 = self.server.submit(j2)
         self.server.expect(JOB, {'job_state': 'R'}, jid_1)
         self.server.expect(JOB, {'job_state': 'R'}, jid_2)
@@ -162,8 +162,9 @@ class TestQueRescUsage(TestFunctional):
         q_status = self.server.status(QUEUE, id='workq')
         self.assertEqual(
             int(q_status[0]['resources_assigned.foo']), 0, self.err_msg)
-        self.server.expect(JOB, 'queue', op=UNSET, id=jid_1)
-        self.server.expect(JOB, 'queue', op=UNSET, id=jid_2)
+        delta = time() - t1
+        self.server.expect(JOB, 'queue', op=UNSET, id=jid_1, offset=delta)
+        self.server.expect(JOB, 'queue', op=UNSET, id=jid_2, offset=delta)
         # jobs are finished now, resources_assigned should unset this time
         self.server.restart()
         q_status = self.server.status(QUEUE, id='workq')

--- a/test/tests/functional/pbs_que_resc_usage.py
+++ b/test/tests/functional/pbs_que_resc_usage.py
@@ -39,7 +39,6 @@
 
 
 from tests.functional import *
-from time import time
 
 
 class TestQueRescUsage(TestFunctional):
@@ -91,7 +90,6 @@ class TestQueRescUsage(TestFunctional):
         self.assertEqual(
             int(q_status[0]['resources_available.ncpus']), 8, self.err_msg)
         # job submission
-        t1 = time()
         j_attr = {'Resource_List.ncpus': '3'}
         j1 = Job(attrs=j_attr)
         jid_1 = self.server.submit(j1)
@@ -121,9 +119,8 @@ class TestQueRescUsage(TestFunctional):
         self.assertEqual(
             int(q_status[0]['resources_assigned.ncpus']), 6, self.err_msg)
         # If no jobs are running at the time of restart the server
-        delta = time() - t1
-        self.server.expect(JOB, 'queue', op=UNSET, id=jid_1, offset=delta)
-        self.server.expect(JOB, 'queue', op=UNSET, id=jid_2, offset=delta)
+        self.server.delete(jid_1, extend='force', wait=True)
+        self.server.delete(jid_2, extend='force', wait=True)
         self.server.restart()
         q_status = self.server.status(QUEUE, id='workq')
         self.assertNotIn('resources_available.ncpus',
@@ -142,7 +139,6 @@ class TestQueRescUsage(TestFunctional):
         # create a resource
         self.create_custom_resc()
 
-        t1 = time()
         # resources_assigned is zero but still jobs are in the system
         j1_attr = {'Resource_List.foo': '3'}
         j1 = Job(attrs=j1_attr)
@@ -162,9 +158,8 @@ class TestQueRescUsage(TestFunctional):
         q_status = self.server.status(QUEUE, id='workq')
         self.assertEqual(
             int(q_status[0]['resources_assigned.foo']), 0, self.err_msg)
-        delta = time() - t1
-        self.server.expect(JOB, 'queue', op=UNSET, id=jid_1, offset=delta)
-        self.server.expect(JOB, 'queue', op=UNSET, id=jid_2, offset=delta)
+        self.server.delete(jid_1, extend='force', wait=True)
+        self.server.delete(jid_2, extend='force', wait=True)
         # jobs are finished now, resources_assigned should unset this time
         self.server.restart()
         q_status = self.server.status(QUEUE, id='workq')


### PR DESCRIPTION
#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
"test_resc_assigned_set_unset" & "test_resources_assigned_with_zero_val" fails with assertion error.
As the sleep time of jobs was less, till the time the server restarts, the jobs got finished. As a result, we were not able to get the "resouces_assigned.ncpus" value in the queue's status.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* Letting the sleep time of the jobs be set to default so that it doesn't fail on slower machines.
* Also, as the test is expecting the jobs to be finished after the restart, I am adding an offset to wait for the jobs to finish.

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|6798|18|0|0|0|0|18|


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
