### PR TITLE
Test 'test_comm_log_events' is failing while verifying the log-msg due to race condition

### DIFF
--- a/test/tests/functional/pbs_test_tpp.py
+++ b/test/tests/functional/pbs_test_tpp.py
@@ -918,7 +918,7 @@ class TestTPP(TestFunctional):
         """
         Test for verifying the allowable values for PBS_COMM_LOG_EVENTS
         """
-        a = [0, 511, "T"]
+        a = [0, "T", 511]
         for log_event in a:
             hook_name = "begin_" + str(log_event)
             attrib = {'PBS_COMM_LOG_EVENTS': log_event}
@@ -926,20 +926,22 @@ class TestTPP(TestFunctional):
                 existence = False
             else:
                 existence = True
-            start_time = time.time()
             self.set_pbs_conf(host_name=self.server.shortname,
                               conf_param=attrib)
-            attrs = {'event': 'execjob_begin', 'enabled': 'True'}
-            self.server.create_hook(hook_name, attrs)
             exp_msg = ["MCAST packet from .*:15001",
                        "mcast done"]
+            attrs = {'event': 'execjob_begin', 'enabled': 'True'}
+            start_time = time.time()
+            self.server.create_hook(hook_name, attrs)
             for msg in exp_msg:
                 self.comm.log_match(msg, existence=existence,
                                     starttime=start_time, regexp=True)
+            start_time = time.time()
             self.server.import_hook(hook_name, body="import pbs")
             for msg in exp_msg:
                 self.comm.log_match(msg, existence=existence,
                                     starttime=start_time, regexp=True)
+            start_time = time.time()
             self.server.manager(MGR_CMD_DELETE, HOOK, id=hook_name)
             for msg in exp_msg:
                 self.comm.log_match(msg, existence=existence,


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature

- Test 'test_comm_log_events' is failing while verifying the log-msg due to race condition


#### Describe Your Change

-  In the test we are setting different log events and expecting that when log event is set to T then the following log msg "MCAST packet from .*:15001" should not be logged in comm logs. But in the failed scenario the msg is existing. This is because prior to setting the event to T, the test is setting event as 511 and for this log event the msgs are logged. The start time for verifying the non-existence of the log msg is same as the time log msg has appeared for event 511.
- I have modified the test to include start_time of each of the actions(creating hook, importing hook and deleting hook) in log match instead of passing the start time taken before setting the log event in pbs.conf file



#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output

- [Execution_logs_TPP_bfr_fix.txt](https://github.com/openpbs/openpbs/files/6236954/Execution_logs_TPP_bfr_fix.txt)


- [Execution_logs_TPP_aftr_fix.txt](https://github.com/openpbs/openpbs/files/6236951/Execution_logs_TPP_aftr_fix.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
