### PR TITLE
Tests having "mom_on_server=True" and _no_mom_on_server=true" are not behaving as expected if mom is on remote host

### DIFF
--- a/test/fw/ptl/utils/plugins/ptl_test_runner.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_runner.py
@@ -1041,7 +1041,7 @@ class PTLTestRunner(Plugin):
         hosts = set(self.param_dict['moms'])
         for server in self.param_dict['servers']:
             if server not in hosts:
-                hosts.extend(server)
+                hosts.update(server)
         for user in PBS_USERS:
             self.logger.debug('Cleaning %s\'s home directory' % (str(user)))
             runas = PbsUser.get_user(user)

--- a/test/fw/ptl/utils/plugins/ptl_test_runner.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_runner.py
@@ -1038,10 +1038,10 @@ class PTLTestRunner(Plugin):
     def _cleanup(self):
         self.logger.info('Cleaning up temporary files')
         du = DshUtils()
-        hosts = self.param_dict['moms']
+        hosts = list(self.param_dict['moms'])
         for server in self.param_dict['servers']:
             if server not in self.param_dict['moms']:
-                hosts.update(self.param_dict['servers'])
+                hosts.extend(self.param_dict['servers'])
         for user in PBS_USERS:
             self.logger.debug('Cleaning %s\'s home directory' % (str(user)))
             runas = PbsUser.get_user(user)

--- a/test/fw/ptl/utils/plugins/ptl_test_runner.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_runner.py
@@ -1038,10 +1038,10 @@ class PTLTestRunner(Plugin):
     def _cleanup(self):
         self.logger.info('Cleaning up temporary files')
         du = DshUtils()
-        hosts = list(self.param_dict['moms'])
+        hosts = set(self.param_dict['moms'])
         for server in self.param_dict['servers']:
-            if server not in self.param_dict['moms']:
-                hosts.extend(self.param_dict['servers'])
+            if server not in hosts:
+                hosts.extend(server)
         for user in PBS_USERS:
             self.logger.debug('Cleaning %s\'s home directory' % (str(user)))
             runas = PbsUser.get_user(user)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Test having "no_mom_on_server=True" are skipping even mom is on remote host and "mom_on_server=True" should be skipped when mom is on remote host but tests are failing. Because the set holding the mom hostname is updated with server hostname.


#### Describe Your Change
In _cleanup(), used list to store server and mom hostname. because when we assign one set to other set and other set is updated then both set will be updated. so here mom hostname set is updated with server hostname


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
**test having "mom_on_Server=True"**
Before the changes
Description: Tests from given sources on platforms SUSE15, CENTOS8, CENTOS7
Platforms: SUSE15,CENTOS8,CENTOS7
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|6839|12|12|0|0|0|0|


After the changes
Description: Rerun All Tests From #6839
Platforms: SUSE15,CENTOS8,CENTOS7
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|6843|12|0|0|0|12|0|


**Tests having "no_mom_on_server=True"**
Before the changes
Description: Tests from given build on platforms UBUNTU1804, SUSE15
Platforms: UBUNTU1804,SUSE15
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|6835|7|0|0|0|7|0|

After the changes
Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, WIN2K16
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|6841|4|1|0|0|1|2|

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
