### PR TITLE
Sched mem leak/uninitialized read issue

### DIFF
--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -1084,7 +1084,7 @@ struct peer_queue
 	const std::string remote_queue;
 	const std::string remote_server;
 	int peer_sd;
-	peer_queue(const char *lqueue, const char *rqueue, const char *rserver): local_queue(lqueue), remote_queue(rqueue), remote_server(rserver) {}
+	peer_queue(const char *lqueue, const char *rqueue, const char *rserver): local_queue(lqueue), remote_queue(rqueue), remote_server(rserver) {peer_sd = -1;}
 };
 
 struct nspec

--- a/src/scheduler/job_info.cpp
+++ b/src/scheduler/job_info.cpp
@@ -1043,12 +1043,14 @@ query_jobs(status *policy, int pbs_sd, queue_info *qinfo, resource_resv **pjobs,
 		/* don't use multi-threading if I am a worker thread or num_threads is 1 */
 		tdata = alloc_tdata_jquery(policy, pbs_sd, jobs, qinfo, 0, num_new_jobs - 1);
 		if (tdata == NULL) {
+			free_resource_resv_array(resresv_arr);
 			pbs_statfree(jobs);
 			return NULL;
 		}
 		query_jobs_chunk(tdata);
 
 		if (tdata->error || tdata->oarr == NULL) {
+			free_resource_resv_array(resresv_arr);
 			pbs_statfree(jobs);
 			free(tdata->oarr);
 			free(tdata);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Scheduler showed following two valgrind warnings
> Conditional jump or move depends on uninitialised value(s)
   at 0x48A735: end_cycle_tasks(server_info*) (fifo.cpp:1149)
   by 0x48949F: scheduling_cycle(int, sched_cmd const*) (fifo.cpp:617)
   by 0x489360: intermediate_schedule(int, sched_cmd const*) (fifo.cpp:547)
   by 0x4892A9: schedule (fifo.cpp:503)
   by 0x4F518A: schedule_wrapper(sched_cmd*, int) (pbs_sched_utils.cpp:1244)
   by 0x4F5033: sched_main(int, char**, int (*)(int, sched_cmd const*)) (pbs_sched_utils.cpp:1190)
   by 0x4880F2: main (pbs_sched.cpp:61)

> 16 bytes in 1 blocks are definitely lost in loss record 33 of 798
   at 0x4C2907D: malloc (vg_replace_malloc.c:298)
   by 0x4C2B049: realloc (vg_replace_malloc.c:785)
   by 0x4946AE: query_jobs(status*, int, queue_info*, resource_resv**, std::string const&) (job_info.cpp:1032)
   by 0x4C9279: query_queues(status*, int, server_info*) (queue_info.cpp:225)
   by 0x4D79C4: query_server(status*, int) (server_info.cpp:267)
   by 0x489461: scheduling_cycle(int, sched_cmd const*) (fifo.cpp:614)
   by 0x489360: intermediate_schedule(int, sched_cmd const*) (fifo.cpp:547)
   by 0x4892A9: schedule (fifo.cpp:503)
   by 0x4F518A: schedule_wrapper(sched_cmd*, int) (pbs_sched_utils.cpp:1244)
   by 0x4F5033: sched_main(int, char**, int (*)(int, sched_cmd const*)) (pbs_sched_utils.cpp:1190)
   by 0x4880F2: main (pbs_sched.cpp:61)


#### Describe Your Change
First issue was caused because the constructor does not initialize a variable. Second issue looks like can only occur in case of an error where the scheduler is not able to process the queried job properly.


#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
arun@Nile Downloads % grep "end_cycle_task" valgrind_sched.txt
arun@Nile Downloads % grep "query_jobs" valgrind_sched.txt
arun@Nile Downloads % grep "uninitialised value" valgrind_sched.txt


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
