### PR TITLE
multi-server: habitat fails to create natural vnode & workq

### DIFF
--- a/src/cmds/scripts/pbs_dataservice
+++ b/src/cmds/scripts/pbs_dataservice
@@ -225,9 +225,22 @@ case "$1" in
 			echo "${msg} - cannot stop"
 			exit 0
 		fi
+		# Check if PBS_SERVER_INSTANCES is set for multi-server
+		if [ ! -z "${PBS_SERVER_INSTANCES}" ]; then
+			# We don't want qstat to try to contact other servers
+			# So, set PBS_SERVER_INSTANCES to the current server's hostname and port
+			if [ -z "${PBS_BATCH_SERVICE_PORT}" ]; then
+				PBS_BATCH_SERVICE_PORT=15001
+			fi
+			msvr_host=${PBS_SERVER_HOST_NAME}
+			if [ -z $msvr_host ]; then
+				msvr_host="$(hostname -s)"
+			fi
+			export PBS_SERVER_INSTANCES="${msvr_host}:${PBS_BATCH_SERVICE_PORT}"
+		fi
 
 		# Check if PBS is running
-		PBS_SERVER_INSTANCES="" ${PBS_EXEC}/bin/qstat -Bf >/dev/null 2>&1
+		${PBS_EXEC}/bin/qstat -Bf >/dev/null 2>&1
 		if [ $? -eq 0 ]; then
 			echo "PBS server is running. Cannot stop PBS Data Service now."
 			server_pid="`ps -ef | grep "pbs_server.bi[n]" | awk '{print $2}'`"
@@ -285,4 +298,3 @@ case "$1" in
 		;;
 esac
 exit 1
-

--- a/src/cmds/scripts/pbs_habitat.in
+++ b/src/cmds/scripts/pbs_habitat.in
@@ -318,7 +318,7 @@ if [ "${PBS_START_SERVER:-0}" != 0 ] ; then
 			exit $ret
 		fi
 		server_started=1
-		
+
 		# Check if PBS_SERVER_INSTANCES is set for multi-server
 		if [ ! -z "${PBS_SERVER_INSTANCES}" ]; then
 			# We don't want qmgr to try to contact other servers, which may not even be up yet
@@ -326,7 +326,11 @@ if [ "${PBS_START_SERVER:-0}" != 0 ] ; then
 			if [ -z "${PBS_BATCH_SERVICE_PORT}" ]; then
 				PBS_BATCH_SERVICE_PORT=15001
 			fi
-			export PBS_SERVER_INSTANCES="$(hostname -s):${PBS_BATCH_SERVICE_PORT}"
+			msvr_host=${PBS_SERVER_HOST_NAME}
+			if [ -z $msvr_host ]; then
+				msvr_host="$(hostname -s)"
+			fi
+			export PBS_SERVER_INSTANCES="${msvr_host}:${PBS_BATCH_SERVICE_PORT}"
 		fi
 		if is_cray_xt; then
 			${PBS_EXEC}/bin/qmgr <<-EOF > /dev/null

--- a/src/cmds/scripts/pbs_habitat.in
+++ b/src/cmds/scripts/pbs_habitat.in
@@ -318,15 +318,31 @@ if [ "${PBS_START_SERVER:-0}" != 0 ] ; then
 			exit $ret
 		fi
 		server_started=1
+		
+		PSI_VAL=
+		# Check if PBS_SERVER_INSTANCES is set for multi-server
+		if [ ! -z "${PBS_SERVER_INSTANCES}" ]; then
+			# We want to set PBS_SERVER_INSTANCES to just the server that's being started
+			# this is needed so that qmgr doesn't try to contact other servers, which may not be up yet
+			IFS=',' read -ra PSIARR <<< "$PBS_SERVER_INSTANCES"
+			for psi_svr in "${PSIARR[@]}"; do
+				psi_hostport=(${psi_svr//:/ })
+				psi_port=${psi_hostport[1]}
+				if [[ "$psi_port" == "$PBS_BATCH_SERVICE_PORT" ]]; then
+					PSI_VAL=$psi_svr
+					break
+				fi
+			done
+		fi
 		if is_cray_xt; then
-			${PBS_EXEC}/bin/qmgr <<-EOF > /dev/null
+			PBS_SERVER_INSTANCES=$PSI_VAL ${PBS_EXEC}/bin/qmgr <<-EOF > /dev/null
 				set server restrict_res_to_release_on_suspend = ncpus
 			EOF
 		fi
 		tries=3
 		while [ $tries -ge 0 ]
 		do
-			${PBS_EXEC}/bin/qmgr <<-EOF > /dev/null
+			PBS_SERVER_INSTANCES=$PSI_VAL ${PBS_EXEC}/bin/qmgr <<-EOF > /dev/null
 				create queue workq
 			EOF
 			ret=$?
@@ -336,7 +352,7 @@ if [ "${PBS_START_SERVER:-0}" != 0 ] ; then
 			tries=$((tries-1))
 			sleep 2
 		done
-		${PBS_EXEC}/bin/qmgr <<-EOF > /dev/null
+		PBS_SERVER_INSTANCES=$PSI_VAL ${PBS_EXEC}/bin/qmgr <<-EOF > /dev/null
 			set queue workq queue_type = Execution
 			set queue workq enabled = True
 			set queue workq started = True
@@ -346,7 +362,7 @@ if [ "${PBS_START_SERVER:-0}" != 0 ] ; then
 			read ans < ${PBS_HOME}/server_priv/$PBS_licensing_loc_file
 			echo "*** Setting license file location(s)."
 			echo "***"
-			${PBS_EXEC}/bin/qmgr <<-EOF > /dev/null
+			PBS_SERVER_INSTANCES=$PSI_VAL ${PBS_EXEC}/bin/qmgr <<-EOF > /dev/null
 				set server pbs_license_info = $ans
 			EOF
 			if ! is_cray_xt; then
@@ -361,13 +377,13 @@ if [ "${PBS_START_SERVER:-0}" != 0 ] ; then
 			echo "*** Setting license file location(s)."
 			echo "***"
 			${PBS_EXEC}/sbin/pbs_server > /dev/null
-			${PBS_EXEC}/bin/qmgr <<-EOF > /dev/null
+			PBS_SERVER_INSTANCES=$PSI_VAL ${PBS_EXEC}/bin/qmgr <<-EOF > /dev/null
 				set server pbs_license_info = $ans
 			EOF
 			if ! is_cray_xt; then
 				rm -f ${PBS_HOME}/server_priv/$PBS_licensing_loc_file	# clean up after INSTALL
 			else
-				${PBS_EXEC}/bin/qmgr <<-EOF > /dev/null
+				PBS_SERVER_INSTANCES=$PSI_VAL ${PBS_EXEC}/bin/qmgr <<-EOF > /dev/null
 					set server restrict_res_to_release_on_suspend += ncpus
 				EOF
 			fi
@@ -386,14 +402,14 @@ if [ "${PBS_START_SERVER:-0}" != 0 ] ; then
 			:
 		else
 			# node $server is not already available, create
-			${PBS_EXEC}/bin/qmgr <<-EOF > /dev/null
+			PBS_SERVER_INSTANCES=$PSI_VAL ${PBS_EXEC}/bin/qmgr <<-EOF > /dev/null
 				create node $server
 			EOF
 		fi
 	fi
 
 	if [ $server_started -eq 1 ]; then
-		${PBS_EXEC}/bin/qterm
+		PBS_SERVER_INSTANCES=$PSI_VAL ${PBS_EXEC}/bin/qterm
 	fi
 fi
 

--- a/src/cmds/scripts/pbs_habitat.in
+++ b/src/cmds/scripts/pbs_habitat.in
@@ -319,30 +319,24 @@ if [ "${PBS_START_SERVER:-0}" != 0 ] ; then
 		fi
 		server_started=1
 		
-		PSI_VAL=
 		# Check if PBS_SERVER_INSTANCES is set for multi-server
 		if [ ! -z "${PBS_SERVER_INSTANCES}" ]; then
-			# We want to set PBS_SERVER_INSTANCES to just the server that's being started
-			# this is needed so that qmgr doesn't try to contact other servers, which may not be up yet
-			IFS=',' read -ra PSIARR <<< "$PBS_SERVER_INSTANCES"
-			for psi_svr in "${PSIARR[@]}"; do
-				psi_hostport=(${psi_svr//:/ })
-				psi_port=${psi_hostport[1]}
-				if [[ "$psi_port" == "$PBS_BATCH_SERVICE_PORT" ]]; then
-					PSI_VAL=$psi_svr
-					break
-				fi
-			done
+			# We don't want qmgr to try to contact other servers, which may not even be up yet
+			# So, set PBS_SERVER_INSTANCES to the current server's hostname and port
+			if [ -z "${PBS_BATCH_SERVICE_PORT}" ]; then
+				PBS_BATCH_SERVICE_PORT=15001
+			fi
+			export PBS_SERVER_INSTANCES="$(hostname -s):${PBS_BATCH_SERVICE_PORT}"
 		fi
 		if is_cray_xt; then
-			PBS_SERVER_INSTANCES=$PSI_VAL ${PBS_EXEC}/bin/qmgr <<-EOF > /dev/null
+			${PBS_EXEC}/bin/qmgr <<-EOF > /dev/null
 				set server restrict_res_to_release_on_suspend = ncpus
 			EOF
 		fi
 		tries=3
 		while [ $tries -ge 0 ]
 		do
-			PBS_SERVER_INSTANCES=$PSI_VAL ${PBS_EXEC}/bin/qmgr <<-EOF > /dev/null
+			${PBS_EXEC}/bin/qmgr <<-EOF > /dev/null
 				create queue workq
 			EOF
 			ret=$?
@@ -352,7 +346,7 @@ if [ "${PBS_START_SERVER:-0}" != 0 ] ; then
 			tries=$((tries-1))
 			sleep 2
 		done
-		PBS_SERVER_INSTANCES=$PSI_VAL ${PBS_EXEC}/bin/qmgr <<-EOF > /dev/null
+		${PBS_EXEC}/bin/qmgr <<-EOF > /dev/null
 			set queue workq queue_type = Execution
 			set queue workq enabled = True
 			set queue workq started = True
@@ -362,7 +356,7 @@ if [ "${PBS_START_SERVER:-0}" != 0 ] ; then
 			read ans < ${PBS_HOME}/server_priv/$PBS_licensing_loc_file
 			echo "*** Setting license file location(s)."
 			echo "***"
-			PBS_SERVER_INSTANCES=$PSI_VAL ${PBS_EXEC}/bin/qmgr <<-EOF > /dev/null
+			${PBS_EXEC}/bin/qmgr <<-EOF > /dev/null
 				set server pbs_license_info = $ans
 			EOF
 			if ! is_cray_xt; then
@@ -377,13 +371,13 @@ if [ "${PBS_START_SERVER:-0}" != 0 ] ; then
 			echo "*** Setting license file location(s)."
 			echo "***"
 			${PBS_EXEC}/sbin/pbs_server > /dev/null
-			PBS_SERVER_INSTANCES=$PSI_VAL ${PBS_EXEC}/bin/qmgr <<-EOF > /dev/null
+			${PBS_EXEC}/bin/qmgr <<-EOF > /dev/null
 				set server pbs_license_info = $ans
 			EOF
 			if ! is_cray_xt; then
 				rm -f ${PBS_HOME}/server_priv/$PBS_licensing_loc_file	# clean up after INSTALL
 			else
-				PBS_SERVER_INSTANCES=$PSI_VAL ${PBS_EXEC}/bin/qmgr <<-EOF > /dev/null
+				${PBS_EXEC}/bin/qmgr <<-EOF > /dev/null
 					set server restrict_res_to_release_on_suspend += ncpus
 				EOF
 			fi
@@ -402,14 +396,14 @@ if [ "${PBS_START_SERVER:-0}" != 0 ] ; then
 			:
 		else
 			# node $server is not already available, create
-			PBS_SERVER_INSTANCES=$PSI_VAL ${PBS_EXEC}/bin/qmgr <<-EOF > /dev/null
+			${PBS_EXEC}/bin/qmgr <<-EOF > /dev/null
 				create node $server
 			EOF
 		fi
 	fi
 
 	if [ $server_started -eq 1 ]; then
-		PBS_SERVER_INSTANCES=$PSI_VAL ${PBS_EXEC}/bin/qterm
+		${PBS_EXEC}/bin/qterm
 	fi
 fi
 

--- a/src/cmds/scripts/pbs_init.d.in
+++ b/src/cmds/scripts/pbs_init.d.in
@@ -450,7 +450,20 @@ stop_pbs() {
 					echo "pbs_server evaluating ${PBS_HOME}/server_priv/qmgr_shutdown"
 					${PBS_EXEC}/bin/qmgr <"${PBS_HOME}/server_priv/qmgr_shutdown"
 				fi
-				PBS_SERVER_INSTANCES="" ${PBS_EXEC}/bin/qterm -t quick
+				# Check if PBS_SERVER_INSTANCES is set for multi-server
+				if [ ! -z "${PBS_SERVER_INSTANCES}" ]; then
+					# We don't want qterm to try to contact other servers
+					# So, set PBS_SERVER_INSTANCES to the current server's hostname and port
+					if [ -z "${PBS_BATCH_SERVICE_PORT}" ]; then
+						PBS_BATCH_SERVICE_PORT=15001
+					fi
+					msvr_host=${PBS_SERVER_HOST_NAME}
+					if [ -z $msvr_host ]; then
+						msvr_host="$(hostname -s)"
+					fi
+					export PBS_SERVER_INSTANCES="${msvr_host}:${PBS_BATCH_SERVICE_PORT}"
+				fi
+				${PBS_EXEC}/bin/qterm -t quick
 				echo "PBS server - was pid: ${pbs_server_pid}"
 			elif [ ${is_secondary} -eq 1 ]; then
 				echo "This is secondary server, killing process."


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
pbs_habitat uses qmgr to create natural vnode and default queue (workq). With multi-server, it's important to restrict the qmgr from habitat to just the server which is being set up as the other servers might not be up yet (causing qmgr to fail) and there can be difference in the pbs.conf of the different servers, so it's also safer to restrict it to only the relevant server anyways.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
I changed the script to look for PBS_SERVER_INSTANCES, and if it's set, then figure out the 'hostname':'port number' for the server being set up and use just that as PBS_SERVER_INSTANCES to all qmgr commands issued by habitat.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Manually tested that with my changes, we can directly use the start/stop script to setup each server's PBS_HOME correctly and start the servers:
```
[root@pbspro ravi]# PBS_CONF_FILE=/etc/pbs_1.conf /etc/init.d/pbs start
Starting PBS
PBS Home directory /var/spool/pbs_1 does not exist.
Running /opt/pbs/libexec/pbs_habitat to create it.
***
/bin/ls: cannot access /var/spool/pbs_1: No such file or directory
*** WARNING: PBS_HOME not found in /var/spool/pbs_1
*** PBS Installation Summary
***
*** Postinstall script called as follows:
*** /opt/pbs/libexec/pbs_postinstall server 20.0.0 /opt/pbs /var/spool/pbs_1 '' sameconf 
***
*** PBS_HOME is /var/spool/pbs_1
*** Creating new file /var/spool/pbs_1/pbs_environment
*** WARNING: TZ not set in /var/spool/pbs_1/pbs_environment
***
*** The PBS server has been installed in /opt/pbs/sbin.
*** The PBS scheduler has been installed in /opt/pbs/sbin.
***
*** The PBS communication agent has been installed in /opt/pbs/sbin.
***
*** The PBS MOM has been installed in /opt/pbs/sbin.
***
*** The PBS commands have been installed in /opt/pbs/bin.
***
*** End of /opt/pbs/libexec/pbs_postinstall
*** Setting default queue and resource limits.
***
*** End of /opt/pbs/libexec/pbs_habitat
Home directory /var/spool/pbs_1 created.
/opt/pbs/sbin/pbs_comm ready (pid=71097), Proxy Name:pbspro:17001, Threads:4
PBS comm
PBS mom
PBS sched
Connecting to PBS dataservice...connected to PBS dataservice@pbspro
PBS server
[root@pbspro ravi]# PBS_CONF_FILE=/etc/pbs_2.conf /etc/init.d/pbs start
Starting PBS
PBS Home directory /var/spool/pbs_2 does not exist.
Running /opt/pbs/libexec/pbs_habitat to create it.
***
/bin/ls: cannot access /var/spool/pbs_2: No such file or directory
*** WARNING: PBS_HOME not found in /var/spool/pbs_2
*** PBS Installation Summary
***
*** Postinstall script called as follows:
*** /opt/pbs/libexec/pbs_postinstall server 20.0.0 /opt/pbs /var/spool/pbs_2 '' sameconf 
***
*** PBS_HOME is /var/spool/pbs_2
*** Creating new file /var/spool/pbs_2/pbs_environment
*** WARNING: TZ not set in /var/spool/pbs_2/pbs_environment
***
*** The PBS server has been installed in /opt/pbs/sbin.
*** The PBS scheduler has been installed in /opt/pbs/sbin.
***
*** The PBS communication agent has been installed in /opt/pbs/sbin.
***
*** The PBS MOM has been installed in /opt/pbs/sbin.
***
*** The PBS commands have been installed in /opt/pbs/bin.
***
*** End of /opt/pbs/libexec/pbs_postinstall
*** Setting default queue and resource limits.
***
*** End of /opt/pbs/libexec/pbs_habitat
Home directory /var/spool/pbs_2 created.
/opt/pbs/sbin/pbs_comm ready (pid=72248), Proxy Name:pbspro:17001, Threads:4
PBS comm
Connecting to PBS dataservice...connected to PBS dataservice@pbspro
PBS server
[root@pbspro ravi]# exit
exit
[ravi@pbspro ~]$ pbsnodes -av
pbspro
     Mom = pbspro
     ntype = PBS
     state = free
     pcpus = 4
     resources_available.arch = linux
     resources_available.host = pbspro
     resources_available.mem = 2036452kb
     resources_available.ncpus = 4
     resources_available.vnode = pbspro
     resources_assigned.accelerator_memory = 0kb
     resources_assigned.hbmem = 0kb
     resources_assigned.mem = 0kb
     resources_assigned.naccelerators = 0
     resources_assigned.ncpus = 0
     resources_assigned.vmem = 0kb
     resv_enable = True
     sharing = default_shared
     license = l
     last_state_change_time = Wed Apr  7 17:25:36 2021

[ravi@pbspro ~]$ 
[ravi@pbspro ~]$ 
[ravi@pbspro ~]$ qsub -- /bin/sleep 1000
001.pbspro
[ravi@pbspro ~]$ qsub -- /bin/sleep 1000
000.pbspro
[ravi@pbspro ~]$ qsub -- /bin/sleep 1000
101.pbspro
[ravi@pbspro ~]$ qsub -- /bin/sleep 1000
100.pbspro
[ravi@pbspro ~]$ qstat
Job id            Name             User              Time Use S Queue
----------------  ---------------- ----------------  -------- - -----
000.pbspro        STDIN            ravi                     0 R workq           
001.pbspro        STDIN            ravi                     0 R workq           
101.pbspro        STDIN            ravi                     0 R workq           
100.pbspro        STDIN            ravi                     0 R workq 
```


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
