### PR TITLE
Test "test_comm_with_mom" is failing while verifying log msgs from PBS daemons

### DIFF
--- a/test/tests/functional/pbs_test_tpp.py
+++ b/test/tests/functional/pbs_test_tpp.py
@@ -243,19 +243,14 @@ class TestTPP(TestFunctional):
         Node 2 : Mom
         """
         log_msgs = ["TPP initialization done",
-                    "Single pbs_comm configured, " +
-                    "TPP Fault tolerant mode disabled",
                     "Connected to pbs_comm %s.*:17001" % self.server.shortname]
         for msg in log_msgs:
             self.server.log_match(msg, regexp=True)
-            self.scheduler.log_match(msg, regexp=True)
             for mom in self.moms.values():
                 self.mom.log_match(msg, regexp=True)
         server_ip = socket.gethostbyname(self.server.hostname)
         msg = "Registering address %s:15001 to pbs_comm" % server_ip
         self.server.log_match(msg)
-        msg = "Registering address %s:15004 to pbs_comm" % server_ip
-        self.scheduler.log_match(msg)
         for mom in self.moms.values():
             ip = socket.gethostbyname(mom.shortname)
             msg1 = "Registering address %s:15003 to pbs_comm" % ip


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature

- Test "test_comm_with_mom" is failing while verifying log msgs from PBS daemons

#### Describe Your Change

- Test is checking few of the TPP related msgs in scheduler logs which have been removed as part of PR:https://github.com/openpbs/openpbs/pull/1783 and few of the msgs have been removed as part of PR:https://github.com/openpbs/openpbs/pull/2157

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output

- [Execution_logs_TestTPP_comm_with_mom_aftr_fix.txt](https://github.com/openpbs/openpbs/files/6277920/Execution_logs_TestTPP_comm_with_mom_aftr_fix.txt)

- [Execution_logs_TestTPP_comm_with_mom_bfr_fix.txt](https://github.com/openpbs/openpbs/files/6277936/Execution_logs_TestTPP_comm_with_mom_bfr_fix.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
