### PR TITLE
multi-server: enhancing client commands

### DIFF
--- a/src/cmds/pbs_ralter.c
+++ b/src/cmds/pbs_ralter.c
@@ -294,7 +294,7 @@ main(int argc, char *argv[], char *envp[])		/* pbs_ralter */
 			pbs_server, pbs_errno);
 		CS_close_app();
 		exit(pbs_errno);
-	} else
+	} else if (pbs_errno)
 		show_svr_inst_fail(connect, argv[0]);
 
 	pbs_strncpy(resv_id, argv[optind], sizeof(resv_id));

--- a/src/cmds/pbs_ralter.c
+++ b/src/cmds/pbs_ralter.c
@@ -294,7 +294,8 @@ main(int argc, char *argv[], char *envp[])		/* pbs_ralter */
 			pbs_server, pbs_errno);
 		CS_close_app();
 		exit(pbs_errno);
-	}
+	} else
+		show_svr_inst_fail(connect, argv[0]);
 
 	pbs_strncpy(resv_id, argv[optind], sizeof(resv_id));
 	if (get_server(resv_id, resv_id_out, server_out)) {

--- a/src/cmds/pbs_rdel.c
+++ b/src/cmds/pbs_rdel.c
@@ -127,7 +127,7 @@ main(int argc, char **argv, char **envp)
 				pbs_server, pbs_errno);
 			any_failed = pbs_errno;
 			continue;
-		} else
+		} else if (pbs_errno)
 			show_svr_inst_fail(connect, argv[0]);
 
 		stat = pbs_delresv(connect, resv_id_out, dest_queue);

--- a/src/cmds/pbs_rdel.c
+++ b/src/cmds/pbs_rdel.c
@@ -120,14 +120,15 @@ main(int argc, char **argv, char **envp)
 			any_failed = 1;
 			continue;
 		}
-		connect = cnt2server(server_out);
 
+		connect = cnt2server(server_out);
 		if (connect <= 0) {
 			fprintf(stderr, "pbs_rdel: cannot connect to server %s (errno=%d)\n",
 				pbs_server, pbs_errno);
 			any_failed = pbs_errno;
 			continue;
-		}
+		} else
+			show_svr_inst_fail(connect, argv[0]);
 
 		stat = pbs_delresv(connect, resv_id_out, dest_queue);
 		if (stat) {

--- a/src/cmds/pbs_release_nodes.c
+++ b/src/cmds/pbs_release_nodes.c
@@ -169,7 +169,9 @@ main(int argc, char **argv, char **envp) /* pbs_release_nodes */
 				"pbs_release_nodes: cannot connect to server %s (errno=%d)\n",
 							pbs_server, pbs_errno);
 			break;
-		}
+		} else
+			show_svr_inst_fail(connect, argv[0]);
+		
 
 		stat = pbs_relnodesjob(connect, job_id_out, node_list, keep_opt);
 		if (stat && (pbs_errno == PBSE_UNKJOBID)) {

--- a/src/cmds/pbs_release_nodes.c
+++ b/src/cmds/pbs_release_nodes.c
@@ -169,7 +169,7 @@ main(int argc, char **argv, char **envp) /* pbs_release_nodes */
 				"pbs_release_nodes: cannot connect to server %s (errno=%d)\n",
 							pbs_server, pbs_errno);
 			break;
-		} else
+		} else if (pbs_errno)
 			show_svr_inst_fail(connect, argv[0]);
 		
 

--- a/src/cmds/pbs_rstat.c
+++ b/src/cmds/pbs_rstat.c
@@ -331,7 +331,6 @@ handle_resv(char *resv_id, char *server, int how)
 	struct batch_status *server_attrs;
 
 	pbs_sd = cnt2server(server);
-
 	if (pbs_sd < 0) {
 		fprintf(stderr, "pbs_rstat: cannot connect to server (errno=%d)\n",
 			pbs_errno);

--- a/src/cmds/pbsnodes.c
+++ b/src/cmds/pbsnodes.c
@@ -1090,7 +1090,7 @@ main(int argc, char *argv[])
 				argv[0], def_server, pbs_errno);
 		CS_close_app();
 		exit(1);
-	} else
+	} else if (!quiet)
 		show_svr_inst_fail(con, argv[0]);
 	
 

--- a/src/cmds/pbsnodes.c
+++ b/src/cmds/pbsnodes.c
@@ -1090,7 +1090,7 @@ main(int argc, char *argv[])
 				argv[0], def_server, pbs_errno);
 		CS_close_app();
 		exit(1);
-	} else if (!quiet)
+	} else if (!quiet && pbs_errno)
 		show_svr_inst_fail(con, argv[0]);
 	
 

--- a/src/cmds/pbsnodes.c
+++ b/src/cmds/pbsnodes.c
@@ -1090,7 +1090,9 @@ main(int argc, char *argv[])
 				argv[0], def_server, pbs_errno);
 		CS_close_app();
 		exit(1);
-	}
+	} else
+		show_svr_inst_fail(con, argv[0]);
+	
 
 	/* if do_vnodes is set, get status of all virtual nodes (vnodes) */
 	/* else if oper is ALL then get status of all hosts              */

--- a/src/cmds/qalter.c
+++ b/src/cmds/qalter.c
@@ -341,7 +341,8 @@ cnt:
 				pbs_server, pbs_errno);
 			any_failed = pbs_errno;
 			continue;
-		}
+		} else
+			show_svr_inst_fail(connect, argv[0]);
 
 		stat = pbs_alterjob(connect, job_id_out, attrib, NULL);
 		if (stat && (pbs_errno != PBSE_UNKJOBID)) {

--- a/src/cmds/qalter.c
+++ b/src/cmds/qalter.c
@@ -341,7 +341,7 @@ cnt:
 				pbs_server, pbs_errno);
 			any_failed = pbs_errno;
 			continue;
-		} else
+		} else if (pbs_errno)
 			show_svr_inst_fail(connect, argv[0]);
 
 		stat = pbs_alterjob(connect, job_id_out, attrib, NULL);

--- a/src/cmds/qdel.c
+++ b/src/cmds/qdel.c
@@ -196,7 +196,9 @@ delete_jobs_for_cluster(char *clusterid, char **jobids, int numids, int dfltmail
 	if (connect <= 0) {
 		fprintf(stderr, "Couldn't connect to cluster: %s\n", clusterid);
 		return pbs_errno;
-	}
+	} else
+		show_svr_inst_fail(connect, "qdel");
+	
 
 	/* retrieve default: suppress_email from server: default_qdel_arguments */
 	mails = dfltmail;

--- a/src/cmds/qdel.c
+++ b/src/cmds/qdel.c
@@ -196,7 +196,7 @@ delete_jobs_for_cluster(char *clusterid, char **jobids, int numids, int dfltmail
 	if (connect <= 0) {
 		fprintf(stderr, "Couldn't connect to cluster: %s\n", clusterid);
 		return pbs_errno;
-	} else
+	} else if (pbs_errno)
 		show_svr_inst_fail(connect, "qdel");
 	
 

--- a/src/cmds/qhold.c
+++ b/src/cmds/qhold.c
@@ -183,7 +183,9 @@ cnt:
 				pbs_server, pbs_errno);
 			any_failed = pbs_errno;
 			continue;
-		}
+		} else
+			show_svr_inst_fail(connect, argv[0]);
+		
 
 		stat = pbs_holdjob(connect, job_id_out, hold_type, NULL);
 		if (stat && (err_list = pbs_get_attributes_in_error(connect)))

--- a/src/cmds/qhold.c
+++ b/src/cmds/qhold.c
@@ -183,7 +183,7 @@ cnt:
 				pbs_server, pbs_errno);
 			any_failed = pbs_errno;
 			continue;
-		} else
+		} else if (pbs_errno)
 			show_svr_inst_fail(connect, argv[0]);
 		
 

--- a/src/cmds/qmove.c
+++ b/src/cmds/qmove.c
@@ -117,7 +117,7 @@ cnt:
 				pbs_server, pbs_errno);
 			any_failed = pbs_errno;
 			continue;
-		} else
+		} else if (pbs_errno)
 			show_svr_inst_fail(connect, argv[0]);
 		
 

--- a/src/cmds/qmove.c
+++ b/src/cmds/qmove.c
@@ -117,7 +117,9 @@ cnt:
 				pbs_server, pbs_errno);
 			any_failed = pbs_errno;
 			continue;
-		}
+		} else
+			show_svr_inst_fail(connect, argv[0]);
+		
 
 		stat = pbs_movejob(connect, job_id_out, destination, NULL);
 		if (stat && (pbs_errno != PBSE_UNKJOBID)) {

--- a/src/cmds/qmsg.c
+++ b/src/cmds/qmsg.c
@@ -137,7 +137,9 @@ cnt:
 				pbs_server, pbs_errno);
 			any_failed = pbs_errno;
 			continue;
-		}
+		} else
+			show_svr_inst_fail(connect, argv[0]);
+		
 
 		stat = pbs_msgjob(connect, job_id_out, to_file, msg_string, NULL);
 		if (stat && (pbs_errno != PBSE_UNKJOBID)) {

--- a/src/cmds/qmsg.c
+++ b/src/cmds/qmsg.c
@@ -137,7 +137,7 @@ cnt:
 				pbs_server, pbs_errno);
 			any_failed = pbs_errno;
 			continue;
-		} else
+		} else if (pbs_errno)
 			show_svr_inst_fail(connect, argv[0]);
 		
 

--- a/src/cmds/qorder.c
+++ b/src/cmds/qorder.c
@@ -148,7 +148,8 @@ main(int argc, char **argv, char **envp)
 		fprintf(stderr, "qorder: cannot connect to server %s (errno=%d)\n",
 			pbs_server, pbs_errno);
 		exit(1);;
-	}
+	} else
+		show_svr_inst_fail(connect, argv[0]);
 
 	stat = pbs_orderjob(connect, job_id1_out, job_id2_out, NULL);
 	if (stat) {

--- a/src/cmds/qorder.c
+++ b/src/cmds/qorder.c
@@ -148,7 +148,7 @@ main(int argc, char **argv, char **envp)
 		fprintf(stderr, "qorder: cannot connect to server %s (errno=%d)\n",
 			pbs_server, pbs_errno);
 		exit(1);;
-	} else
+	} else if (pbs_errno)
 		show_svr_inst_fail(connect, argv[0]);
 
 	stat = pbs_orderjob(connect, job_id1_out, job_id2_out, NULL);

--- a/src/cmds/qrerun.c
+++ b/src/cmds/qrerun.c
@@ -131,7 +131,9 @@ cnt:
 				pbs_server, pbs_errno);
 			any_failed = pbs_errno;
 			continue;
-		}
+		} else
+			show_svr_inst_fail(connect, argv[0]);
+		
 
 		stat = pbs_rerunjob(connect, job_id_out, extra);
 		if (stat && (pbs_errno != PBSE_UNKJOBID)) {

--- a/src/cmds/qrerun.c
+++ b/src/cmds/qrerun.c
@@ -131,7 +131,7 @@ cnt:
 				pbs_server, pbs_errno);
 			any_failed = pbs_errno;
 			continue;
-		} else
+		} else if (pbs_errno)
 			show_svr_inst_fail(connect, argv[0]);
 		
 

--- a/src/cmds/qrls.c
+++ b/src/cmds/qrls.c
@@ -159,7 +159,7 @@ cnt:
 				pbs_server, pbs_errno);
 			any_failed = pbs_errno;
 			continue;
-		} else
+		} else if (pbs_errno)
 			show_svr_inst_fail(connect, argv[0]);
 
 		stat = pbs_rlsjob(connect, job_id_out, hold_type, NULL);

--- a/src/cmds/qrls.c
+++ b/src/cmds/qrls.c
@@ -159,7 +159,8 @@ cnt:
 				pbs_server, pbs_errno);
 			any_failed = pbs_errno;
 			continue;
-		}
+		} else
+			show_svr_inst_fail(connect, argv[0]);
 
 		stat = pbs_rlsjob(connect, job_id_out, hold_type, NULL);
 		if (stat && (pbs_errno != PBSE_UNKJOBID)) {

--- a/src/cmds/qrun.c
+++ b/src/cmds/qrun.c
@@ -178,6 +178,7 @@ execute(char *job, char *server, char *location)
 cnt:
 	if ((ct = cnt2server(server)) > 0) {
 
+		show_svr_inst_fail(ct, "qrun");
 		if (async)
 			err = pbs_asyrunjob(ct, job, location, NULL);
 		else

--- a/src/cmds/qrun.c
+++ b/src/cmds/qrun.c
@@ -177,8 +177,8 @@ execute(char *job, char *server, char *location)
 
 cnt:
 	if ((ct = cnt2server(server)) > 0) {
-
-		show_svr_inst_fail(ct, "qrun");
+		if (pbs_errno)
+			show_svr_inst_fail(ct, "qrun");
 		if (async)
 			err = pbs_asyrunjob(ct, job, location, NULL);
 		else

--- a/src/cmds/qselect.c
+++ b/src/cmds/qselect.c
@@ -564,7 +564,8 @@ main(int argc, char **argv, char **envp) /* qselect */
 		CS_close_app();
 
 		exit(pbs_errno);
-	}
+	} else
+		show_svr_inst_fail(connect, argv[0]);
 
 	if (extendopts[0] == '\0')
 		selectjob_list = pbs_selectjob(connect, select_list, NULL);

--- a/src/cmds/qselect.c
+++ b/src/cmds/qselect.c
@@ -564,7 +564,7 @@ main(int argc, char **argv, char **envp) /* qselect */
 		CS_close_app();
 
 		exit(pbs_errno);
-	} else
+	} else if (pbs_errno)
 		show_svr_inst_fail(connect, argv[0]);
 
 	if (extendopts[0] == '\0')

--- a/src/cmds/qsig.c
+++ b/src/cmds/qsig.c
@@ -125,7 +125,8 @@ cnt:
 				pbs_server, pbs_errno);
 			any_failed = pbs_errno;
 			continue;
-		}
+		} else
+			show_svr_inst_fail(connect, argv[0]);
 
 		stat = pbs_sigjob(connect, job_id_out, sig_string, NULL);
 		if (stat && (pbs_errno != PBSE_UNKJOBID)) {

--- a/src/cmds/qsig.c
+++ b/src/cmds/qsig.c
@@ -125,7 +125,7 @@ cnt:
 				pbs_server, pbs_errno);
 			any_failed = pbs_errno;
 			continue;
-		} else
+		} else if (pbs_errno)
 			show_svr_inst_fail(connect, argv[0]);
 
 		stat = pbs_sigjob(connect, job_id_out, sig_string, NULL);

--- a/src/cmds/qstat.c
+++ b/src/cmds/qstat.c
@@ -2929,7 +2929,7 @@ job_no_args:
 #endif /* localmod 071 */
 					any_failed = conn;
 					break;
-				} else
+				} else if (pbs_errno)
 					show_svr_inst_fail(conn, "qstat");
 
 				if (strcmp(pbs_server, server_old) != 0) {
@@ -3114,7 +3114,7 @@ que_no_args:
 #endif /* localmod 071 */
 					any_failed = conn;
 					break;
-				} else
+				} else if (pbs_errno)
 					show_svr_inst_fail(conn, argv[0]);
 				
 				p_status = pbs_statque(conn, queue_name_out, NULL, NULL);
@@ -3164,7 +3164,7 @@ svr_no_args:
 #endif /* localmod 071 */
 					any_failed = conn;
 					break;
-				} else
+				} else if (pbs_errno)
 					show_svr_inst_fail(conn, argv[0]);
 				
 				p_status = pbs_statserver(conn, NULL, NULL);

--- a/src/cmds/qstat.c
+++ b/src/cmds/qstat.c
@@ -2929,8 +2929,8 @@ job_no_args:
 #endif /* localmod 071 */
 					any_failed = conn;
 					break;
-				}
-				show_svr_inst_fail(conn, "qstat");
+				} else
+					show_svr_inst_fail(conn, "qstat");
 
 				if (strcmp(pbs_server, server_old) != 0) {
 					/* changing to a different server */
@@ -3114,7 +3114,9 @@ que_no_args:
 #endif /* localmod 071 */
 					any_failed = conn;
 					break;
-				}
+				} else
+					show_svr_inst_fail(conn, argv[0]);
+				
 				p_status = pbs_statque(conn, queue_name_out, NULL, NULL);
 				if (p_status == NULL) {
 					if (pbs_errno && (pbs_errno != PBSE_NOSERVER)) {
@@ -3162,7 +3164,9 @@ svr_no_args:
 #endif /* localmod 071 */
 					any_failed = conn;
 					break;
-				}
+				} else
+					show_svr_inst_fail(conn, argv[0]);
+				
 				p_status = pbs_statserver(conn, NULL, NULL);
 				if (p_status == NULL) {
 					if (pbs_errno && (pbs_errno != PBSE_NOSERVER)) {

--- a/src/cmds/scripts/pbs_init.d.in
+++ b/src/cmds/scripts/pbs_init.d.in
@@ -461,9 +461,8 @@ stop_pbs() {
 					if [ -z $msvr_host ]; then
 						msvr_host="$(hostname -s)"
 					fi
-					export PBS_SERVER_INSTANCES="${msvr_host}:${PBS_BATCH_SERVICE_PORT}"
 				fi
-				${PBS_EXEC}/bin/qterm -t quick
+				PBS_SERVER_INSTANCES="${msvr_host}:${PBS_BATCH_SERVICE_PORT}" ${PBS_EXEC}/bin/qterm -t quick
 				echo "PBS server - was pid: ${pbs_server_pid}"
 			elif [ ${is_secondary} -eq 1 ]; then
 				echo "This is secondary server, killing process."

--- a/src/include/libpbs.h
+++ b/src/include/libpbs.h
@@ -138,7 +138,6 @@ pthread_mutex_t * get_conn_mutex(int);
 #define SVR_CONN_STATE_DOWN 0
 #define SVR_CONN_STATE_UP 1
 
-#define NSVR pbs_conf.pbs_num_servers
 int get_num_servers(void);
 
 /* max number of preempt orderings */

--- a/src/include/libpbs.h
+++ b/src/include/libpbs.h
@@ -138,6 +138,7 @@ pthread_mutex_t * get_conn_mutex(int);
 #define SVR_CONN_STATE_DOWN 0
 #define SVR_CONN_STATE_UP 1
 
+#define NSVR pbs_conf.pbs_num_servers
 int get_num_servers(void);
 
 /* max number of preempt orderings */

--- a/src/lib/Libcmds/err_handling.c
+++ b/src/lib/Libcmds/err_handling.c
@@ -62,8 +62,8 @@ show_svr_inst_fail(int fd, char *client)
 		svr_conns = get_conn_svr_instances(fd);
 		for (i = 0; svr_conns[i]; i++) {
 			if (svr_conns[i]->state != SVR_CONN_STATE_UP)
-				fprintf(stderr, "%s: cannot connect to server %s (errno=%d)\n",
-					client, pbs_conf.psi[i].name, pbs_errno);
+				fprintf(stderr, "%s: cannot connect to server %s runs on port %d (errno=%d)\n",
+					client, pbs_conf.psi[i].name, pbs_conf.psi[i].port, pbs_errno);
 		}
 	}
 }

--- a/src/lib/Libcmds/err_handling.c
+++ b/src/lib/Libcmds/err_handling.c
@@ -62,7 +62,8 @@ show_svr_inst_fail(int fd, char *client)
 		svr_conns = get_conn_svr_instances(fd);
 		for (i = 0; svr_conns[i]; i++) {
 			if (svr_conns[i]->state != SVR_CONN_STATE_UP)
-				fprintf(stderr, "%s: cannot connect to server %s\n", client, pbs_conf.psi[i].name);
+				fprintf(stderr, "%s: cannot connect to server %s (errno=%d)\n",
+					client, pbs_conf.psi[i].name, pbs_errno);
 		}
 	}
 }

--- a/src/lib/Libifl/ifl_util.c
+++ b/src/lib/Libifl/ifl_util.c
@@ -180,7 +180,7 @@ get_obj_location_hint(char *obj_id, int obj_type)
 
 	svridx = strtol(ptr_idx, &endptr, 10);
 
-	if (*endptr != '\0' || svridx >= NSVR)
+	if (*endptr != '\0' || svridx >= get_num_servers())
 		svridx = -1;
 
 	if (ptr)

--- a/src/lib/Libifl/ifl_util.c
+++ b/src/lib/Libifl/ifl_util.c
@@ -157,7 +157,6 @@ random_srv_conn(int fd, svr_conn_t **svr_conns)
 int
 get_obj_location_hint(char *obj_id, int obj_type)
 {
-	int nsvrs = get_num_servers();
 	char *ptr = NULL;
 	char *ptr_idx = NULL;
 	int svridx = -1;
@@ -181,7 +180,7 @@ get_obj_location_hint(char *obj_id, int obj_type)
 
 	svridx = strtol(ptr_idx, &endptr, 10);
 
-	if (*endptr != '\0' || svridx >= nsvrs)
+	if (*endptr != '\0' || svridx >= NSVR)
 		svridx = -1;
 
 	if (ptr)

--- a/src/lib/Libifl/int_manager.c
+++ b/src/lib/Libifl/int_manager.c
@@ -130,7 +130,6 @@ PBSD_manager(int c, int rq_type, int command, int objtype, char *objname, struct
 	svr_conn_t **svr_conns = get_conn_svr_instances(c);
 	int start = 0;
 	int ct;
-	int nsvrs = get_num_servers();
 
 	/* verify the object name if creating a new one */
 	if (command == MGR_CMD_CREATE)
@@ -149,7 +148,7 @@ PBSD_manager(int c, int rq_type, int command, int objtype, char *objname, struct
 		if ((start = get_obj_location_hint(objname, objtype)) == -1)
 		    start = 0;
 
-		for (i = start, ct = 0; ct < nsvrs; i = (i + 1) % nsvrs, ct++) {
+		for (i = start, ct = 0; ct < NSVR; i = (i + 1) % NSVR, ct++) {
 
 			if (!svr_conns[i] || svr_conns[i]->state != SVR_CONN_STATE_UP)
 				continue;

--- a/src/lib/Libifl/int_manager.c
+++ b/src/lib/Libifl/int_manager.c
@@ -130,6 +130,7 @@ PBSD_manager(int c, int rq_type, int command, int objtype, char *objname, struct
 	svr_conn_t **svr_conns = get_conn_svr_instances(c);
 	int start = 0;
 	int ct;
+	int nsvr = get_num_servers();
 
 	/* verify the object name if creating a new one */
 	if (command == MGR_CMD_CREATE)
@@ -148,7 +149,7 @@ PBSD_manager(int c, int rq_type, int command, int objtype, char *objname, struct
 		if ((start = get_obj_location_hint(objname, objtype)) == -1)
 		    start = 0;
 
-		for (i = start, ct = 0; ct < NSVR; i = (i + 1) % NSVR, ct++) {
+		for (i = start, ct = 0; ct < nsvr; i = (i + 1) % nsvr, ct++) {
 
 			if (!svr_conns[i] || svr_conns[i]->state != SVR_CONN_STATE_UP)
 				continue;

--- a/src/lib/Libifl/int_manager.c
+++ b/src/lib/Libifl/int_manager.c
@@ -162,8 +162,9 @@ PBSD_manager(int c, int rq_type, int command, int objtype, char *objname, struct
 						aoplp,
 						extend);
 
-			if (objtype == MGR_OBJ_JOB || objtype == MGR_OBJ_RESV) {
-				if (rc == PBSE_NONE || (pbs_errno != PBSE_UNKJOBID && pbs_errno != PBSE_UNKRESVID))
+			/* break the loop for sharded objects */
+			if (objtype == MGR_OBJ_JOB || objtype == MGR_OBJ_RESV || objtype == MGR_OBJ_NODE) {
+				if (rc == PBSE_NONE || (pbs_errno != PBSE_UNKJOBID && pbs_errno != PBSE_UNKRESVID && pbs_errno != PBSE_UNKNODE))
 					break;
 			}
 		}

--- a/src/lib/Libifl/int_status.c
+++ b/src/lib/Libifl/int_status.c
@@ -505,11 +505,12 @@ PBSD_status_aggregate(int c, int cmd, char *id, void *attrib, char *extend, int 
 	int ct;
 	struct batch_status *last = NULL;
 	int pbs_errno_clear_cnt = 0;
+	int nsvr = get_num_servers();
 
 	if (!svr_conns)
 		return NULL;
 
-	failed_conn = calloc(NSVR, sizeof(int));
+	failed_conn = calloc(nsvr, sizeof(int));
 
 	if (pbs_client_thread_init_thread_context() != 0)
 		return NULL;
@@ -526,7 +527,7 @@ PBSD_status_aggregate(int c, int cmd, char *id, void *attrib, char *extend, int 
 	if (pbs_client_thread_lock_connection(c) != 0)
 		goto end;
 
-	for (i = start, ct = 0; ct < NSVR; i = (i + 1) % NSVR, ct++) {
+	for (i = start, ct = 0; ct < nsvr; i = (i + 1) % nsvr, ct++) {
 
 		if (!svr_conns[i] || svr_conns[i]->state != SVR_CONN_STATE_UP) {
 			rc = PBSE_NOSERVER;
@@ -549,7 +550,7 @@ PBSD_status_aggregate(int c, int cmd, char *id, void *attrib, char *extend, int 
 			break;
 	}
 
-	for (i = start, ct = 0; ct < NSVR; i = (i + 1) % NSVR, ct++) {
+	for (i = start, ct = 0; ct < nsvr; i = (i + 1) % nsvr, ct++) {
 
 		if (!svr_conns[i] ||
 		    svr_conns[i]->state != SVR_CONN_STATE_UP ||
@@ -578,7 +579,7 @@ PBSD_status_aggregate(int c, int cmd, char *id, void *attrib, char *extend, int 
 				}
 			}
 		} else if (!single_itr && (pbs_errno == PBSE_UNKQUE || pbs_errno == PBSE_UNKRESVID)) {
-			if (pbs_errno_clear_cnt < (NSVR - 1)) {
+			if (pbs_errno_clear_cnt < (nsvr - 1)) {
 				/* As resv/resv queue is present only in one of the server-instances, we should consider
 				 * PBSE_UNKQUE/PBSE_UNKRESVID only when all instances raise this error and hence this code
 				 */

--- a/src/lib/Libifl/int_status.c
+++ b/src/lib/Libifl/int_status.c
@@ -499,7 +499,6 @@ PBSD_status_aggregate(int c, int cmd, char *id, void *attrib, char *extend, int 
 	struct batch_status *next = NULL;
 	struct batch_status *cur = NULL;
 	svr_conn_t **svr_conns = get_conn_svr_instances(c);
-	int nsvrs = get_num_servers();
 	int *failed_conn;
 	int single_itr = 0;
 	int start = 0;
@@ -510,7 +509,7 @@ PBSD_status_aggregate(int c, int cmd, char *id, void *attrib, char *extend, int 
 	if (!svr_conns)
 		return NULL;
 
-	failed_conn = calloc(nsvrs, sizeof(int));
+	failed_conn = calloc(NSVR, sizeof(int));
 
 	if (pbs_client_thread_init_thread_context() != 0)
 		return NULL;
@@ -527,7 +526,7 @@ PBSD_status_aggregate(int c, int cmd, char *id, void *attrib, char *extend, int 
 	if (pbs_client_thread_lock_connection(c) != 0)
 		goto end;
 
-	for (i = start, ct = 0; ct < nsvrs; i = (i + 1) % nsvrs, ct++) {
+	for (i = start, ct = 0; ct < NSVR; i = (i + 1) % NSVR, ct++) {
 
 		if (!svr_conns[i] || svr_conns[i]->state != SVR_CONN_STATE_UP) {
 			rc = PBSE_NOSERVER;
@@ -550,7 +549,7 @@ PBSD_status_aggregate(int c, int cmd, char *id, void *attrib, char *extend, int 
 			break;
 	}
 
-	for (i = start, ct = 0; ct < nsvrs; i = (i + 1) % nsvrs, ct++) {
+	for (i = start, ct = 0; ct < NSVR; i = (i + 1) % NSVR, ct++) {
 
 		if (!svr_conns[i] ||
 		    svr_conns[i]->state != SVR_CONN_STATE_UP ||
@@ -579,7 +578,7 @@ PBSD_status_aggregate(int c, int cmd, char *id, void *attrib, char *extend, int 
 				}
 			}
 		} else if (!single_itr && (pbs_errno == PBSE_UNKQUE || pbs_errno == PBSE_UNKRESVID)) {
-			if (pbs_errno_clear_cnt < (nsvrs - 1)) {
+			if (pbs_errno_clear_cnt < (NSVR - 1)) {
 				/* As resv/resv queue is present only in one of the server-instances, we should consider
 				 * PBSE_UNKQUE/PBSE_UNKRESVID only when all instances raise this error and hence this code
 				 */

--- a/src/lib/Libifl/pbsD_Preempt_Jobs.c
+++ b/src/lib/Libifl/pbsD_Preempt_Jobs.c
@@ -163,7 +163,7 @@ __pbs_preempt_jobs(int c, char **preempt_jobs_list)
 	if (!svr_connections)
 		return NULL;
 
-	p_replies = calloc(NSVR, sizeof(preempt_job_info *));
+	p_replies = calloc(get_num_servers(), sizeof(preempt_job_info *));
 	if (p_replies == NULL) {
 		pbs_errno = PBSE_SYSTEM;
 		goto err;
@@ -187,7 +187,7 @@ __pbs_preempt_jobs(int c, char **preempt_jobs_list)
 	/* With multi-server, jobs are sharded across multiple servers.
 	 * So, send the request to all the active servers and collate their replies
 	 */
-	for (i = 0; i < NSVR; i++) {
+	for (i = 0; i < get_num_servers(); i++) {
 		if (preempt_jobs_send(svr_connections[i]->sd, preempt_jobs_list) != 0)
 			goto err;
 	}
@@ -206,7 +206,7 @@ __pbs_preempt_jobs(int c, char **preempt_jobs_list)
 	 * 	- Using the AVL tree avoids the cost of N strcmps otherwise needed to find the jobid
 	 *  in the first array
 	 */
-	for (i = 0; i < NSVR; last_count = count, i++) {
+	for (i = 0; i < get_num_servers(); last_count = count, i++) {
 		if ((p_replies[i] = preempt_jobs_recv(svr_connections[i]->sd, &count)) == NULL)
 			goto err;
 		if (last_count != -1 && count != last_count) {
@@ -217,7 +217,7 @@ __pbs_preempt_jobs(int c, char **preempt_jobs_list)
 
 	/* Find jobs which couldn't be found on the first server and store them in AVL tree */
 	for (i = 0; i < count; i++) {
-		if (p_replies[retidx][i].order[0] == 'D' && NSVR > 1) {
+		if (p_replies[retidx][i].order[0] == 'D' && get_num_servers() > 1) {
 			int *data = malloc(sizeof(int));
 			if (data == NULL) {
 				pbs_errno = PBSE_SYSTEM;
@@ -229,8 +229,8 @@ __pbs_preempt_jobs(int c, char **preempt_jobs_list)
 	}
 	ret = p_replies[retidx];
 
-	if (missing_jobs != NULL && NSVR > 1) {
-		for (i = 1; i < NSVR; i++) {	/* Starting from 1 as retidx == 0 */
+	if (missing_jobs != NULL && get_num_servers() > 1) {
+		for (i = 1; i < get_num_servers(); i++) {	/* Starting from 1 as retidx == 0 */
 			int j;
 
 			if (p_replies[i] == NULL)
@@ -261,7 +261,7 @@ __pbs_preempt_jobs(int c, char **preempt_jobs_list)
 		goto err;
 
 	/* Free up all the other lists */
-	for (i = 1; i < NSVR; i++) {
+	for (i = 1; i < get_num_servers(); i++) {
 		free(p_replies[i]);
 	}
 	free(p_replies);
@@ -271,7 +271,7 @@ __pbs_preempt_jobs(int c, char **preempt_jobs_list)
 
 err:
 	if (p_replies != NULL) {
-		for (i = 0; i < NSVR; i++) {
+		for (i = 0; i < get_num_servers(); i++) {
 			free(p_replies[i]);
 		}
 		free(p_replies);

--- a/src/lib/Libifl/pbsD_Preempt_Jobs.c
+++ b/src/lib/Libifl/pbsD_Preempt_Jobs.c
@@ -153,7 +153,6 @@ __pbs_preempt_jobs(int c, char **preempt_jobs_list)
 {
 	preempt_job_info **p_replies = NULL;
 	svr_conn_t **svr_connections = get_conn_svr_instances(c);
-	int num_cfg_svrs = get_num_servers();
 	int i;
 	int count = 0;
 	int last_count = -1;
@@ -164,7 +163,7 @@ __pbs_preempt_jobs(int c, char **preempt_jobs_list)
 	if (!svr_connections)
 		return NULL;
 
-	p_replies = calloc(num_cfg_svrs, sizeof(preempt_job_info *));
+	p_replies = calloc(NSVR, sizeof(preempt_job_info *));
 	if (p_replies == NULL) {
 		pbs_errno = PBSE_SYSTEM;
 		goto err;
@@ -188,7 +187,7 @@ __pbs_preempt_jobs(int c, char **preempt_jobs_list)
 	/* With multi-server, jobs are sharded across multiple servers.
 	 * So, send the request to all the active servers and collate their replies
 	 */
-	for (i = 0; i < num_cfg_svrs; i++) {
+	for (i = 0; i < NSVR; i++) {
 		if (preempt_jobs_send(svr_connections[i]->sd, preempt_jobs_list) != 0)
 			goto err;
 	}
@@ -207,7 +206,7 @@ __pbs_preempt_jobs(int c, char **preempt_jobs_list)
 	 * 	- Using the AVL tree avoids the cost of N strcmps otherwise needed to find the jobid
 	 *  in the first array
 	 */
-	for (i = 0; i < num_cfg_svrs; last_count = count, i++) {
+	for (i = 0; i < NSVR; last_count = count, i++) {
 		if ((p_replies[i] = preempt_jobs_recv(svr_connections[i]->sd, &count)) == NULL)
 			goto err;
 		if (last_count != -1 && count != last_count) {
@@ -218,7 +217,7 @@ __pbs_preempt_jobs(int c, char **preempt_jobs_list)
 
 	/* Find jobs which couldn't be found on the first server and store them in AVL tree */
 	for (i = 0; i < count; i++) {
-		if (p_replies[retidx][i].order[0] == 'D' && num_cfg_svrs > 1) {
+		if (p_replies[retidx][i].order[0] == 'D' && NSVR > 1) {
 			int *data = malloc(sizeof(int));
 			if (data == NULL) {
 				pbs_errno = PBSE_SYSTEM;
@@ -230,8 +229,8 @@ __pbs_preempt_jobs(int c, char **preempt_jobs_list)
 	}
 	ret = p_replies[retidx];
 
-	if (missing_jobs != NULL && num_cfg_svrs > 1) {
-		for (i = 1; i < num_cfg_svrs; i++) {	/* Starting from 1 as retidx == 0 */
+	if (missing_jobs != NULL && NSVR > 1) {
+		for (i = 1; i < NSVR; i++) {	/* Starting from 1 as retidx == 0 */
 			int j;
 
 			if (p_replies[i] == NULL)
@@ -262,7 +261,7 @@ __pbs_preempt_jobs(int c, char **preempt_jobs_list)
 		goto err;
 
 	/* Free up all the other lists */
-	for (i = 1; i < num_cfg_svrs; i++) {
+	for (i = 1; i < NSVR; i++) {
 		free(p_replies[i]);
 	}
 	free(p_replies);
@@ -272,7 +271,7 @@ __pbs_preempt_jobs(int c, char **preempt_jobs_list)
 
 err:
 	if (p_replies != NULL) {
-		for (i = 0; i < num_cfg_svrs; i++) {
+		for (i = 0; i < NSVR; i++) {
 			free(p_replies[i]);
 		}
 		free(p_replies);

--- a/src/lib/Libifl/pbsD_connect.c
+++ b/src/lib/Libifl/pbsD_connect.c
@@ -532,7 +532,6 @@ static bool
 part_of_cluster(char *svrhost, uint port, svr_conn_t **svr_conns)
 {
 	int i;
-	int nsvrs = get_num_servers();
 
 	if (!svrhost)
 		return true;
@@ -540,7 +539,7 @@ part_of_cluster(char *svrhost, uint port, svr_conn_t **svr_conns)
 	if (is_same_host(svrhost, pbs_default()) && port == pbs_conf.batch_service_port)
 		return true;
 
-	for (i = 0; i < nsvrs; i++) {
+	for (i = 0; i < NSVR; i++) {
 		if (is_same_host(svrhost, pbs_conf.psi[i].name) &&
 		    port == pbs_conf.psi[i].port)
 			return true;
@@ -567,7 +566,6 @@ connect_to_servers(char *svrhost, uint port, char *extend_data)
 	int fd = -1;
 	svr_conns_list_t *new_conns = create_conn_svr_instances();
 	svr_conn_t **svr_conns;
-	int nsvrs = get_num_servers();
 
 	if (new_conns == NULL)
 		return -1;
@@ -585,7 +583,7 @@ connect_to_servers(char *svrhost, uint port, char *extend_data)
 	}
 
 	/* Try to connect to all servers in the cluster */
-	for (i = 0; i < nsvrs; i++) {
+	for (i = 0; i < NSVR; i++) {
 		svr_conns[i] = add_instance(pbs_conf.psi[i].name, pbs_conf.psi[i].port);
 		if (!svr_conns[i])
 			goto err;
@@ -634,7 +632,6 @@ __pbs_connect_extend(char *server, char *extend_data)
 	unsigned int server_port;
 	char	*altservers[2];
 	int	have_alt = 0;
-	int	nsvrs;
 	int	sock = -1;
 	int	i;
 	int	f;
@@ -656,9 +653,7 @@ __pbs_connect_extend(char *server, char *extend_data)
 		return -1;
 	}
 
-	nsvrs = get_num_servers();
-
-	if (nsvrs == 1 && pbs_conf.pbs_primary && pbs_conf.pbs_secondary) {	
+	if (NSVR == 1 && pbs_conf.pbs_primary && pbs_conf.pbs_secondary) {	
 		/* failover configuered ...   */	
 		if (is_same_host(server, pbs_conf.pbs_primary)) {	
 			have_alt = 1;	
@@ -695,7 +690,7 @@ __pbs_connect_extend(char *server, char *extend_data)
 			break; 
 	}
 	
-	if (nsvrs > 1)
+	if (NSVR > 1)
 		return sock;
 	
 	if (i >= (have_alt+1) && sock == -1) {
@@ -1235,7 +1230,7 @@ pbs_register_sched(const char *sched_id, int primary_conn_id, int secondary_conn
 	if (svr_conns_secondary == NULL)
 		return -1;
 
-	for (i = 0; i < get_num_servers(); i++) {
+	for (i = 0; i < NSVR; i++) {
 		if (svr_conns_primary[i]->sd < 0 ||
 		    send_register_sched(svr_conns_primary[i]->sd, sched_id) != 0)
 			return -1;
@@ -1305,7 +1300,7 @@ server_name_to_fd(int c, char *svrname)
 		pbs_errno = PBSE_NOCONNECTS;
 		return -1;
 	}
-	for (i = 0; i < get_num_servers(); i++) {
+	for (i = 0; i < NSVR; i++) {
 		if (strcmp(conns[i]->name, svrname) == 0)
 			return conns[i]->sd;
 	}
@@ -1360,9 +1355,8 @@ int
 multi_svr_op(int fd)
 {
 	svr_conn_t **conns = get_conn_svr_instances(fd);
-	int num_svrs = get_num_servers();
 
-	if (conns == NULL || num_svrs == 1 || fd == conns[0]->sd)
+	if (conns == NULL || get_num_servers() == 1 || fd == conns[0]->sd)
 		return FALSE;
 
 	return TRUE;

--- a/src/lib/Libifl/pbsD_connect.c
+++ b/src/lib/Libifl/pbsD_connect.c
@@ -566,7 +566,7 @@ connect_to_servers(char *svrhost, uint port, char *extend_data)
 	int fd = -1;
 	svr_conns_list_t *new_conns = create_conn_svr_instances();
 	svr_conn_t **svr_conns;
-	int last_err;
+	int last_err = PBSE_NONE;
 
 	if (new_conns == NULL)
 		return -1;
@@ -1360,7 +1360,7 @@ multi_svr_op(int fd)
 {
 	svr_conn_t **conns = get_conn_svr_instances(fd);
 
-	if (conns == NULL || get_num_servers() == 1 || fd == conns[0]->sd)
+	if (conns == NULL || NSVR == 1 || fd == conns[0]->sd)
 		return FALSE;
 
 	return TRUE;

--- a/src/lib/Libifl/pbsD_connect.c
+++ b/src/lib/Libifl/pbsD_connect.c
@@ -539,7 +539,7 @@ part_of_cluster(char *svrhost, uint port, svr_conn_t **svr_conns)
 	if (is_same_host(svrhost, pbs_default()) && port == pbs_conf.batch_service_port)
 		return true;
 
-	for (i = 0; i < NSVR; i++) {
+	for (i = 0; i < get_num_servers(); i++) {
 		if (is_same_host(svrhost, pbs_conf.psi[i].name) &&
 		    port == pbs_conf.psi[i].port)
 			return true;
@@ -584,7 +584,7 @@ connect_to_servers(char *svrhost, uint port, char *extend_data)
 	}
 
 	/* Try to connect to all servers in the cluster */
-	for (i = 0; i < NSVR; i++) {
+	for (i = 0; i < get_num_servers(); i++) {
 		svr_conns[i] = add_instance(pbs_conf.psi[i].name, pbs_conf.psi[i].port);
 		if (!svr_conns[i])
 			goto err;
@@ -657,7 +657,7 @@ __pbs_connect_extend(char *server, char *extend_data)
 		return -1;
 	}
 
-	if (NSVR == 1 && pbs_conf.pbs_primary && pbs_conf.pbs_secondary) {	
+	if (get_num_servers() == 1 && pbs_conf.pbs_primary && pbs_conf.pbs_secondary) {	
 		/* failover configuered ...   */	
 		if (is_same_host(server, pbs_conf.pbs_primary)) {	
 			have_alt = 1;	
@@ -694,7 +694,7 @@ __pbs_connect_extend(char *server, char *extend_data)
 			break; 
 	}
 	
-	if (NSVR > 1)
+	if (get_num_servers() > 1)
 		return sock;
 	
 	if (i >= (have_alt+1) && sock == -1) {
@@ -1234,7 +1234,7 @@ pbs_register_sched(const char *sched_id, int primary_conn_id, int secondary_conn
 	if (svr_conns_secondary == NULL)
 		return -1;
 
-	for (i = 0; i < NSVR; i++) {
+	for (i = 0; i < get_num_servers(); i++) {
 		if (svr_conns_primary[i]->sd < 0 ||
 		    send_register_sched(svr_conns_primary[i]->sd, sched_id) != 0)
 			return -1;
@@ -1304,7 +1304,7 @@ server_name_to_fd(int c, char *svrname)
 		pbs_errno = PBSE_NOCONNECTS;
 		return -1;
 	}
-	for (i = 0; i < NSVR; i++) {
+	for (i = 0; i < get_num_servers(); i++) {
 		if (strcmp(conns[i]->name, svrname) == 0)
 			return conns[i]->sd;
 	}
@@ -1360,7 +1360,7 @@ multi_svr_op(int fd)
 {
 	svr_conn_t **conns = get_conn_svr_instances(fd);
 
-	if (conns == NULL || NSVR == 1 || fd == conns[0]->sd)
+	if (conns == NULL || get_num_servers() == 1 || fd == conns[0]->sd)
 		return FALSE;
 
 	return TRUE;

--- a/src/lib/Libifl/pbsD_connect.c
+++ b/src/lib/Libifl/pbsD_connect.c
@@ -566,6 +566,7 @@ connect_to_servers(char *svrhost, uint port, char *extend_data)
 	int fd = -1;
 	svr_conns_list_t *new_conns = create_conn_svr_instances();
 	svr_conn_t **svr_conns;
+	int last_err;
 
 	if (new_conns == NULL)
 		return -1;
@@ -601,8 +602,11 @@ connect_to_servers(char *svrhost, uint port, char *extend_data)
 				new_conns->cfd = vfd;
 			}
 		}
+		if (pbs_errno != PBSE_NONE)
+			last_err = pbs_errno;
 	}
 
+	pbs_errno = last_err;
 	return new_conns->cfd;
 
 err:

--- a/src/lib/Libifl/pbsD_deljoblist.c
+++ b/src/lib/Libifl/pbsD_deljoblist.c
@@ -351,7 +351,6 @@ broadcast_deljob(int c, int function, char **jobids, int numids, char *extend)
 {
 	int *skip_list;
 	svr_conn_t **conns = get_conn_svr_instances(c);
-	int num_svrs = get_num_servers();
 	int i;
 	struct batch_deljob_status **svr_retlist = NULL;
 	struct batch_deljob_status *retlist = NULL;
@@ -364,13 +363,13 @@ broadcast_deljob(int c, int function, char **jobids, int numids, char *extend)
 		return NULL;
 	}
 
-	skip_list = calloc(num_svrs, sizeof(int));
+	skip_list = calloc(NSVR, sizeof(int));
 	if (skip_list == NULL) {
 		pbs_errno = PBSE_SYSTEM;
 		return NULL;
 	}
 
-	svr_retlist = calloc(num_svrs, sizeof(struct batch_deljob_status *));
+	svr_retlist = calloc(NSVR, sizeof(struct batch_deljob_status *));
 	if (svr_retlist == NULL) {
 		free(skip_list);
 		pbs_errno = PBSE_SYSTEM;
@@ -401,7 +400,7 @@ broadcast_deljob(int c, int function, char **jobids, int numids, char *extend)
 		int error_code = PBSE_UNKJOBID;
 
 		/* Make sure that this jid is in ALL of the other lists as well */
-		for (i = 1; i < num_svrs; i++) {
+		for (i = 1; i < NSVR; i++) {
 			int job_found = 0;
 
 			for (iter_list2 = svr_retlist[i]; iter_list2 != NULL; iter_list2 = iter_list2->next) {
@@ -418,7 +417,7 @@ broadcast_deljob(int c, int function, char **jobids, int numids, char *extend)
 				break;	/* job deleted on this server, no point checking others */
 		}
 
-		if (job_count != num_svrs) {	/* Job was found (and deleted) on at least 1 server */
+		if (job_count != NSVR) {	/* Job was found (and deleted) on at least 1 server */
 			/* Remove the job from the list to return */
 			if (prev != NULL)
 				prev->next = next;

--- a/src/lib/Libifl/pbsD_deljoblist.c
+++ b/src/lib/Libifl/pbsD_deljoblist.c
@@ -363,13 +363,13 @@ broadcast_deljob(int c, int function, char **jobids, int numids, char *extend)
 		return NULL;
 	}
 
-	skip_list = calloc(NSVR, sizeof(int));
+	skip_list = calloc(get_num_servers(), sizeof(int));
 	if (skip_list == NULL) {
 		pbs_errno = PBSE_SYSTEM;
 		return NULL;
 	}
 
-	svr_retlist = calloc(NSVR, sizeof(struct batch_deljob_status *));
+	svr_retlist = calloc(get_num_servers(), sizeof(struct batch_deljob_status *));
 	if (svr_retlist == NULL) {
 		free(skip_list);
 		pbs_errno = PBSE_SYSTEM;
@@ -400,7 +400,7 @@ broadcast_deljob(int c, int function, char **jobids, int numids, char *extend)
 		int error_code = PBSE_UNKJOBID;
 
 		/* Make sure that this jid is in ALL of the other lists as well */
-		for (i = 1; i < NSVR; i++) {
+		for (i = 1; i < get_num_servers(); i++) {
 			int job_found = 0;
 
 			for (iter_list2 = svr_retlist[i]; iter_list2 != NULL; iter_list2 = iter_list2->next) {
@@ -417,7 +417,7 @@ broadcast_deljob(int c, int function, char **jobids, int numids, char *extend)
 				break;	/* job deleted on this server, no point checking others */
 		}
 
-		if (job_count != NSVR) {	/* Job was found (and deleted) on at least 1 server */
+		if (job_count != get_num_servers()) {	/* Job was found (and deleted) on at least 1 server */
 			/* Remove the job from the list to return */
 			if (prev != NULL)
 				prev->next = next;

--- a/src/lib/Libifl/pbsD_locjob.c
+++ b/src/lib/Libifl/pbsD_locjob.c
@@ -142,6 +142,8 @@ pbs_locjob2(int c, char *jobid, char *extend)
 char *
 __pbs_locjob(int c, char *jobid, char *extend)
 {
+	int nsvr = get_num_servers();
+
 	if ((jobid == NULL) || (*jobid == '\0')) {
 		pbs_errno = PBSE_IVALREQ;
 		return NULL;
@@ -157,7 +159,7 @@ __pbs_locjob(int c, char *jobid, char *extend)
 		if ((start = get_obj_location_hint(jobid, MGR_OBJ_JOB)) == -1)
 		    start = 0;
 
-		for (i = start, ct = 0; ct < NSVR; i = (i + 1) % NSVR, ct++) {
+		for (i = start, ct = 0; ct < nsvr; i = (i + 1) % nsvr, ct++) {
 			if (!svr_conns[i] || svr_conns[i]->state != SVR_CONN_STATE_UP)
 				continue;
 			ret = pbs_locjob2(svr_conns[i]->sd, jobid, extend);

--- a/src/lib/Libifl/pbsD_locjob.c
+++ b/src/lib/Libifl/pbsD_locjob.c
@@ -151,14 +151,13 @@ __pbs_locjob(int c, char *jobid, char *extend)
 		svr_conn_t **svr_conns = get_conn_svr_instances(c);
 		int start = 0;
 		int ct;
-		int nsvrs = get_num_servers();
 		char *ret = NULL;
 		int i;
 
 		if ((start = get_obj_location_hint(jobid, MGR_OBJ_JOB)) == -1)
 		    start = 0;
 
-		for (i = start, ct = 0; ct < nsvrs; i = (i + 1) % nsvrs, ct++) {
+		for (i = start, ct = 0; ct < NSVR; i = (i + 1) % NSVR, ct++) {
 			if (!svr_conns[i] || svr_conns[i]->state != SVR_CONN_STATE_UP)
 				continue;
 			ret = pbs_locjob2(svr_conns[i]->sd, jobid, extend);

--- a/src/lib/Libifl/pbsD_modify_resv.c
+++ b/src/lib/Libifl/pbsD_modify_resv.c
@@ -71,6 +71,7 @@ pbs_modify_resv(int c, char *resv_id, struct attropl *attrib, char *extend)
 	char *ret = NULL;
 	int i;
 	svr_conn_t **svr_conns = get_conn_svr_instances(c);
+	int nsvr = get_num_servers();
 	int start = 0;
 	int ct;
 
@@ -95,7 +96,7 @@ pbs_modify_resv(int c, char *resv_id, struct attropl *attrib, char *extend)
 		if ((start = get_obj_location_hint(resv_id, MGR_OBJ_RESV)) == -1)
 			start = 0;
 
-		for (i = start, ct = 0; ct < NSVR; i = (i + 1) % NSVR, ct++) {
+		for (i = start, ct = 0; ct < nsvr; i = (i + 1) % nsvr, ct++) {
 
 			if (!svr_conns[i] || svr_conns[i]->state != SVR_CONN_STATE_UP)
 				continue;

--- a/src/lib/Libifl/pbsD_modify_resv.c
+++ b/src/lib/Libifl/pbsD_modify_resv.c
@@ -73,7 +73,6 @@ pbs_modify_resv(int c, char *resv_id, struct attropl *attrib, char *extend)
 	svr_conn_t **svr_conns = get_conn_svr_instances(c);
 	int start = 0;
 	int ct;
-	int nsvrs = get_num_servers();
 
 	for (pal = attrib; pal; pal = pal->next)
 		pal->op = SET;
@@ -96,7 +95,7 @@ pbs_modify_resv(int c, char *resv_id, struct attropl *attrib, char *extend)
 		if ((start = get_obj_location_hint(resv_id, MGR_OBJ_RESV)) == -1)
 			start = 0;
 
-		for (i = start, ct = 0; ct < nsvrs; i = (i + 1) % nsvrs, ct++) {
+		for (i = start, ct = 0; ct < NSVR; i = (i + 1) % NSVR, ct++) {
 
 			if (!svr_conns[i] || svr_conns[i]->state != SVR_CONN_STATE_UP)
 				continue;

--- a/src/lib/Libifl/pbsD_movejob.c
+++ b/src/lib/Libifl/pbsD_movejob.c
@@ -131,6 +131,7 @@ __pbs_movejob(int c, char *jobid, char *destin, char *extend)
 	int i;
 	int rc = 0;
 	svr_conn_t **svr_conns = get_conn_svr_instances(c);
+	int nsvr = get_num_servers();
 	int start = 0;
 	int ct;
 
@@ -152,7 +153,7 @@ __pbs_movejob(int c, char *jobid, char *destin, char *extend)
 		if ((start = get_obj_location_hint(jobid, MGR_OBJ_JOB)) == -1)
 		    start = 0;
 
-		for (i = start, ct = 0; ct < NSVR; i = (i + 1) % NSVR, ct++) {
+		for (i = start, ct = 0; ct < nsvr; i = (i + 1) % nsvr, ct++) {
 
 			if (!svr_conns[i] || svr_conns[i]->state != SVR_CONN_STATE_UP)
 				continue;

--- a/src/lib/Libifl/pbsD_movejob.c
+++ b/src/lib/Libifl/pbsD_movejob.c
@@ -49,7 +49,6 @@
 #include "dis.h"
 #include "pbs_ecl.h"
 
-
 /**
  * @brief
  *	send move job request
@@ -65,21 +64,11 @@
  *
  */
 
-int
-__pbs_movejob(int c, char *jobid, char *destin, char *extend)
+static int
+__pbs_movejob_inner(int c, char *jobid, char *destin, char *extend)
 {
 	int		    rc;
 	struct batch_reply *reply;
-
-
-	if ((jobid == NULL) || (*jobid == '\0'))
-		return (pbs_errno = PBSE_IVALREQ);
-	if (destin == NULL)
-		destin = "";
-
-	/* initialize the thread context data, if not already initialized */
-	if (pbs_client_thread_init_thread_context() != 0)
-		return pbs_errno;
 
 	/* lock pthread mutex here for this connection */
 	/* blocking call, waits for mutex release */
@@ -121,4 +110,65 @@ __pbs_movejob(int c, char *jobid, char *destin, char *extend)
 		return pbs_errno;
 
 	return rc;
+}
+
+/**
+ * @brief
+ *	send move job request
+ *
+ * @param[in] c - connection handler
+ * @param[in] jobid - job identifier
+ * @param[in] destin - job moved to
+ * @param[in] extend - string to encode req
+ *
+ * @return      int
+ * @retval      0       success
+ * @retval      !0      error
+ *
+ */
+
+int
+__pbs_movejob(int c, char *jobid, char *destin, char *extend)
+{
+	int i;
+	int rc = 0;
+	svr_conn_t **svr_conns = get_conn_svr_instances(c);
+	int start = 0;
+	int ct;
+
+
+	if ((jobid == NULL) || (*jobid == '\0'))
+		return (pbs_errno = PBSE_IVALREQ);
+	if (destin == NULL)
+		destin = "";
+
+	/* initialize the thread context data, if not already initialized */
+	if (pbs_client_thread_init_thread_context() != 0)
+		return pbs_errno;
+
+	if (svr_conns) {
+		/* For a single server cluster, instance fd and cluster fd are the same */
+		if (svr_conns[0]->sd == c)
+			return __pbs_movejob_inner(c, jobid, destin, extend);
+
+		if ((start = get_obj_location_hint(jobid, MGR_OBJ_JOB)) == -1)
+		    start = 0;
+
+		for (i = start, ct = 0; ct < NSVR; i = (i + 1) % NSVR, ct++) {
+
+			if (!svr_conns[i] || svr_conns[i]->state != SVR_CONN_STATE_UP)
+				continue;
+
+			rc = __pbs_movejob_inner(svr_conns[i]->sd, jobid, destin, extend);
+
+			/* break the loop for sharded objects */
+			if (rc == PBSE_NONE || pbs_errno != PBSE_UNKJOBID)
+				break;
+		}
+
+		return rc;
+	}
+
+	/* Not a cluster fd. Treat it as an instance fd */
+	return __pbs_movejob_inner(c, jobid, destin, extend);
 }

--- a/src/lib/Libifl/pbsD_movejob.c
+++ b/src/lib/Libifl/pbsD_movejob.c
@@ -51,7 +51,7 @@
 
 /**
  * @brief
- *	send move job request
+ *	send move job request (for single instance connection)
  *
  * @param[in] c - connection handler
  * @param[in] jobid - job identifier
@@ -63,7 +63,6 @@
  * @retval      !0      error
  *
  */
-
 static int
 __pbs_movejob_inner(int c, char *jobid, char *destin, char *extend)
 {
@@ -126,7 +125,6 @@ __pbs_movejob_inner(int c, char *jobid, char *destin, char *extend)
  * @retval      !0      error
  *
  */
-
 int
 __pbs_movejob(int c, char *jobid, char *destin, char *extend)
 {

--- a/src/lib/Libifl/pbsD_msgjob.c
+++ b/src/lib/Libifl/pbsD_msgjob.c
@@ -55,6 +55,7 @@
 /**
  * @brief
  *	-send the MessageJob request and get the reply.
+ *	(for single instance connection)
  *
  * @param[in] c - socket descriptor
  * @param[in] jobid - job id
@@ -67,7 +68,6 @@
  * @retval	!0	error
  *
  */
-
 static int
 __pbs_msgjob_inner(int c, char *jobid, int fileopt, char *msg, char *extend)
 {
@@ -128,7 +128,6 @@ __pbs_msgjob_inner(int c, char *jobid, int fileopt, char *msg, char *extend)
  * @retval	!0	error
  *
  */
-
 int
 __pbs_msgjob(int c, char *jobid, int fileopt, char *msg, char *extend)
 {
@@ -247,6 +246,7 @@ pbs_py_spawn(int c, char *jobid, char **argv, char **envp)
  * 	-pbs_relnodesjob - release a set of sister nodes or vnodes,
  * 	or all sister nodes or vnodes assigned to the specified PBS
  * 	batch job.
+ * 	works with single instance connection.
  *
  * @param[in] c 	communication handle
  * @param[in] jobid  job identifier

--- a/src/lib/Libifl/pbsD_msgjob.c
+++ b/src/lib/Libifl/pbsD_msgjob.c
@@ -199,16 +199,69 @@ pbs_py_spawn(int c, char *jobid, char **argv, char **envp)
  * @retval	!0	error
  *
  */
-
-int
-pbs_relnodesjob(c, jobid, node_list, extend)
-int c;
-char *jobid;
-char *node_list;
-char *extend;
+static int
+pbs_relnodesjob_inner(int c, char *jobid, char *node_list, char *extend)
 {
 	struct batch_reply *reply;
 	int	rc;
+
+	/* lock pthread mutex here for this connection */
+	/* blocking call, waits for mutex release */
+	if (pbs_client_thread_lock_connection(c) != 0)
+		return pbs_errno;
+
+	/* setup DIS support routines for following DIS calls */
+
+	DIS_tcp_funcs();
+
+	if ((rc = PBSD_relnodes_put(c, jobid, node_list, extend, 0, NULL)) != 0) {
+		if (set_conn_errtxt(c, dis_emsg[rc]) != 0) {
+			pbs_errno = PBSE_SYSTEM;
+		} else {
+			pbs_errno = PBSE_PROTOCOL;
+		}
+		(void)pbs_client_thread_unlock_connection(c);
+		return pbs_errno;
+	}
+
+	/* read reply */
+
+	reply = PBSD_rdrpy(c);
+	rc = get_conn_errno(c);
+
+	PBSD_FreeReply(reply);
+
+	/* unlock the thread lock and update the thread context data */
+	if (pbs_client_thread_unlock_connection(c) != 0)
+		return pbs_errno;
+
+	return rc;
+}
+
+/**
+ * @brief
+ * 	-pbs_relnodesjob - release a set of sister nodes or vnodes,
+ * 	or all sister nodes or vnodes assigned to the specified PBS
+ * 	batch job.
+ *
+ * @param[in] c 	communication handle
+ * @param[in] jobid  job identifier
+ * @param[in] node_list 	list of hosts or vnodes to be released
+ * @param[in] extend 	additional params, currently passes -k arguments
+ *
+ * @return	int
+ * @retval	0	Success
+ * @retval	!0	error
+ *
+ */
+int
+pbs_relnodesjob(int c, char *jobid, char *node_list, char *extend)
+{
+	int i;
+	int rc = 0;
+	svr_conn_t **svr_conns = get_conn_svr_instances(c);
+	int start = 0;
+	int ct;
 
 	if ((jobid == NULL) || (*jobid == '\0') ||
 					(node_list == NULL))
@@ -267,35 +320,29 @@ char *extend;
 			return rc;
 	}
 
-	/* lock pthread mutex here for this connection */
-	/* blocking call, waits for mutex release */
-	if (pbs_client_thread_lock_connection(c) != 0)
-		return pbs_errno;
+	if (svr_conns) {
+		/* For a single server cluster, instance fd and cluster fd are the same */
+		if (svr_conns[0]->sd == c)
+			return pbs_relnodesjob_inner(c, jobid, node_list, extend);
 
-	/* setup DIS support routines for following DIS calls */
+		if ((start = get_obj_location_hint(jobid, MGR_OBJ_JOB)) == -1)
+		    start = 0;
 
-	DIS_tcp_funcs();
+		for (i = start, ct = 0; ct < NSVR; i = (i + 1) % NSVR, ct++) {
 
-	if ((rc = PBSD_relnodes_put(c, jobid, node_list, extend, 0, NULL)) != 0) {
-		if (set_conn_errtxt(c, dis_emsg[rc]) != 0) {
-			pbs_errno = PBSE_SYSTEM;
-		} else {
-			pbs_errno = PBSE_PROTOCOL;
+			if (!svr_conns[i] || svr_conns[i]->state != SVR_CONN_STATE_UP)
+				continue;
+
+			rc = pbs_relnodesjob_inner(svr_conns[i]->sd, jobid, node_list, extend);
+
+			/* break the loop for sharded objects */
+			if (rc == PBSE_NONE || pbs_errno != PBSE_UNKJOBID)
+				break;
 		}
-		(void)pbs_client_thread_unlock_connection(c);
-		return pbs_errno;
+
+		return rc;
 	}
 
-	/* read reply */
-
-	reply = PBSD_rdrpy(c);
-	rc = get_conn_errno(c);
-
-	PBSD_FreeReply(reply);
-
-	/* unlock the thread lock and update the thread context data */
-	if (pbs_client_thread_unlock_connection(c) != 0)
-		return pbs_errno;
-
-	return rc;
+	/* Not a cluster fd. Treat it as an instance fd */
+	return pbs_relnodesjob_inner(c, jobid, node_list, extend);
 }

--- a/src/lib/Libifl/pbsD_msgjob.c
+++ b/src/lib/Libifl/pbsD_msgjob.c
@@ -134,6 +134,7 @@ __pbs_msgjob(int c, char *jobid, int fileopt, char *msg, char *extend)
 	int i;
 	int rc = 0;
 	svr_conn_t **svr_conns = get_conn_svr_instances(c);
+	int nsvr = get_num_servers();
 	int start = 0;
 	int ct;
 
@@ -153,7 +154,7 @@ __pbs_msgjob(int c, char *jobid, int fileopt, char *msg, char *extend)
 		if ((start = get_obj_location_hint(jobid, MGR_OBJ_JOB)) == -1)
 		    start = 0;
 
-		for (i = start, ct = 0; ct < NSVR; i = (i + 1) % NSVR, ct++) {
+		for (i = start, ct = 0; ct < nsvr; i = (i + 1) % nsvr, ct++) {
 
 			if (!svr_conns[i] || svr_conns[i]->state != SVR_CONN_STATE_UP)
 				continue;
@@ -319,6 +320,7 @@ pbs_relnodesjob(int c, char *jobid, char *node_list, char *extend)
 	int i;
 	int rc = 0;
 	svr_conn_t **svr_conns = get_conn_svr_instances(c);
+	int nsvr = get_num_servers();
 	int start = 0;
 	int ct;
 
@@ -387,7 +389,7 @@ pbs_relnodesjob(int c, char *jobid, char *node_list, char *extend)
 		if ((start = get_obj_location_hint(jobid, MGR_OBJ_JOB)) == -1)
 		    start = 0;
 
-		for (i = start, ct = 0; ct < NSVR; i = (i + 1) % NSVR, ct++) {
+		for (i = start, ct = 0; ct < nsvr; i = (i + 1) % nsvr, ct++) {
 
 			if (!svr_conns[i] || svr_conns[i]->state != SVR_CONN_STATE_UP)
 				continue;

--- a/src/lib/Libifl/pbsD_orderjo.c
+++ b/src/lib/Libifl/pbsD_orderjo.c
@@ -132,6 +132,7 @@ __pbs_orderjob(int c, char *job1, char *job2, char *extend)
 	int i;
 	int rc = 0;
 	svr_conn_t **svr_conns = get_conn_svr_instances(c);
+	int nsvr = get_num_servers();
 	int start = 0;
 	int ct;
 
@@ -151,7 +152,7 @@ __pbs_orderjob(int c, char *job1, char *job2, char *extend)
 		if ((start = get_obj_location_hint(job1, MGR_OBJ_JOB)) == -1)
 		    start = 0;
 
-		for (i = start, ct = 0; ct < NSVR; i = (i + 1) % NSVR, ct++) {
+		for (i = start, ct = 0; ct < nsvr; i = (i + 1) % nsvr, ct++) {
 
 			if (!svr_conns[i] || svr_conns[i]->state != SVR_CONN_STATE_UP)
 				continue;

--- a/src/lib/Libifl/pbsD_orderjo.c
+++ b/src/lib/Libifl/pbsD_orderjo.c
@@ -52,7 +52,7 @@
 
 /**
  * @brief
- *	-send order job batch request
+ *	-send order job batch request (for single instance connection)
  *
  * @param[in] c - connection handler
  * @param[in] job1 - job identifier
@@ -64,7 +64,6 @@
  * @retval      !0      error
  *
  */
-
 static int
 __pbs_orderjob_inner(int c, char *job1, char *job2, char *extend)
 {
@@ -127,7 +126,6 @@ __pbs_orderjob_inner(int c, char *job1, char *job2, char *extend)
  * @retval      !0      error
  *
  */
-
 int
 __pbs_orderjob(int c, char *job1, char *job2, char *extend)
 {

--- a/src/lib/Libifl/pbsD_orderjo.c
+++ b/src/lib/Libifl/pbsD_orderjo.c
@@ -65,20 +65,11 @@
  *
  */
 
-int
-__pbs_orderjob(int c, char *job1, char *job2, char *extend)
+static int
+__pbs_orderjob_inner(int c, char *job1, char *job2, char *extend)
 {
 	struct batch_reply *reply;
 	int rc;
-
-
-	if ((job1 == NULL) || (*job1 == '\0') ||
-		(job2 == NULL) || (*job2 == '\0'))
-		return (pbs_errno = PBSE_IVALREQ);
-
-	/* initialize the thread context data, if not already initialized */
-	if (pbs_client_thread_init_thread_context() != 0)
-		return pbs_errno;
 
 	/* lock pthread mutex here for this connection */
 	/* blocking call, waits for mutex release */
@@ -119,4 +110,64 @@ __pbs_orderjob(int c, char *job1, char *job2, char *extend)
 		return pbs_errno;
 
 	return rc;
+}
+
+
+/**
+ * @brief
+ *	-send order job batch request
+ *
+ * @param[in] c - connection handler
+ * @param[in] job1 - job identifier
+ * @param[in] job2 - job identifier
+ * @param[in] extend - string to encode req
+ *
+ * @return      int
+ * @retval      0       success
+ * @retval      !0      error
+ *
+ */
+
+int
+__pbs_orderjob(int c, char *job1, char *job2, char *extend)
+{
+	int i;
+	int rc = 0;
+	svr_conn_t **svr_conns = get_conn_svr_instances(c);
+	int start = 0;
+	int ct;
+
+	if ((job1 == NULL) || (*job1 == '\0') ||
+		(job2 == NULL) || (*job2 == '\0'))
+		return (pbs_errno = PBSE_IVALREQ);
+
+	/* initialize the thread context data, if not already initialized */
+	if (pbs_client_thread_init_thread_context() != 0)
+		return pbs_errno;
+
+	if (svr_conns) {
+		/* For a single server cluster, instance fd and cluster fd are the same */
+		if (svr_conns[0]->sd == c)
+			return __pbs_orderjob_inner(c, job1, job2, extend);
+
+		if ((start = get_obj_location_hint(job1, MGR_OBJ_JOB)) == -1)
+		    start = 0;
+
+		for (i = start, ct = 0; ct < NSVR; i = (i + 1) % NSVR, ct++) {
+
+			if (!svr_conns[i] || svr_conns[i]->state != SVR_CONN_STATE_UP)
+				continue;
+
+			rc = __pbs_orderjob_inner(svr_conns[i]->sd, job1, job2, extend);
+
+			/* break the loop for sharded objects */
+			if (rc == PBSE_NONE || pbs_errno != PBSE_UNKJOBID)
+				break;
+		}
+
+		return rc;
+	}
+
+	/* Not a cluster fd. Treat it as an instance fd */
+	return __pbs_orderjob_inner(c, job1, job2, extend);
 }

--- a/src/lib/Libifl/pbsD_rerunjo.c
+++ b/src/lib/Libifl/pbsD_rerunjo.c
@@ -54,7 +54,7 @@
 
 /**
  * @brief
- *	-send rerun batch request
+ *	-send rerun batch request (for single instance connection.)
  *
  * @param[in] c - connection handler
  * @param[in] jobid - job identifier
@@ -65,7 +65,6 @@
  * @retval      !0      error
  *
  */
-
 static int
 PBSD_rerunjob(int c, char *jobid, char *extend)
 {

--- a/src/lib/Libifl/pbsD_rerunjo.c
+++ b/src/lib/Libifl/pbsD_rerunjo.c
@@ -150,6 +150,7 @@ __pbs_rerunjob(int c, char *jobid, char *extend)
 {
 	int rc = 0;
 	svr_conn_t **svr_conns = get_conn_svr_instances(c);
+	int nsvr = get_num_servers();
 	int i;
 	int start = 0;
 	int ct;
@@ -165,7 +166,7 @@ __pbs_rerunjob(int c, char *jobid, char *extend)
 		if ((start = get_obj_location_hint(jobid, MGR_OBJ_JOB)) == -1)
 			start = 0;
 
-		for (i = start, ct = 0; ct < NSVR; i = (i + 1) % NSVR, ct++) {
+		for (i = start, ct = 0; ct < nsvr; i = (i + 1) % nsvr, ct++) {
 
 			if (!svr_conns[i] || svr_conns[i]->state != SVR_CONN_STATE_UP)
 				continue;

--- a/src/lib/Libifl/pbsD_rerunjo.c
+++ b/src/lib/Libifl/pbsD_rerunjo.c
@@ -66,8 +66,8 @@
  *
  */
 
-int
-__pbs_rerunjob(int c, char *jobid, char *extend)
+static int
+PBSD_rerunjob(int c, char *jobid, char *extend)
 {
 	int	rc;
 	struct batch_reply *reply;
@@ -131,4 +131,61 @@ __pbs_rerunjob(int c, char *jobid, char *extend)
 		return pbs_errno;
 
 	return rc;
+}
+
+/**
+ * @brief
+ *	-send rerun batch request
+ *
+ * @param[in] c - connection handler
+ * @param[in] jobid - job identifier
+ * @param[in] extend - string to encode req
+ *
+ * @return      int
+ * @retval      0       success
+ * @retval      !0      error
+ *
+ */
+int
+__pbs_rerunjob(int c, char *jobid, char *extend)
+{
+	int rc = 0;
+	svr_conn_t **svr_conns = get_conn_svr_instances(c);
+	int i;
+	int start = 0;
+	int ct;
+
+	if ((jobid == NULL) || (*jobid == '\0'))
+		return (pbs_errno = PBSE_IVALREQ);
+
+	/* initialize the thread context data, if not already initialized */
+	if (pbs_client_thread_init_thread_context() != 0)
+		return pbs_errno;
+
+	if (svr_conns) {
+		if ((start = get_obj_location_hint(jobid, MGR_OBJ_JOB)) == -1)
+			start = 0;
+
+		for (i = start, ct = 0; ct < NSVR; i = (i + 1) % NSVR, ct++) {
+
+			if (!svr_conns[i] || svr_conns[i]->state != SVR_CONN_STATE_UP)
+				continue;
+
+			/*
+			* For a single server cluster, instance fd and cluster fd are the same. 
+			* Hence breaking the loop.
+			*/
+			if (svr_conns[i]->sd == c)
+				return PBSD_rerunjob(c, jobid, extend);
+
+			rc = PBSD_rerunjob(svr_conns[i]->sd, jobid, extend);
+			if (rc == 0 || pbs_errno != PBSE_UNKJOBID)
+				break;
+		}
+
+		return pbs_errno;
+	}
+
+	/* Not a cluster fd. Treat it as an instance fd */
+	return PBSD_rerunjob(c, jobid, extend);
 }

--- a/src/lib/Libifl/pbsD_runjob.c
+++ b/src/lib/Libifl/pbsD_runjob.c
@@ -145,7 +145,6 @@ __runjob_helper(int c, char *jobid, char *location, char *extend, int req_type)
 	int i;
 	int start = 0;
 	int ct;
-	int nsvrs = get_num_servers();
 
 	if ((jobid == NULL) || (*jobid == '\0'))
 		return (pbs_errno = PBSE_IVALREQ);
@@ -154,7 +153,7 @@ __runjob_helper(int c, char *jobid, char *location, char *extend, int req_type)
 		if ((start = get_obj_location_hint(jobid, MGR_OBJ_JOB)) == -1)
 			start = 0;
 
-		for (i = start, ct = 0; ct < nsvrs; i = (i + 1) % nsvrs, ct++) {
+		for (i = start, ct = 0; ct < NSVR; i = (i + 1) % NSVR, ct++) {
 
 			if (!svr_conns[i] || svr_conns[i]->state != SVR_CONN_STATE_UP)
 				continue;

--- a/src/lib/Libifl/pbsD_runjob.c
+++ b/src/lib/Libifl/pbsD_runjob.c
@@ -142,6 +142,7 @@ __runjob_helper(int c, char *jobid, char *location, char *extend, int req_type)
 {
 	int rc = 0;
 	svr_conn_t **svr_conns = get_conn_svr_instances(c);
+	int nsvr = get_num_servers();
 	int i;
 	int start = 0;
 	int ct;
@@ -153,7 +154,7 @@ __runjob_helper(int c, char *jobid, char *location, char *extend, int req_type)
 		if ((start = get_obj_location_hint(jobid, MGR_OBJ_JOB)) == -1)
 			start = 0;
 
-		for (i = start, ct = 0; ct < NSVR; i = (i + 1) % NSVR, ct++) {
+		for (i = start, ct = 0; ct < nsvr; i = (i + 1) % nsvr, ct++) {
 
 			if (!svr_conns[i] || svr_conns[i]->state != SVR_CONN_STATE_UP)
 				continue;

--- a/src/lib/Libifl/pbsD_selectj.c
+++ b/src/lib/Libifl/pbsD_selectj.c
@@ -202,14 +202,13 @@ __pbs_selectjob(int c, struct attropl *attrib, char *extend)
 	struct reply_list *rlist = NULL;
 	struct reply_list *cur;
 	svr_conn_t **svr_conns = get_conn_svr_instances(c);
-	int nsvrs = get_num_servers();
 	int *failed_conn;
 	int rc = 0;
 
 	if (!svr_conns)
 		return NULL;
 
-	failed_conn = calloc(nsvrs, sizeof(int));
+	failed_conn = calloc(NSVR, sizeof(int));
 
 	if (pbs_client_thread_init_thread_context() != 0)
 		return NULL;

--- a/src/lib/Libifl/pbsD_selectj.c
+++ b/src/lib/Libifl/pbsD_selectj.c
@@ -208,7 +208,7 @@ __pbs_selectjob(int c, struct attropl *attrib, char *extend)
 	if (!svr_conns)
 		return NULL;
 
-	failed_conn = calloc(NSVR, sizeof(int));
+	failed_conn = calloc(get_num_servers(), sizeof(int));
 
 	if (pbs_client_thread_init_thread_context() != 0)
 		return NULL;

--- a/src/lib/Libifl/pbsD_sigjob.c
+++ b/src/lib/Libifl/pbsD_sigjob.c
@@ -116,6 +116,7 @@ __pbs_sigjob(int c, char *jobid, char *sig, char *extend)
 {
 	int rc = 0;
 	svr_conn_t **svr_conns = get_conn_svr_instances(c);
+	int nsvr = get_num_servers();
 	int i;
 	int start = 0;
 	int ct;
@@ -127,7 +128,7 @@ __pbs_sigjob(int c, char *jobid, char *sig, char *extend)
 		if ((start = get_obj_location_hint(jobid, MGR_OBJ_JOB)) == -1)
 			start = 0;
 
-		for (i = start, ct = 0; ct < NSVR; i = (i + 1) % NSVR, ct++) {
+		for (i = start, ct = 0; ct < nsvr; i = (i + 1) % nsvr, ct++) {
 
 			if (!svr_conns[i] || svr_conns[i]->state != SVR_CONN_STATE_UP)
 				continue;

--- a/src/lib/Libifl/pbsD_sigjob.c
+++ b/src/lib/Libifl/pbsD_sigjob.c
@@ -119,7 +119,6 @@ __pbs_sigjob(int c, char *jobid, char *sig, char *extend)
 	int i;
 	int start = 0;
 	int ct;
-	int nsvrs = get_num_servers();
 
 	if ((jobid == NULL) || (*jobid == '\0') || (sig == NULL))
 		return (pbs_errno = PBSE_IVALREQ);
@@ -128,7 +127,7 @@ __pbs_sigjob(int c, char *jobid, char *sig, char *extend)
 		if ((start = get_obj_location_hint(jobid, MGR_OBJ_JOB)) == -1)
 			start = 0;
 
-		for (i = start, ct = 0; ct < nsvrs; i = (i + 1) % nsvrs, ct++) {
+		for (i = start, ct = 0; ct < NSVR; i = (i + 1) % NSVR, ct++) {
 
 			if (!svr_conns[i] || svr_conns[i]->state != SVR_CONN_STATE_UP)
 				continue;

--- a/src/scheduler/fifo.cpp
+++ b/src/scheduler/fifo.cpp
@@ -747,7 +747,6 @@ get_high_prio_cmd(int *is_conn_lost, sched_cmd *high_prior_cmd)
 {
 	int i;
 	sched_cmd cmd;
-	int nsvrs = get_num_servers();
 	svr_conn_t **svr_conns = get_conn_svr_instances(clust_secondary_sock);
 	if (svr_conns == NULL) {
 		log_event(PBSEVENT_SCHED, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__,
@@ -771,7 +770,7 @@ get_high_prio_cmd(int *is_conn_lost, sched_cmd *high_prior_cmd)
 
 		if (cmd.cmd == SCH_SCHEDULE_RESTART_CYCLE) {
 			*high_prior_cmd = cmd;
-			if (i == nsvrs - 1)  {
+			if (i == NSVR - 1)  {
 				/* We need to return only after checking all servers. This way even if multiple
 				 * servers send SCH_SCHEDULE_RESTART_CYCLE we only have to consider one such request
 				 */

--- a/src/scheduler/fifo.cpp
+++ b/src/scheduler/fifo.cpp
@@ -770,7 +770,7 @@ get_high_prio_cmd(int *is_conn_lost, sched_cmd *high_prior_cmd)
 
 		if (cmd.cmd == SCH_SCHEDULE_RESTART_CYCLE) {
 			*high_prior_cmd = cmd;
-			if (i == NSVR - 1)  {
+			if (i == get_num_servers() - 1)  {
 				/* We need to return only after checking all servers. This way even if multiple
 				 * servers send SCH_SCHEDULE_RESTART_CYCLE we only have to consider one such request
 				 */

--- a/src/scheduler/fifo.cpp
+++ b/src/scheduler/fifo.cpp
@@ -745,7 +745,7 @@ scheduling_cycle(int sd, const sched_cmd *cmd)
 static int
 get_high_prio_cmd(int *is_conn_lost, sched_cmd *high_prior_cmd)
 {
-	uint i;
+	int i;
 	sched_cmd cmd;
 	svr_conn_t **svr_conns = get_conn_svr_instances(clust_secondary_sock);
 	if (svr_conns == NULL) {

--- a/src/scheduler/fifo.cpp
+++ b/src/scheduler/fifo.cpp
@@ -745,7 +745,7 @@ scheduling_cycle(int sd, const sched_cmd *cmd)
 static int
 get_high_prio_cmd(int *is_conn_lost, sched_cmd *high_prior_cmd)
 {
-	int i;
+	uint i;
 	sched_cmd cmd;
 	svr_conn_t **svr_conns = get_conn_svr_instances(clust_secondary_sock);
 	if (svr_conns == NULL) {
@@ -789,6 +789,7 @@ get_high_prio_cmd(int *is_conn_lost, sched_cmd *high_prior_cmd)
 			}
 		}
 	}
+
 	return 0;
 }
 

--- a/src/scheduler/pbs_sched_utils.cpp
+++ b/src/scheduler/pbs_sched_utils.cpp
@@ -574,7 +574,6 @@ connect_svrpool()
 	int i;
 	svr_conn_t **svr_conns_primary = NULL;
 	svr_conn_t **svr_conns_secondary = NULL;
-	int num_conf_svrs = get_num_servers();
 
 	while (1) {
 		/* pbs_connect() will return a connection handle for all servers
@@ -613,7 +612,7 @@ connect_svrpool()
 			}
 		}
 
-		if (i != num_conf_svrs) {
+		if (i != NSVR) {
 			/* If we reached here means one of the servers is down or not connected
 			 * we should go to the top of the loop again and call pbs_connect
 			 * Also wait for 2s for not to burn too much CPU
@@ -658,14 +657,14 @@ static void
 sched_svr_init(void)
 {
 	if (poll_context == NULL) {
-		poll_context = tpp_em_init(get_num_servers());
+		poll_context = tpp_em_init(NSVR);
 		if (poll_context == NULL) {
 			log_err(errno, __func__, "Failed to init cmd connections context");
 			die(-1);
 		}
 	}
 
-	qrun_list = static_cast<sched_cmd *>(malloc((get_num_servers() + 1) * sizeof(sched_cmd)));
+	qrun_list = static_cast<sched_cmd *>(malloc((NSVR + 1) * sizeof(sched_cmd)));
 	if (qrun_list == NULL) {
 		log_err(errno, __func__, MEM_ERR_MSG);
 		die(0);

--- a/src/scheduler/pbs_sched_utils.cpp
+++ b/src/scheduler/pbs_sched_utils.cpp
@@ -571,7 +571,7 @@ close_servers(void)
 static void
 connect_svrpool()
 {
-	uint i;
+	int i;
 	svr_conn_t **svr_conns_primary = NULL;
 	svr_conn_t **svr_conns_secondary = NULL;
 

--- a/src/scheduler/pbs_sched_utils.cpp
+++ b/src/scheduler/pbs_sched_utils.cpp
@@ -612,7 +612,7 @@ connect_svrpool()
 			}
 		}
 
-		if (i != NSVR) {
+		if (i != get_num_servers()) {
 			/* If we reached here means one of the servers is down or not connected
 			 * we should go to the top of the loop again and call pbs_connect
 			 * Also wait for 2s for not to burn too much CPU
@@ -657,14 +657,14 @@ static void
 sched_svr_init(void)
 {
 	if (poll_context == NULL) {
-		poll_context = tpp_em_init(NSVR);
+		poll_context = tpp_em_init(get_num_servers());
 		if (poll_context == NULL) {
 			log_err(errno, __func__, "Failed to init cmd connections context");
 			die(-1);
 		}
 	}
 
-	qrun_list = static_cast<sched_cmd *>(malloc((NSVR + 1) * sizeof(sched_cmd)));
+	qrun_list = static_cast<sched_cmd *>(malloc((get_num_servers() + 1) * sizeof(sched_cmd)));
 	if (qrun_list == NULL) {
 		log_err(errno, __func__, MEM_ERR_MSG);
 		die(0);

--- a/src/scheduler/pbs_sched_utils.cpp
+++ b/src/scheduler/pbs_sched_utils.cpp
@@ -571,7 +571,7 @@ close_servers(void)
 static void
 connect_svrpool()
 {
-	int i;
+	uint i;
 	svr_conn_t **svr_conns_primary = NULL;
 	svr_conn_t **svr_conns_secondary = NULL;
 

--- a/src/server/multi_svr.c
+++ b/src/server/multi_svr.c
@@ -637,7 +637,7 @@ init_msi()
 	CLEAR_HEAD(peersvrl);
 	alien_node_idx = pbs_idx_create(0, 0);
 
-	for (i = 0; i < get_num_servers(); i++) {
+	for (i = 0; i < NSVR; i++) {
 
 		if (pbs_conf.psi[i].port == pbs_server_port_dis &&
 		    is_same_host(pbs_conf.psi[i].name, server_host)) {

--- a/src/server/multi_svr.c
+++ b/src/server/multi_svr.c
@@ -637,7 +637,7 @@ init_msi()
 	CLEAR_HEAD(peersvrl);
 	alien_node_idx = pbs_idx_create(0, 0);
 
-	for (i = 0; i < NSVR; i++) {
+	for (i = 0; i < get_num_servers(); i++) {
 
 		if (pbs_conf.psi[i].port == pbs_server_port_dis &&
 		    is_same_host(pbs_conf.psi[i].name, server_host)) {

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -6579,10 +6579,14 @@ set_nodes(void *pobj, int objtype, char *execvnod_in, char **execvnod_out, char 
 		if (parse_node_resc(chunk, &vname, &nelem, &pkvp) == 0) {
 			if ((pnode = find_nodebyname(vname)) == NULL &&
 			    (pnode = find_alien_node(vname)) == NULL) {
-				if (svr_init && (pjob->ji_qs.ji_svrflags & JOB_SVFLG_RescUpdt_Rqd))
-					continue;
-				log_eventf(PBSEVENT_DEBUG, PBS_EVENTCLASS_SERVER, LOG_INFO,
-					   __func__, "Unknown node %s received", vname);
+				if (objtype == JOB_OBJECT) {
+					if (svr_init && (pjob->ji_qs.ji_svrflags & JOB_SVFLG_RescUpdt_Rqd))
+						continue;
+					log_eventf(PBSEVENT_DEBUG, PBS_EVENTCLASS_JOB, LOG_INFO,
+						   pjob->ji_qs.ji_jobid, "Unknown node %s received", vname);
+				} else if (objtype == RESC_RESV_OBJECT)
+					log_eventf(PBSEVENT_DEBUG, PBS_EVENTCLASS_RESV, LOG_INFO,
+						   presv->ri_qs.ri_resvID, "Unknown node %s received", vname);
 				free(execvncopy);
 				rc = PBSE_UNKNODE;
 				send_nodestat_req();

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -6581,10 +6581,10 @@ set_nodes(void *pobj, int objtype, char *execvnod_in, char **execvnod_out, char 
 			    (pnode = find_alien_node(vname)) == NULL) {
 				if (svr_init && (pjob->ji_qs.ji_svrflags & JOB_SVFLG_RescUpdt_Rqd))
 					continue;
+				log_eventf(PBSEVENT_DEBUG, PBS_EVENTCLASS_SERVER, LOG_INFO,
+					   __func__, "Unknown node %s received", vname);
 				free(execvncopy);
 				rc = PBSE_UNKNODE;
-				log_eventf(PBSEVENT_DEBUG, PBS_EVENTCLASS_JOB, LOG_INFO,
-					   pjob->ji_qs.ji_jobid, "Unknown node received");
 				send_nodestat_req();
 				goto end;
 			}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* pbsnodes -av, and possibly other client commands don't throw any error message letting users know that a server is down and the data reported might be incomplete. It should behave similarly to qstat which does the following:

[ravi@pbspro ~]$ qstat

qstat: cannot connect to server pbspro

Job id            Name             User              Time Use S Queue

----------------  ---------------- ----------------  -------- - -----

000.pbspro        STDIN            ravi                     0 Q workq 

* pbs_release_nodes command does not work with multi-server
* pbs_movejob does not work with multi-server.
* pbs_msgjob does not work with multi-server.
* pbs_orderjob does not work with multi-server.
* pbs_rerunjob does not work with multi-server
* export from init script masks PSI value for daemons.

[test.log](https://github.com/openpbs/openpbs/files/6304478/test.log)

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* pbsnodes and other commands will throw an error if it cannot connect to one of the instances.
* pbs_release_node should iterate through instance fds when a virtual fd is provided.
* pbs_movejob should iterate through instance fds when a virtual fd is provided.
* pbs_msgjob should iterate through instance fds when a virtual fd is provided.
* pbs_orderjob should iterate through instance fds when a virtual fd is provided. It only works when both the jobid belongs to the same server.
* pbs_rerunjob should iterate through instance fds when a virtual fd is provided.
* set PSI while executing command instead of exporting


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
[test.log](https://github.com/openpbs/openpbs/files/6304479/test.log)

Regression Results:
Description: Tests from given sources on platforms SUSE15, CENTOS8, CENTOS7
Platforms: SUSE15,CENTOS8,CENTOS7
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|7037|2023|6|0|0|0|2017|

Description: Rerun Only Failed Tests From #7037
Platforms: SUSE15,CENTOS8,CENTOS7
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|7039|6|1|0|0|0|5|



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
