### PR TITLE
multi-server: server local scheduling is broken

### DIFF
--- a/src/server/multi_svr.c
+++ b/src/server/multi_svr.c
@@ -680,12 +680,13 @@ gen_svr_inst_id(void)
 	if (svr_inst_id == NULL) {
 		unsigned int svr_inst_port;
 		char svr_inst_name[PBS_MAXHOSTNAME + 1];
+		char svr_inst_fname[PBS_MAXHOSTNAME + 1];
 
 		if (gethostname(svr_inst_name, PBS_MAXHOSTNAME) == 0)
-			get_fullhostname(svr_inst_name, svr_inst_name, PBS_MAXHOSTNAME);
+			get_fullhostname(svr_inst_name, svr_inst_fname, PBS_MAXHOSTNAME);
 
 		svr_inst_port = pbs_conf.batch_service_port;
-		pbs_asprintf(&svr_inst_id, "%s:%d", svr_inst_name, svr_inst_port);
+		pbs_asprintf(&svr_inst_id, "%s:%d", svr_inst_fname, svr_inst_port);
 	}
 
 	return svr_inst_id;
@@ -703,6 +704,8 @@ gen_svr_inst_id(void)
 int
 get_server_index(void)
 {
+	if (svridx == -1)
+		init_msi();
 	return svridx;
 }
 

--- a/src/server/pbsd_init.c
+++ b/src/server/pbsd_init.c
@@ -672,6 +672,9 @@ pbsd_init(int type)
 		return (-1);
 	}
 
+	/* Initialize server instsances before loading jobs/resv */
+	init_msi();
+
 	/* Open and read in node list if one exists */
 	if ((rc = setup_nodes()) == -1) {
 		/* log_buffer set in setup_nodes */
@@ -691,9 +694,6 @@ pbsd_init(int type)
 	 * This is used for standing reservations user of libical */
 	sprintf(zone_dir, "%s%s", pbs_conf.pbs_exec_path, ICAL_ZONEINFO_DIR);
 	set_ical_zoneinfo(zone_dir);
-
-	/* Initialize server instsances before loading jobs/resv */
-	init_msi();
 
 	/* load reservations */
 	if ((resvs_idx = pbs_idx_create(0, 0)) == NULL) {


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Server local scheduling seems to be broken. This was likely introduced by https://github.com/openpbs/openpbs/pull/2304 where we changed the location of calling init_msi() to be after setup_nodes(). This meant that inside setup_nodes() when we didn't set the node resource msvr_node_group correctly (it calls get_server_index(), which relies on multi-server metadata which is set by init_msi()). So, it gets set to -1, which means scheduler cannot do server local scheduling properly and it ends up running jobs on nodes which don't belong to the server.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
moved the call to init_msi() to before setup_nodes(). Also, inside get_server_index(), we check to see if init_msi() was called, and if not then we call it to ensure that the metadata is set up before we return the server index.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
