### PR TITLE
In revert_mom() allow time for mom to sync with server prior to create node.

### DIFF
--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -1531,6 +1531,8 @@ class PBSTestSuite(unittest.TestCase):
             mom.signal('-HUP')
         if not mom.isUp():
             self.logger.error('mom ' + mom.shortname + ' is down after revert')
+        # give mom enough time to network sync with the server
+        time.sleep(4)
         a = {'state': 'free'}
         self.server.manager(MGR_CMD_CREATE, NODE, None, mom.shortname)
         if enabled_cpuset:

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -1531,8 +1531,9 @@ class PBSTestSuite(unittest.TestCase):
             mom.signal('-HUP')
         if not mom.isUp():
             self.logger.error('mom ' + mom.shortname + ' is down after revert')
-        # give mom enough time to network sync with the server
-        time.sleep(4)
+        # give mom enough time to network sync with the server on cpuset system
+        if enabled_cpuset:
+            time.sleep(4)
         a = {'state': 'free'}
         self.server.manager(MGR_CMD_CREATE, NODE, None, mom.shortname)
         if enabled_cpuset:


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
During revert_mom(), intermittently observable on cpuset systems, the mom would fail to sync with the server before create node. The mom ends up with a corrupted pbs_cgroups.PY and the create node will fail to create the NUMA vnodes on cpuset systems.

#### Describe Your Change
Added a sleep after a mom restart or HUP before qmgr create node.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
Note: Results show tests are skipped due to a separate existing issue.
[Test_Rrecord_with_resources_used.txt](https://github.com/openpbs/openpbs/files/6287220/Test_Rrecord_with_resources_used.txt)
[TestCgroupsHook.txt](https://github.com/openpbs/openpbs/files/6287221/TestCgroupsHook.txt)

test results after using sleep on cpuset systems only:
[th3_results.txt](https://github.com/openpbs/openpbs/files/6340478/th3_results.txt)
[jenkins_results.txt](https://github.com/openpbs/openpbs/files/6340479/jenkins_results.txt)





<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
