### PR TITLE
Fixed set_resource() to always set def

### DIFF
--- a/src/scheduler/node_partition.cpp
+++ b/src/scheduler/node_partition.cpp
@@ -442,7 +442,10 @@ create_node_partitions(status *policy, node_info **nodes, const char * const *re
 
 			if (res == NULL && (flags & NP_CREATE_REST)) {
 				unset_res->name = resnames[res_i];
-				set_resource(unset_res, "\"\"", RF_AVAIL);
+				if (set_resource(unset_res, "\"\"", RF_AVAIL) == 0) {
+					free_node_partition_array(np_arr);
+					return NULL;
+				}
 				res = unset_res;
 			}
 			if (res != NULL) {

--- a/src/scheduler/server_info.cpp
+++ b/src/scheduler/server_info.cpp
@@ -3121,8 +3121,10 @@ set_resource(schd_resource *res, const char *val, enum resource_fields field)
 
 	if (rdef != NULL)
 		res->type = rdef->type;
-	else
+	else {
+		log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_RESC, LOG_WARNING, res->name, "Can't find resource definition");
 		return 0;
+	}
 
 	if (field == RF_AVAIL) {
 		/* if this resource is being re-set, lets free the memory we previously
@@ -3159,12 +3161,16 @@ set_resource(schd_resource *res, const char *val, enum resource_fields field)
 			res->avail = res_to_num(val, NULL);
 			if (res->avail == SCHD_INFINITY_RES) {
 				/* Verify that this is a string type resource */
-				if (!res->def->type.is_string)
+				if (!res->def->type.is_string) {
+					log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_RESC, LOG_WARNING, res->name, "Invalid value for consumable resource");
 					return 0;
+				}
 			}
 			res->str_avail = break_comma_list(const_cast<char *>(val));
-			if (res->str_avail == NULL)
+			if (res->str_avail == NULL) {
+				log_eventf(PBSEVENT_ERROR, PBS_EVENTCLASS_RESC, LOG_WARNING, res->name, "Invalid value: %s", val);
 				return 0;
+			}
 		}
 	} else if (field == RF_ASSN) {
 		/* clear previously allocated memory in the case of a reassignment */

--- a/src/scheduler/server_info.cpp
+++ b/src/scheduler/server_info.cpp
@@ -3116,14 +3116,13 @@ set_resource(schd_resource *res, const char *val, enum resource_fields field)
 	if (res == NULL || val == NULL)
 		return 0;
 
-	if (res->def != NULL)
-		rdef = res->def;
-	else {
-		rdef = find_resdef(res->name);
-		res->def = rdef;
-	}
+	rdef = find_resdef(res->name);
+	res->def = rdef;
+
 	if (rdef != NULL)
 		res->type = rdef->type;
+	else
+		return 0;
 
 	if (field == RF_AVAIL) {
 		/* if this resource is being re-set, lets free the memory we previously


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
The scheduler could crash after a HUP if psets were in use

#### Describe Your Change
The scheduler will create a pset for all nodes which do not have a pset resource set.  To do this, it uses a resource it fills in with the value of "".  So we don't have to continually allocate a new schd_resource structure for this, the unset_res variable is static.  The problem is when we call set_resource(), it checks if unset_res->def is set, and if it is, it'll use that.  

The resource definitions will be requeried on a HUP (or SCH_CONFIGURE) and will change.  

On the next call to create_nodepart(), we'll use unset_res with the old def.  When we call set_resource(), it'll see the def set and use it.  That pointer is pointing at a freed resource definition.

The fix is to always find the resource definition.  The resource definitions are stored in an unordered_map, so lookups are O(1).

#### Attach Test and Valgrind Logs/Output
Before:
==294681== Invalid read of size 2
==294681==    at 0x4B78A9: set_resource(schd_resource*, char const*, resource_fields) (server_info.cpp:3126)
==294681==    by 0x494473: create_node_partitions(status*, node_info**, char const* const*, unsigned int, int*) (node_partition.cpp:445)
==294681==    by 0x4963BD: create_placement_sets(status*, server_info*) (node_partition.cpp:1266)
==294681==    by 0x4B1D4C: query_server(status*, int) (server_info.cpp:460)
==294681==    by 0x45E63B: scheduling_cycle(int, sched_cmd const*) (fifo.cpp:614)
==294681==    by 0x45E551: intermediate_schedule(int, sched_cmd const*) (fifo.cpp:547)
==294681==    by 0x45E497: schedule (fifo.cpp:503)
==294681==    by 0x4CE45D: schedule_wrapper(sched_cmd*, int) (pbs_sched_utils.cpp:1244)
==294681==    by 0x4CE339: sched_main(int, char**, int (*)(int, sched_cmd const*)) (pbs_sched_utils.cpp:1190)
==294681==    by 0x45D472: main (pbs_sched.cpp:61)
==294681==  Address 0xbc48410 is 32 bytes inside a block of size 40 free'd
==294681==    at 0x4C325FC: operator delete(void*) (vg_replace_malloc.c:584)
==294681==    by 0x4A454C: update_resource_defs(int) (resource.cpp:393)
==294681==    by 0x45E4F2: schedule (fifo.cpp:513)
==294681==    by 0x4CE45D: schedule_wrapper(sched_cmd*, int) (pbs_sched_utils.cpp:1244)
==294681==    by 0x4CE339: sched_main(int, char**, int (*)(int, sched_cmd const*)) (pbs_sched_utils.cpp:1190)


After valgrind didn't report that any more.