### PR TITLE
Do not duplicate PBS directive lines in qsub

### DIFF
--- a/src/cmds/qsub_sup.c
+++ b/src/cmds/qsub_sup.c
@@ -260,14 +260,6 @@ get_script(FILE *file, char *script, char *prefix)
 
 	while ((in = pbs_fgets_extend(&s_in, &s_len, file)) != NULL) {
 		if (!exec && ((sopt = pbs_ispbsdir(s_in, prefix)) != NULL)) {
-			if (fputs(in, TMP_FILE) < 0) {
-				perror("fputs");
-				fprintf(stderr,
-					"qsub: error writing copy of script, %s\n", tmp_name);
-				fclose(TMP_FILE);
-				free(s_in);
-				return (3);
-			}
 			/*
 			 * Setting options from the job script will not overwrite
 			 * options set on the command line. CMDLINE-1 means

--- a/test/tests/functional/pbs_qsub_script.py
+++ b/test/tests/functional/pbs_qsub_script.py
@@ -1,0 +1,83 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2021 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of both the OpenPBS software ("OpenPBS")
+# and the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# OpenPBS is free software. You can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# OpenPBS is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# PBS Pro is commercially licensed software that shares a common core with
+# the OpenPBS software.  For a copy of the commercial license terms and
+# conditions, go to: (http://www.pbspro.com/agreement.html) or contact the
+# Altair Legal Department.
+#
+# Altair's dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of OpenPBS and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair's trademarks, including but not limited to "PBS™",
+# "OpenPBS®", "PBS Professional®", and "PBS Pro™" and Altair's logos is
+# subject to Altair's trademark licensing policies.
+
+
+from tests.functional import *
+
+
+class TestQsubScript(TestFunctional):
+    """
+    This test suite validates that qsub does not modify the script file
+    """
+
+    def setUp(self):
+        TestFunctional.setUp(self)
+
+        self.server.manager(MGR_CMD_SET, SERVER,
+                            {'job_history_enable': 'true'})
+        self.qsub_cmd = os.path.join(
+            self.server.pbs_conf['PBS_EXEC'], 'bin', 'qsub')
+        self.sub_dir = self.du.create_temp_dir(asuser=TEST_USER)
+
+    def test_qsub_basic_job(self):
+        """
+        This test case ensures that #PBS directive lines are not
+        modified
+        """
+        script = """#!/bin/sh
+        #PBS -m n
+        cat $0
+        """
+
+        fn = self.du.create_temp_file(body=script, asuser=TEST_USER)
+        cmd = [self.qsub_cmd, fn]
+        rv = self.du.run_cmd(self.server.hostname,
+                             cmd=cmd,
+                             runas=TEST_USER,
+                             cwd=self.sub_dir)
+        self.assertEqual(rv['rc'], 0, 'qsub failed')
+        jid = rv['out'][0]
+        self.logger.info("Job ID: %s" % jid)
+
+        self.server.expect(JOB, {'job_state': 'F'}, id=jid, extend='x')
+        job_status = self.server.status(JOB, id=jid, extend='x')
+        if job_status:
+            job_output_file = job_status[0]['Output_Path'].split(':')[1]
+        rc = self.du.cmp(fileA=fn, fileB=job_output_file, runas=TEST_USER)
+        self.assertEqual(rc, 0, 'cmp of job files failed')


### PR DESCRIPTION
Correct an issue where qsub was duplicating all directive (#PBS) lines
in the job script. This was especially problematic in cases where
self-resubmitting scripts used the currently running script as a
template.

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
When submitting a job with **qsub** all the PBS directive lines (#PBS) are duplicated due to the two `fputs` calls in the loop in `get_script`. This is especially an issue with self-resubmitting jobs that use the currently running script as the template, causing further duplication on each re-submission.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Deleted the un-necessary `fputs` call block in `get_script`

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
N/A

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[test_log.txt](https://github.com/openpbs/openpbs/files/6293305/test_log.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
