### PR TITLE
[WIP] fix TPP mbox full error

### DIFF
--- a/src/lib/Libtpp/tpp_em.c
+++ b/src/lib/Libtpp/tpp_em.c
@@ -1083,6 +1083,7 @@ tpp_mbox_read(tpp_mbox_t *mbox, unsigned int *tfd, int *cmdval, void **data)
 
 	/* if no more data, clear all notifications */
 	if (cmd == NULL) {
+		mbox->mbox_size = 0;
 #ifdef HAVE_SYS_EVENTFD_H
 		read(mbox->mbox_eventfd, &u, sizeof(uint64_t));
 #else
@@ -1091,7 +1092,7 @@ tpp_mbox_read(tpp_mbox_t *mbox, unsigned int *tfd, int *cmdval, void **data)
 	} else {
 		/* reduce from mbox size during read */
 		mbox->mbox_size -= cmd->sz;
-#ifdef DEBUG
+#ifdef TPPDEBUG
 		if ((mbox->max_size != -1) && (cmd->sz > 0)) {
 			TPP_DBPRT("Mbox %s, after reading %d size = %d", mbox->mbox_name, cmd->sz, mbox->mbox_size);
 		}
@@ -1150,7 +1151,6 @@ tpp_mbox_clear(tpp_mbox_t *mbox, tpp_que_elem_t **n, unsigned int tfd, short *cm
 		cmd = TPP_QUE_DATA(*n);
 		if (cmd && cmd->tfd == tfd) {
 			*n = tpp_que_del_elem(&mbox->mbox_queue, *n);
-			mbox->mbox_size -= cmd->sz;
 			if (cmdval)
 				*cmdval = cmd->cmdval;
 			if (data)
@@ -1160,6 +1160,7 @@ tpp_mbox_clear(tpp_mbox_t *mbox, tpp_que_elem_t **n, unsigned int tfd, short *cm
 			break;
 		}
 	}
+	mbox->mbox_size = 0;
 
 	tpp_unlock(&mbox->mbox_mutex);
 
@@ -1229,7 +1230,7 @@ tpp_mbox_post(tpp_mbox_t *mbox, unsigned int tfd, char cmdval, void *data, int s
 	/* add to the size to global size during enque */
 	mbox->mbox_size += sz;
 
-#ifdef DEBUG
+#ifdef TPPDEBUG
 	if ((mbox->max_size != -1) && (sz > 0)) {
 		TPP_DBPRT("Mbox %s, after adding %d  size = %d",  mbox->mbox_name, sz, mbox->mbox_size);
 	}

--- a/src/lib/Libtpp/tpp_transport.c
+++ b/src/lib/Libtpp/tpp_transport.c
@@ -1893,7 +1893,7 @@ add_pkt(phy_conn_t *conn)
 					} else if (rc == -2) {
 						conn->ev_mask &= ~EM_IN; /* reciever buffer full, must wait, remove EM_IN */
 						tpp_log(LOG_INFO, __func__, "tfd=%d, Receive buffer full, will wait", conn->sock_fd);
-						enque_deferred_event(conn->td, -1, TPP_CMD_READ, 0);
+						enque_deferred_event(conn->td, conn->sock_fd, TPP_CMD_READ, 0);
 						mod_rc = tpp_em_mod_fd(conn->td->em_context, conn->sock_fd, conn->ev_mask);
 					}
 				} else {


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
TPP does some rudimentary amount of throttling, so that no one client can flood the pipes. The pipes are managed by the mbox data structures, which have max_size and a mbox_size. The mbox_size parameter was not being computed properly (not correctly reset to zero in certain cases). The other issue was that when receiver buffer was full, we had the logic to check the buffer at periodic intervals, but that did not work due to a missing socket fd in the comparison.


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
- Set mbox_size (current size of the pipe) to 0 at some places where we clear the mbox
- passing conn->sock_fd to the deferred event enquing, since the fd is checked at the time of dequeuing (the fd was being set to -1 earlier)

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Manual test procedure:
- Stand up a single host pbs installation
- Set the mom to have 1000 ncpus
- Turn off scheduling and submit 600 jobs
- Turn on scheduling
- The target receiver buffer will get full due to the quick TPP actions, but due to the bug will not get cleared
- This will result in obit acks no longer reaching the mom and many jobs will remain stuck in 41 substate

Description: Tests from given sources on platforms SUSE15, CENTOS8, CENTOS7
Platforms: SUSE15,CENTOS8,CENTOS7
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|7032|2023|3|1|0|0|2019|

Master results are as follows:
Description: Tests from given sources on platforms SUSE15, CENTOS8, CENTOS7
Platforms: SUSE15,CENTOS8,CENTOS7
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|7033|2023|2|0|0|0|2021|

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
