### PR TITLE
msvr: sched doesn't reject reservations for svrs without nodes

### DIFF
--- a/src/scheduler/check.cpp
+++ b/src/scheduler/check.cpp
@@ -1651,7 +1651,7 @@ check_normal_node_path(status *policy, server_info *sinfo, queue_info *qinfo, re
 		}
 
 		/* Handle server local scheduling for multi-server setup */
-		if (resresv->svr_inst_id != NULL) {
+		if (pbs_conf.pbs_num_servers > 1 && resresv->svr_inst_id != NULL) {
 			if (sinfo->svr_to_psets.find(resresv->svr_inst_id) != sinfo->svr_to_psets.end()) {
 				msvr_pset[0] = sinfo->svr_to_psets[resresv->svr_inst_id];
 

--- a/src/scheduler/check.cpp
+++ b/src/scheduler/check.cpp
@@ -1650,19 +1650,24 @@ check_normal_node_path(status *policy, server_info *sinfo, queue_info *qinfo, re
 				ninfo_arr = qinfo->nodes;
 		}
 
-		/* Handle multi-server psets */
-		if (resresv->svr_inst_id != NULL &&
-		    sinfo->svr_to_psets.find(resresv->svr_inst_id) != sinfo->svr_to_psets.end()) {
-			msvr_pset[0] = sinfo->svr_to_psets[resresv->svr_inst_id];
+		/* Handle server local scheduling for multi-server setup */
+		if (resresv->svr_inst_id != NULL) {
+			if (sinfo->svr_to_psets.find(resresv->svr_inst_id) != sinfo->svr_to_psets.end()) {
+				msvr_pset[0] = sinfo->svr_to_psets[resresv->svr_inst_id];
 
-			/* Restrict job arrays and reservations to owner server */
-			if (resresv->is_resv || resresv->job->is_array)
-				msvr_pset[1] = NULL;
-			else {	/* If owner's nodes don't work, use all */
-				msvr_pset[1] = sinfo->allpart;
-				msvr_pset[2] = NULL;
+				/* Restrict job arrays and reservations to owner server */
+				if (resresv->is_resv || resresv->job->is_array)
+					msvr_pset[1] = NULL;
+				else { /* If owner's nodes don't work, use all */
+					msvr_pset[1] = sinfo->allpart;
+					msvr_pset[2] = NULL;
+				}
+				nodepart = msvr_pset;
+			} else if (resresv->is_resv || resresv->job->is_array) {
+				/* No nodes associated with owner server, so reject the job array/reservation */
+				set_schd_error_codes(err, NOT_RUN, NO_NODE_RESOURCES);
+				return NULL;
 			}
-			nodepart = msvr_pset;
 		}
 	}
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
When setting up 2 serves, one with no nodes, with with some, and submitting a reservation to the server with no nodes, scheduler tries to place it on nodes of the other server, even though reservations are restricted to owner server's nodes right now, so scheduler should just be rejecting such reservations.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
inside check_normal_node_path(), we were not doing anything for the case where a reservation's server had no nodes. Now we reject the reservation/job array if its owner doesn't have any resources.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
```
[ravi@pbspro ~]$ PBS_SERVER_INSTANCES=pbspro:18002 pbs_rsub -lncpus=4 -R 0000 -E 0100
R001.pbspro UNCONFIRMED
[ravi@pbspro ~]$ pbs_rstat
[ravi@pbspro ~]$ cd /var/spool/pbs_1/sched_logs/
[ravi@pbspro sched_logs]$ grep "R001.pbspro" *
04/12/2021 22:01:38;0200;pbs_sched;Resv;R001.pbspro;PBS Failed to confirm resv: No available resources on nodes
[ravi@pbspro sched_logs]$ 
```

buckets code path:
```
[ravi@pbspro ~]$ PBS_SERVER_INSTANCES=pbspro:18002 qsub -lplace=excl -lselect=1:ncpus=4 -- /bin/sleep 100
301.pbspro
[ravi@pbspro ~]$ qstat
Job id            Name             User              Time Use S Queue
----------------  ---------------- ----------------  -------- - -----
301.pbspro        STDIN            ravi                     0 Q workq   
[ravi@pbspro ~]$ cd /var/spool/pbs/sched_logs/
[ravi@pbspro sched_logs]$ cd ..
[ravi@pbspro pbs]$ cd ..
[ravi@pbspro spool]$ cd pbs_1
[ravi@pbspro pbs_1]$ cd sched_logs/
[ravi@pbspro sched_logs]$ ls
20210414
[ravi@pbspro sched_logs]$ grep "301.pbspro" *
04/14/2021 16:21:14;0080;pbs_sched;Job;301.pbspro;Considering job to run
04/14/2021 16:21:14;0040;pbs_sched;Job;301.pbspro;No available resources on nodes
```


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
