### PR TITLE
Snapshot test fails because of qstat_tf.out file

### DIFF
--- a/test/tests/functional/pbs_snapshot_unittest.py
+++ b/test/tests/functional/pbs_snapshot_unittest.py
@@ -950,7 +950,8 @@ pbs.logmsg(pbs.EVENT_DEBUG,"%s")
                         "scheduler/qmgr_lsched.out", "node/pbsnodes_va.out",
                         "reservation/pbs_rstat_f.out", "job/qstat_f.out",
                         "hook/qmgr_lpbshook.out", "server_priv/resourcedef",
-                        "pbs.conf", "pbs_snapshot.log", "ctime"]
+                        "pbs.conf", "pbs_snapshot.log", "ctime",
+                        "job/qstat_tf.out"]
         target_files = [os.path.join(snap_dir, f) for f in target_files]
         sched_priv_dir = os.path.join(snap_dir, "sched_priv")
         for (root, dirs, files) in os.walk(snap_dir):


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Due to recent changes to pbs_snapshot --basic option where it captures qstat -tf output, a snapshot test has started failing.

#### Describe Your Change
Change the test to expect qstat_tf.out file to be captured in '--basic' mode.

#### Link to Design Doc
NA
#### Attach Test and Valgrind Logs/Output
[test_snapshot.txt](https://github.com/openpbs/openpbs/files/6300553/test_snapshot.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
