### PR TITLE
Mom hook update on job's runcount is ignored by the server

### DIFF
--- a/src/server/req_quejob.c
+++ b/src/server/req_quejob.c
@@ -1134,8 +1134,8 @@ req_quejob(struct batch_request *preq)
 					(int)(sizeof(hook_msg) - 2), hook_buf);
 			}
 
-			reply_text(preq, hook_errcode, hook_msg);
 			job_purge(pj);
+			reply_text(preq, hook_errcode, hook_msg);
 			return;
 	}
 #endif


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
MoM hook updates done on the job's run count are ignored by the Server when the hook is rejected. This is due to recent MoM bundling changes which changed the order of update to the server. Now send job reply can go before MoM sends changes happened to the job. post_sendmom() marks the job to Q and when the server gets to update later, it ignores the changes since the job is in Q state.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Reply to the server after we purge the job, this makes sure we send changes to the server before post_sendmom() gets called.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
