### PR TITLE
Only attempt to extend job script directive lines

### DIFF
--- a/src/cmds/qsub_sup.c
+++ b/src/cmds/qsub_sup.c
@@ -284,9 +284,7 @@ get_script(FILE *file, char *script, char *prefix)
 			 */
 			if (do_dir(sopt, CMDLINE - 1, retmsg, MAXPATHLEN) != 0) {
 				fprintf(stderr, "%s", retmsg);
-				if (extend_in != NULL) {
-					free(extend_in);
-				}
+				free(extend_in);
 				free(s_in);
 				return (-1);
 			}
@@ -298,17 +296,13 @@ get_script(FILE *file, char *script, char *prefix)
 			fprintf(stderr, "qsub: error writing copy of script, %s\n",
 				tmp_name);
 			fclose(TMP_FILE);
-			if (extend_in != NULL) {
-				free(extend_in);
-			}
+			free(extend_in);
 			free(s_in);
 			return (3);
 		}
 	}
 
-	if (extend_in != NULL) {
-		free(extend_in);
-	}
+	free(extend_in);
 	free(s_in);
 	if (fclose(TMP_FILE) != 0) {
 		perror(" qsub: copy of script to tmp failed on close");

--- a/src/include/libutil.h
+++ b/src/include/libutil.h
@@ -210,6 +210,7 @@ char *pbs_strcpy(char *dest, const char *src);
  */
 char *pbs_strncpy(char *dest, const char *src, size_t n);
 
+int pbs_extendable_line(char *buf);
 char *pbs_fgets(char **pbuf, int *pbuf_size, FILE *fp);
 char *pbs_fgets_extend(char **pbuf, int *pbuf_size, FILE *fp);
 

--- a/test/tests/functional/pbs_qsub_script.py
+++ b/test/tests/functional/pbs_qsub_script.py
@@ -87,25 +87,31 @@ class TestQsubScript(TestFunctional):
         This test case ensures that only #PBS directive lines are treated
         as candidates for line extension
         """
-        script = """#!/bin/sh
-        #PBS -m n
-        # This is a test comment that shouldn't be extended \\
-        cat $0
-        """
+        script = '''\
+#!/bin/sh
+#PBS -m \\
+\\
+n
+# This is a test comment that shouldn't be extended \\
+cat $0
+'''
+        expected_script = '''\
+#!/bin/sh
+#PBS -m n
+# This is a test comment that shouldn't be extended \\
+cat $0
+'''
 
-        fn = self.du.create_temp_file(body=script, asuser=TEST_USER)
-        cmd = [self.qsub_cmd, fn]
-        rv = self.du.run_cmd(self.server.hostname,
-                             cmd=cmd,
-                             runas=TEST_USER,
-                             cwd=self.sub_dir)
-        self.assertEqual(rv['rc'], 0, 'qsub failed')
-        jid = rv['out'][0]
-        self.logger.info("Job ID: %s" % jid)
-
+        j = Job()
+        j.create_script(body=script, asuser=TEST_USER)
+        submitted_script = j.script
+        jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'F'}, id=jid, extend='x')
         job_status = self.server.status(JOB, id=jid, extend='x')
         if job_status:
             job_output_file = job_status[0]['Output_Path'].split(':')[1]
-        rc = self.du.cmp(fileA=fn, fileB=job_output_file, runas=TEST_USER)
+        expected_fn = self.du.create_temp_file(
+            body=expected_script, asuser=TEST_USER)
+        rc = self.du.cmp(fileA=expected_fn,
+                         fileB=job_output_file, runas=TEST_USER)
         self.assertEqual(rc, 0, 'cmp of job files failed')


### PR DESCRIPTION
PBS job scripts should only extend PBS directives in the script. Line
extensions in the rest of the script can change the meaning of the job
script. For example, a comment line in a shell script that ended with
'\' would cause the next line of the script to be commented out if the
line is processed with the line extension code.

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
When submitting a job script PBS should not attempt to perform line extension on the non-directive lines (non-#PBS lines). For example:

```
#!/bin/sh
#PBS -m n
        
# This is a test comment that shouldn't be extended \
cat $0
```

By incorrectly performing line extension on the comment line above, the line below it in the script becomes part of the comment and is never executed.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
We now read the job script with `pbs_fgets`, and while processing a PBS directive line (#PBS) we check if the line needs extension. To do the check, `pbs_extendable_line` has been factored out of `pbs_fgets_extend` so we can use the same logic as `pbs_fgets_extend` does.

If it's a line that requires extension, we read any further lines using `pbs_fgets_extend` and `pbs_strcat` them together for the final extended line that we should be processing.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[functional_test_output.txt](https://github.com/openpbs/openpbs/files/6307641/functional_test_output.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
