### PR TITLE
Remove mbox size check

### DIFF
--- a/src/lib/Libtpp/tpp_client.c
+++ b/src/lib/Libtpp/tpp_client.c
@@ -2324,7 +2324,6 @@ leaf_next_event_expiry(time_t now)
  * @return Error code
  * @retval 0 - Success
  * @retval -1 - Failure
- * @retval -2 - App mbox full
  *
  * @par Side Effects:
  *	None
@@ -2376,10 +2375,8 @@ send_pkt_to_app(stream_t *strm, unsigned char type, void *data, int sz, int totl
 	if (rc != 0) {
 		if (obj)
 			tpp_free_pkt(obj);
-		if (rc == -1)
-			tpp_log(LOG_CRIT, __func__, "Error writing to app mbox");
-		else if (rc == -2)
-			tpp_log(LOG_CRIT, __func__, "App mbox is full");
+
+		tpp_log(LOG_CRIT, __func__, "Error writing to app mbox");
 	}
 	return rc;
 }


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Remove the checks for mbox sizes, since it does not make much difference and is adding extra complexity (the previous versions of PBS did not have this check as well, so we won't miss any functionality). The functionality that was added needs proper overhaul to add some kind of throttling on a sending flooding receiver with messages, but the current code is not useful, and hence the removal.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Keep the code that computes the mbox sizes, just do not reject messages on a particular mbox size (just remove the checks)


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Description: Tests from given sources on platforms SUSE15, CENTOS8, CENTOS7
Platforms: SUSE15,CENTOS8,CENTOS7
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|7070|2023|3|7|0|0|2013|

Failures are present in master as well


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
