### PR TITLE
Enforce jobscript_max_size larger than SCRIPT_CHUNK_Z

### DIFF
--- a/src/server/req_quejob.c
+++ b/src/server/req_quejob.c
@@ -1395,7 +1395,7 @@ req_jobscript(struct batch_request *preq)
 #else /* server - server - server - server */
 	/* add the script to the job */
 	size = get_bytes_from_attr(&attr_jobscript_max_size);
-	if (preq->rq_ind.rq_jobfile.rq_size > size){
+	if (pj->ji_qs.ji_un.ji_newt.ji_scriptsz + preq->rq_ind.rq_jobfile.rq_size > size){
 		job_purge(pj);
 		req_reject(PBSE_JOBSCRIPTMAXSIZE, 0, preq);
 		return;

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -1435,12 +1435,13 @@ class SmokeTest(PBSTestSuite):
         """
 
         scr = []
-        scr += ['echo "This is a very long line, it will exceed 20 bytes"']
+        for i in range(2048):
+            scr += ['echo "This is a very long line, it will exceed 20 bytes"']
 
         j = Job()
         j.create_script(scr)
 
-        self.server.manager(MGR_CMD_SET, SERVER, {'jobscript_max_size': 10})
+        self.server.manager(MGR_CMD_SET, SERVER, {'jobscript_max_size': 65537})
         try:
             self.server.submit(j)
         except PbsSubmitError as e:


### PR DESCRIPTION
When comparing the size of the job script we need to compare it to the
total job script size, not the size of the current chunk.

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Currently the server `jobscript_max_size` property is broken for values over `SCRIPT_CHUNK_Z` (currently 64K) as only the size of the chunk is compared, ignoring how much of the script has already been sent to the server.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Correct the comparison to compare current chunk size + existing script size on server. Update existing smoke test for this feature to test a limit larger than `SCRIPT_CHUNK_Z` as this is the more complex case.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

[smoke_test_results.txt](https://github.com/openpbs/openpbs/files/6315797/smoke_test_results.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
