### PR TITLE
Fix job's sleep time of TestProvisioningJob_Enh

### DIFF
--- a/test/tests/functional/pbs_provisioning_enhancement.py
+++ b/test/tests/functional/pbs_provisioning_enhancement.py
@@ -132,7 +132,6 @@ e.reject()
         Test application provisioning
         """
         j = Job(TEST_USER1)
-        j.set_sleep_time(5)
         j.set_attributes({'Resource_List.select': '1:aoe=App1'})
         jid = self.server.submit(j)
 
@@ -156,7 +155,6 @@ e.reject()
         """
 
         j = Job(TEST_USER1)
-        j.set_sleep_time(10)
         j.set_attributes({'Resource_List.select': '1:aoe=osimage1'})
         jid = self.server.submit(j)
 
@@ -187,7 +185,6 @@ e.reject()
         j = Job(TEST_USER1)
         j.set_attributes({'Resource_List.select':
                           '1:ncpus=1:aoe=App1+1:ncpus=12'})
-        j.set_sleep_time(5)
         jid = self.server.submit(j)
 
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid)
@@ -211,7 +208,6 @@ e.reject()
         """
         a = {'Resource_List.select': '1:aoe=osimage1+1:ncpus=12'}
         j = Job(TEST_USER1, a)
-        j.set_sleep_time(10)
         jid = self.server.submit(j)
         self.server.expect(JOB, ATTR_execvnode, id=jid, op=SET)
         nodes = j.get_vnodes(j.exec_vnode)
@@ -238,7 +234,6 @@ e.reject()
         # and no single node have all the requested resource.
 
         j = Job(TEST_USER1)
-        j.set_sleep_time(5)
         j.set_attributes({"Resource_List.aoe": "App1",
                           "Resource_List.ncpus": 12})
         jid = self.server.submit(j)
@@ -275,7 +270,6 @@ e.reject()
 
         j = Job(TEST_USER1)
         j.set_attributes(a1)
-        j.set_sleep_time(5)
         jid = None
         try:
             jid = self.server.submit(j)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Few tests from TestProvisioningJob_Enh failed with error " no data for job_state = R && substate = 42" for job submitted.
This is due to less job's sleep time in the test case.

#### Describe Your Change
I have removed Job's sleep time set to 5s, 10s from test cases to avoid race condition.


#### Attach Test and Valgrind Logs/Output
Description: Tests from given build on platforms CENTOS8,CENTOS7,SLES15
Platforms: CENTOS8,CENTOS7,SLES15
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|7097|30|0|0|0|0|30|



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
