### PR TITLE
pbs_snapshot --obfuscate performance and bugfixes

### DIFF
--- a/test/fw/ptl/utils/pbs_snaputils.py
+++ b/test/fw/ptl/utils/pbs_snaputils.py
@@ -439,7 +439,8 @@ class ObfuscateSnapshot(object):
             plist = []
             for _ in range(ncpus):
                 acct_fpath = acct_fpaths[i]
-                p = Process(target=self._obfuscate_acct_file, args=(attrs_to_obf, acct_fpath))
+                p = Process(target=self._obfuscate_acct_file,
+                            args=(attrs_to_obf, acct_fpath))
                 p.start()
                 plist.append(p)
                 i += 1

--- a/test/fw/ptl/utils/pbs_snaputils.py
+++ b/test/fw/ptl/utils/pbs_snaputils.py
@@ -433,9 +433,7 @@ class ObfuscateSnapshot(object):
         ncpus = min(ncpus, 10)
         nfiles = len(acct_fpaths)
         i = 0
-        while True:
-            if i >= nfiles:
-                break
+        while i < nfiles:
             plist = []
             for _ in range(ncpus):
                 acct_fpath = acct_fpaths[i]

--- a/test/fw/ptl/utils/pbs_snaputils.py
+++ b/test/fw/ptl/utils/pbs_snaputils.py
@@ -566,7 +566,8 @@ class ObfuscateSnapshot(object):
                               "simply be deleted")
         jobspath = os.path.join(snap_dir, MOM_PRIV_PATH, "jobs")
         jbcontent = {}
-        jbfilelist = self.du.listdir(path=jobspath, sudo=sudo_val)
+        jbfilelist = self.du.listdir(path=jobspath, sudo=sudo_val,
+                                     fullpath=False)
         if jbfilelist is not None:
             for name in jbfilelist:
                 if name.endswith(".JB"):


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Fixes the following bugs:
- —obfuscate for filenames with sensitive data would fail to delete the file with sensitive name
- --obfuscate captures sched_logs without scrubbing all sensitive data

And --obfuscate can take a very long time to complete for sites with a large number of accounting logs and topology/ files

#### Changes
- Fixed the filename issue
- Deleted sched logs with --obfuscate
- Added multi-processing + some optimizations to make obfuscating accounting logs faster, and deleted topology/ instead of scrubbing it.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Obfuscation of a snapshot with 3.3G of accounting logs used to take a very long time, I ran it for **5.5 hours** before I killed it. Now it takes around **12.5 mins**.


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
