### PR TITLE
qdel overwrites Wforce flag

### DIFF
--- a/src/cmds/qdel.c
+++ b/src/cmds/qdel.c
@@ -198,7 +198,6 @@ delete_jobs_for_cluster(char *clusterid, char **jobids, int numids, int dfltmail
 		return pbs_errno;
 	} else if (pbs_errno)
 		show_svr_inst_fail(connect, "qdel");
-	
 
 	/* retrieve default: suppress_email from server: default_qdel_arguments */
 	mails = dfltmail;
@@ -227,7 +226,7 @@ delete_jobs_for_cluster(char *clusterid, char **jobids, int numids, int dfltmail
 		* current warg1 "nomail" should be at start
 		*/
 		strcat(warg1, warg);
-		pbs_strncpy(warg, warg1, sizeof(warg));
+		pbs_strncpy(warg, warg1, MAX_TIME_DELAY_LEN + 1);	/* size of warg is MAX_TIME_DELAY_LEN + 1 */
 
 		p_delstatus = pbs_deljoblist(connect, &jobids[numofjobs], (numids - numofjobs), warg);
 		any_failed_local = process_deljobstat(clusterid, &p_delstatus, &rmtsvr_jobid_list);

--- a/src/cmds/qdel.c
+++ b/src/cmds/qdel.c
@@ -173,7 +173,7 @@ get_mail_suppress_count(int connect)
  * @retval pbs_errno
  */
 static int
-delete_jobs_for_cluster(char *clusterid, char **jobids, int numids, int dfltmail, char *warg)
+delete_jobs_for_cluster(char *clusterid, char **jobids, int numids, int dfltmail, char *warg, int wargsz)
 {
 	int connect;
 	int mails; /* number of emails we can send */
@@ -226,8 +226,7 @@ delete_jobs_for_cluster(char *clusterid, char **jobids, int numids, int dfltmail
 		* current warg1 "nomail" should be at start
 		*/
 		strcat(warg1, warg);
-		pbs_strncpy(warg, warg1, MAX_TIME_DELAY_LEN + 1);	/* size of warg is MAX_TIME_DELAY_LEN + 1 */
-
+		pbs_strncpy(warg, warg1, wargsz);
 		p_delstatus = pbs_deljoblist(connect, &jobids[numofjobs], (numids - numofjobs), warg);
 		any_failed_local = process_deljobstat(clusterid, &p_delstatus, &rmtsvr_jobid_list);
 		pbs_delstatfree(p_delstatus);
@@ -405,7 +404,7 @@ char **envp;
 	}
 	for (iter_list = jobsbycluster; iter_list != NULL; iter_list = iter_list->next) {
 		any_failed_local = delete_jobs_for_cluster(iter_list->svrname, iter_list->jobids,
-						     iter_list->total_jobs, dfltmail, warg);
+						     iter_list->total_jobs, dfltmail, warg, sizeof(warg));
 	}
 	free_svrjobidlist(jobsbycluster, 1);
 	if (any_failed_local)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
qdel ends up sending the server 'nomailf' in rq_extend of the batch request instead of "nomailforce" when qdel is invoked with -Wforce. This happens because of an incorrect pbs_strncpy() call, we end up asking pbs_strncpy to only copy sizeof(pointer) bytes so it cuts the string short.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
fixed the pbs_strncpy call in qdel

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, WIN2K16
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|7127|4106|0|2|0|1|4103|

Description: Rerun Only Failed Tests From #7127
Platforms: CENTOS7
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|7139|2|0|0|0|0|2|


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
