### PR TITLE
pbs_snapshot: adding ability to obfuscate existing snapshots

### DIFF
--- a/test/fw/bin/pbs_snapshot
+++ b/test/fw/bin/pbs_snapshot
@@ -144,7 +144,7 @@ def get_snapshot_from_tar(logger, tarpath):
         main_snap = os.path.join(os.path.abspath(parentdir), main_snap)
         if os.path.isdir(main_snap):
             logger.error("Existing snapshot %s found, cannot extract tar" %
-                        main_snap)
+                         main_snap)
             return (main_snap, False)
         tar.extractall(path=parentdir)
 

--- a/test/fw/bin/pbs_snapshot
+++ b/test/fw/bin/pbs_snapshot
@@ -101,10 +101,10 @@ Usage: pbs_snapshot -o <path to existing output directory> [OPTION]
     --obfuscate                       obfuscates sensitive data
     --with-sudo                       Uses sudo to capture privileged data
     --version                         print version number and exit
-    --obf-snap                        path to existing snapshot directory to obfuscate
+    --obf-snap                        path to existing snapshot to obfuscate
 """
-
     print(msg)
+
 
 def create_snapshot_tar(snappath):
     """
@@ -125,6 +125,7 @@ def create_snapshot_tar(snappath):
 
     return outtar
 
+
 def get_snapshot_from_tar(logger, tarpath):
     """
     Extract the snapshot from tarfile given
@@ -134,20 +135,22 @@ def get_snapshot_from_tar(logger, tarpath):
 
     :return tuple of (string path to extracted snapshot, True/False),
         True: if the extraction was a success
-        False: if there was already a snapshot by the name of the snapshot being extracted, so
-            the tar was not untar'd
+        False: if there was already a snapshot by the name of the one
+            being extracted, so the tar was not untar'd
     """
     parentdir = Path(tarpath).parent
     tar = tarfile.open(tarpath)
     main_snap = tar.getnames()[0].split(os.sep, 1)[0]
     main_snap = os.path.join(os.path.abspath(parentdir), main_snap)
     if os.path.isdir(main_snap):
-        logger.error("Existing snapshot %s found, cannot extract tar" % main_snap)
+        logger.error("Existing snapshot %s found, cannot extract tar" %
+                     main_snap)
         tar.close()
         return (main_snap, False)
     tar.extractall(path=parentdir)
     tar.close()
     return (main_snap, True)
+
 
 def remotesnap_thread(logger, host):
     """
@@ -228,6 +231,7 @@ def obfuscate_snapshot_wrapper(snap_name, map_file=None, sudo_val=False):
         map_file = os.path.join(snappath.parent, "obfuscate.map")
     obj = ObfuscateSnapshot()
     obj.obfuscate_snapshot(snap_name, map_file, sudo_val)
+
 
 def capture_local_snap(sudo_val):
     """
@@ -343,7 +347,7 @@ if __name__ == '__main__':
         sys.exit(1)
     elif not os.path.isdir(out_dir):
         sys.stderr.write("-o path should exist,"
-                        " this is where the snapshot is captured")
+                         " this is where the snapshot is captured")
         usage()
         sys.exit(1)
 
@@ -383,10 +387,11 @@ if __name__ == '__main__':
         obfout = obf_snap + "_obf"
         if os.path.isfile(obfout + ".tgz"):
             ptl_logger.error("%s.tgz already exists, "
-            "delete it to create a new obfuscated snapshot tar" % obfout)
+                             "delete it to create a new obfuscated snapshot" %
+                             obfout)
             if istar:
                 # If input was a tar file, then we'd have extracted it
-                # So, delete the directory that was extracted from the input tar
+                # So, delete the dir that was extracted from the input tar
                 du.rm(path=obf_snap, force=True, recursive=True)
             sys.exit(1)
         du.run_copy(src=obf_snap, dest=obfout, recursive=True)

--- a/test/fw/bin/pbs_snapshot
+++ b/test/fw/bin/pbs_snapshot
@@ -50,6 +50,7 @@ import tarfile
 
 from getopt import GetoptError
 from threading import Thread
+from pathlib import Path
 
 from ptl.lib.pbs_testlib import PtlConfig
 from ptl.utils.pbs_snaputils import PBSSnapUtils, ObfuscateSnapshot
@@ -100,10 +101,53 @@ Usage: pbs_snapshot -o <path to existing output directory> [OPTION]
     --obfuscate                       obfuscates sensitive data
     --with-sudo                       Uses sudo to capture privileged data
     --version                         print version number and exit
+    --obf-snap                        path to existing snapshot directory to obfuscate
 """
 
     print(msg)
 
+def create_snapshot_tar(snappath):
+    """
+    Create a compressed tar for the snapshot given
+    Warning: Deletes the snapshot directory after creating its tar
+
+    snappath: path to snapshot to compress and tar
+    type: str
+
+    return: str - path to the compressed tar file
+    """
+    outtar = snappath + ".tgz"
+    with tarfile.open(outtar, "w:gz") as tar:
+        tar.add(snappath, arcname=os.path.basename(snappath))
+
+    # Delete the snapshot directory itself
+    du.rm(path=snappath, recursive=True, force=True)
+
+    return outtar
+
+def get_snapshot_from_tar(logger, tarpath):
+    """
+    Extract the snapshot from tarfile given
+
+    :tarpath - path to the tar
+    :type - str
+
+    :return tuple of (string path to extracted snapshot, True/False),
+        True: if the extraction was a success
+        False: if there was already a snapshot by the name of the snapshot being extracted, so
+            the tar was not untar'd
+    """
+    parentdir = Path(tarpath).parent
+    tar = tarfile.open(tarpath)
+    main_snap = tar.getnames()[0].split(os.sep, 1)[0]
+    main_snap = os.path.join(os.path.abspath(parentdir), main_snap)
+    if os.path.isdir(main_snap):
+        logger.error("Existing snapshot %s found, cannot extract tar" % main_snap)
+        tar.close()
+        return (main_snap, False)
+    tar.extractall(path=parentdir)
+    tar.close()
+    return (main_snap, True)
 
 def remotesnap_thread(logger, host):
     """
@@ -174,6 +218,17 @@ def remotesnap_thread(logger, host):
     du.rm(hostname=host, path=snap_home, recursive=True, force=True)
 
 
+def obfuscate_snapshot_wrapper(snap_name, map_file=None, sudo_val=False):
+    if map_file is None:
+        snappath = Path(snap_name)
+        if snappath is None:
+            sys.stderr.write("snapshot path not found")
+            usage()
+            sys.exit(1)
+        map_file = os.path.join(snappath.parent, "obfuscate.map")
+    obj = ObfuscateSnapshot()
+    obj.obfuscate_snapshot(snap_name, map_file, sudo_val)
+
 def capture_local_snap(sudo_val):
     """
     Helper method to capture snapshot of the local host
@@ -195,16 +250,10 @@ def capture_local_snap(sudo_val):
         snap_name = snap_utils.capture_all()
 
     if obfuscate:
-        obj = ObfuscateSnapshot()
-        obj.obfuscate_snapshot(snap_name, map_file, sudo_val)
+        obfuscate_snapshot_wrapper(snap_name, map_file, sudo_val)
         if additional_hosts is None:
             # Now create the tar
-            outtar = snap_name + ".tgz"
-            with tarfile.open(outtar, "w:gz") as tar:
-                tar.add(snap_name, arcname=os.path.basename(snap_name))
-            # Delete the snapshot directory itself
-            du.rm(path=snap_name, recursive=True, force=True)
-            snap_name = outtar
+            snap_name = create_snapshot_tar(snap_name)
 
     return snap_name
 
@@ -224,6 +273,7 @@ if __name__ == '__main__':
     with_sudo = False
     du = DshUtils()
     basic = False
+    obf_snap = None
 
     PtlConfig()
 
@@ -232,7 +282,7 @@ if __name__ == '__main__':
         sopt = "d:H:l:o:h"
         lopt = ["basic", "accounting-logs=", "daemon-logs=", "help",
                 "additional-hosts=", "map=", "obfuscate", "with-sudo",
-                "version"]
+                "version", "obf-snap="]
         opts, args = getopt.getopt(sys.argv[1:], sopt, lopt)
     except GetoptError:
         usage()
@@ -273,29 +323,29 @@ if __name__ == '__main__':
         elif o == "--version":
             print(ptl.__version__)
             sys.exit(0)
+        elif o == "--obf-snap":
+            obf_snap = val
         else:
             sys.stderr.write("Unrecognized option")
             usage()
             sys.exit(1)
 
-    # -o is a mandatory option, so make sure that it was provided
+    if obf_snap:
+        obfuscate = True
+        path = Path(obf_snap)
+        if path:
+            out_dir = str(path.parent)
+
+    # Check that parent of snapshot directory exists
     if out_dir is None:
         sys.stderr.write("-o option not provided")
         usage()
         sys.exit(1)
     elif not os.path.isdir(out_dir):
         sys.stderr.write("-o path should exist,"
-                         " this is where the snapshot is captured")
+                        " this is where the snapshot is captured")
         usage()
         sys.exit(1)
-
-    if not basic:
-        # Capture 5 days of daemon logs and 30 days of accounting logs
-        # by default
-        if daemon_logs is None:
-            daemon_logs = 5
-        if acct_logs is None:
-            acct_logs = 30
 
     fmt = '%(asctime)-15s %(levelname)-8s %(message)s'
     level_int = CliUtils.get_logging_level(log_level)
@@ -315,6 +365,47 @@ if __name__ == '__main__':
         out_abspath = os.path.abspath(out_dir)
         if map_file is None:
             map_file = os.path.join(out_abspath, "obfuscate.map")
+
+    # Obfuscate an existing snapshot
+    if obf_snap:
+        istar = False
+        if os.path.isfile(obf_snap):
+            if tarfile.is_tarfile(obf_snap):
+                istar = True
+                obf_snap, ret = get_snapshot_from_tar(ptl_logger, obf_snap)
+                if ret is False:
+                    sys.exit(1)
+            else:
+                ptl_logger.error("Path is not a valid snapshot")
+                sys.exit(1)
+
+        # The obfuscated snapshot will be at path: <obf_snap>_obf
+        obfout = obf_snap + "_obf"
+        if os.path.isfile(obfout + ".tgz"):
+            ptl_logger.error("%s.tgz already exists, "
+            "delete it to create a new obfuscated snapshot tar" % obfout)
+            if istar:
+                # If input was a tar file, then we'd have extracted it
+                # So, delete the directory that was extracted from the input tar
+                du.rm(path=obf_snap, force=True, recursive=True)
+            sys.exit(1)
+        du.run_copy(src=obf_snap, dest=obfout, recursive=True)
+        obfuscate_snapshot_wrapper(obfout, map_file, with_sudo)
+        # Create the tar
+        obfout = create_snapshot_tar(obfout)
+        if istar:
+            du.rm(path=obf_snap, force=True, recursive=True)
+
+        print("Obfuscated snapshot at: " + str(obfout))
+        sys.exit(0)
+
+    if not basic:
+        # Capture 5 days of daemon logs and 30 days of accounting logs
+        # by default
+        if daemon_logs is None:
+            daemon_logs = 5
+        if acct_logs is None:
+            acct_logs = 30
 
     if additional_hosts is not None:
         # Capture snapshot of remote hosts in addition to the main host
@@ -345,11 +436,8 @@ if __name__ == '__main__':
             # We need to copy additional hosts' snapshosts in
             # the main snapshot, so un-tar the snapshot
             p_snappath = os.path.join(out_dir, primary_host + "_snapshot.tgz")
-            tar = tarfile.open(p_snappath)
-            main_snap = tar.getnames()[0].split(os.sep, 1)[0]
-            main_snap = os.path.join(os.path.abspath(out_dir), main_snap)
-            tar.extractall(path=out_dir)
-            tar.close()
+            main_snap, _ = get_snapshot_from_tar(ptl_logger, p_snappath)
+
             # Delete the tar file
             du.rm(path=p_snappath, force=True)
 
@@ -363,12 +451,7 @@ if __name__ == '__main__':
                 du.rm(path=host_snappath, force=True)
 
         # Finally, create a tar of the whole snapshot
-        outtar = main_snap + ".tgz"
-        with tarfile.open(outtar, "w:gz") as tar:
-            tar.add(main_snap, arcname=os.path.basename(main_snap))
-
-        # Delete the snapshot directory itself
-        du.rm(path=main_snap, recursive=True, force=True)
+        outtar = create_snapshot_tar(main_snap)
     elif not du.is_localhost(primary_host):
         # Capture snapshot of a remote host
         remotesnap_thread(ptl_logger, primary_host)

--- a/test/fw/bin/pbs_snapshot
+++ b/test/fw/bin/pbs_snapshot
@@ -139,16 +139,15 @@ def get_snapshot_from_tar(logger, tarpath):
             being extracted, so the tar was not untar'd
     """
     parentdir = Path(tarpath).parent
-    tar = tarfile.open(tarpath)
-    main_snap = tar.getnames()[0].split(os.sep, 1)[0]
-    main_snap = os.path.join(os.path.abspath(parentdir), main_snap)
-    if os.path.isdir(main_snap):
-        logger.error("Existing snapshot %s found, cannot extract tar" %
-                     main_snap)
-        tar.close()
-        return (main_snap, False)
-    tar.extractall(path=parentdir)
-    tar.close()
+    with tarfile.open(tarpath) as tar:
+        main_snap = tar.getnames()[0].split(os.sep, 1)[0]
+        main_snap = os.path.join(os.path.abspath(parentdir), main_snap)
+        if os.path.isdir(main_snap):
+            logger.error("Existing snapshot %s found, cannot extract tar" %
+                        main_snap)
+            return (main_snap, False)
+        tar.extractall(path=parentdir)
+
     return (main_snap, True)
 
 
@@ -461,10 +460,10 @@ if __name__ == '__main__':
         # Capture snapshot of a remote host
         remotesnap_thread(ptl_logger, primary_host)
         p_snappath = os.path.join(out_dir, primary_host + "_snapshot.tgz")
-        tar = tarfile.open(p_snappath)
-        main_snap = tar.getnames()[0].split(os.sep, 1)[0]
-        main_snap = os.path.join(os.path.abspath(out_dir), main_snap)
-        tar.close()
+        with tarfile.open(p_snappath) as tar:
+            main_snap = tar.getnames()[0].split(os.sep, 1)[0]
+            main_snap = os.path.join(os.path.abspath(out_dir), main_snap)
+
         outtar = main_snap + ".tgz"
 
         # remotesnap_thread named the tar as <hostname>_snapshot.tgz

--- a/test/tests/functional/pbs_snapshot_unittest.py
+++ b/test/tests/functional/pbs_snapshot_unittest.py
@@ -230,7 +230,7 @@ class TestPBSSnapshot(TestFunctional):
 
     def check_snap_obfuscated(self, snap_dir, real_values):
         """
-        Helper function to check that a snapshot doesn't contain any sensitive values
+        Check that a snapshot doesn't contain any sensitive values
 
         :param snap_dir: path to the snapshot dir
         :type str
@@ -1032,7 +1032,7 @@ pbs.logmsg(pbs.EVENT_DEBUG,"%s")
         self.du.rm(path=snap_obf, force=True, recursive=True)
         self.du.rm(path=snap_dir, force=True, recursive=True)
 
-        # Now, do obfuscate using the tar file directly instead of the snapshot dir
+        # Now, obfuscate using the tar directly instead of the snapshot dir
         self.du.rm(path=snap_obf_tar, force=True)
         (_, snap_obf) = self.take_snapshot(obf_snap=snap_tar)
         self.check_snap_obfuscated(snap_obf, real_values)

--- a/test/tests/functional/pbs_snapshot_unittest.py
+++ b/test/tests/functional/pbs_snapshot_unittest.py
@@ -150,7 +150,7 @@ class TestPBSSnapshot(TestFunctional):
 
     def take_snapshot(self, acct_logs=None, daemon_logs=None,
                       obfuscate=None, with_sudo=True, hosts=None,
-                      primary_host=None, basic=None):
+                      primary_host=None, basic=None, obf_snap=None):
         """
         Take a snapshot using pbs_snapshot command
 
@@ -168,32 +168,34 @@ class TestPBSSnapshot(TestFunctional):
         :type primary_host: str
         :param basic: use --basic option
         :type bool
+        :param obf_snap: path to existing snapshot to obfuscate
+        :type str
         :return a tuple of name of tarball and snapshot directory captured:
             (tarfile, snapdir)
         """
         if self.pbs_snapshot_path is None:
             self.skip_test("pbs_snapshot not found")
 
-        snap_cmd = [self.pbs_snapshot_path, "-o", self.parent_dir]
-        if acct_logs is not None:
-            snap_cmd.append("--accounting-logs=" + str(acct_logs))
-
-        if daemon_logs is not None:
-            snap_cmd.append("--daemon-logs=" + str(daemon_logs))
-
-        if obfuscate:
-            snap_cmd.append("--obfuscate")
+        if obf_snap:
+            snap_cmd = [self.pbs_snapshot_path, "--obf-snap", obf_snap]
+        else:
+            snap_cmd = [self.pbs_snapshot_path, "-o", self.parent_dir]
+            if acct_logs is not None:
+                snap_cmd.append("--accounting-logs=" + str(acct_logs))
+            if daemon_logs is not None:
+                snap_cmd.append("--daemon-logs=" + str(daemon_logs))
+            if obfuscate:
+                snap_cmd.append("--obfuscate")
+            if hosts is not None:
+                hosts_str = ",".join(hosts)
+                snap_cmd.append("--additional-hosts=" + hosts_str)
+            if primary_host is not None:
+                snap_cmd.append("-H " + primary_host)
+            if basic is not None:
+                snap_cmd.append("--basic")
 
         if with_sudo:
             snap_cmd.append("--with-sudo")
-
-        if hosts is not None:
-            hosts_str = ",".join(hosts)
-            snap_cmd.append("--additional-hosts=" + hosts_str)
-        if primary_host is not None:
-            snap_cmd.append("-H " + primary_host)
-        if basic is not None:
-            snap_cmd.append("--basic")
 
         ret = self.du.run_cmd(cmd=snap_cmd, logerr=False, as_script=True)
         self.assertEqual(ret['rc'], 0)
@@ -201,7 +203,7 @@ class TestPBSSnapshot(TestFunctional):
         # Get the name of the tarball that was created
         # pbs_snapshot prints to stdout only the following:
         #     "Snapshot available at: <path to tarball>"
-        self.assertTrue(len(ret['out']) > 0)
+        self.assertTrue(len(ret['out']) > 0, str(ret))
         snap_out = ret['out'][0]
         output_tar = snap_out.split(":")[1]
         output_tar = output_tar.strip()
@@ -225,6 +227,34 @@ class TestPBSSnapshot(TestFunctional):
         self.snaptars.append(output_tar)
 
         return (output_tar, snap_dir)
+
+    def check_snap_obfuscated(self, snap_dir, real_values):
+        """
+        Helper function to check that a snapshot doesn't contain any sensitive values
+
+        :param snap_dir: path to the snapshot dir
+        :type str
+        :param real_values: map of {attribute name: sensitive value}
+        :type dict
+        """
+        values = real_values.values()
+        for val_list in values:
+            for val in val_list:
+                # Just do a grep for the value in the snapshot
+                cmd = ["grep", "-wR", "\'" + str(val) + "\'", snap_dir]
+                ret = self.du.run_cmd(cmd=cmd, level=logging.DEBUG)
+                # grep returns 2 if an error occurred
+                self.assertNotEqual(ret["rc"], 2, "grep failed!")
+                self.assertIn(ret["out"], ["", None, []], str(val) +
+                              " was not obfuscated. Real values:\n" +
+                              str(real_values))
+                # Also make sure that no filenames contain the sensitive val
+                cmd = ["find", snap_dir, "-name", "\'*" + str(val) + "*\'"]
+                ret = self.du.run_cmd(cmd=cmd, level=logging.DEBUG)
+                self.assertEqual(ret["rc"], 0, "find command failed!")
+                self.assertIn(ret["out"], ["", None, []], str(val) +
+                              " was not obfuscated. Real values:\n" +
+                              str(real_values))
 
     def test_capture_server(self):
         """
@@ -914,24 +944,7 @@ pbs.logmsg(pbs.EVENT_DEBUG,"%s")
         (_, snap_dir) = self.take_snapshot(obfuscate=True)
 
         # Make sure that none of the sensitive values were captured
-        values = real_values.values()
-        for val_list in values:
-            for val in val_list:
-                # Just do a grep for the value in the snapshot
-                cmd = ["grep", "-wR", "\'" + str(val) + "\'", snap_dir]
-                ret = self.du.run_cmd(cmd=cmd, level=logging.DEBUG)
-                # grep returns 2 if an error occurred
-                self.assertNotEqual(ret["rc"], 2, "grep failed!")
-                self.assertIn(ret["out"], ["", None, []], str(val) +
-                              " was not obfuscated. Real values:\n" +
-                              str(real_values))
-                # Also make sure that no filenames contain the sensitive val
-                cmd = ["find", snap_dir, "-name", "\'*" + str(val) + "*\'"]
-                ret = self.du.run_cmd(cmd=cmd, level=logging.DEBUG)
-                self.assertEqual(ret["rc"], 0, "find command failed!")
-                self.assertIn(ret["out"], ["", None, []], str(val) +
-                              " was not obfuscated. Real values:\n" +
-                              str(real_values))
+        self.check_snap_obfuscated(snap_dir, real_values)
 
     def test_basic_option(self):
         """
@@ -976,6 +989,53 @@ pbs.logmsg(pbs.EVENT_DEBUG,"%s")
 
         # Bring the rest of daemons up otherwise tearDown will error out
         self.server.pi.initd(op="start", daemon="all")
+
+    def test_obfuscate_existing(self):
+        """
+        Test the --obf-snap option which obfuscates an existing snapshot
+        """
+        if self.pbs_snapshot_path is None:
+            self.skip_test("pbs_snapshot not found")
+
+        now = int(time.time())
+
+        # Submit a job with sensitive attributes set
+        a = {ATTR_project: 'p1', ATTR_A: 'a1', ATTR_g: TSTGRP0,
+             ATTR_M: TEST_USER, ATTR_u: TEST_USER,
+             ATTR_l + ".walltime": "00:01:00", ATTR_S: "/bin/bash"}
+        j = Job(TEST_USER, attrs=a)
+        j.set_sleep_time(1000)
+        self.server.submit(j)
+
+        # Add job's attributes to the list
+        # TEST_USER belongs to group TESTGRP0
+        real_values = {}
+        real_values[ATTR_euser] = [TEST_USER]
+        real_values[ATTR_egroup] = [TSTGRP0]
+        real_values[ATTR_project] = ['p1']
+        real_values[ATTR_A] = ['a1']
+        real_values[ATTR_g] = [TSTGRP0]
+        real_values[ATTR_M] = [TEST_USER]
+        real_values[ATTR_u] = [TEST_USER]
+        real_values[ATTR_owner] = [TEST_USER, self.server.hostname]
+        real_values[ATTR_exechost] = [self.server.hostname]
+        real_values[ATTR_S] = ["/bin/bash"]
+
+        # Take a normal snapshot
+        (snap_tar, snap_dir) = self.take_snapshot(0, 0, with_sudo=True)
+
+        # Now, obfuscate the snapshot that we just took
+        (snap_obf_tar, snap_obf) = self.take_snapshot(obf_snap=snap_dir)
+
+        # Make sure that none of the sensitive values were captured
+        self.check_snap_obfuscated(snap_obf, real_values)
+        self.du.rm(path=snap_obf, force=True, recursive=True)
+        self.du.rm(path=snap_dir, force=True, recursive=True)
+
+        # Now, do obfuscate using the tar file directly instead of the snapshot dir
+        self.du.rm(path=snap_obf_tar, force=True)
+        (_, snap_obf) = self.take_snapshot(obf_snap=snap_tar)
+        self.check_snap_obfuscated(snap_obf, real_values)
 
     def tearDown(self):
         # Delete the snapshot directories and tarballs created


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Often times, it’s useful to be able to obfuscate an existing snapshot. For instance: user took a snapshot of a hard to reproduce issue but forgot to run pbs_snapshot in obfuscation mode. Since the issue is hard to reproduce, it’d be much easier if user could just obfuscate the already captured snapshot. So, this will add the ability to pbs_snapshot to be able to take an existing snapshot and obfuscate it.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
See design doc for details

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
https://openpbs.atlassian.net/wiki/spaces/PD/pages/2732032016/pbs+snapshot+Add+the+ability+to+obfuscate+existing+snapshots

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[test_obfuscate_existing.log](https://github.com/openpbs/openpbs/files/6328185/test_obfuscate_existing.log)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
