### PR TITLE
Handle shared default $jobdir_root location.

### DIFF
--- a/src/include/mom_func.h
+++ b/src/include/mom_func.h
@@ -84,7 +84,7 @@ extern char	pbs_tmpdir[];
 /* used by mom_main.c and start_exec.c for PBS_JOBDIR */
 extern char	pbs_jobdir_root[];
 extern int	pbs_jobdir_root_shared;
-#define JOBDIR_DEFAULT	"default"
+#define JOBDIR_DEFAULT	"PBS_USER_HOME"
 
 /* test bits */
 #define PBSQA_DELJOB_SLEEP	1

--- a/src/include/mom_func.h
+++ b/src/include/mom_func.h
@@ -84,7 +84,7 @@ extern char	pbs_tmpdir[];
 /* used by mom_main.c and start_exec.c for PBS_JOBDIR */
 extern char	pbs_jobdir_root[];
 extern int	pbs_jobdir_root_shared;
-#define JOBDIR_DEFAULT	"<default>"
+#define JOBDIR_DEFAULT	"default"
 
 /* test bits */
 #define PBSQA_DELJOB_SLEEP	1

--- a/src/include/mom_func.h
+++ b/src/include/mom_func.h
@@ -84,6 +84,7 @@ extern char	pbs_tmpdir[];
 /* used by mom_main.c and start_exec.c for PBS_JOBDIR */
 extern char	pbs_jobdir_root[];
 extern int	pbs_jobdir_root_shared;
+#define JOBDIR_DEFAULT	"<default>"
 
 /* test bits */
 #define PBSQA_DELJOB_SLEEP	1

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -2811,7 +2811,7 @@ set_jobdir_root(char *value)
 	}
 
 #if !defined(DEBUG) && !defined(NO_SECURITY_CHECK)
-	if (verify_dir(cleaned_value, 1, 1, 0, 1)) {
+	if ((strcmp(cleaned_value, JOBDIR_DEFAULT) != 0) && (verify_dir(cleaned_value, 1, 1, 0, 1))) {
 		free(cleaned_value);
 		return HANDLER_FAIL;
 	}

--- a/src/resmom/stage_func.c
+++ b/src/resmom/stage_func.c
@@ -1215,14 +1215,15 @@ rmjobdir(char *jobid, char *jobdir, uid_t uid, gid_t gid, int check_shared)
 	if (check_shared &&
 	    (pbs_jobdir_root[0] != '\0') &&
 	    pbs_jobdir_root_shared &&
-	    (strncmp(pbs_jobdir_root, jobdir, strlen(pbs_jobdir_root)) == 0)) {
+	    ((strcmp(pbs_jobdir_root, JOBDIR_DEFAULT) == 0) ||
+	     (strncmp(pbs_jobdir_root, jobdir, strlen(pbs_jobdir_root)) == 0))) {
 		log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_JOB, LOG_DEBUG, jobid?jobid:"", "shared jobdir %s to be removed by primary mom", jobdir);
 
 		return;
 	}
 
 #ifndef WIN32
-	if (pbs_jobdir_root[0] == '\0') {
+	if ((pbs_jobdir_root[0] == '\0') || (strcmp(pbs_jobdir_root, JOBDIR_DEFAULT) == 0)) {
 		/* In user's home, need to be user */
 		/* The rest must be done as the User */
 		if (impersonate_user(uid, gid) == -1)
@@ -1233,7 +1234,7 @@ rmjobdir(char *jobid, char *jobdir, uid_t uid, gid_t gid, int check_shared)
 	/* Hello, is any body there? */
 	if (stat(jobdir, &sb) == -1) {
 #ifndef WIN32
-		if (pbs_jobdir_root[0] == '\0') {
+		if ((pbs_jobdir_root[0] == '\0') || (strcmp(pbs_jobdir_root, JOBDIR_DEFAULT) == 0)) {
 			/* oops, have to go back to being root */
 			revert_from_user();
 		}
@@ -1268,7 +1269,7 @@ rmjobdir(char *jobid, char *jobdir, uid_t uid, gid_t gid, int check_shared)
 
 	if (strncmp(nameptr, "pbs.", 4) != 0) {
 #ifndef WIN32
-		if (pbs_jobdir_root[0] == '\0')
+		if ((pbs_jobdir_root[0] == '\0') || (strcmp(pbs_jobdir_root, JOBDIR_DEFAULT) == 0))
 			revert_from_user();
 #endif
 		sprintf(log_buffer, "%s is not a staging and execution directory", jobdir);
@@ -1307,7 +1308,7 @@ rmjobdir(char *jobid, char *jobdir, uid_t uid, gid_t gid, int check_shared)
 	pid = fork();
 	if (pid != 0) {	/* parent or error */
 		int err = errno;
-		if (pbs_jobdir_root[0] == '\0')
+		if ((pbs_jobdir_root[0] == '\0') || (strcmp(pbs_jobdir_root, JOBDIR_DEFAULT) == 0))
 			revert_from_user();
 
 		if (pid < 0)

--- a/src/resmom/start_exec.c
+++ b/src/resmom/start_exec.c
@@ -762,7 +762,7 @@ jobdirname(char *sequence, char *homedir)
 	 **	sprintf(dir, "%s/%s.%s", pbs_jobdir_root, sequence, unique);
 	 */
 
-	if (pbs_jobdir_root[0] != '\0') {
+	if ((pbs_jobdir_root[0] != '\0') && (strcmp(pbs_jobdir_root, JOBDIR_DEFAULT) != 0)) {
 		sprintf(dir, "%s/pbs.%s.%s", pbs_jobdir_root, sequence, FAKE_RANDOM);
 	} else if ((homedir != NULL) && (*homedir != '\0')) {
 		/*
@@ -997,7 +997,7 @@ mkjobdir(char *jobid, char *jobdir, uid_t uid, gid_t gid)
 {
 	int	rc;
 
-	if (pbs_jobdir_root[0] != '\0') {
+	if ((pbs_jobdir_root[0] != '\0') && (strcmp(pbs_jobdir_root, JOBDIR_DEFAULT) != 0)) {
 
 		/* making the directory as root in a secure root owned dir */
 

--- a/test/tests/functional/pbs_qsub_opts_args.py
+++ b/test/tests/functional/pbs_qsub_opts_args.py
@@ -254,6 +254,6 @@ bhtiusabsdlg' % (os.environ['HOME'])
         """
         Test submission of job with sandbox=PRIVATE,
         and moms have $jobdir_root set to shared,
-        with location set to default.
+        with location set to PBS_USER_HOME.
         """
-        self.jobdir_shared_body("default")
+        self.jobdir_shared_body("PBS_USER_HOME")

--- a/test/tests/functional/pbs_qsub_opts_args.py
+++ b/test/tests/functional/pbs_qsub_opts_args.py
@@ -254,6 +254,6 @@ bhtiusabsdlg' % (os.environ['HOME'])
         """
         Test submission of job with sandbox=PRIVATE,
         and moms have $jobdir_root set to shared,
-        with location set to <default>.
+        with location set to default.
         """
-        self.jobdir_shared_body("<default>")
+        self.jobdir_shared_body("default")

--- a/test/tests/functional/pbs_qsub_opts_args.py
+++ b/test/tests/functional/pbs_qsub_opts_args.py
@@ -107,7 +107,7 @@ class TestQsubOptionsArguments(TestFunctional):
              ATTR_sandbox: 'PRIVATE',
              }
         j = Job(TEST_USER, attrs=a)
-        j.set_sleep_time(10)
+        j.set_sleep_time(30)
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
         attribs = self.server.status(JOB, id=jid)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* If a job has been submitted with sandbox attribute set to PRIVATE, (i.e. qsub -W sandbox=PRIVATE), a special job’s staging and execution directory is created under the directory specified in MoM $jobdir_root configuration option.
* When $jobdir_root is not set,  the location defaults to the user's home directory. 
* When a site sets up user's home directory to be on a shared location, calling pbs_release_nodes would be a problem.
* The sister mom on the the released node, would delete the files in the shared home directory location that is also seen by primary mom. 
* In this case, the primary mom would lose the ability to  stage out files and return stdout/stderr files, and executing job could actually abort.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* Given mom config file option:
```
         $jobdir_root <stage directory root> shared
```
A special <stage directory root> value of "*PBS_USER_HOME*" is introduced to refer to the default location set up by PBS, which is the user's home directory.  
* So for example,

         $jobdir_root PBS_USER_HOME shared

this means the sister mom would not cleanup the job files under the default user's home directory,  which is shared, when a request to delete the job on the node managed by that sister mom is received. Only the primary mom would take care of cleaning up the files.
#### Link to Design Doc
Added the "PBS_USER_HOME" keyword to:
 [Option for sister moms to not delete job's files sitting on shared location](https://openpbs.atlassian.net/wiki/spaces/PD/pages/1979482121/Option+for+sister+moms+to+not+delete+job+s+files+sitting+on+shared+location)


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

* [valgrind.msmom.txt](https://github.com/openpbs/openpbs/files/6328630/valgrind.msmom.txt)
* [valgrind.sismom.txt](https://github.com/openpbs/openpbs/files/6328631/valgrind.sismom.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
