### PR TITLE
Reservation test fails on cpuset machines

### DIFF
--- a/test/tests/functional/pbs_reservations.py
+++ b/test/tests/functional/pbs_reservations.py
@@ -789,9 +789,14 @@ class TestReservations(TestFunctional):
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
 
+        if self.mom.is_cpuset_mom():
+            select_val = vnode_val
+        else:
+            select_val = '1:ncpus=1'
+
         # Submit a reservation that will start after the job starts running
         rid1 = self.submit_reservation(user=TEST_USER,
-                                       select='1:ncpus=1',
+                                       select=select_val,
                                        start=now + 360,
                                        end=now + 3600)
 

--- a/test/tests/functional/pbs_reservations.py
+++ b/test/tests/functional/pbs_reservations.py
@@ -776,6 +776,9 @@ class TestReservations(TestFunctional):
         vnode_val = None
         if self.mom.is_cpuset_mom():
             vnode_val = '1:ncpus=1:vnode=' + self.server.status(NODE)[1]['id']
+            select_val = vnode_val
+        else:
+            select_val = '1:ncpus=1'
 
         now = int(time.time())
         # Submit a job but do not specify walltime, scheduler will consider
@@ -788,11 +791,6 @@ class TestReservations(TestFunctional):
         j = Job(TEST_USER, attrs=a)
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
-
-        if self.mom.is_cpuset_mom():
-            select_val = vnode_val
-        else:
-            select_val = '1:ncpus=1'
 
         # Submit a reservation that will start after the job starts running
         rid1 = self.submit_reservation(user=TEST_USER,


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
A reservation test fails on a cpuset machine


#### Describe Your Change
On a cpuset machine the test submits a job to run on a particular vnode but it does not submit the reservation to also run on the same vnode. Because of this, the reservation gets confirmed elsewhere and the test fails.

#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
[test_resv.txt](https://github.com/openpbs/openpbs/files/6339730/test_resv.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
