### PR TITLE
Remove starving support

### DIFF
--- a/src/lib/Libecl/ecl_verify_values.c
+++ b/src/lib/Libecl/ecl_verify_values.c
@@ -88,7 +88,6 @@ const char *preempt_prio_names[] = {
 	"fairshare",
 	"queue_softlimits",
 	"server_softlimits",
-	"starving_jobs",
 	"express_queue",
 };
 static long ecl_pbs_max_licenses = PBS_MAX_LICENSING_LICENSES;

--- a/src/scheduler/check.h
+++ b/src/scheduler/check.h
@@ -169,13 +169,6 @@ int dedtime_conflict(resource_resv *resresv);
  */
 enum sched_error_code check_ded_time_boundary(resource_resv *job);
 
-
-/*
- *      check_starvation - if there are starving job, don't allow jobs to run
- *                         which conflict with the starving job (i.e. backfill)
- */
-int check_backfill(resource_resv *resresv, server_info *sinfo);
-
 /*
  *      check_prime_queue - Check primetime status of the queue.  If the queue
  *                          is a primetime queue and it is primetime or if the

--- a/src/scheduler/config.h
+++ b/src/scheduler/config.h
@@ -137,7 +137,6 @@
 #define PARSE_PEER_QUEUE "peer_queue"
 #define PARSE_PEER_TRANSLATION "peer_translation"
 #define PARSE_NODE_GROUP_KEY "node_group_key"
-#define PARSE_DONT_PREEMPT_STARVING "dont_preempt_starving"
 #define PARSE_ENFORCE_NO_SHARES "fairshare_enforce_no_shares"
 #define PARSE_STRICT_ORDERING "strict_ordering"
 #define PARSE_RES_UNSET_INFINITE "resource_unset_infinite"
@@ -166,8 +165,6 @@
 #define PARSE_ALLOW_AOE_CALENDAR "allow_aoe_calendar"
 
 /* deprecated */
-#define PARSE_PREEMPT_STARVING "preempt_starving"
-#define PARSE_PREEMPT_FAIRSHARE "preempt_fairshare"
 #define PARSE_STRICT_FIFO "strict_fifo"
 
 

--- a/src/scheduler/constant.h
+++ b/src/scheduler/constant.h
@@ -80,7 +80,7 @@ enum skip
 	SKIP_NOTHING,
 	/* Value used to know whether reservations are already scheduled or not */
 	SKIP_RESERVATIONS = 1,
-	/* Value used to know whether express, preempted, starving jobs are already scheduled or not */
+	/* Value used to know whether express, preempted, are already scheduled or not */
 	SKIP_NON_NORMAL_JOBS = 2
 };
 
@@ -471,7 +471,6 @@ enum preempt
 	PREEMPT_OVER_FS_LIMIT,	/* jobs over their fairshare of the machine */
 	PREEMPT_OVER_QUEUE_LIMIT,	/* jobs over queue run limits (maxrun etc) */
 	PREEMPT_OVER_SERVER_LIMIT,	/* jobs over server run limits */
-	PREEMPT_STARVING,		/* starving jobs */
 	PREEMPT_EXPRESS,		/* jobs in express queue */
 	PREEMPT_QRUN,			/* job is being qrun */
 	PREEMPT_ERR,			/* error occurred during preempt computation */

--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -1167,7 +1167,6 @@ struct config
 	std::unordered_set<std::string> res_to_check;		/* the resources schedule on */
 	std::unordered_set<resdef *> resdef_to_check;		/* the res to schedule on in def form */
 	std::unordered_set<std::string> ignore_res;		/* resources - unset implies infinite */
-	time_t max_starve;			/* starving threshold */
 	/* order to preempt jobs */
 	std::vector<sort_info> prime_node_sort;	/* node sorting primetime */
 	std::vector<sort_info> non_prime_node_sort;	/* node sorting non primetime */

--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -316,7 +316,6 @@ struct status
 	bool strict_fifo:1;		/* deprecated */
 	bool strict_ordering:1;
 	bool fair_share:1;
-	bool help_starving_jobs:1;
 	bool backfill:1;
 	bool sort_nodes:1;
 	bool backfill_prime:1;
@@ -566,7 +565,6 @@ struct job_info
 	bool can_requeue:1;	/* this job can be requeued */
 	bool can_suspend:1;	/* this job can be suspended */
 
-	bool is_starving:1;		/* job has waited passed starvation time */
 	bool is_array:1;		/* is the job a job array object */
 	bool is_subjob:1;		/* is a subjob of a job array */
 
@@ -1124,8 +1122,6 @@ struct config
 	bool non_prime_so:1;
 	bool prime_fs:1;		/* fair share */
 	bool non_prime_fs:1;
-	bool prime_hsv:1;		/* help starving jobs */
-	bool non_prime_hsv:1;
 	bool prime_bf:1;		/* back filling */
 	bool non_prime_bf:1;
 	bool prime_sn:1;		/* sort nodes by priority */
@@ -1136,9 +1132,6 @@ struct config
 	bool non_prime_pre:1;
 	bool update_comments:1;	/* should we update comments or not */
 	bool prime_exempt_anytime_queues:1; /* backfill affects anytime queues */
-	bool preempt_starving:1;	/* once jobs become starving, it can preempt */
-	bool preempt_fairshare:1; /* normal jobs can preempt over usage jobs */
-	bool dont_preempt_starving:1; /* don't preempt staving jobs */
 	bool enforce_no_shares:1;	/* jobs with 0 shares don't run */
 	bool node_sort_unused:1;	/* node sorting by unused/assigned is used */
 	bool resv_conf_ignore:1;	/* if we want to ignore dedicated time when confirming reservations.  Move to enum if ever expanded */

--- a/src/scheduler/fifo.h
+++ b/src/scheduler/fifo.h
@@ -127,7 +127,7 @@ resource_resv *next_job(status *policy, server_info *sinfo, int flag);
 int find_runnable_resresv_ind(resource_resv **resresv_arr, int start_index);
 
 /*
- *	find_non_normal_job_ind - find the index of the next runnable express,preempted,starving job
+ *	find_non_normal_job_ind - find the index of the next runnable express,preempted
  */
 int find_non_normal_job_ind(resource_resv **resresv_arr, int start_index);
 

--- a/src/scheduler/globals.cpp
+++ b/src/scheduler/globals.cpp
@@ -108,7 +108,6 @@ const struct enum_conv preempt_prio_info[] =
 	{ PREEMPT_OVER_FS_LIMIT, "fairshare" },
 	{ PREEMPT_OVER_QUEUE_LIMIT, "queue_softlimits" },
 	{ PREEMPT_OVER_SERVER_LIMIT, "server_softlimits" },
-	{ PREEMPT_STARVING, "starving_jobs" },
 	{ PREEMPT_EXPRESS, "express_queue" },
 	{ PREEMPT_ERR, "" },			/* no corresponding config file value */
 	{ PREEMPT_HIGH, "" }

--- a/src/scheduler/job_info.h
+++ b/src/scheduler/job_info.h
@@ -290,29 +290,6 @@ char * getaoename(selspec *select);
  */
 char * geteoename(selspec *select);
 
-/**
- *	job_starving - returns if a job is starving, and if the job is
- *		       starving, it returns a notion of how starving the
- *		       job is.  The higher the number, the more starving.
- *
- *	  \param sjob - the job to check if it's starving
- *
- *	\return starving number or 0 if not starving
- *
- */
-long job_starving(status *policy, resource_resv *sjob);
-
-/*
- *	mark_job_starving - mark a job starving and handle setting all the
- *			    approprate elements and bits which go with it.
- *
- *	  sjob - the starving job
- *	  sch_priority - the sch_priority of the starving job
- *
- *	return nothing
- */
-void mark_job_starving(resource_resv *sjob, long sch_priority);
-
 /*
  *
  *	update_estimated_attrs - updated the estimated.start_time and

--- a/src/scheduler/misc.cpp
+++ b/src/scheduler/misc.cpp
@@ -260,7 +260,7 @@ res_to_num(const char *res_str, struct resource_type *type)
 
 		if (type != NULL) {
 			type->is_consumable = 1;
-			if (is_size  )
+			if (is_size)
 				type->is_size = 1;
 			else if (is_time)
 				type->is_time = 1;

--- a/src/scheduler/parse.cpp
+++ b/src/scheduler/parse.cpp
@@ -87,8 +87,6 @@ config::config()
 	non_prime_so = 0;
 	prime_fs = 0;
 	non_prime_fs = 0;
-	prime_hsv = 0;
-	non_prime_hsv = 0;
 	prime_bf = 1;
 	non_prime_bf = 1;
 	prime_sn = 0;
@@ -99,9 +97,6 @@ config::config()
 	non_prime_pre = 0;
 	update_comments = 1;
 	prime_exempt_anytime_queues = 0;
-	preempt_starving = 1;
-	preempt_fairshare = 1;
-	dont_preempt_starving = 0;
 	enforce_no_shares = 1;
 	node_sort_unused = 0;
 	resv_conf_ignore = 0;
@@ -277,12 +272,9 @@ parse_config(const char *fname)
 						tmpconf.non_prime_fs = num ? 1 : 0;
 				}
 				else if (!strcmp(config_name, PARSE_HELP_STARVING_JOBS)) {
-					if (prime == PRIME || prime == PT_ALL)
-						tmpconf.prime_hsv = num ? 1 : 0;
-					if (prime == NON_PRIME || prime == PT_ALL)
-						tmpconf.non_prime_hsv = num ? 1 : 0;
-				}
-				else if (!strcmp(config_name, PARSE_BACKFILL)) {
+					obsolete[0] = config_name;
+					obsolete[1] = "use eligible_time in job_sort_formula";
+				} else if (!strcmp(config_name, PARSE_BACKFILL)) {
 					if (prime == PRIME || prime == PT_ALL)
 						tmpconf.prime_bf = num ? 1 : 0;
 					if (prime == NON_PRIME || prime == PT_ALL)
@@ -290,33 +282,22 @@ parse_config(const char *fname)
 
 					obsolete[0] = config_name;
 					obsolete[1] = "server's backfill_depth=0";
-				}
-				else if (!strcmp(config_name, PARSE_SORT_QUEUES)) {
+				} else if (!strcmp(config_name, PARSE_SORT_QUEUES)) {
 					obsolete[0] = config_name;
-				}
-				else if (!strcmp(config_name, PARSE_UPDATE_COMMENTS)) {
+				} else if (!strcmp(config_name, PARSE_UPDATE_COMMENTS)) {
 					tmpconf.update_comments = num ? 1 : 0;
-				}
-				else if (!strcmp(config_name, PARSE_BACKFILL_PRIME)) {
+				} else if (!strcmp(config_name, PARSE_BACKFILL_PRIME)) {
 					if (prime == PRIME || prime == PT_ALL)
 						tmpconf.prime_bp = num ? 1 : 0;
 					if (prime == NON_PRIME || prime == PT_ALL)
 						tmpconf.non_prime_bp = num ? 1 : 0;
-				}
-				else if (!strcmp(config_name, PARSE_PREEMPIVE_SCHED)) {
+				} else if (!strcmp(config_name, PARSE_PREEMPIVE_SCHED)) {
 					if (prime == PRIME || prime == PT_ALL)
 						tmpconf.prime_pre = num ? 1 : 0;
 					if (prime == NON_PRIME || prime == PT_ALL)
 						tmpconf.non_prime_pre = num ? 1 : 0;
-				}
-				else if (!strcmp(config_name, PARSE_PRIME_EXEMPT_ANYTIME_QUEUES))
+				} else if (!strcmp(config_name, PARSE_PRIME_EXEMPT_ANYTIME_QUEUES))
 					tmpconf.prime_exempt_anytime_queues = num ? 1 : 0;
-				else if (!strcmp(config_name, PARSE_PREEMPT_STARVING))
-					tmpconf.preempt_starving = num ? 1 : 0;
-				else if (!strcmp(config_name, PARSE_PREEMPT_FAIRSHARE))
-					tmpconf.preempt_fairshare = num ? 1 : 0;
-				else if (!strcmp(config_name, PARSE_DONT_PREEMPT_STARVING))
-					tmpconf.dont_preempt_starving = num ? 1 : 0;
 				else if (!strcmp(config_name, PARSE_ENFORCE_NO_SHARES))
 					tmpconf.enforce_no_shares = num ? 1 : 0;
 				else if (!strcmp(config_name, PARSE_ALLOW_AOE_CALENDAR))
@@ -338,8 +319,9 @@ parse_config(const char *fname)
 						snprintf(errbuf, sizeof(errbuf), "Invalid time %s", config_value);
 						error = true;
 					}
-				}
-				else if (!strcmp(config_name, PARSE_HALF_LIFE) || !strcmp(config_name, PARSE_FAIRSHARE_DECAY_TIME)) {
+					obsolete[0] = config_name;
+					obsolete[1] = "use eligible_time in job_sort_formula";
+				} else if (!strcmp(config_name, PARSE_HALF_LIFE) || !strcmp(config_name, PARSE_FAIRSHARE_DECAY_TIME)) {
 					if(!strcmp(config_name, PARSE_HALF_LIFE)) {
 						obsolete[0] = PARSE_HALF_LIFE;
 						obsolete[1] = PARSE_FAIRSHARE_DECAY_TIME " and " PARSE_FAIRSHARE_DECAY_FACTOR " instead";
@@ -349,8 +331,7 @@ parse_config(const char *fname)
 						snprintf(errbuf, sizeof(errbuf), "Invalid time %s", config_value);
 						error = true;
 					}
-				}
-				else if (!strcmp(config_name, PARSE_UNKNOWN_SHARES))
+				} else if (!strcmp(config_name, PARSE_UNKNOWN_SHARES))
 					tmpconf.unknown_shares = num;
 				else if (!strcmp(config_name, PARSE_FAIRSHARE_DECAY_FACTOR)) {
 					float fnum;

--- a/src/scheduler/parse.cpp
+++ b/src/scheduler/parse.cpp
@@ -121,7 +121,6 @@ config::config()
 	max_preempt_attempts = SCHD_INFINITY;					/* max num of preempt attempts per cyc*/
 	max_jobs_to_check = SCHD_INFINITY;			/* max number of jobs to check in cyc*/
 	fairshare_decay_factor = .5;		/* decay factor used when decaying fairshare tree */
-	max_starve = 0;
 #ifdef NAS
 	/* localmod 034 */
 	max_borrow = 0;			/* job share borrowing limit */
@@ -314,11 +313,6 @@ parse_config(const char *fname)
 					}
 				}
 				else if (!strcmp(config_name, PARSE_MAX_STARVE)) {
-					tmpconf.max_starve = res_to_num(config_value, &type);
-					if (!type.is_time) {
-						snprintf(errbuf, sizeof(errbuf), "Invalid time %s", config_value);
-						error = true;
-					}
 					obsolete[0] = config_name;
 					obsolete[1] = "use eligible_time in job_sort_formula";
 				} else if (!strcmp(config_name, PARSE_HALF_LIFE) || !strcmp(config_name, PARSE_FAIRSHARE_DECAY_TIME)) {

--- a/src/scheduler/pbs_sched_config
+++ b/src/scheduler/pbs_sched_config
@@ -78,41 +78,9 @@ by_queue: True		non_prime
 #	"less deserving" jobs provided that they do not delay the start time
 #	of the "most deserving" job.
 #
-#       PRIME OPTION
-
-strict_ordering: false	ALL
-
-#### STARVING JOB OPTIONS
-
-#
-# help_starving_jobs
-#
-#	NOTE: The help_starving_jobs option is deprecated and will likely go away in a future release.
-#	      Use job_sort_formula specifying eligible_time to establish equivalent behavior.
-#
-#	When this option is turned on, jobs which have been waiting a long
-#	time are considered to be "starving".  The default amount of time for
-#	a job to wait before it is considered starving is 24 hours, but you can
-#	specify the minimum time in the max_starve scheduler parameter.  Note
-#	that unless you use backfilling, this option can result in significant
-#	idle time while starving jobs wait for resources.
-#
 #	PRIME OPTION
 
-help_starving_jobs:	true	ALL
-
-#
-# max_starve
-#	Maximum  duration before a job is considered starving.
-#
-#  	Examples:
-#  	max_starve: 24:00:00
-#  	This means that jobs waiting/queued for 24 hours will be given higher
-#  	priority to run. NOTE: help_starving_jobs must be enabled.
-#
-#	NO PRIME OPTION
-
-max_starve: 24:00:00
+strict_ordering: false	ALL
 
 #### PRIMETIME OPTIONS:
 
@@ -134,7 +102,7 @@ backfill_prime:	false	ALL
 #
 #	Avoid backfill on queues that are not defined as primetime
 #	or nonprimetime.
-#	NOTE: This is not related to backfill for starving jobs.
+#	NOTE: This is not related to backfill for strict_ordering.
 #
 #	NO PRIME OPTION
 

--- a/src/scheduler/prime.cpp
+++ b/src/scheduler/prime.cpp
@@ -686,7 +686,6 @@ init_prime_time(struct status *policy, char *arg)
 	policy->strict_ordering = conf.prime_so;
 	policy->sort_by = &conf.prime_sort;
 	policy->fair_share = conf.prime_fs;
-	policy->help_starving_jobs = conf.prime_hsv;
 	policy->backfill = conf.prime_bf;
 	policy->sort_nodes = conf.prime_sn;
 	policy->backfill_prime = conf.prime_bp;
@@ -733,7 +732,6 @@ init_non_prime_time(struct status *policy, char *arg)
 	policy->strict_ordering = conf.non_prime_so;
 	policy->sort_by = &conf.non_prime_sort;
 	policy->fair_share = conf.non_prime_fs;
-	policy->help_starving_jobs = conf.non_prime_hsv;
 	policy->backfill = conf.non_prime_bf;
 	policy->sort_nodes = conf.non_prime_sn;
 	policy->backfill_prime = conf.non_prime_bp;

--- a/src/scheduler/sort.cpp
+++ b/src/scheduler/sort.cpp
@@ -68,7 +68,6 @@
  * 	cmp_node_host()
  * 	cmp_aoe()
  * 	cmp_job_preemption_time_asc()
- * 	cmp_starving_jobs()
  * 	sort_jobs()
  * 	swapfunc()
  * 	med3()
@@ -758,9 +757,8 @@ node_sort_cmp(const void *vp1, const void *vp2, const struct sort_info& si, cons
  *
  *		1. Sort all preemption priority jobs in the front
  *		2. Sort all preempted jobs in ascending order of their preemption time
- *		3. Sort all starving jobs after the high priority jobs
- *		4. Sort jobs according to their fairshare usage.
- *		5. sort by unique rank to stabilize the sort
+ *		3. Sort jobs according to their fairshare usage.
+ *		4. sort by unique rank to stabilize the sort
  *
  * @param[in]	v1	-	resource_resv 1
  * @param[in]	v2	-	resource_resv 2
@@ -800,13 +798,7 @@ cmp_sort(const void *v1, const void *v2)
 		cmp = cmp_job_preemption_time_asc(&r1, &r2);
 		if (cmp != 0)
 			return cmp;
-#ifndef NAS /* localmod 041 */
-		if (r1->is_job && r1->server->policy->help_starving_jobs) {
-			cmp = cmp_starving_jobs(&r1, &r2);
-			if (cmp != 0)
-				return cmp;
-		}
-#endif /* localmod 041 */
+
 		/* sort on the basis of job sort formula */
 		cmp = cmp_job_sort_formula(&r1, &r2);
 		if (cmp != 0)
@@ -1161,50 +1153,6 @@ cmp_job_preemption_time_asc(const void *j1, const void *j2)
 
 /**
  * @brief
- * 		cmp_starving_jobs - compare based on eligible_time
- *
- * @param[in] j1 - job to compare.
- * @param[in] j2 - job to compare.
- *
- * @return	int
- * @retval -1 : If j1 was starving and j2 is not.
- * @retval  0 : If both are either starving or not starving.
- * @retval  1 : if j2 was starving and j1 is not.
- */
-int
-cmp_starving_jobs(const void *j1, const void *j2)
-{
-	resource_resv *r1 = *(resource_resv**)j1;
-	resource_resv *r2 = *(resource_resv**)j2;
-
-	if (r1 == NULL && r2 == NULL)
-		return 0;
-
-	if (r1 != NULL && r2 == NULL)
-		return -1;
-
-	if (r1 == NULL && r2 != NULL)
-		return 1;
-
-	if (r1->job == NULL || r2->job ==NULL)
-		return 0;
-
-	if (!r1->job->is_starving && !r2->job->is_starving)
-		return 0;
-	else if (!r1->job->is_starving  && r2->job->is_starving)
-		return 1;
-	else if (r1->job->is_starving && !r2->job->is_starving)
-		return -1;
-
-	if (r1->sch_priority > r2->sch_priority)
-		return -1;
-	if (r1->sch_priority < r2->sch_priority)
-		return 1;
-	return 0;
-}
-
-/**
- * @brief
  * cmp_resv_state	- compare reservation state with RESV_BEING_ALTERED.
  *
  * @param[in] r1	- reservation to compare.
@@ -1254,7 +1202,7 @@ sort_jobs(status *policy, server_info *sinfo)
 	int count = 0;
 
 	/** sort jobs in such a way that Higher Priority jobs come on top
-	 * followed by preempted jobs and then starving jobs and normal jobs
+	 * followed by preempted jobs and then normal jobs
 	 */
 	if (policy->fair_share) {
 		/** sort per queue basis and then use these jobs (combined from all the queues)
@@ -1262,7 +1210,7 @@ sort_jobs(status *policy, server_info *sinfo)
 		 */
 		if (policy->by_queue || policy->round_robin) {
 			/* cycle through queues and sort them on the basis of preemption priority,
-			 * preempted jobs, starving jobs and fairshare usage
+			 * preempted jobs, and fairshare usage
 			 */
 			for (; i < sinfo->num_queues; i++) {
 				if (sinfo->queues[i]->sc.total > 0) {

--- a/src/scheduler/sort.h
+++ b/src/scheduler/sort.h
@@ -182,11 +182,6 @@ int cmp_job_preemption_time_asc(const void *j1, const void *j2);
 int cmp_preemption(resource_resv *r1, resource_resv *r2);
 
 /*
- * cmp_starving_jobs - compare based on eligible_time
- */
-int cmp_starving_jobs(const void *j1, const void *j2);
-
-/*
  * cmp_resv_state - compare based on resv_state
  */
 int cmp_resv_state(const void *r1, const void *r2);

--- a/test/fw/ptl/lib/ptl_sched.py
+++ b/test/fw/ptl/lib/ptl_sched.py
@@ -98,8 +98,6 @@ class Scheduler(PBSService):
     sched_dflt_config = {
         "backfill": "true        ALL",
         "backfill_prime": "false ALL",
-        "help_starving_jobs": "true     ALL",
-        "max_starve": "24:00:00",
         "strict_ordering": "false ALL",
         "provision_policy": "\"aggressive_provision\"",
         "preempt_order": "\"SCR\"",
@@ -123,14 +121,12 @@ class Scheduler(PBSService):
     }
 
     sched_config_options = ["node_group_key",
-                            "dont_preempt_starving",
+
                             "fairshare_enforce_no_shares",
                             "strict_ordering",
                             "resource_unset_infinite",
                             "unknown_shares",
                             "dedicated_prefix",
-                            "help_starving_jobs",
-                            "max_starve",
                             "sort_queues",
                             "backfill",
                             "primetime_prefix",
@@ -148,9 +144,7 @@ class Scheduler(PBSService):
                             "preempt_checkpoint",
                             "preempt_requeue",
                             "preemptive_sched",
-                            "dont_preempt_starving",
                             "node_group_key",
-                            "dont_preempt_starving",
                             "fairshare_enforce_no_shares",
                             "strict_ordering",
                             "resource_unset_infinite",
@@ -162,8 +156,6 @@ class Scheduler(PBSService):
                             "update_comments",
                             "sort_by",
                             "key",
-                            "preempt_starving",
-                            "preempt_fairshare",
                             "assign_ssinodes",
                             "cpus_per_ssinode",
                             "mem_per_ssinode",

--- a/test/tests/functional/pbs_sched_fifo.py
+++ b/test/tests/functional/pbs_sched_fifo.py
@@ -53,8 +53,7 @@ class TestSchedFifo(TestFunctional):
 
         # Configure sched for FIFO
         self.scheduler.set_sched_config({'strict_ordering': 'True',
-                                         'by_queue': 'False',
-                                         'help_starving_jobs': 'False'})
+                                         'by_queue': 'False' })
 
         # Create a new queue to test FIFO
         queue_attrib = {ATTR_qtype: 'execution',

--- a/test/tests/functional/pbs_sched_fifo.py
+++ b/test/tests/functional/pbs_sched_fifo.py
@@ -53,7 +53,7 @@ class TestSchedFifo(TestFunctional):
 
         # Configure sched for FIFO
         self.scheduler.set_sched_config({'strict_ordering': 'True',
-                                         'by_queue': 'False' })
+                                         'by_queue': 'False'})
 
         # Create a new queue to test FIFO
         queue_attrib = {ATTR_qtype: 'execution',

--- a/test/tests/functional/pbs_strict_ordering.py
+++ b/test/tests/functional/pbs_strict_ordering.py
@@ -245,7 +245,7 @@ class TestStrictOrderingAndBackfilling(TestFunctional):
 
         rv = self.scheduler.set_sched_config(
             {'round_robin': 'false all', 'by_queue': 'false all',
-             'strict_ordering': 'true all' })
+             'strict_ordering': 'true all'})
         self.assertTrue(rv)
 
         a = {'backfill_depth': 0}

--- a/test/tests/functional/pbs_strict_ordering.py
+++ b/test/tests/functional/pbs_strict_ordering.py
@@ -58,8 +58,7 @@ class TestStrictOrderingAndBackfilling(TestFunctional):
 
         rv = self.scheduler.set_sched_config(
             {'round_robin': 'false all', 'by_queue': 'false all',
-             'strict_ordering': 'true all',
-             'help_starving_jobs': 'false all'})
+             'strict_ordering': 'true all'})
         self.assertTrue(rv)
 
         a = {'backfill_depth': 0}
@@ -168,8 +167,7 @@ class TestStrictOrderingAndBackfilling(TestFunctional):
 
         rv = self.scheduler.set_sched_config(
             {'round_robin': 'false all', 'by_queue': 'false all',
-             'strict_ordering': 'true all',
-             'help_starving_jobs': 'false all'})
+             'strict_ordering': 'true all'})
         self.assertTrue(rv)
 
         a = {'backfill_depth': 0}
@@ -247,8 +245,7 @@ class TestStrictOrderingAndBackfilling(TestFunctional):
 
         rv = self.scheduler.set_sched_config(
             {'round_robin': 'false all', 'by_queue': 'false all',
-             'strict_ordering': 'true all',
-             'help_starving_jobs': 'false all'})
+             'strict_ordering': 'true all' })
         self.assertTrue(rv)
 
         a = {'backfill_depth': 0}

--- a/test/tests/interfaces/pbs_preempt_params.py
+++ b/test/tests/interfaces/pbs_preempt_params.py
@@ -123,13 +123,11 @@ class TestPreemptParamsQmgr(TestInterfaces):
 
         self.server.manager(MGR_CMD_SET, SCHED, a, runas=ROOT_USER)
 
-        p = '"starving_jobs, normal_jobs, starving_jobs+fairshare, fairshare"'
+        p = '"express_queue, normal_jobs, express_queue+fairshare, fairshare"'
         a = {param: p}
         self.server.manager(MGR_CMD_SET, SCHED, a,
                             runas=ROOT_USER)
 
-        p = 'starving_jobs, normal_jobs, starving_jobs+fairshare,fairshare'
-        a = {param: p}
         self.server.manager(MGR_CMD_LIST, SCHED, a, runas=ROOT_USER)
 
         self.server.manager(MGR_CMD_UNSET, SCHED, param,


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Starving support has been deprecated for many years now.  The binary nature of jobs gaining super high priority is bad.  Jobs should gain priority gradually as they wait.  This can be done using eligible_time in the job_sort_formula

#### Describe Your Change
Removed help_starving_jobs and max_starve

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://openpbs.atlassian.net/wiki/spaces/PD/pages/2408087553/Obsolete+help+starving+jobs+max+starve)** -->


#### Attach Test and Valgrind Logs/Output
I reran the failed/error tests and they passed.

Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|7191|4081|3|6|0|1|4071|