### PR TITLE
fix test_terminal_control_shell_function on RHEL7

### DIFF
--- a/test/fw/ptl/lib/ptl_mom.py
+++ b/test/fw/ptl/lib/ptl_mom.py
@@ -52,6 +52,7 @@ import string
 import sys
 import tempfile
 import time
+import pkg_resources
 
 
 from ptl.utils.pbs_testusers import (ROOT_USER, TEST_USER, PbsUser,
@@ -688,6 +689,19 @@ class MoM(PBSService):
         Returns True if MoM is only Linux
         """
         return True
+
+    def check_mom_bash_version(self):
+        """
+        Return True if bash version on mom is greater than or equal to 4.2.46
+        """
+        cmd = ['echo', '${BASH_VERSION%%[^0-9.]*}']
+        ret = self.du.run_cmd(self.hostname, cmd=cmd, sudo=True, as_script=True)
+        req_bash_version = "4.2.46"
+        mom_bash_version = ret['out'][0]
+        if mom_bash_version >= req_bash_version:
+            return True
+        else:
+            return False
 
     def is_cpuset_mom(self):
         """

--- a/test/fw/ptl/lib/ptl_mom.py
+++ b/test/fw/ptl/lib/ptl_mom.py
@@ -695,7 +695,8 @@ class MoM(PBSService):
         Return True if bash version on mom is greater than or equal to 4.2.46
         """
         cmd = ['echo', '${BASH_VERSION%%[^0-9.]*}']
-        ret = self.du.run_cmd(self.hostname, cmd=cmd, sudo=True, as_script=True)
+        ret = self.du.run_cmd(self.hostname, cmd=cmd, sudo=True,
+                              as_script=True)
         req_bash_version = "4.2.46"
         mom_bash_version = ret['out'][0]
         if mom_bash_version >= req_bash_version:

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -611,10 +611,10 @@ class PBSTestSuite(unittest.TestCase):
         skip_test = False
         msg = 'capability supported only for bash version >= 4.2.46'
         for mom in cls.moms.values():
-            if mom.check_mom_bash_version():
+            if not mom.check_mom_bash_version():
                 skip_test = True
                 break
-        if skip_test:
+        if not skip_test:
             return
         if cls.__dict__.get('__check_mom_bash_version__', False):
             # skip all test cases in this test suite

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -168,6 +168,12 @@ def runOnlyOnLinux(function):
     function.__run_only_on_linux__ = True
     return function
 
+def checkMomBashVersion(function):
+    """
+    Decorator to skip a test if bash version is less than 4.2.46
+    """
+    function.__check_mom_bash_version__ = True
+    return function
 
 def requirements(*args, **kwargs):
     """
@@ -468,6 +474,7 @@ class PBSTestSuite(unittest.TestCase):
         cls.skip_shasta_tests()
         cls.skip_cpuset_tests()
         cls.run_only_on_linux()
+        cls.check_mom_bash_version()
 
     def setUp(self):
         if 'skip-setup' in self.conf:
@@ -594,6 +601,23 @@ class PBSTestSuite(unittest.TestCase):
             # skip individual test cases
             for test_item in cls.test_dict.values():
                 if test_item.__dict__.get('__run_only_on_linux__', False):
+                    test_item.__unittest_skip__ = True
+                    test_item.__unittest_skip_why__ = msg
+
+    @classmethod
+    def check_mom_bash_version(cls):
+        if cls.mom.check_mom_bash_version():
+            return
+        msg = 'capability supported only for bash version >= 4.2.46'
+        if cls.__dict__.get('__check_mom_bash_version__', False):
+            # skip all test cases in this test suite
+            for test_item in cls.test_dict.values():
+                test_item.__unittest_skip__ = True
+                test_item.__unittest_skip_why__ = msg
+        else:
+            # skip individual test cases
+            for test_item in cls.test_dict.values():
+                if test_item.__dict__.get('__check_mom_bash_version__', False):
                     test_item.__unittest_skip__ = True
                     test_item.__unittest_skip_why__ = msg
 

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -168,12 +168,14 @@ def runOnlyOnLinux(function):
     function.__run_only_on_linux__ = True
     return function
 
+
 def checkMomBashVersion(function):
     """
     Decorator to skip a test if bash version is less than 4.2.46
     """
     function.__check_mom_bash_version__ = True
     return function
+
 
 def requirements(*args, **kwargs):
     """

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -608,9 +608,14 @@ class PBSTestSuite(unittest.TestCase):
 
     @classmethod
     def check_mom_bash_version(cls):
-        if cls.mom.check_mom_bash_version():
+        skip_test = False
+        for mom in cls.moms.values():
+            if mom.check_mom_bash_version():
+                skip_test = True
+                msg = 'capability supported only for bash version >= 4.2.46'
+                break
+        if not skip_test:
             return
-        msg = 'capability supported only for bash version >= 4.2.46'
         if cls.__dict__.get('__check_mom_bash_version__', False):
             # skip all test cases in this test suite
             for test_item in cls.test_dict.values():

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -609,12 +609,12 @@ class PBSTestSuite(unittest.TestCase):
     @classmethod
     def check_mom_bash_version(cls):
         skip_test = False
+        msg = 'capability supported only for bash version >= 4.2.46'
         for mom in cls.moms.values():
             if mom.check_mom_bash_version():
                 skip_test = True
-                msg = 'capability supported only for bash version >= 4.2.46'
                 break
-        if not skip_test:
+        if skip_test:
             return
         if cls.__dict__.get('__check_mom_bash_version__', False):
             # skip all test cases in this test suite

--- a/test/tests/functional/pbs_nonprint_characters.py
+++ b/test/tests/functional/pbs_nonprint_characters.py
@@ -147,11 +147,11 @@ sleep 5
                           option="-v")
         j_output = ""
         if len(ret['out']) > 0:
-            if len(ret['out']) > 1:
-                j_output = '\n'.join(ret['out'])
+            if '\t' in chk_var:
+                j_output = '\n'.join(ret['out']).replace('\t\t', '\t')
             else:
-                j_output = ret['out'][0].strip()
-        self.assertEqual(j_output, chk_var)
+                j_output = '\n'.join(ret['out']).replace('\t', '')
+        self.assertIn(chk_var, j_output)
         self.logger.info('job output has: %s' % chk_var)
 
     def check_qstatout(self, chk_var, jid):
@@ -313,6 +313,7 @@ sleep 5
                 chk_var = 'NONPRINT_VAR=X%sY' % self.npcat[ch]
             self.check_jobout(chk_var, jid, job_outfile, job_host)
 
+    @checkMomBashVersion
     def test_nonprint_shell_function(self):
         """
         Export a shell function with a non-printable character and check
@@ -444,6 +445,7 @@ sleep 5
         # Reset the terminal
         self.logger.info('%sReset terminal' % self.reset)
 
+    @checkMomBashVersion
     def test_terminal_control_shell_function(self):
         """
         Export a shell function with terminal control


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Test case: test_nonprint_shell_function, test_terminal_control_shell_function fails on rhel7 due to bash version.
Bash version required to run these test cases must be greater than or equal to 4.2.46.

#### Describe Your Change
1. Add a decorator to check for bash version
2. Skip tests if bash version is less than 4.2.46


#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
[7194-regression_report.txt](https://github.com/openpbs/openpbs/files/6342947/7194-regression_report.txt)

[7194-ALL.zip](https://github.com/openpbs/openpbs/files/6342977/7194-ALL.zip)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
