### PR TITLE
corrections to mom_resize tests

### DIFF
--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -3892,21 +3892,8 @@ event.accept()
         self.moms_list[0].log_match(
             "Job;%s;Cannot resize the job" % (jid),
             starttime=stime, interval=2, n='ALL')
-        # Check the exec_vnode after job is in substate 42
-        self.server.expect(JOB, {ATTR_substate: '42'}, id=jid)
-        # Check for the pruned exec_vnode due to release_nodes() in launch hook
-        self.server.expect(JOB, 'exec_vnode', id=jid, op=SET)
-        job_stat = self.server.status(JOB, id=jid)
-        execvnode2 = job_stat[0]['exec_vnode']
-        self.logger.info("pruned exec_vnode: %s" % execvnode2)
-        pruned_vnodes = execvnode2.split('+')
-        # Check that the pruned exec_vnode has one less than initial value
-        self.assertEqual(len(pruned_vnodes) + 1, len(initial_vnodes))
-        # Check that the exec_vnode got pruned
-        self.moms_list[1].log_match("Job;%s;pruned from exec_vnode=%s" % (
-            jid, execvnode1), starttime=stime, n='ALL')
-        self.moms_list[1].log_match("Job;%s;pruned to exec_vnode=%s" % (
-            jid, execvnode2), starttime=stime, n='ALL')
+        # Check that job is in substate 20 (Held due to reruns)
+        self.server.expect(JOB, {ATTR_substate: '20'}, id=jid)
         # Check that MS saw that the sister mom failed to update the job
         # This message is on MS mom[1] but mentions sismom mom[0]
         self.moms_list[1].log_match(
@@ -3963,20 +3950,8 @@ event.accept()
         self.moms_list[1].log_match(
             "Job;%s;Cannot resize the job" % (jid),
             starttime=stime, interval=2, n='ALL')
-        # Check the exec_vnode after job is in substate 42
-        self.server.expect(JOB, {ATTR_substate: '42'}, id=jid)
-        self.server.expect(JOB, 'exec_vnode', id=jid, op=SET)
-        job_stat = self.server.status(JOB, id=jid)
-        execvnode2 = job_stat[0]['exec_vnode']
-        self.logger.info("pruned exec_vnode: %s" % execvnode2)
-        pruned_vnodes = execvnode2.split('+')
-        # Check that the pruned exec_vnode has one less than initial value
-        self.assertEqual(len(pruned_vnodes) + 1, len(initial_vnodes))
-        # Check that the exec_vnode got pruned
-        self.moms_list[1].log_match("Job;%s;pruned from exec_vnode=%s" % (
-            jid, execvnode1), starttime=stime, n='ALL')
-        self.moms_list[1].log_match("Job;%s;pruned to exec_vnode=%s" % (
-            jid, execvnode2), starttime=stime, n='ALL')
+        # Check the exec_vnode after job is in substate 20 (Held due to reruns)
+        self.server.expect(JOB, {ATTR_substate: '20'}, id=jid)
         # Because of resize hook reject Mom failed to update the job.
         # Check that job got requeued
         self.server.log_match("Job;%s;Job requeued" % (jid), starttime=stime)

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -3887,13 +3887,10 @@ event.accept()
         job_stat = self.server.status(JOB, id=jid)
         execvnode1 = job_stat[0]['exec_vnode']
         self.logger.info("initial exec_vnode: %s" % execvnode1)
-        initial_vnodes = execvnode1.split('+')
         # Check the exec_resize hook reject message in sister mom logs
         self.moms_list[0].log_match(
             "Job;%s;Cannot resize the job" % (jid),
             starttime=stime, interval=2, n='ALL')
-        # Check that job is in substate 20 (Held due to reruns)
-        self.server.expect(JOB, {ATTR_substate: '20'}, id=jid)
         # Check that MS saw that the sister mom failed to update the job
         # This message is on MS mom[1] but mentions sismom mom[0]
         self.moms_list[1].log_match(
@@ -3945,13 +3942,10 @@ event.accept()
         job_stat = self.server.status(JOB, id=jid)
         execvnode1 = job_stat[0]['exec_vnode']
         self.logger.info("initial exec_vnode: %s" % execvnode1)
-        initial_vnodes = execvnode1.split('+')
         # Check the exec_resize hook reject message in MS log
         self.moms_list[1].log_match(
             "Job;%s;Cannot resize the job" % (jid),
             starttime=stime, interval=2, n='ALL')
-        # Check the exec_vnode after job is in substate 20 (Held due to reruns)
-        self.server.expect(JOB, {ATTR_substate: '20'}, id=jid)
         # Because of resize hook reject Mom failed to update the job.
         # Check that job got requeued
         self.server.log_match("Job;%s;Job requeued" % (jid), starttime=stime)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Corrections to mom_resize tests.

#### Describe Your Change
There was a corrected behavior when a requeued/restarted job involves having some vnodes released. The correct behavior is for the job to restart using the original resource request and not the modified resource request. The test will need only check that the mom can't resize the job and the job got requeued.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->

#### Attach Test and Valgrind Logs/Output
[after_update.txt](https://github.com/openpbs/openpbs/files/6387964/after.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
