### PR TITLE
server can go in infinite loop with deljoblist

### DIFF
--- a/src/include/svrfunc.h
+++ b/src/include/svrfunc.h
@@ -210,7 +210,7 @@ extern void eval_chkpnt(job *pjob, attribute *queckp);
 #ifdef _BATCH_REQUEST_H
 extern int svr_startjob(job *, struct batch_request *);
 extern int svr_authorize_jobreq(struct batch_request *, job *);
-extern void dup_br_for_subjob(struct batch_request *, job *, void (*)(struct batch_request *, job *));
+extern int dup_br_for_subjob(struct batch_request *, job *, int (*)(struct batch_request *, job *));
 extern void set_old_nodes(job *);
 extern int send_job_exec_update_to_mom(job *, char *, int, struct batch_request *);
 extern int free_sister_vnodes(job *, char *, char *, char *, int, struct batch_request *);

--- a/src/server/array_func.c
+++ b/src/server/array_func.c
@@ -816,7 +816,7 @@ dup_br_for_subjob(struct batch_request *opreq, job *pjob, int (*func)(struct bat
 
 	npreq = alloc_br(opreq->rq_type);
 	if (npreq == NULL)
-		return 0;
+		return 1;
 
 	npreq->rq_perm    = opreq->rq_perm;
 	npreq->rq_fromsvr = opreq->rq_fromsvr;
@@ -859,7 +859,7 @@ dup_br_for_subjob(struct batch_request *opreq, job *pjob, int (*func)(struct bat
 		default:
 			delete_link(&npreq->rq_link);
 			free(npreq);
-			return 0;
+			return 1;
 	}
 
 	npreq->rq_parentbr = opreq;

--- a/src/server/array_func.c
+++ b/src/server/array_func.c
@@ -806,15 +806,17 @@ create_subjob(job *parent, char *newjid, int *rc)
  *		PBS_Batch_Rerun, and PBS_Batch_RunJob subjob requests.
  *		For any other request types, be sure to add another switch case below
  *		(matching request type).
+ * @return int
+ * @retval return value of the callback function
  */
-void
-dup_br_for_subjob(struct batch_request *opreq, job *pjob, void (*func)(struct batch_request *, job *))
+int
+dup_br_for_subjob(struct batch_request *opreq, job *pjob, int (*func)(struct batch_request *, job *))
 {
 	struct batch_request  *npreq;
 
 	npreq = alloc_br(opreq->rq_type);
 	if (npreq == NULL)
-		return;
+		return 0;
 
 	npreq->rq_perm    = opreq->rq_perm;
 	npreq->rq_fromsvr = opreq->rq_fromsvr;
@@ -857,11 +859,11 @@ dup_br_for_subjob(struct batch_request *opreq, job *pjob, void (*func)(struct ba
 		default:
 			delete_link(&npreq->rq_link);
 			free(npreq);
-			return;
+			return 0;
 	}
 
 	npreq->rq_parentbr = opreq;
 	opreq->rq_refct++;
 
-	func(npreq, pjob);
+	return func(npreq, pjob);
 }

--- a/src/server/array_func.c
+++ b/src/server/array_func.c
@@ -807,7 +807,7 @@ create_subjob(job *parent, char *newjid, int *rc)
  *		For any other request types, be sure to add another switch case below
  *		(matching request type).
  * @return int
- * @retval return value of the callback function
+ * @retval return value of the callback function (0 for success, 1 for error)
  */
 int
 dup_br_for_subjob(struct batch_request *opreq, job *pjob, int (*func)(struct batch_request *, job *))

--- a/src/server/req_delete.c
+++ b/src/server/req_delete.c
@@ -600,6 +600,13 @@ req_deletejob(struct batch_request *preq)
 						job_purge(pjob);
 					} else {
 						dup_br_for_subjob(preq, pjob, req_deletejob2);
+						if (suspenddelete) {
+							preq->rq_ind.rq_deletejoblist.jobid_to_resume = j;
+							preq->rq_ind.rq_deletejoblist.subjobid_to_resume = i;
+							--preq->rq_refct;
+							preply->brp_un.brp_deletejoblist.tot_arr_jobs--;
+							return;
+						}
 						del_parent = 0;
 					}
 				} else {
@@ -702,8 +709,15 @@ req_deletejob(struct batch_request *preq)
 					if (check_job_state(pjob, JOB_STATE_LTR_EXPIRED)) {
 						log_eventf(PBSEVENT_DEBUG, PBS_EVENTCLASS_JOB, LOG_INFO, pjob->ji_qs.ji_jobid, msg_job_history_delete, preq->rq_user, preq->rq_host);
 						job_purge(pjob);
-					} else
+					} else {
 						dup_br_for_subjob(preq, pjob, req_deletejob2);
+						if (suspenddelete) {
+							preq->rq_ind.rq_deletejoblist.jobid_to_resume = j;
+							preq->rq_ind.rq_deletejoblist.subjobid_to_resume = i;
+							--preq->rq_refct;
+							return;
+						}
+					}
 				} else {
 					/* Queued, Waiting, Held, just set to expired */
 					if (sjst != JOB_STATE_LTR_EXPIRED) {

--- a/src/server/req_delete.c
+++ b/src/server/req_delete.c
@@ -847,8 +847,7 @@ req_deletejob2(struct batch_request *preq, job *pjob)
 			update_deletejob_stat(pjob->ji_qs.ji_jobid, preq, PBSE_SYSTEM);
 			if (preply->brp_un.brp_deletejoblist.tot_rpys == preply->brp_un.brp_deletejoblist.tot_jobs)
 				req_reject(PBSE_SYSTEM, 0, preq);
-		}
-		if (preq->rq_type == PBS_BATCH_DeleteJobList) {
+		} else if (preq->rq_type == PBS_BATCH_DeleteJobList) {
 			/* let the caller know that the deljoblist request needs to be suspended */
 			suspenddelete = true;
 		}

--- a/src/server/req_rerun.c
+++ b/src/server/req_rerun.c
@@ -75,7 +75,7 @@
 
 
 /* Private Function local to this file */
-static void req_rerunjob2(struct batch_request *preq, job *pjob);
+static int req_rerunjob2(struct batch_request *preq, job *pjob);
 
 /* Global Data Items: */
 
@@ -369,8 +369,12 @@ timeout_rerun_request(struct work_task *pwt)
  *
  *  @param[in,out]	preq	-	Job Request
  *  @param[in,out]	pjob	-	ptr to the subjob
+ *
+ * @return int
+ * @retval 0 for Success
+ * @retval 1 for Error
  */
-static void
+static int
 req_rerunjob2(struct batch_request *preq, job *pjob)
 {
 	long	force = 0;
@@ -390,7 +394,7 @@ req_rerunjob2(struct batch_request *preq, job *pjob)
 		if (pjob->ji_pmt_preq != NULL)
 			reply_preempt_jobs_request(PBSE_NORERUN, PREEMPT_METHOD_REQUEUE, pjob);
 		req_reject(PBSE_NORERUN, 0, preq);
-		return;
+		return 0;
 	}
 
 	/* the job must be running */
@@ -400,7 +404,7 @@ req_rerunjob2(struct batch_request *preq, job *pjob)
 			reply_preempt_jobs_request(PBSE_BADSTATE, PREEMPT_METHOD_REQUEUE, pjob);
 
 		req_reject(PBSE_BADSTATE, 0, preq);
-		return;
+		return 0;
 	}
 	/* a node failure tolerant job could be waiting for healthy nodes
 	 * and it would have a JOB_SUBSTATE_PRERUN substate.
@@ -410,7 +414,7 @@ req_rerunjob2(struct batch_request *preq, job *pjob)
 		if (pjob->ji_pmt_preq != NULL)
 			reply_preempt_jobs_request(PBSE_BADSTATE, PREEMPT_METHOD_REQUEUE, pjob);
 		req_reject(PBSE_BADSTATE, 0, preq);
-		return;
+		return 0;
 	}
 
 	/* ask MOM to kill off the job */
@@ -445,7 +449,7 @@ req_rerunjob2(struct batch_request *preq, job *pjob)
 		if (pdep != NULL)
 			depend_runone_release_all(pjob);
 		reply_ack(preq);
-		return;
+		return 0;
 
 	}
 
@@ -453,7 +457,7 @@ req_rerunjob2(struct batch_request *preq, job *pjob)
 		if (pjob->ji_pmt_preq != NULL)
 			reply_preempt_jobs_request(rc, PREEMPT_METHOD_REQUEUE, pjob);
 		req_reject(rc, 0, preq);
-		return;
+		return 0;
 	}
 
 	/* So job has run and is to be rerun (not restarted) */
@@ -498,4 +502,5 @@ req_rerunjob2(struct batch_request *preq, job *pjob)
 			conn->cn_authen |= PBS_NET_CONN_NOTIMEOUT;
 	}
 
+	return 0;
 }

--- a/src/server/req_rerun.c
+++ b/src/server/req_rerun.c
@@ -394,7 +394,7 @@ req_rerunjob2(struct batch_request *preq, job *pjob)
 		if (pjob->ji_pmt_preq != NULL)
 			reply_preempt_jobs_request(PBSE_NORERUN, PREEMPT_METHOD_REQUEUE, pjob);
 		req_reject(PBSE_NORERUN, 0, preq);
-		return 0;
+		return 1;
 	}
 
 	/* the job must be running */
@@ -404,7 +404,7 @@ req_rerunjob2(struct batch_request *preq, job *pjob)
 			reply_preempt_jobs_request(PBSE_BADSTATE, PREEMPT_METHOD_REQUEUE, pjob);
 
 		req_reject(PBSE_BADSTATE, 0, preq);
-		return 0;
+		return 1;
 	}
 	/* a node failure tolerant job could be waiting for healthy nodes
 	 * and it would have a JOB_SUBSTATE_PRERUN substate.
@@ -414,7 +414,7 @@ req_rerunjob2(struct batch_request *preq, job *pjob)
 		if (pjob->ji_pmt_preq != NULL)
 			reply_preempt_jobs_request(PBSE_BADSTATE, PREEMPT_METHOD_REQUEUE, pjob);
 		req_reject(PBSE_BADSTATE, 0, preq);
-		return 0;
+		return 1;
 	}
 
 	/* ask MOM to kill off the job */
@@ -457,7 +457,7 @@ req_rerunjob2(struct batch_request *preq, job *pjob)
 		if (pjob->ji_pmt_preq != NULL)
 			reply_preempt_jobs_request(rc, PREEMPT_METHOD_REQUEUE, pjob);
 		req_reject(rc, 0, preq);
-		return 0;
+		return 1;
 	}
 
 	/* So job has run and is to be rerun (not restarted) */

--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -723,14 +723,14 @@ req_runjob2(struct batch_request *preq, job *pjob)
 		if (job_save_db(pjob)) {
 			free_nodes(pjob);
 			req_reject(PBSE_SAVE_ERR, 0, preq);
-			return 0;
+			return 1;
 		}
 	}
 
 	if (prov_rc) { /* problem with the request */
 		free_nodes(pjob);
 		req_reject(prov_rc, 0, preq);
-		return 0;
+		return 1;
 	} else if (need_prov == 1) { /* prov required and request is fine */
 		/* allocate resources right away */
 		set_resc_assigned((void *)pjob, 0,  INCR);
@@ -754,7 +754,7 @@ req_runjob2(struct batch_request *preq, job *pjob)
 		/* Neither the run request nor the job specified an execvnode. */
 		free_nodes(pjob);
 		req_reject(PBSE_IVALREQ, 0, preq);
-		return 0;
+		return 1;
 	}
 	sprintf(log_buffer, msg_manager, msg_jobrun, preq->rq_user, preq->rq_host);
 	strcat(log_buffer, " on exec_vnode ");
@@ -777,6 +777,7 @@ req_runjob2(struct batch_request *preq, job *pjob)
 		free_nodes(pjob);
 		if (preq)
 			req_reject(rc, 0, preq);
+		return 1;
 	}
 
 	return 0;

--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -125,7 +125,7 @@ void post_sendmom(struct work_task *);
 static int  svr_stagein(job *, struct batch_request *, char, int);
 static int  svr_strtjob2(job *, struct batch_request *);
 static job *chk_job_torun(struct batch_request *preq, job *);
-static void req_runjob2(struct batch_request *preq, job *pjob);
+static int req_runjob2(struct batch_request *preq, job *pjob);
 static job *where_to_runjob(struct batch_request *preq, job *);
 static void convert_job_to_resv(job *pjob);
 /* Global Data Items: */
@@ -702,7 +702,7 @@ req_runjob(struct batch_request *preq)
  * @param[in,out]	preq	-	Run Job Requests
  * @param[in,out]	pjob	-	job pointer
  */
-static void
+static int
 req_runjob2(struct batch_request *preq, job *pjob)
 {
 	int		  rc;
@@ -723,14 +723,14 @@ req_runjob2(struct batch_request *preq, job *pjob)
 		if (job_save_db(pjob)) {
 			free_nodes(pjob);
 			req_reject(PBSE_SAVE_ERR, 0, preq);
-			return;
+			return 0;
 		}
 	}
 
 	if (prov_rc) { /* problem with the request */
 		free_nodes(pjob);
 		req_reject(prov_rc, 0, preq);
-		return;
+		return 0;
 	} else if (need_prov == 1) { /* prov required and request is fine */
 		/* allocate resources right away */
 		set_resc_assigned((void *)pjob, 0,  INCR);
@@ -738,7 +738,7 @@ req_runjob2(struct batch_request *preq, job *pjob)
 		/* provisioning was needed and was qneueued successfully */
 		/* Allways send ack for prov jobs, even if not async run */
 		reply_ack(preq);
-		return;
+		return 0;
 	}
 
 	/* if need_prov ==0 then no prov required, so continue normal flow */
@@ -754,7 +754,7 @@ req_runjob2(struct batch_request *preq, job *pjob)
 		/* Neither the run request nor the job specified an execvnode. */
 		free_nodes(pjob);
 		req_reject(PBSE_IVALREQ, 0, preq);
-		return;
+		return 0;
 	}
 	sprintf(log_buffer, msg_manager, msg_jobrun, preq->rq_user, preq->rq_host);
 	strcat(log_buffer, " on exec_vnode ");
@@ -778,6 +778,8 @@ req_runjob2(struct batch_request *preq, job *pjob)
 		if (preq)
 			req_reject(rc, 0, preq);
 	}
+
+	return 0;
 }
 
 

--- a/src/server/req_signal.c
+++ b/src/server/req_signal.c
@@ -266,12 +266,12 @@ req_signaljob2(struct batch_request *preq, job *pjob)
 	if (!check_job_state(pjob, JOB_STATE_LTR_RUNNING) ||
 		(check_job_state(pjob, JOB_STATE_LTR_RUNNING) && check_job_substate(pjob, JOB_SUBSTATE_PROVISION))) {
 		req_reject(PBSE_BADSTATE, 0, preq);
-		return 0;
+		return 1;
 	}
 	if ((strcmp(preq->rq_ind.rq_signal.rq_signame, SIG_ADMIN_RESUME) == 0 && !(pjob->ji_qs.ji_svrflags & JOB_SVFLG_AdmSuspd)) ||
 		(strcmp(preq->rq_ind.rq_signal.rq_signame, SIG_RESUME) == 0 && (pjob->ji_qs.ji_svrflags & JOB_SVFLG_AdmSuspd))) {
 		req_reject(PBSE_WRONG_RESUME, 0, preq);
-		return 0;
+		return 1;
 	}
 
 	if (strcmp(preq->rq_ind.rq_signal.rq_signame, SIG_RESUME) == 0 || strcmp(preq->rq_ind.rq_signal.rq_signame, SIG_ADMIN_RESUME) == 0)
@@ -306,7 +306,7 @@ req_signaljob2(struct batch_request *preq, job *pjob)
 							/* if resume fails,need to free resources */
 						} else {
 							req_reject(rc, 0, preq);
-							return 0;
+							return 1;
 						}
 					}
 					if (is_jattr_set(pjob, JOB_ATR_exec_vnode_deallocated)) {
@@ -341,7 +341,7 @@ req_signaljob2(struct batch_request *preq, job *pjob)
 			} else {
 				/* Job can be resumed only on suspended state */
 				req_reject(PBSE_BADSTATE, 0, preq);
-				return 0;
+				return 1;
 			}
 		}
 	}
@@ -357,6 +357,7 @@ req_signaljob2(struct batch_request *preq, job *pjob)
 		if (resume)
 			rel_resc(pjob);
 		req_reject(rc, 0, preq);	/* unable to get to MOM */
+		return 1;
 	}
 
 	return 0;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Server could go into an infinite loop if qdel was executed while some jobs were in the "prerun" substate, and mom takes some time to send updates to the server. It's caused by the recent deljoblist enhancement as follows:
- when server encounters a job in the prerun state, it adds a work task (post_delete_route) to get back to it after a second.
- The problem is: it uses the original batch_request, so it adds a post_delete_route for ALL jobs.
- It also does this for every job that's in the prerun substate
- So, if mom takes longer than a second, the work tasks start getting executed. Since they also try to delete ALL jobs, they end up creating work tasks of their own, again each of them trying to delete ALL jobs.
- Server gets stuck in this cycle and goes into an infinite loop where it stops responding to any requests, including the updates from mom which would have saved it

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
req_deletejob2 now sets a flag which tells req_deletejob that a post_delete_route work task has been added so it needs to suspend the deletion of jobs. So, it resumes deleting the jobs from the first job that it finds in the prerun state, and keeps after every second until the mom sends updates. This is similar to how it used to behave before deljoblist enhancement.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
After the change, the server no longer goes into an infinite loop. There's no good test for this since it's a race condition. Please inspect the code. I'll do regressions to make sure nothing breaks


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
