### PR TITLE
fix execjob_resize call to configure_job

### DIFF
--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -1374,7 +1374,7 @@ class HookUtils(object):
                                'deleting cpuset cgroup')
 
         # Configure the cgroup
-        cgroup.configure_job(event.job.id, jobutil.assigned_resources,
+        cgroup.configure_job(event.job, jobutil.assigned_resources,
                              node, cgroup, event.type)
         # Write out the assigned resources
         cgroup.write_cgroup_assigned_resources(event.job.id)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
An earlier PR introduced changes to configure_job, which now accepts the event job structure instead of just the ID (a string which is the "id" attribute of the structure), so that other attributes than the ID can be used in the function.

Sadly, the call to that function in the execjob_resize_handler somehow reverted to its earlier incarnation, which leads to exceptions when the execjob_resize event is handled:

```
04/22/2021 18:50:13.160723;0080;pbs_python;Hook;pbs_python;['Traceback (most recent call last):', ' File "<embedded code object>", line 6351, in main', ' File "<embedded code object>", line 1022, in invoke_handler', ' File "<embedded code object>", line 1378, in _execjob_resize_handler', ' File "<embedded code object>", line 4982, in configure_job', "AttributeError: 'str' object has no attribute 'id'"]
04/22/2021 18:50:13.160739;0800;pbs_python;Hook;pbs_python;event_name: Method called
04/22/2021 18:50:13.160832;0001;pbs_python;Hook;pbs_python;Unexpected error in pbs_cgroups handling execjob_resize event for job 1.x7246-29-0 (system hold failed): AttributeError ("'str' object has no attribute 'id'",)
```

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
configure_job when called by the execjob_begin handler now reads:

```
# Configure the new cgroup
cgroup.configure_job(event.job, jobutil.assigned_resources, node, cgroup, event.type)
```
So configure_job accepts the entire job structure, and then does:

```
def configure_job(self, job, hostresc, node, cgroup, event_type):
[...]
jobid = job.id
```
to derive the jobid (which _used_ to be the only thing used in the routine).

But if you look at the resize handler call, it still reads:

```
# Configure the cgroup
cgroup.configure_job(event.job.id, jobutil.assigned_resources, node, cgroup, event.type)
```
so it passes the job ID instead of the event job structure, as older hooks used to do.

The fix is to delete the extraneous ".id" in that call.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
N/A, not a design change, but a bug fix

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Tests are running on TH test harness -- will be included when ready.

Please note that the *resize_fail PTL tests are incorrect; the tests still rely on incorrect behaviour that was fixed in an earlier PR, so these failures are to be expected (until the tests are fixed).


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
