### PR TITLE
Fix: qsub does not accept paths with colons for output files

### DIFF
--- a/src/lib/Libcmds/prepare_path.c
+++ b/src/lib/Libcmds/prepare_path.c
@@ -165,9 +165,23 @@ prepare_path(char *path_in, char *path_out)
 				}
 			}
 			if (*c != ':')
-				return 1;
-			/* Advance past the colon */
-			c++;
+			{
+				if (*c == '/') {
+					/* There's a colon in the path */ 
+					host_given = NULL;
+					host_name[0] = '\0';
+					for (c = path_in; *c; c++) {
+						if (isspace(*c) == 0)
+							break;
+					}
+				}
+				else
+					return 1;
+			}
+			else {
+				/* Advance past the colon */
+				c++;
+			}
 		}
 	}
 

--- a/src/lib/Libcmds/prepare_path.c
+++ b/src/lib/Libcmds/prepare_path.c
@@ -164,8 +164,7 @@ prepare_path(char *path_in, char *path_out)
 					break;
 				}
 			}
-			if (*c != ':')
-			{
+			if (*c != ':') {
 				if (*c == '/') {
 					/* There's a colon in the path */ 
 					host_given = NULL;
@@ -177,8 +176,7 @@ prepare_path(char *path_in, char *path_out)
 				}
 				else
 					return 1;
-			}
-			else {
+			} else {
 				/* Advance past the colon */
 				c++;
 			}

--- a/src/lib/Libcmds/prepare_path.c
+++ b/src/lib/Libcmds/prepare_path.c
@@ -173,8 +173,7 @@ prepare_path(char *path_in, char *path_out)
 						if (isspace(*c) == 0)
 							break;
 					}
-				}
-				else
+				} else
 					return 1;
 			} else {
 				/* Advance past the colon */

--- a/test/tests/functional/pbs_qsub_opts_args.py
+++ b/test/tests/functional/pbs_qsub_opts_args.py
@@ -261,11 +261,11 @@ bhtiusabsdlg' % (os.environ['HOME'])
     @runOnlyOnLinux
     def test_qsub_with_options_o_e_with_colon(self):
         """
-        Test submission of job with output and error 
+        Test submission of job with output and error
         paths with a colon
         """
         self.server.manager(MGR_CMD_SET, SERVER,
-                {'job_history_enable': 'true'})
+                            {'job_history_enable': 'true'})
         tmp_dir = self.du.create_temp_dir(asuser=TEST_USER)
         err_file = os.path.join(tmp_dir, 'err:or_file')
         out_file = os.path.join(tmp_dir, 'out:put_file')
@@ -274,5 +274,7 @@ bhtiusabsdlg' % (os.environ['HOME'])
         j.set_sleep_time(1)
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'F'}, extend='x', id=jid)
-        self.assertTrue(os.path.isfile(err_file), "The error file was not found")
-        self.assertTrue(os.path.isfile(out_file), "The output file was not found")
+        self.assertTrue(os.path.isfile(err_file),
+                        "The error file was not found")
+        self.assertTrue(os.path.isfile(out_file),
+                        "The output file was not found")

--- a/test/tests/functional/pbs_qsub_opts_args.py
+++ b/test/tests/functional/pbs_qsub_opts_args.py
@@ -257,3 +257,22 @@ bhtiusabsdlg' % (os.environ['HOME'])
         with location set to PBS_USER_HOME.
         """
         self.jobdir_shared_body("PBS_USER_HOME")
+
+    @runOnlyOnLinux
+    def test_qsub_with_options_o_e_with_colon(self):
+        """
+        Test submission of job with output and error 
+        paths with a colon
+        """
+        self.server.manager(MGR_CMD_SET, SERVER,
+                {'job_history_enable': 'true'})
+        tmp_dir = self.du.create_temp_dir(asuser=TEST_USER)
+        err_file = os.path.join(tmp_dir, 'err:or_file')
+        out_file = os.path.join(tmp_dir, 'out:put_file')
+        a = {ATTR_e: err_file, ATTR_o: out_file}
+        j = Job(TEST_USER, attrs=a)
+        j.set_sleep_time(1)
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'F'}, extend='x', id=jid)
+        self.assertTrue(os.path.isfile(err_file), "The error file was not found")
+        self.assertTrue(os.path.isfile(out_file), "The output file was not found")


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Linux allows the file path to contain colons(:). However, while specifying a file path for ATTR_o or ATTR_e (output and error paths) qsub rejects a path with a colon in it.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
If a path with a colon is provided to qsub, it considers it to include a hostname compulsorily. In `prepare_path` when we parse the string to extract a hostname we break out of the loop if the character is not a valid character for hosts (alphanumeric, periods, and hyphens). So we check for a '/' there (signifying a path with a possible colon) and continue the function with no host.


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[logs_qsub_colon.txt](https://github.com/openpbs/openpbs/files/6392327/logs_qsub_colon.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
[ptl.log](https://github.com/openpbs/openpbs/files/6396649/ptl.log)
![th3_open](https://user-images.githubusercontent.com/40992476/116509657-50b3ca00-a8e1-11eb-9a64-01e7dd06deb8.PNG)
