### PR TITLE
Fix systemd version detection in cgroup hook

### DIFF
--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -3758,7 +3758,8 @@ class CgroupUtils(object):
             # before calling splitlines
             # should not happen since we pass universal_newlines True
             out_split = stringified_output(out).splitlines()
-            ver = int(re.sub(r'Version=\D*(\d+)', r'\1', out_split[0]))
+            ver = int(re.sub(r'Version=\D*(\d+)', r'\1',
+                             out_split[0].split()[0]))
         except Exception:
             # Note we also get here if we can't decode an int version
             return 0

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -1367,7 +1367,7 @@ sleep 300
             "default"            : "256MB",
             "reserve_percent"    : 0,
             "swappiness"         : 0,
-            "reserve_amount"     : "2GB",
+            "reserve_amount"     : "1GB",
             "enforce_default"    : true,
             "exclhost_ignore_default" : true
         },
@@ -1436,7 +1436,7 @@ sleep 300
             "default"            : "100MB",
             "reserve_percent"    : 0,
             "swappiness"         : 0,
-            "reserve_amount"     : "2GB",
+            "reserve_amount"     : "1GB",
             "enforce_default"    : %s,
             "exclhost_ignore_default" : true
         },


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
After updating RedHat 8, I have noticed that systemd now reports the version string differently.

$ systemctl --system show --property=Version
Version=$ systemctl --system show --property=Version
Version=239 (239-41.el8_3.2)

The addition of a space and a parenthesized version (which is not purely numerical) is an unannounced systemd external interface change, and throws off the systemd detection code in the master hook. As a result systemd_version is set to 0 because of the exception converting "239 (239-41.el8_3.2)" rather than just "239" to an integer.

```
04/22/2021 17:54:01.573777;0800;pbs_python;Hook;pbs_python;_get_systemd_version: Method called
04/22/2021 17:54:01.578396;0800;pbs_python;Hook;pbs_python;__init__: systemd version seems to be 0
```

If you remove the exception catcher that hides the cause of the problem that sets the systemd version incorrectly, you can see an exception because of the extended string:

```
04/22/2021 18:54:14.526440;0080;pbs_python;Hook;pbs_python;['Traceback (most recent call last):', '  File "<embedded code object>", line 6337, in main', '  File "<embedded code object>", line 2817, in __init__', '  File "<embedded code object>", line 3808, in _get_systemd_version', "ValueError: invalid literal for int() with base 10: '239 (239-41.el8_3.1)'"]
```

A systemd version of 0 in turn results in a hook that does not create a pbs_jobs.service service and registers it to systemd to get delegate authority/control over the cgroups created; in the past we've seen that lead to errors because systemd interferes with the setttings (systemd thinks it 'owns' the entire hierarchy and if it thinks it's "inconsistent" with what it knows can move processes out of the cgroups, reset limits (e.g. reset memory limits to unlimited) and reset default devices.list (which breaks GPU assignment when sharing a host between different jobs each wanting a GPU); we've even seen systemd kill processes.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Pass only the string up to but not including the first whitespace to the regular expression parser that removes a possible "Version=" string at the start. If there are no spaces, split() will simply return the entire string (as before).

i.e. instead of 
```
            ver = int(re.sub(r'Version=\D*(\d+)', r'\1', out_split[0]))
```
use 
```
            ver = int(re.sub(r'Version=\D*(\d+)', r'\1',
                             out_split[0].split()[0]))
```

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
No design document -- just a bug fix to add compatibility with all currently known versions of systemd.

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Tests to be run on TH.

Note: the current branch code includes the fix submitted in PR https://github.com/openpbs/openpbs/pull/2370 , to get a minimal set of test failures. If that PR is merged, I will rebase so that the difference for this PR is minimal with respect to master is minimal and concerns only this bug.

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
