### PR TITLE
Cgroup mount paths

### DIFF
--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -3001,7 +3001,7 @@ class CgroupUtils(object):
                 prefix = subsys + '.2MB.'
             elif subsys == 'memsw':
                 prefix = 'memory.' + subsys + '.'
-            elif subsys in ['freezer', 'systemd']:
+            elif subsys in ['systemd', 'perf_event']:
                 prefix = ''
             else:
                 prefix = subsys + '.'
@@ -3018,7 +3018,9 @@ class CgroupUtils(object):
         pbs.logmsg(pbs.EVENT_DEBUG4, '%s: Method called' % caller_name())
         paths = {}
         subsys_to_discover = {'blkio', 'cpu', 'cpuacct', 'cpuset', 'devices',
-                              'freezer', 'hugetlb', 'pids', 'memory'}
+                              'freezer', 'hugetlb', 'memory', 'net_cls',
+                              'net_prio', 'perf_event', 'pids', 'rdma',
+                              'systemd'}
         subsys_to_skip = set()
 
         # First deal with the ones with paths set in the configuration file
@@ -3404,6 +3406,13 @@ class CgroupUtils(object):
         defaults['cgroup']['hugetlb']['reserve_percent'] = 0
         defaults['cgroup']['hugetlb']['reserve_amount'] = '0MB'
         defaults['cgroup']['hugetlb']['vnode_hidden_mb'] = 1
+
+        # These are unmanaged -- if enabled only creation/removal
+        # and filling in 'tasks' are currently performed
+        defaults['cgroup']['blkio'] = {}
+        defaults['cgroup']['blkio']['enabled'] = False
+        defaults['cgroup']['freezer'] = {}
+        defaults['cgroup']['freezer']['enabled'] = False
         defaults['cgroup']['net_cls'] = {}
         defaults['cgroup']['net_cls']['enabled'] = False
         defaults['cgroup']['net_prio'] = {}
@@ -3412,10 +3421,8 @@ class CgroupUtils(object):
         defaults['cgroup']['perf_event']['enabled'] = False
         defaults['cgroup']['pids'] = {}
         defaults['cgroup']['pids']['enabled'] = False
-        defaults['cgroup']['freezer'] = {}
-        defaults['cgroup']['freezer']['enabled'] = False
-        defaults['cgroup']['blkio'] = {}
-        defaults['cgroup']['blkio']['enabled'] = False
+        defaults['cgroup']['rdma'] = {}
+        defaults['cgroup']['rdma']['enabled'] = False
 
         # Identify the config file and read in the data
         config_file = ''
@@ -3683,7 +3690,9 @@ class CgroupUtils(object):
                    % (mem_avail, vmem_avail, hpmem_avail))
 
         for key in self.paths:
-            if key in ('blkio', 'cpu', 'cpuacct', 'freezer', 'systemd'):
+            if key in ('blkio', 'cpu', 'cpuacct', 'freezer',
+                        'net_cls', 'net_prio', 'perf_event',
+                        'pids', 'rdma', 'systemd'):
                 continue
             if not self.enabled(key):
                 continue
@@ -3768,12 +3777,8 @@ class CgroupUtils(object):
                                            '= %s'
                                            % (caller_name(), jobid, key,
                                               assigned[jobid][key]['list']))
-                elif key == 'pids':
-                    pbs.logmsg(pbs.EVENT_DEBUG4, '%s: subsystem %s' %
-                               (caller_name(), key))
-                elif key == 'systemd':
-                    pbs.logmsg(pbs.EVENT_DEBUG4, '%s: subsystem %s' %
-                               (caller_name(), key))
+                # Note: unmanaged but known subsystems should be filtered
+                # at the top of the loop body
                 else:
                     pbs.logmsg(pbs.EVENT_DEBUG4, '%s: Unknown subsystem %s' %
                                (caller_name(), key))
@@ -3799,6 +3804,8 @@ class CgroupUtils(object):
             # if we get a non-str type then convert
             # before calling splitlines
             # should not happen since we pass universal_newlines True
+            # Note: some versions prepend "Version=", other versions
+            # add a more precise version in parentheses after a space
             out_split = stringified_output(out).splitlines()
             ver = int(re.sub(r'Version=\D*(\d+)', r'\1',
                              out_split[0].split()[0]))

--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -2203,8 +2203,8 @@ class NodeUtils(object):
                        caller_name())
         cpuinfo['physical_cpus'] = int(cpuinfo['logical_cpus']
                                        // cpuinfo['hyperthreads_per_core'])
-        wanted_keys = ['physical_cpus', 'logical_cpus','hyperthreads_per_core',
-                       'hyperthreads']
+        wanted_keys = ['physical_cpus', 'logical_cpus',
+                       'hyperthreads_per_core', 'hyperthreads']
         cpuinfo_short = dict((k, cpuinfo[k])
                              for k in wanted_keys if k in cpuinfo)
         pbs.logmsg(pbs.EVENT_DEBUG4, "%s returning: %s"
@@ -3017,6 +3017,37 @@ class CgroupUtils(object):
         """
         pbs.logmsg(pbs.EVENT_DEBUG4, '%s: Method called' % caller_name())
         paths = {}
+        subsys_to_discover = {'blkio', 'cpu', 'cpuacct', 'cpuset', 'devices',
+                              'freezer', 'hugetlb', 'pids', 'memory'}
+        subsys_to_skip = set()
+
+        # First deal with the ones with paths set in the configuration file
+        for subsys in subsys_to_discover:
+            if (subsys in self.cfg['cgroup']
+                    and 'mount_path' in self.cfg['cgroup'][subsys]
+                    and self.cfg['cgroup'][subsys]['mount_path']):
+                flags = []
+                if (subsys == 'cpuset'
+                        and os.path.exists(os.path.join(self.cfg['cgroup']
+                                                                ['cpuset']
+                                                                ['mount_path'],
+                                                        'cpus'))):
+                    flags = ['noprefix']
+                paths[subsys] = \
+                    self._assemble_path(subsys,
+                                        self.cfg['cgroup'][subsys]
+                                                ['mount_path'],
+                                        flags)
+                # memory -> memsw, different prefix
+                if (subsys == 'memory'):
+                    paths['memsw'] = \
+                        self._assemble_path(subsys,
+                                            self.cfg['cgroup']['memory']
+                                                    ['mount_path'],
+                                            flags)
+                subsys_to_skip.add(subsys)
+        subsys_to_discover -= subsys_to_skip
+
         # Loop through the mounts and collect the ones for cgroups
         with open(os.path.join(os.sep, 'proc', 'mounts'), 'r') as desc:
             for line in desc:
@@ -3026,21 +3057,28 @@ class CgroupUtils(object):
                 # It is possible to have more than one cgroup mounted in
                 # the same place, so check them all for each mount.
                 flags = entries[3].split(',')
-                for subsys in ['blkio', 'cpu', 'cpuacct', 'cpuset', 'devices',
-                               'freezer', 'hugetlb', 'pids']:
-                    if subsys in flags:
-                        paths[subsys] = self._assemble_path(subsys, entries[1],
-                                                            flags)
-                if 'memory' in flags:
-                    paths['memory'] = \
-                        self._assemble_path('memory', entries[1], flags)
-                    # memory and memsw share a common mount point,
-                    # but use a different prefix
-                    paths['memsw'] = \
-                        self._assemble_path('memsw', entries[1], flags)
-                if 'systemd' in flags or 'name=systemd' in flags:
-                    paths['systemd'] = \
-                        self._assemble_path('systemd', entries[1], flags)
+                for subsys in subsys_to_discover:
+                    if (subsys in flags
+                            or (subsys == 'systemd'
+                                and ('name=systemd' in flags))):
+                        subsys_path_candidate = \
+                            self._assemble_path(subsys, entries[1], flags)
+                        # If there are more than one option, prefer shortest
+                        if (subsys not in paths
+                            or (len(paths[subsys])
+                                > len(subsys_path_candidate))):
+                            if subsys in paths:
+                                pbs.logmsg(pbs.EVENT_DEBUG3,
+                                           '_get_paths: shorter path+prefix '
+                                           '%s used for subsystem %s'
+                                           % (subsys_path_candidate, subsys))
+                            if subsys == 'memory':
+                                # memory and memsw share a common mount point,
+                                # but use a different prefix
+                                paths['memsw'] = \
+                                    self._assemble_path('memsw', entries[1],
+                                                        flags)
+                            paths[subsys] = subsys_path_candidate
 
         # if a host does not have any cgroup controllers mounted
         # don't panic here, let main code handle it by just accepting event
@@ -3374,6 +3412,10 @@ class CgroupUtils(object):
         defaults['cgroup']['perf_event']['enabled'] = False
         defaults['cgroup']['pids'] = {}
         defaults['cgroup']['pids']['enabled'] = False
+        defaults['cgroup']['freezer'] = {}
+        defaults['cgroup']['freezer']['enabled'] = False
+        defaults['cgroup']['blkio'] = {}
+        defaults['cgroup']['blkio']['enabled'] = False
 
         # Identify the config file and read in the data
         config_file = ''

--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -3691,8 +3691,8 @@ class CgroupUtils(object):
 
         for key in self.paths:
             if key in ('blkio', 'cpu', 'cpuacct', 'freezer',
-                        'net_cls', 'net_prio', 'perf_event',
-                        'pids', 'rdma', 'systemd'):
+                       'net_cls', 'net_prio', 'perf_event',
+                       'pids', 'rdma', 'systemd'):
                 continue
             if not self.enabled(key):
                 continue

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -5235,7 +5235,7 @@ sleep 300
         a = {'Resource_List.select':
              "1:ncpus=1:host=%s" % self.hosts_list[0]}
         j = Job(TEST_USER, attrs=a)
-        j.create_script(self.sleep100_job)
+        j.create_script(self.sleep600_job)
         jid = self.server.submit(j)
         a = {'job_state': 'R'}
         self.server.expect(JOB, a, jid)

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -4770,7 +4770,7 @@ sleep 300
         # N is the number of 'cpu cores' per M. and P being the
         # number of hyperthreads per core.
         njobs = len(phys) * cores * hyperthreads_per_core
-        if njobs > 64:
+        if njobs > 100:
             self.skipTest("too many jobs (%d) to submit" % njobs)
         a = {'Resource_List.select': '1:ncpus=1:mem=300mb:host=%s' %
              self.hosts_list[0], ATTR_N: name + 'a'}

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -1767,9 +1767,13 @@ if %s e.job.in_ms_mom():
         events = ['execjob_begin', 'execjob_launch', 'execjob_attach',
                   'execjob_epilogue', 'execjob_end', 'exechost_startup',
                   'exechost_periodic', 'execjob_resize', 'execjob_abort']
+        # Alarm timeout should be set really large because some tests will
+        # create a lot of simultaneous jobs on a single (slow) MoM
+        # Shipped default is 90 seconds, which is reasonable for real hosts,
+        # but not for containers or VMs sharing a host
         a = {'enabled': 'True',
              'freq': '10',
-             'alarm': 30,
+             'alarm': 120,
              'event': events}
         # Sometimes the deletion of the old hook is still pending
         failed = True

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -2618,7 +2618,7 @@ if %s e.job.in_ms_mom():
         # Submit M jobs N cpus wide, where M is the amount of physical
         # processors and N is number of 'cpu cores' per M. Expect them to run.
         njobs = phys
-        if njobs > 64:
+        if njobs > 100:
             self.skipTest("too many jobs (%d) to submit" % njobs)
         a = {'Resource_List.select': '1:ncpus=%s:mem=300mb:host=%s' %
              (cores, self.hosts_list[0]), ATTR_N: name + 'a'}

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -4776,6 +4776,9 @@ sleep 300
              self.hosts_list[0], ATTR_N: name + 'a'}
         for _ in range(njobs):
             j = Job(TEST_USER, attrs=a)
+            # make sure this stays around for an hour
+            # (or until deleted in teardown)
+            j.set_sleep_time(3600)
             jid = self.server.submit(j)
             a1 = {'job_state': 'R'}
             self.server.expect(JOB, a1, jid)

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -2702,7 +2702,7 @@ if %s e.job.in_ms_mom():
 
         a = {
             'Resource_List.select':
-            '1:ncpus=1:mem=300mb:vmem=320mb:host=%s' % self.hosts_list[0],
+            '1:ncpus=1:mem=400mb:vmem=420mb:host=%s' % self.hosts_list[0],
             ATTR_N: name}
         j = Job(TEST_USER, attrs=a)
         j.create_script(self.eatmem_job1)
@@ -5147,7 +5147,7 @@ sleep 300
         # First job -- request vmem and no pvmem,
         # RLIMIT_AS shoud be unlimited
         a = {'Resource_List.select':
-             '1:ncpus=0:mem=300mb:vmem=300mb:vnode=%s'
+             '1:ncpus=0:mem=400mb:vmem=400mb:vnode=%s'
              % self.mom.shortname}
 
         j = Job(TEST_USER, attrs=a)
@@ -5173,7 +5173,7 @@ sleep 300
 
         # Second job -- see if pvmem still works
         # RLIMIT_AS should correspond to pvmem
-        a['Resource_List.pvmem'] = '300mb'
+        a['Resource_List.pvmem'] = '400mb'
         j = Job(TEST_USER, attrs=a)
         j.create_script("#!/bin/bash\nulimit -v")
         jid = self.server.submit(j)
@@ -5193,9 +5193,9 @@ sleep 300
         job_out = '\n'.join(result['out'])
         self.logger.info("job_out=%s" % job_out)
         # ulimit reports kb, not bytes
-        self.assertTrue(str(300 * 1024) in job_out)
-        self.logger.info("Job that requests 300mb pvmem "
-                         "correctly has 300mb RLIMIT_AS")
+        self.assertTrue(str(400 * 1024) in job_out)
+        self.logger.info("Job that requests 400mb pvmem "
+                         "correctly has 400mb RLIMIT_AS")
 
     def test_cgroup_mount_paths(self):
         """

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -5203,29 +5203,23 @@ sleep 300
         but also if it can be overrided in the config file
         """
 
-        if (self.paths[self.hosts_list[0]]['cpuset']
-                != '/sys/fs/cgroup/cpuset'):
-            self.skipTest('Test requires main "cpuset" ctrlr mount '
-                          'under /sys/fs/cgroup')
         if self.du.isdir(self.hosts_list[0], '/dev/tstc'):
-            self.skipTest('Test requires /dev/tstcs not to exist')
+            self.skipTest('Test requires /dev/tstc not to exist')
         if self.du.isdir(self.hosts_list[0], '/dev/tstm'):
             self.skipTest('Test requires /dev/tstm not to exist')
 
         self.load_config(self.cfg17)
 
-        self.du.run_cmd(self.hosts_list[0],
-                        ['mkdir', '/dev/tstm'],
-                        sudo=True)
+        self.du.mkdir(hostname=self.hosts_list[0],
+                      path='/dev/tstm', mode=0o0755, sudo=True)
         self.du.run_cmd(self.hosts_list[0],
                         ['mount', '-t', 'cgroup', '-o',
                          'rw,nosuid,nodev,noexec,relatime,seclabel,memory',
                          'cgroup', '/dev/tstm'],
                         sudo=True)
 
-        self.du.run_cmd(self.hosts_list[0],
-                        ['mkdir', '/dev/tstc'],
-                        sudo=True)
+        self.du.mkdir(hostname=self.hosts_list[0],
+                      path='/dev/tstc', mode=0o0755, sudo=True)
         self.du.run_cmd(self.hosts_list[0],
                         ['mount', '-t', 'cgroup', '-o',
                          'rw,nosuid,nodev,noexec,relatime,seclabel,cpuset',

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -5210,21 +5210,52 @@ sleep 300
 
         self.load_config(self.cfg17)
 
-        self.du.mkdir(hostname=self.hosts_list[0],
-                      path='/dev/tstm', mode=0o0755, sudo=True)
-        self.du.run_cmd(self.hosts_list[0],
-                        ['mount', '-t', 'cgroup', '-o',
-                         'rw,nosuid,nodev,noexec,relatime,seclabel,memory',
-                         'cgroup', '/dev/tstm'],
-                        sudo=True)
+        dir_created = self.du.mkdir(hostname=self.hosts_list[0],
+                                    path='/dev/tstm', mode=0o0755,
+                                    sudo=True)
+        if not dir_created:
+            self.skipTest('not able to create /dev/tstm')
+        result = self.du.run_cmd(self.hosts_list[0],
+                                 ['mount', '-t', 'cgroup', '-o',
+                                  'rw,nosuid,nodev,noexec,relatime,seclabel,'
+                                  'memory',
+                                  'cgroup', '/dev/tstm'],
+                                 sudo=True)
+        if result['rc'] != 0:
+            self.du.run_cmd(self.hosts_list[0],
+                            ['rmdir', '/dev/tstm'],
+                            sudo=True)
+            self.skipTest('not able to mount /dev/tstm')
 
-        self.du.mkdir(hostname=self.hosts_list[0],
-                      path='/dev/tstc', mode=0o0755, sudo=True)
-        self.du.run_cmd(self.hosts_list[0],
-                        ['mount', '-t', 'cgroup', '-o',
-                         'rw,nosuid,nodev,noexec,relatime,seclabel,cpuset',
-                         'cgroup', '/dev/tstc'],
-                        sudo=True)
+        dir_created = self.du.mkdir(hostname=self.hosts_list[0],
+                                    path='/dev/tstc', mode=0o0755,
+                                    sudo=True)
+        if not dir_created:
+            self.du.run_cmd(self.hosts_list[0],
+                            ['umount', '/dev/tstm'],
+                            sudo=True)
+            self.du.run_cmd(self.hosts_list[0],
+                            ['rmdir', '/dev/tstm'],
+                            sudo=True)
+            self.skipTest('not able to create /dev/tstc')
+
+        result = self.du.run_cmd(self.hosts_list[0],
+                                 ['mount', '-t', 'cgroup', '-o',
+                                  'rw,nosuid,nodev,noexec,relatime,seclabel,'
+                                  'cpuset',
+                                  'cgroup', '/dev/tstc'],
+                                 sudo=True)
+        if result['rc'] != 0:
+            self.du.run_cmd(self.hosts_list[0],
+                            ['umount', '/dev/tstm'],
+                            sudo=True)
+            self.du.run_cmd(self.hosts_list[0],
+                            ['rmdir', '/dev/tstm'],
+                            sudo=True)
+            self.du.run_cmd(self.hosts_list[0],
+                            ['rmdir', '/dev/tstc'],
+                            sudo=True)
+            self.skipTest('not able to mount /dev/tstc')
 
         # sleep 2s: make sure no old log lines will match 'begin' time
         time.sleep(2)

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -1506,7 +1506,7 @@ sleep 300
             "default"            : "100MB",
             "reserve_percent"    : 0,
             "swappiness"         : 0,
-            "reserve_amount"     : "2GB",
+            "reserve_amount"     : "1GB",
             "enforce_default"    : true,
             "exclhost_ignore_default" : true
         },


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
We have two sites in Europe using Docker in combination with the cgroup hook (sometimes in parallel with PBSPro, i.e. with Docker making containers alongside the PBSPro ones made by the cgroup hook, sometimes cooperatively, with the PBSPro container hook creating cgroups within the per-job ones set up by pbs_cgroups.PY).

Very rarely, we see that the parsing of /proc/mounts makes it pick up different mounts of the cgroup controllers as the mount path to use; most of the time this has few ill effects, but since the mounts do not seem to be permanent and we don't synchronise with the docker daemon messing with them, the cgroup hook picks up a mount path but fails when it wants to actually use it.

The cgroup hook code indeed does not seem to countenance that a controller could be mounted in more than one spot, and certainly not that some of the mount paths encountered could be volatile. Furthermore, it always sets paths up using the last mount encountered for the controller in /proc/mounts, which is a recipe for disaster if we have other software adding mounts and then removing them.

At one site, the mount paths picked up usually refer to paths set up by Docker for individual containers (possibly in preparation for the cgroup controller mounts in the container?) At a second site, we see volatile mounts straight in /sys/fs/cgroup.

If those paths stay valid while an event is being processed it's invisible to the end user. Alas, if the cgroup hook picks up a mount path and then tries to use it when it no longer exists, it fails, with a message like e.g.:

"CgroupConfigError ('Failed to create directory: /sys/fs/cgroup/blkio,cpuacct,memory,freezer/pbspro.slice/pbspro-413268.pbs10.slice/ (ENOMEM)',)"

At that site, inspection of the host after the error was discovered did confirm that /sys/fs/cgroup/blkio,cpuacct,memory,freezer is nowhere to be found, but it must have been there when the execjob_begin event for that job caused the hook to start running.

In the past, for one site we've extended the cgroup config file syntax to allow the site admin to hardcode the cgroup controller mount paths. That seems to have fixed all issues, so there's every chance to believe that the /sys/fs/cgroup/<controller> paths are unharmed and always usable. But of course it's onerous for a site admin to have to specify these. This was not submitted in a pull request, but since the problem is resurfacing at other sites, we probably need to reintroduce this.


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
For the new build which I have created to address the issue, when there are competing mounts discovered for a given controller, the hook will always use the shorter one; that will automatically pick up a permanent mount in all use cases I've seen and for all errors that I have seen up to now (note: on some systems like HPE/Cray or HPE/SGI, it may pick up /dev/cpuset or /dev/cgmem to manage cpusets resp. memory cgroup controllers instead of the distribution-standard /sys/fs/cgroup mount, but that is not a problem – these are permanent aliases).

But just in case this would not be caused by extra mounts but by a kernel bug that gives an incorrect path for the existing mount in rare race conditions, I also would like to introduce code to allow the mount paths for the cgroup controllers to be specified explicitly. That way sites could work around even those issues without us having to spin another version of the cgroup hook.

I also defined extra controllers that can be enabled, should Docker play more nicely with us when trying to create child cgroups in controller hierarchies that we do not manage (it may be because we do not create directories for some controllers Docker knows about that it is messing with the cgroup controller mounts). If you enable these controllers, the hook will do nothing except correctly populate the tasks file for them (and destroy them when the job ends).

The selection of the shorter mount and the introduction of "no operation" support for extra controllers is not truly an interface change, but I'll still describe it the design document as well.
#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
https://openpbs.atlassian.net/wiki/spaces/PD/pages/2750709761/Make+cgroup+hook+robust+in+the+face+of+volatile+cgroup+controller+mounts

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Changes to be tested on TH, results to be added in a note.

There is a new PTL test that mounts the cpuset controller on /dev/tstc and the memory controller on /dev/tstm. It then loads a config file that specifies /sys/fs/cgroup/cpuset to be forced for the cpuset controller.

Expected result: for the memory controller the hook shall use the shorter /dev/tstm path, for the cpuset controller it shall use the path specified in the configuration file.

Note: the code currently includes changes for PRs:
https://github.com/openpbs/openpbs/pull/2370
https://github.com/openpbs/openpbs/pull/2372

to ensure it works on my test system (which has a systemd that does not play nice with master) and that there is a minimal set of spurious test failures.

If those PRs are merged before this one, I'll rebase so that the differences will no longer include changes for these other issues.

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
