### PR TITLE
fix tpp large data packet handling

### DIFF
--- a/src/lib/Libtpp/tpp_em.c
+++ b/src/lib/Libtpp/tpp_em.c
@@ -1092,11 +1092,6 @@ tpp_mbox_read(tpp_mbox_t *mbox, unsigned int *tfd, int *cmdval, void **data)
 	} else {
 		/* reduce from mbox size during read */
 		mbox->mbox_size -= cmd->sz;
-#ifdef TPPDEBUG
-		if ((mbox->max_size != -1) && (cmd->sz > 0)) {
-			TPP_DBPRT("Mbox %s, after reading %d size = %d", mbox->mbox_name, cmd->sz, mbox->mbox_size);
-		}
-#endif
 	}
 
 	tpp_unlock(&mbox->mbox_mutex);
@@ -1221,12 +1216,6 @@ tpp_mbox_post(tpp_mbox_t *mbox, unsigned int tfd, char cmdval, void *data, int s
 	
 	/* add to the size to global size during enque */
 	mbox->mbox_size += sz;
-
-#ifdef TPPDEBUG
-	if ((mbox->max_size != -1) && (sz > 0)) {
-		TPP_DBPRT("Mbox %s, after adding %d  size = %d",  mbox->mbox_name, sz, mbox->mbox_size);
-	}
-#endif
 
 	tpp_unlock(&mbox->mbox_mutex);
 

--- a/src/lib/Libtpp/tpp_internal.h
+++ b/src/lib/Libtpp/tpp_internal.h
@@ -139,7 +139,7 @@ typedef struct {
 typedef struct {
 	pbs_list_link chunk_link;
 	char *data;	/* pointer to the data buffer */
-	int len;	/* length of the data buffer */
+	size_t len;	/* length of the data buffer */
 	char *pos;	/* current position - till which data is consumed */
 } tpp_chunk_t;
 
@@ -150,12 +150,12 @@ typedef struct {
 typedef struct {
 	pbs_list_head chunks;
 	tpp_chunk_t *curr_chunk;
-	int totlen;
+	size_t totlen;
 	int ref_count;	/* number of accessors */
 } tpp_packet_t;
 
 typedef struct {
-	int ntotlen;
+	unsigned int ntotlen;
 	char type;
 } tpp_encrypt_hdr_t;
 
@@ -163,7 +163,7 @@ typedef struct {
  * The authenticate packet header structure
  */
 typedef struct {
-	int ntotlen;
+	unsigned int ntotlen;
 	unsigned char type;
 	unsigned int for_encrypt;
 	char auth_method[MAXAUTHNAME + 1];
@@ -175,7 +175,7 @@ typedef struct {
  * The Join packet header structure
  */
 typedef struct {
-	int ntotlen;
+	unsigned int ntotlen;
 	unsigned char type;         /* type packet, JOIN, LEAVE etc */
 	unsigned char hop;          /* hop count */
 	unsigned char node_type;    /* node type - leaf or router */
@@ -188,7 +188,7 @@ typedef struct {
  * The Leave packet header structure
  */
 typedef struct {
-	int ntotlen;
+	unsigned int ntotlen;
 	unsigned char type;      /* type packet, JOIN, LEAVE etc */
 	unsigned char hop;
 	unsigned char ecode;
@@ -200,7 +200,7 @@ typedef struct {
  * The control packet header structure, MSG, NOROUTE etc
  */
 typedef struct {
-	int ntotlen;
+	unsigned int ntotlen;
 	unsigned char type;
 	unsigned char code;        /* NOROUTE, UPDATE, ERROR */
 	unsigned char error_num;   /* error_num in case of NOROUTE, ERRORs */
@@ -213,7 +213,7 @@ typedef struct {
  * The data packet header structure
  */
 typedef struct {
-	int ntotlen;
+	unsigned int ntotlen;
 	unsigned char type;        /* type of the packet - TPP_DATA, JOIN etc */	
 
 	unsigned int src_magic;    /* magic id of source stream */
@@ -231,7 +231,7 @@ typedef struct {
  * The multicast packet header structure
  */
 typedef struct {
-	int ntotlen;
+	unsigned int ntotlen;
 	unsigned char type;       /* type of packet - TPP_MCAST_DATA */
 	unsigned char hop;        /* hop count */
 	unsigned int num_streams; /* number of member streams */

--- a/src/lib/Libtpp/tpp_util.c
+++ b/src/lib/Libtpp/tpp_util.c
@@ -725,6 +725,18 @@ tpp_bld_pkt(tpp_packet_t *pkt, void *data, int len, int dup, void **dup_data)
 	return pkt;
 }
 
+/**
+ * @brief
+ *	Free a chunk
+ *
+ * @param[in] - chunk - Ptr to the chunk to be freed.
+ *
+ * @par Side Effects:
+ *	None
+ *
+ * @par MT-safe: Yes
+ *
+ */
 void
 tpp_free_chunk(tpp_chunk_t *chunk)
 {
@@ -2474,7 +2486,8 @@ print_packet_hdr(const char *fnc, void *data, int len)
 		tpp_data_pkt_hdr_t *dhdr = (tpp_data_pkt_hdr_t *) data;
 
 		strncpy(buff, tpp_netaddr(&dhdr->src_addr), sizeof(buff));
-		tpp_log(LOG_CRIT, __func__, "%s: src_host=%s, dest_host=%s, len=%d, src_sd=%d, dest_sd=%d, src_magic=%d", str_types[type - 1], buff, tpp_netaddr(&dhdr->dest_addr), len,
+		tpp_log(LOG_CRIT, __func__, "%s: src_host=%s, dest_host=%s, len=%d, data_len=%d, src_sd=%d, dest_sd=%d, src_magic=%d", 
+			str_types[type - 1], buff, tpp_netaddr(&dhdr->dest_addr), len + sizeof(tpp_data_pkt_hdr_t), len,
 			ntohl(dhdr->src_sd), (ntohl(dhdr->dest_sd) == UNINITIALIZED_INT) ? -1 : ntohl(dhdr->dest_sd), ntohl(dhdr->src_magic));
 
 	} else {


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
the tcp recv() call's return value was being collected in a short. This is an obvious oversight. A packet size larger than can hold in a short resulted in a negative value of the return, and thus resulted in communication breakdown.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Fixed the return value (and for send as well) to be ssize_t.
Along with that fixed a few ints to be unsigned ints, some logging fixes.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Description: Tests from given sources on platforms SUSE15, CENTOS8, CENTOS7
Platforms: SUSE15,CENTOS8,CENTOS7
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|7296|2036|1|0|0|8|2027|

The single failure is unrelated to TPP anyway


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
