### PR TITLE
Sched multi-threading doesn't block relevant signals

### DIFF
--- a/src/scheduler/multi_threading.cpp
+++ b/src/scheduler/multi_threading.cpp
@@ -60,6 +60,8 @@
 #include "resource_resv.h"
 #include "multi_threading.h"
 
+extern sigset_t allsigs;
+
 /**
  * @brief	create the thread id key & set it for the main thread
  *
@@ -237,8 +239,8 @@ worker(void *tid)
 	pthread_setspecific(th_id_key, tid);
 	ntid = *(int *)tid;
 
-	/* Block HUPs, if we ever unblock this, we'll need to modify 'restart()' to handle MT */
-	sigemptyset(&set);
+	/* Add HUP to the list of signals to block, if we ever unblock this, we'll need to modify 'restart()' to handle MT */
+	set = allsigs;
 	sigaddset(&set, SIGHUP);
 
 	if (pthread_sigmask(SIG_BLOCK, &set, NULL) != 0) {


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Scheduler's MT code blocks SIGHUP, but no other signals. Since the main thread blocks the relevant signals after the threads are already created, the threads don't inherit the main thread's sigmask. This means that they can be interrupted while doing critical operations and lead to unexpected behavior.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Added SIGHUP to the sigmask that sched blocks instead of only adding SIGHUP. Now worker threads will block all relevant signals

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
**Before**
```
Thread 2 "pbs_sched" hit Breakpoint 1, check_node_eligibility_chunk (data=0x1655530) at ../../../src/scheduler/node_info.cpp:5567
5567		if (data == NULL)
(gdb) n

Thread 2 "pbs_sched" received signal SIGTERM, Terminated.
check_node_eligibility_chunk (data=0x1655530) at ../../../src/scheduler/node_info.cpp:5567
5567		if (data == NULL)
(gdb) n
die (sig=15) at ../../../src/scheduler/pbs_sched_utils.cpp:235
235		ret_lock = pthread_mutex_trylock(&cleanup_lock);
(gdb) n
236		if (ret_lock != 0)
(gdb) 
```

**After**
```
Thread 2 "pbs_sched" hit Breakpoint 1, check_node_eligibility_chunk (data=0xde3920) at ../../../src/scheduler/node_info.cpp:5567
5567		if (data == NULL)
(gdb) n

Thread 2 "pbs_sched" hit Breakpoint 1, check_node_eligibility_chunk (data=0xde3920) at ../../../src/scheduler/node_info.cpp:5570
5570		err = new_schd_error();
(gdb) n
5571		if (err == NULL) {
(gdb) n
5575		misc_err = new_schd_error();
(gdb) n
5576		if (misc_err == NULL) {
(gdb) finish
Run till exit from #0  check_node_eligibility_chunk (data=0xde3920) at ../../../src/scheduler/node_info.cpp:5576
[Switching to Thread 0x14c82f4e9700 (LWP 9933)]

Thread 3 "pbs_sched" hit Breakpoint 1, check_node_eligibility_chunk (data=0x90c8c0) at ../../../src/scheduler/node_info.cpp:5567
5567		if (data == NULL)
(gdb) c
Continuing.
[Switching to Thread 0x14c82f6ea700 (LWP 9932)]

Thread 2 "pbs_sched" hit Breakpoint 1, check_node_eligibility_chunk (data=0x90c8f0) at ../../../src/scheduler/node_info.cpp:5567
5567		if (data == NULL)
(gdb) c
Continuing.
[Switching to Thread 0x14c82f4e9700 (LWP 9933)]

Thread 3 "pbs_sched" hit Breakpoint 1, check_node_eligibility_chunk (data=0x90c8c0) at ../../../src/scheduler/node_info.cpp:5570
5570		err = new_schd_error();
(gdb) c
Continuing.
[Switching to Thread 0x14c82f6ea700 (LWP 9932)]

Thread 2 "pbs_sched" hit Breakpoint 1, check_node_eligibility_chunk (data=0x90c8f0) at ../../../src/scheduler/node_info.cpp:5570
5570		err = new_schd_error();
(gdb) c
Continuing.

Thread 1 "pbs_sched" received signal SIGTERM, Terminated.
[Switching to Thread 0x14c83454a740 (LWP 9924)]
0x000014c83266dac1 in sigprocmask () from /lib64/libc.so.6
```


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
