### PR TITLE
detect and initalize postgres in pbs_habitat to support centos8 stream

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -17,7 +17,7 @@ How to install PBS using the configure script.
       libX11-devel libXt-devel libedit-devel libical-devel \
       ncurses-devel perl postgresql-devel postgresql-contrib python3-devel tcl-devel \
       tk-devel swig expat-devel openssl-devel libXext libXft \
-      autoconf automake gcc-c++
+      autoconf automake gcc-c++ postgresql-server
 
   For CentOS-7 systems you should run the following command as root:
 

--- a/src/cmds/scripts/pbs_habitat.in
+++ b/src/cmds/scripts/pbs_habitat.in
@@ -59,6 +59,12 @@ get_db_user() {
 }
 
 chk_dataservice_user() {
+
+	# verify that postgres has been initalized correctly
+	if [ ! -d /var/lib/pgsql/ ]; then
+		postgresql-setup --initdb --unit postgresql
+	fi
+
 	chk_usr="$1"
 
 	# do user-id related stuff first


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
1. In CentOS 8 Stream PBS fails to initialize PostgreSQL properly due to the missing dependency `postgresql-server`
2. Without the instillation of `postgresql-server` and the execution of `postgresql-setup --initdb --unit postgresql`,
    `/etc/init.d/pbs start` will not start gracefully siting the error.

```
Starting PBS
PBS Home directory /var/spool/pbs needs updating.
Running /opt/pbs/libexec/pbs_habitat to update it.
***
PBS Data Service user postgres does not exist
```

3. This bug is due to the way CentOS 8 Stream `dnf` handles the post install of `postgresql` and will not initialize itself after a 
    `dnf install ...`

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
This problem is fixed by added a dependency in the INSTALL guide requiring the install of `postgresql-setup` for CentOS 8 Stream.
PostgreSQL initialization can be checked by checking the `/var/lib/pgsql` folder. If it doesn't exist then PostgresSQL has
never been initialized as such `postgresql-setup --initdb --unit postgresql` should be run which will intern generate
the `postgres` user and setup PostgreSQL to allow for  `/etc/init.d/pbs start` to start gracefully.



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
