### PR TITLE
Refactoring: removing the global for signal mask in sched

### DIFF
--- a/src/scheduler/multi_threading.cpp
+++ b/src/scheduler/multi_threading.cpp
@@ -238,7 +238,7 @@ worker(void *tid)
 	ntid = *(int *)tid;
 
 	/* Add HUP to the list of signals to block, if we ever unblock this, we'll need to modify 'restart()' to handle MT */
-	pthread_sigmask(SIG_BLOCK, NULL, &set);
+	sigemptyset(&set);
 	sigaddset(&set, SIGHUP);
 
 	if (pthread_sigmask(SIG_BLOCK, &set, NULL) != 0) {

--- a/src/scheduler/multi_threading.cpp
+++ b/src/scheduler/multi_threading.cpp
@@ -60,8 +60,6 @@
 #include "resource_resv.h"
 #include "multi_threading.h"
 
-extern sigset_t allsigs;
-
 /**
  * @brief	create the thread id key & set it for the main thread
  *
@@ -240,7 +238,7 @@ worker(void *tid)
 	ntid = *(int *)tid;
 
 	/* Add HUP to the list of signals to block, if we ever unblock this, we'll need to modify 'restart()' to handle MT */
-	set = allsigs;
+	pthread_sigmask(SIG_BLOCK, NULL, &set);
 	sigaddset(&set, SIGHUP);
 
 	if (pthread_sigmask(SIG_BLOCK, &set, NULL) != 0) {

--- a/src/scheduler/pbs_sched_utils.cpp
+++ b/src/scheduler/pbs_sched_utils.cpp
@@ -105,6 +105,9 @@ char **glob_argv;
 char usage[] = "[-d home][-L logfile][-p file][-I schedname][-n][-N][-c clientsfile][-t num threads]";
 struct sockaddr_in saddr;
 sigset_t allsigs;
+sigset_t oldsigs;
+
+int sigstoblock[] = {SIGHUP, SIGINT, SIGTERM, SIGUSR1};
 
 /* if we received a sigpipe, this probably means the server went away. */
 
@@ -1047,10 +1050,11 @@ sched_main(int argc, char *argv[], schedule_func sched_ptr)
 		exit(1);
 	}
 	act.sa_flags = 0;
-	sigaddset(&allsigs, SIGHUP);  /* remember to block these */
-	sigaddset(&allsigs, SIGINT);  /* during critical sections */
-	sigaddset(&allsigs, SIGTERM); /* so we don't get confused */
-	sigaddset(&allsigs, SIGUSR1);
+
+	/* remember to block these during critical sections so we don't get confused */
+	for (auto &sig: sigstoblock) {
+		sigaddset(&allsigs, sig);
+	}
 	act.sa_mask = allsigs;
 
 	act.sa_handler = restart; /* do a restart on SIGHUP */
@@ -1138,6 +1142,9 @@ sched_main(int argc, char *argv[], schedule_func sched_ptr)
 	/*
 	 *  Local initialization stuff
 	 */
+	/* Set the signal mask temporarily for thread initialization */
+	if (sigprocmask(SIG_BLOCK, &allsigs, &oldsigs) == -1)
+		log_err(errno, __func__, "sigprocmask(SIG_BLOCK)");
 	if (schedinit(nthreads)) {
 		(void) sprintf(log_buffer,
 			       "local initialization failed, terminating");
@@ -1145,6 +1152,8 @@ sched_main(int argc, char *argv[], schedule_func sched_ptr)
 			   __func__, log_buffer);
 		exit(1);
 	}
+	if (sigprocmask(SIG_SETMASK, &oldsigs, NULL) == -1)
+		log_err(errno, __func__, "sigprocmask(SIG_SETMASK)");
 
 	sprintf(log_buffer, "Out of memory");
 
@@ -1218,7 +1227,6 @@ sched_main(int argc, char *argv[], schedule_func sched_ptr)
 static int
 schedule_wrapper(sched_cmd *cmd, int opt_no_restart)
 {
-	sigset_t oldsigs;
 	time_t now;
 
 #ifdef PBS_UNDOLR_ENABLED


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Recently I fixed a signal blocking issue with scheduler multi-threading (https://github.com/openpbs/openpbs/pull/2376), but I added a global dependency on libsched in the process, which can cause issues to anything that links with libsched other than pbs_sched, and is a bad coding practice as well. So, this PR refactors the original fix.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
