### PR TITLE
mem leaks in pbs_ds_password

### DIFF
--- a/src/lib/Libdb/pgsql/db_common.c
+++ b/src/lib/Libdb/pgsql/db_common.c
@@ -723,6 +723,8 @@ pbs_db_password(void *conn, char *userid, char *password, char *olduser)
 		/* alter user ${user} SUPERUSER ENCRYPTED PASSWORD '${passwd}' */
 		sprintf(sqlbuff, "alter user \"%s\" SUPERUSER ENCRYPTED PASSWORD '%s'", olduser, pquoted);
 	}
+	free(pquoted);
+
 	if (db_execute_str(conn, sqlbuff) == -1)
 		return -1;
 	if (change_user) {


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Memory leaks in pbs_ds_password:
```
==52424== HEAP SUMMARY:
==52424==     in use at exit: 10,019 bytes in 28 blocks
==52424==   total heap usage: 282 allocs, 254 frees, 112,583 bytes allocated
==52424==
==52424== 9 bytes in 1 blocks are definitely lost in loss record 8 of 28
==52424==    at 0x4C30F0B: malloc (vg_replace_malloc.c:307)
==52424==    by 0x60EBF4D: strdup (in /usr/lib64/libc-2.28.so)
==52424==    by 0x404998: pbs_get_dataservice_usr (get_dataservice_usr.c:108)
==52424==    by 0x403A9E: main (pbs_ds_password.c:399)
==52424==
==52424== 33 bytes in 1 blocks are definitely lost in loss record 20 of 28
==52424==    at 0x4C3321A: calloc (vg_replace_malloc.c:760)
==52424==    by 0x4E41911: db_escape_str (db_common.c:1306)
==52424==    by 0x4E41911: pbs_db_password (db_common.c:706)
==52424==    by 0x403DF8: main (pbs_ds_password.c:547)
==52424==
==52424== LEAK SUMMARY:
==52424==    definitely lost: 42 bytes in 2 blocks
==52424==    indirectly lost: 0 bytes in 0 blocks
==52424==      possibly lost: 0 bytes in 0 blocks
==52424==    still reachable: 9,977 bytes in 26 blocks
==52424==         suppressed: 0 bytes in 0 blocks
==52424== Reachable blocks (those to which a pointer was found) are not shown.
==52424== To see them, rerun with: --leak-check=full --show-leak-kinds=all
```

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Fixed the leaks

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
```
==55269== Memcheck, a memory error detector
==55269== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==55269== Using Valgrind-3.16.0 and LibVEX; rerun with -h for copyright info
==55269== Command: /opt/pbs/sbin/pbs_ds_password.bin -r
==55269== Parent PID: 55257
==55269== 
==55269== 
==55269== HEAP SUMMARY:
==55269==     in use at exit: 9,977 bytes in 26 blocks
==55269==   total heap usage: 282 allocs, 256 frees, 112,575 bytes allocated
==55269== 
==55269== LEAK SUMMARY:
==55269==    definitely lost: 0 bytes in 0 blocks
==55269==    indirectly lost: 0 bytes in 0 blocks
==55269==      possibly lost: 0 bytes in 0 blocks
==55269==    still reachable: 9,977 bytes in 26 blocks
==55269==         suppressed: 0 bytes in 0 blocks
==55269== Reachable blocks (those to which a pointer was found) are not shown.
==55269== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==55269== 
==55269== For lists of detected and suppressed errors, rerun with: -s
==55269== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```


**Regression results:**
Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, WIN2K16
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|7367|4164|0|0|0|1|4163|

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
