### PR TITLE
Removing clienthost entry from mom config on installation

### DIFF
--- a/src/cmds/scripts/pbs_habitat.in
+++ b/src/cmds/scripts/pbs_habitat.in
@@ -220,30 +220,6 @@ if [ $? -ne 0 ]; then
 fi
 server=`echo ${server_hostname} | awk -F. '{print $1}'`
 
-# Check the clienthost entries if present
-if [ -f "$PBS_HOME/mom_priv/config" ]; then
-	cmd='cat "$PBS_HOME/mom_priv/config"'
-	cmd="$cmd | sed -e 's/\t/ /g' -e 's/ \\+/ /g' -e 's/^ //' -e 's/ $//'"
-	cmd="$cmd | grep '\\\$clienthost' | cut -d' ' -f2"
-	for host in `eval $cmd`; do
-		if [ -z "$host" -o "$host" = 'CHANGE_THIS_TO_PBS_SERVER_HOSTNAME' ]; then
-			echo "***" >&2
-			echo "*** Invalid entry in $PBS_HOME/mom_priv/config" >&2
-			echo "*** for clienthost: $host" >&2
-			echo "***" >&2
-			exit 1
-		fi
-		if ! check_hostname "${host}"; then
-			echo "***" >&2
-			echo "*** Invalid entry in $PBS_HOME/mom_priv/config" >&2
-			echo "*** for clienthost: $host" >&2
-			echo "*** This value must resolve to a valid IP address." >&2
-			echo "***" >&2
-			exit 1
-		fi
-	done
-fi
-
 if [ "${PBS_START_SERVER:-0}" != 0 ] ; then
 	# Check for the db install script
 	if [ ! -x "${PBS_EXEC}/libexec/pbs_db_utility" ]; then

--- a/src/cmds/scripts/pbs_postinstall.in
+++ b/src/cmds/scripts/pbs_postinstall.in
@@ -577,19 +577,7 @@ create_home() {
 			touch "$momconfig"
 			chmod 0644 "$momconfig"
 		fi
-		grep "^\$clienthost.*${PBS_SERVER}" "$momconfig" >/dev/null
-		if [ $? -ne 0 ] ; then
-			echo "\$clienthost $PBS_SERVER" >> $momconfig
-			if [ "${PBS_SERVER}" = 'CHANGE_THIS_TO_PBS_SERVER_HOSTNAME' ]; then
-				echo "***"
-				echo "*** ======="
-				echo "*** NOTICE:"
-				echo "*** ======="
-				echo "*** The clienthost entry for the server must be manually"
-				echo "*** modified in $momconfig"
-				echo "*** Update this value before starting PBS."
-			fi
-		fi
+		
 		if is_cray_xt; then
 			grep "^\$vnodedef_additive" "$momconfig" >/dev/null
 			if [ $? -ne 0 ] ; then

--- a/test/fw/ptl/lib/ptl_mom.py
+++ b/test/fw/ptl/lib/ptl_mom.py
@@ -149,16 +149,14 @@ class MoM(PBSService):
                     alps_client = self.du.which(exe='apbasil')
             else:
                 alps_client = "/opt/alps/apbasil.sh"
-            self.dflt_config = {'$clienthost': self.server.hostname,
-                                '$vnodedef_additive': 0,
+            self.dflt_config = {'$vnodedef_additive': 0,
                                 '$alps_client': alps_client,
                                 '$usecp': '*:%s %s' % (usecp, usecp)}
         elif self.platform == 'shasta':
             usecp = os.path.realpath('/lus')
-            self.dflt_config = {'$clienthost': self.server.hostname,
-                                '$usecp': '*:%s %s' % (usecp, usecp)}
+            self.dflt_config = {'$usecp': '*:%s %s' % (usecp, usecp)}
         else:
-            self.dflt_config = {'$clienthost': self.server.hostname}
+            self.dflt_config = {}
         self._is_cpuset_mom = None
 
         # If this is true, the mom will revert to default.

--- a/test/fw/ptl/lib/ptl_server.py
+++ b/test/fw/ptl/lib/ptl_server.py
@@ -1895,8 +1895,6 @@ class Server(Wrappers):
                 m = MoM(self, hostname, pbsconf_file=_n_pbsconf)
                 if m.isUp():
                     m.stop()
-                if hostname != self.hostname:
-                    m.add_config({'$clienthost': self.hostname})
                 try:
                     m.start()
                 except PbsServiceError:

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -250,7 +250,7 @@ class TestCgroupsHook(TestFunctional):
 
             self.logger.info("increase log level for mom and \
                              set polling intervals")
-            c = {'$logevent': '0xffffffff', '$clienthost': self.server.name,
+            c = {'$logevent': '0xffffffff',
                  '$min_check_poll': 8, '$max_check_poll': 12}
             mom.add_config(c)
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Removing $clienthost entry from mom config file on installation


#### Describe Your Change
Server hostname and local hostname are already been associated internally with clienthost. So keeping clienthost pointing to server name is redundant.
PBS will not keep $clienthost in mom config at installation.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, WIN2K16
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|7407|4164|1|0|0|1|4162|

Description: Rerun Only Failed Tests From #7407
Platforms: SLES12
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|7424|1|0|0|0|0|1|



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
