### PR TITLE
Check return output of mom bash version

### DIFF
--- a/test/fw/ptl/lib/ptl_mom.py
+++ b/test/fw/ptl/lib/ptl_mom.py
@@ -699,10 +699,9 @@ class MoM(PBSService):
         if len(ret['out']) > 0:
             mom_bash_version = ret['out'][0]
         else:
-            # Test case will be skipped when this function returns False,
-            # if it fails to get bash version. Run test if it fails to
-            # get bash version. On some platform command to get bash version
-            # might fail.
+            # If we can't get the bash version, there is no harm
+            # in trying to run the test. It might fail in an error,
+            # but at least we tried.
             return True
         if mom_bash_version >= req_bash_version:
             return True

--- a/test/fw/ptl/lib/ptl_mom.py
+++ b/test/fw/ptl/lib/ptl_mom.py
@@ -699,7 +699,8 @@ class MoM(PBSService):
         if len(ret['out']) > 0:
             mom_bash_version = ret['out'][0]
         else:
-            # If it fails to get bash version return True
+            # Test case will be skipped when this function returns False,
+            # if it fails to get bash version.
             return True
         if mom_bash_version >= req_bash_version:
             return True

--- a/test/fw/ptl/lib/ptl_mom.py
+++ b/test/fw/ptl/lib/ptl_mom.py
@@ -700,7 +700,9 @@ class MoM(PBSService):
             mom_bash_version = ret['out'][0]
         else:
             # Test case will be skipped when this function returns False,
-            # if it fails to get bash version.
+            # if it fails to get bash version. Run test if it fails to
+            # get bash version. On some platform command to get bash version
+            # might fail.
             return True
         if mom_bash_version >= req_bash_version:
             return True

--- a/test/fw/ptl/lib/ptl_mom.py
+++ b/test/fw/ptl/lib/ptl_mom.py
@@ -696,7 +696,11 @@ class MoM(PBSService):
         ret = self.du.run_cmd(self.hostname, cmd=cmd, sudo=True,
                               as_script=True)
         req_bash_version = "4.2.46"
-        mom_bash_version = ret['out'][0]
+        if len(ret['out']) > 0:
+            mom_bash_version = ret['out'][0]
+        else:
+            # If it fails to get bash version return True
+            return True
         if mom_bash_version >= req_bash_version:
             return True
         else:


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Check return output of mom bash version. 
If it fails to get mom bash version then it results in : IndexError: list index out of range

#### Describe Your Change
Check if command execution to get mom version fails then return True

#### Link to Design Doc
NA


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

[TestNonprintingCharacters.zip](https://github.com/openpbs/openpbs/files/6435094/TestNonprintingCharacters.zip)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
