### PR TITLE
Handle build with no libundolr

### DIFF
--- a/m4/with_libundolr.m4
+++ b/m4/with_libundolr.m4
@@ -52,9 +52,9 @@ AC_DEFUN([PBS_AC_WITH_LIBUNDOLR],
   AC_MSG_CHECKING([for libundolr])
   # Using developer installed libundolr
   AS_IF([test -r "$libundolr_dir/undolr.h"],
-    [libundolr_include="$libundolr_dir"],
+    [libundolr_include="$libundolr_dir"
+    libundolr_inc="-I$libundolr_include"],
   )
-  libundolr_inc="-I$libundolr_include"
   AS_IF([test -r "${libundolr_dir}/libundolr_pic_x64.a"],
     [libundolr_lib="${libundolr_dir}/libundolr_pic_x64.a"],
   )


### PR DESCRIPTION
When libundolr is not present, the m4 file generates a compile
-I option with no argument, causing build in Libutil to fail.

#### Describe Bug or Feature
When building on a CentOS 7 host without libundolr, m4/with_libundolr.m4 causes libundolr_inc to be set to "-I" by itself. Later, when this is used by src/lib/Libutil/Makefile.am, the result is a gcc compile line that includes a stranded -I, causing an error:

```
make[3]: Entering directory `/home/dtalcott/work/drtoss_for_bugs/build_alt/src/lib/Libutil'
gcc -DHAVE_CONFIG_H -I. -I/home/dtalcott/work/drtoss_for_bugs/src/lib/Libutil -I../../../src/include  -I/home/dtalcott/work/drtoss_for_bugs/src/include -I    -MT libutil_a-get_hostname.o -MD -MP -MF .deps/libutil_a-get_hostname.Tpo -c -o libutil_a-get_hostname.o `test -f 'get_hostname.c' || echo '/home/dtalcott/work/drtoss_for_bugs/src/lib/Libutil/'`get_hostname.c
gcc: error: libutil_a-get_hostname.o: No such file or directory
make[3]: *** [libutil_a-get_hostname.o] Error 1

```
Note the "-I" before the "-MT".

#### Describe Your Change
The proposed fix sets libundolr_inc only when $libundolr_dir/undolr.h is detected.


#### Link to Design Doc
None


#### Attach Test and Valgrind Logs/Output
With the proposed fix, the make completes.

