### PR TITLE
Fix for test_staging when mom and server are not collocated

### DIFF
--- a/test/fw/ptl/utils/plugins/ptl_test_runner.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_runner.py
@@ -1038,10 +1038,8 @@ class PTLTestRunner(Plugin):
     def _cleanup(self):
         self.logger.info('Cleaning up temporary files')
         du = DshUtils()
-        hosts = set(self.param_dict['moms'])
-        for server in self.param_dict['servers']:
-            if server not in hosts:
-                hosts.update(server)
+        hosts = set(self.param_dict['moms']).union(
+            set(self.param_dict['servers']))
         for user in PBS_USERS:
             self.logger.debug('Cleaning %s\'s home directory' % (str(user)))
             runas = PbsUser.get_user(user)


### PR DESCRIPTION
A fix to sys_copy() which corrects a problem with test_staging when the mom(s) and server are not collocated.   At the beginning of the test, test_staging calls self.mom.create_and_format_stagein_path() which in turn calls self.du.create_temp_file().  create_temp_file() copies the file to the mom node if the mom and server are not running on the same node.  test_staging then submits a job which results in the same file being copied again to the mom node via `scp -p` in sys_copy().  If create_temp_file() creates and then copies the temp file to the mom in the same second, then mtime of the existing file on the mom and the one later copied with `scp -p` in sys_copy() will be the same, and sys_copy() will return that the copy has failed.  Again, this is only an issue if the the server and mom are not on the same hosts.

This commit also includes a fix to the creation of a hosts set from the set of moms and the server specified to pbs_benchpress.  At present, if mom hosts are specified and none are the server host, then _cleanup() will add each character in the server name to the set of hosts rather than the server's hostname.
