### PR TITLE
Make opt_backfill_fuzzy less fuzzy

### DIFF
--- a/src/scheduler/simulate.cpp
+++ b/src/scheduler/simulate.cpp
@@ -190,7 +190,7 @@ simulate_events(status *policy, server_info *sinfo,
 		long t = 0;
 		if(arg != NULL)
 			t = *((long *) arg);
-		event_time = event->event_time + t;
+		event_time = (event->event_time + t) / t * t;
 	}
 	else if (cmd == SIM_TIME)
 		event_time = *((time_t *) arg);

--- a/src/scheduler/simulate.cpp
+++ b/src/scheduler/simulate.cpp
@@ -187,9 +187,13 @@ simulate_events(status *policy, server_info *sinfo,
 	cur_sim_time = (*calendar->current_time);
 
 	if (cmd == SIM_NEXT_EVENT) {
-		long t = 0;
+		long t = 1;
 		if(arg != NULL)
 			t = *((long *) arg);
+		/* t is the opt_backfill_fuzzy window.  In order to create more static estimates
+		 * shorten the first window to the next time boundary (e.g. if t=1hr and it
+		  is now 12:31, the first window is 29m).  The subsequent windows are the same.
+		 */
 		event_time = (event->event_time + t) / t * t;
 	}
 	else if (cmd == SIM_TIME)

--- a/src/scheduler/simulate.cpp
+++ b/src/scheduler/simulate.cpp
@@ -188,11 +188,14 @@ simulate_events(status *policy, server_info *sinfo,
 
 	if (cmd == SIM_NEXT_EVENT) {
 		long t = 1;
-		if(arg != NULL)
+		if(arg != NULL) {
 			t = *((long *) arg);
-		/* t is the opt_backfill_fuzzy window.  In order to create more static estimates
+			if (t == 0)
+				t = 1;
+		}
+		/* t is the opt_backfill_fuzzy window.  In order to create more consistent estimates
 		 * shorten the first window to the next time boundary (e.g. if t=1hr and it
-		 * is now 12:31, the first window is 29m).  The subsequent windows are the same.
+		 * is now 12:31, the first window is 29m).  The subsequent windows will be the same.
 		 */
 		event_time = (event->event_time + t) / t * t;
 	}

--- a/src/scheduler/simulate.cpp
+++ b/src/scheduler/simulate.cpp
@@ -192,7 +192,7 @@ simulate_events(status *policy, server_info *sinfo,
 			t = *((long *) arg);
 		/* t is the opt_backfill_fuzzy window.  In order to create more static estimates
 		 * shorten the first window to the next time boundary (e.g. if t=1hr and it
-		  is now 12:31, the first window is 29m).  The subsequent windows are the same.
+		 * is now 12:31, the first window is 29m).  The subsequent windows are the same.
 		 */
 		event_time = (event->event_time + t) / t * t;
 	}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
The way opt_backfill_fuzzy works is by estimating the next event, and then all events for t seconds after that (where t is based on the level of fuzziness).  For ease of explanation, let's assume this is now + t seconds.  The problem is that the each cycle is some amount of time apart.  This means now + t seconds into the future every cycle.

#### Describe Your Change
While opt_backfill_fuzzy is supposed to make estimates fuzzy, there is something we can do to retain the speed benefits of opt_backfill_fuzzy, but make the estimates more static.  Let's say t=1hr and it is 12:39.  In cycle 1 we will estimate out to 13:39.  If cycle 2 is 2m later, we'll estimate out to 13:41.  The estimate might move 2m further into the future.

The way opt_backfill_fuzzy works is in 1hr windows (using the previous example).  This means we estimate now+1hr, and if the job can't run, we estimate now+2hrs (and 3hrs, and so on).  

If we shorten the first window to be to the next hour boundary, the subsequent windows will all be on the hour boundaries.  In the previous example, the first window would be 21m, pushing us out to 13:00.  The second window would push us out to 14:00.  In the second cycle, the first window would be 19m also pushing us out to 13:00, and keeping the second window at 14:00.

Because the windows are more consistent, the estimates will be as well.

The speed benefits you get from opt_backfill_fuzzy is because we estimate 1hrs of events at a time.  This doesn't appreciatively make the calculation any slower, but should make the estimates more static.

#### Attach Test and Valgrind Logs/Output
Since the estimates moving further out is a race condition, writing an automated that will work on fast and slow machines is too hard.  Here is manual testing:
We use opt_backfill_fuzzy=medium (10m windows)
We have 20 cpus
We submit 5 jobs with walltimes of 30 + (i * 5) where i is the number of the job
We then submit 15 jobs with walltimes of 600 + (i * 5) where i is the number of the job
We then submit a 10 cpu job with walltime of 700s.

Before:
05/18/2021 11:30:14.406121;0080;pbs_sched;Job;53544.henke;Job is a top job and will run at Tue May 18 11:40:36 2021
05/18/2021 11:30:42.055656;0080;pbs_sched;Job;53544.henke;Job is a top job and will run at Tue May 18 11:40:41 2021
05/18/2021 11:30:47.101414;0080;pbs_sched;Job;53544.henke;Job is a top job and will run at Tue May 18 11:40:46 2021
05/18/2021 11:30:52.157077;0080;pbs_sched;Job;53544.henke;Job is a top job and will run at Tue May 18 11:40:56 2021
05/18/2021 11:30:57.218695;0080;pbs_sched;Job;53544.henke;Job is a top job and will run at Tue May 18 11:41:01 2021
05/18/2021 11:30:59.490135;0080;pbs_sched;Job;53544.henke;Job is a top job and will run at Tue May 18 11:41:01 2021

Note the estimates moving out 5s at a time.  This is due to the fact that the cycles are started at 5s intervals when the jobs start ending.

After:
05/18/2021 11:44:53.128630;0080;pbs_sched;Job;53565.henke;Job is a top job and will run at Tue May 18 11:56:00 2021
05/18/2021 11:45:20.778988;0080;pbs_sched;Job;53565.henke;Job is a top job and will run at Tue May 18 11:56:00 2021
05/18/2021 11:45:25.822647;0080;pbs_sched;Job;53565.henke;Job is a top job and will run at Tue May 18 11:56:00 2021
05/18/2021 11:45:30.884498;0080;pbs_sched;Job;53565.henke;Job is a top job and will run at Tue May 18 11:56:00 2021
05/18/2021 11:45:35.942056;0080;pbs_sched;Job;53565.henke;Job is a top job and will run at Tue May 18 11:56:00 2021
05/18/2021 11:45:38.210981;0080;pbs_sched;Job;53565.henke;Job is a top job and will run at Tue May 18 11:56:00 2021

