### PR TITLE
Scheduler quits if any server is down in msvr setup

### DIFF
--- a/src/scheduler/pbs_sched_utils.cpp
+++ b/src/scheduler/pbs_sched_utils.cpp
@@ -611,7 +611,7 @@ connect_svrpool()
 		for (i = 0; svr_conns_primary[i] != NULL && svr_conns_secondary[i] != NULL; i++) {
 			if (svr_conns_primary[i]->state == SVR_CONN_STATE_DOWN ||
 			    svr_conns_secondary[i]->state == SVR_CONN_STATE_DOWN)
-				goto unmask_break;
+				break;
 		}
 
 		if (i != get_num_servers()) {
@@ -629,12 +629,6 @@ connect_svrpool()
 			goto unmask_continue;
 		}
 
-		/* Reached here means everything is success, so we will break out of the loop */
-unmask_break:
-		if (sigprocmask(SIG_SETMASK, &prevsigs, NULL) == -1)
-			log_err(errno, __func__, "sigprocmask(SIG_SETMASK)");
-		break;
-
 unmask_continue:
 		if (sigprocmask(SIG_SETMASK, &prevsigs, NULL) == -1)
 			log_err(errno, __func__, "sigprocmask(SIG_SETMASK)");
@@ -642,6 +636,7 @@ unmask_continue:
 		close_servers();
 		continue;
 	}
+
 	log_eventf(PBSEVENT_ADMIN | PBSEVENT_FORCE, PBS_EVENTCLASS_SCHED,
 		   LOG_INFO, msg_daemonname, "Connected to all the configured servers");
 

--- a/src/scheduler/pbs_sched_utils.cpp
+++ b/src/scheduler/pbs_sched_utils.cpp
@@ -629,6 +629,9 @@ connect_svrpool()
 			goto unmask_continue;
 		}
 
+		/* Reached here means everything is success, so we will break out of the loop */
+		break;
+
 unmask_continue:
 		if (sigprocmask(SIG_SETMASK, &prevsigs, NULL) == -1)
 			log_err(errno, __func__, "sigprocmask(SIG_SETMASK)");
@@ -636,7 +639,6 @@ unmask_continue:
 		close_servers();
 		continue;
 	}
-
 	log_eventf(PBSEVENT_ADMIN | PBSEVENT_FORCE, PBS_EVENTCLASS_SCHED,
 		   LOG_INFO, msg_daemonname, "Connected to all the configured servers");
 

--- a/src/scheduler/pbs_sched_utils.cpp
+++ b/src/scheduler/pbs_sched_utils.cpp
@@ -630,6 +630,8 @@ connect_svrpool()
 		}
 
 		/* Reached here means everything is success, so we will break out of the loop */
+		if (sigprocmask(SIG_SETMASK, &prevsigs, NULL) == -1)
+			log_err(errno, __func__, "sigprocmask(SIG_SETMASK)");
 		break;
 
 unmask_continue:


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
The commit https://github.com/openpbs/openpbs/commit/05e16c3419bb47340c1c5fefb6404d456085033a introduced a bug in scheduler's connect_svrpool() function which makes the code break out if even one of the servers is down (the label unmask_break caused the outer loop to break out instead of the inner for loop which was checking if all servers were connected to), and it ends up exiting the program incorrectly.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Removed the label which was causing the bug

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
