### PR TITLE
server should try connecting to database residing in localhost instead of PBS_SERVER

### DIFF
--- a/src/include/server.h
+++ b/src/include/server.h
@@ -75,6 +75,7 @@ enum srv_atr {
 };
 
 extern char *pbs_server_name;
+extern char server_host[];
 extern uint pbs_server_port_dis;
 extern void *svr_attr_idx;
 extern attribute_def svr_attr_def[];

--- a/src/lib/Libpython/pbs_python_svr_internal.c
+++ b/src/lib/Libpython/pbs_python_svr_internal.c
@@ -94,7 +94,6 @@ extern resource_def *svr_resc_def; /* the resource def structure */
 extern int svr_resc_size; /* static + dynamic */
 extern int svr_resc_unk;  /* the last one */
 extern char          server_name[];
-extern char          server_host[];
 extern struct python_interpreter_data  svr_interp_data;
 extern pbs_list_head       svr_queues;    /* list of queues                   */
 extern pbs_list_head       svr_alljobs;   /* list of all jobs in server       */

--- a/src/server/failover.c
+++ b/src/server/failover.c
@@ -112,7 +112,6 @@ extern char *path_svrlive;
 extern char *path_secondaryact;
 extern time_t secondary_delay;
 extern time_t time_now;
-extern char server_host[];
 
 extern struct connection *svr_conn;
 extern struct batch_request *saved_takeover_req;

--- a/src/server/geteusernam.c
+++ b/src/server/geteusernam.c
@@ -69,7 +69,6 @@
 
 /* External Data */
 
-extern char server_host[];
 
 /**
  * @brief

--- a/src/server/hook_func.c
+++ b/src/server/hook_func.c
@@ -148,7 +148,6 @@
 extern void disable_svr_prov();
 extern void set_srv_prov_attributes();
 extern int  should_retry_route(int);
-extern	char server_host[PBS_MAXHOSTNAME+1];
 
 /* Local Private Functions */
 

--- a/src/server/issue_request.c
+++ b/src/server/issue_request.c
@@ -237,7 +237,6 @@ issue_to_svr(char *servern, struct batch_request *preq, void (*replyfunc)(struct
 	struct work_task *pwt;
 	extern int pbs_failover_active;
 	extern char primary_host[];
-	extern char server_host[];
 
 
 	(void)strcpy(preq->rq_host, servern);

--- a/src/server/multi_svr.c
+++ b/src/server/multi_svr.c
@@ -54,7 +54,6 @@
 #include <arpa/inet.h>
 #include <netdb.h>
 
-extern char	server_host[PBS_MAXHOSTNAME + 1];
 extern unsigned int	pbs_server_port_dis;
 extern	time_t	time_now;
 

--- a/src/server/node_func.c
+++ b/src/server/node_func.c
@@ -101,7 +101,6 @@ extern unsigned int pbs_mom_port;
 extern unsigned int pbs_rm_port;
 extern mominfo_time_t  mominfo_time;
 extern char	*resc_in_err;
-extern char	server_host[];
 extern void *node_idx;
 extern time_t	 time_now;
 extern int write_single_node_mom_attr(struct pbsnode *np);

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -136,7 +136,6 @@ static char *hook_privilege = "Not allowed to update vnodes or to request schedu
 extern struct python_interpreter_data  svr_interp_data;
 
 #if defined(PBS_SECURITY) && (PBS_SECURITY == KRB5)
-extern char server_host[];
 extern void svr_renew_job_cred(struct work_task *pwt);
 #endif
 

--- a/src/server/pbs_db_func.c
+++ b/src/server/pbs_db_func.c
@@ -346,8 +346,10 @@ get_db_connect_information()
 				strncpy(conn_db_host, pbs_conf.pbs_primary, PBS_MAXSERVERNAME);
 			else
 				strncpy(conn_db_host, pbs_conf.pbs_secondary, PBS_MAXSERVERNAME);
-		} else
-			strncpy(conn_db_host, pbs_default(), PBS_MAXSERVERNAME); /* connect to pbs.server */
+		} else if (pbs_conf.pbs_server_host_name)
+			strncpy(conn_db_host, pbs_conf.pbs_server_host_name, PBS_MAXSERVERNAME);
+		else
+			strncpy(conn_db_host, server_host, PBS_MAXSERVERNAME);
 
 		rc = pbs_status_db(conn_db_host, pbs_conf.pbs_data_service_port);
 		if (rc == -1) {

--- a/src/server/pbsd_init.c
+++ b/src/server/pbsd_init.c
@@ -141,7 +141,6 @@ extern char	*path_spool;
 extern char	*path_track;
 extern char	*path_prov_track;
 extern long	 new_log_event_mask;
-extern char	 server_host[];
 extern char	 server_name[];
 extern pbs_list_head svr_newjobs;
 extern pbs_list_head svr_allresvs;

--- a/src/server/process_request.c
+++ b/src/server/process_request.c
@@ -117,7 +117,6 @@ pbs_list_head svr_requests;
 
 
 extern struct server server;
-extern char      server_host[];
 extern pbs_list_head svr_newjobs;
 extern pbs_list_head svr_allconns;
 extern time_t    time_now;

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -127,7 +127,6 @@ extern char *msg_man_set;
 extern char *msg_man_uns;
 extern char *msg_noattr;
 extern unsigned int pbs_mom_port;
-extern char server_host[];
 extern char *path_hooks;
 extern 	int max_concurrent_prov;
 extern char *msg_cannot_set_route_que;

--- a/src/server/req_quejob.c
+++ b/src/server/req_quejob.c
@@ -124,7 +124,6 @@ extern char *path_spool;
 extern struct server server;
 extern struct attribute attr_jobscript_max_size;
 extern char  server_name[];
-extern char server_host[];
 extern unsigned int pbs_server_port_dis;
 extern char *resc_in_err;
 #endif	/* PBS_MOM */

--- a/src/server/req_rescq.c
+++ b/src/server/req_rescq.c
@@ -519,7 +519,6 @@ req_confirmresv(struct batch_request *preq)
 	char *next_execvnode = NULL;
 	char **short_xc = NULL;
 	char **tofree = NULL;
-	extern char server_host[];
 	int is_being_altered = 0;
 	char *tmp_buf = NULL;
 	size_t tmp_buf_size = 0;

--- a/src/server/sched_func.c
+++ b/src/server/sched_func.c
@@ -74,7 +74,6 @@
 #include "svrfunc.h"
 
 extern struct server server;
-extern char server_host[];
 
 /* Functions */
 #ifdef PYTHON

--- a/src/server/svr_chk_owner.c
+++ b/src/server/svr_chk_owner.c
@@ -81,7 +81,6 @@
 
 /* Global Data */
 
-extern char  server_host[];
 extern char *msg_badstate;
 extern char *msg_permlog;
 extern char *msg_unkjobid;

--- a/src/server/svr_func.c
+++ b/src/server/svr_func.c
@@ -100,7 +100,6 @@ extern time_t time_now;
 extern char  *resc_in_err;
 extern char  *msg_daemonname;
 extern char   server_name[];
-extern char   server_host[];
 
 extern pbs_list_head svr_allconns;
 

--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -124,7 +124,6 @@ extern char  *msg_badwait;		/* error message */
 extern char  *msg_daemonname;
 extern char  *msg_also_deleted_job_history;
 extern char   server_name[];
-extern char   server_host[];
 extern pbs_list_head svr_queues;
 extern int    comp_resc_lt;
 extern int    comp_resc_gt;

--- a/src/server/svr_mail.c
+++ b/src/server/svr_mail.c
@@ -180,7 +180,6 @@ svr_mailowner_id(char *jid, job *pjob, int mailpoint, int force, char *text)
 	struct array_strings *pas;
 	char	*stdmessage = NULL;
 	char	*pat;
-	extern  char server_host[];
 
 	FILE   *outmail;
 	pid_t   mcpid;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
In multi-server, PBS_SERVER could be pointing to a different name to represent cluster name. Hence when a server tries to connect to the database that resides in PBS_SERVER, it is trying to reach the wrong host.


#### Describe Your Change
Server will connect to the following when failover is not configured:
PBS_SERVER_HOST_NAME
localhost if the above is not present.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

[test.log](https://github.com/openpbs/openpbs/files/6504008/test.log)

Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, WIN2K16
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|7649|4176|0|1|0|0|4175|

Description: Rerun Only Failed Tests From #7649
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|7657|1|0|0|0|0|1|

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
