### PR TITLE
Fix ptl rpm postinstall script

### DIFF
--- a/openpbs.spec
+++ b/openpbs.spec
@@ -596,35 +596,11 @@ ${RPM_INSTALL_PREFIX:=%{pbs_prefix}}/libexec/pbs_posttrans \
 %config(noreplace) %{_sysconfdir}/profile.d/ptl.*
 
 %post %{pbs_ptl}
-installed_pkg="$(pip3 list)"
-IFS=$'\n' required_pkg=($(cat %{ptl_prefix}/fw/requirements.txt))
-for i in "${required_pkg[@]}"; do
-	if echo $i | grep -E -q '^*#'
-	then
-		continue
-	fi
-	if [[ "$installed_pkg" =~ "$i" ]]; then
-		continue
-	else
-		pip3 install --trusted-host pypi.org --trusted-host files.pythonhosted.org "$i"
-		if [ $? -eq 0 ]; then
-			echo "$i installed successfully"
-		else
-			echo "Failed to install thirdparty package $i required by PTL"
-		fi
-	fi
-done
+pip3 install --trusted-host pypi.org --trusted-host files.pythonhosted.org -r "%{ptl_prefix}/fw/requirements.txt"
 
 %preun %{pbs_ptl}
-installed_pkg="$(pip3 list)"
-IFS=$'\n' required_pkg=($(cat %{ptl_prefix}/fw/requirements.txt))
-for i in "${required_pkg[@]}"; do
-	if [[ "$installed_pkg" =~ "$i" ]]; then
-		pip3 uninstall --yes "$i"
-	else
-		continue
-	fi
-done
+pip3 uninstall --yes -r "%{ptl_prefix}/fw/requirements.txt"
+
 %endif
 
 %changelog

--- a/openpbs.spec
+++ b/openpbs.spec
@@ -599,6 +599,10 @@ ${RPM_INSTALL_PREFIX:=%{pbs_prefix}}/libexec/pbs_posttrans \
 installed_pkg="$(pip3 list)"
 IFS=$'\n' required_pkg=($(cat %{ptl_prefix}/fw/requirements.txt))
 for i in "${required_pkg[@]}"; do
+	if echo $i | grep -E -q '^*#'
+	then
+		continue
+	fi
 	if [[ "$installed_pkg" =~ "$i" ]]; then
 		continue
 	else

--- a/openpbs.spec.in
+++ b/openpbs.spec.in
@@ -596,35 +596,11 @@ ${RPM_INSTALL_PREFIX:=%{pbs_prefix}}/libexec/pbs_posttrans \
 %config(noreplace) %{_sysconfdir}/profile.d/ptl.*
 
 %post %{pbs_ptl}
-installed_pkg="$(pip3 list)"
-IFS=$'\n' required_pkg=($(cat %{ptl_prefix}/fw/requirements.txt))
-for i in "${required_pkg[@]}"; do
-	if echo $i | grep -E -q '^*#'
-	then
-		continue
-	fi
-	if [[ "$installed_pkg" =~ "$i" ]]; then
-		continue
-	else
-		pip3 install --trusted-host pypi.org --trusted-host files.pythonhosted.org "$i"
-		if [ $? -eq 0 ]; then
-			echo "$i installed successfully"
-		else
-			echo "Failed to install thirdparty package $i required by PTL"
-		fi
-	fi
-done
+pip3 install --trusted-host pypi.org --trusted-host files.pythonhosted.org -r "%{ptl_prefix}/fw/requirements.txt"
 
 %preun %{pbs_ptl}
-installed_pkg="$(pip3 list)"
-IFS=$'\n' required_pkg=($(cat %{ptl_prefix}/fw/requirements.txt))
-for i in "${required_pkg[@]}"; do
-	if [[ "$installed_pkg" =~ "$i" ]]; then
-		pip3 uninstall --yes "$i"
-	else
-		continue
-	fi
-done
+pip3 uninstall --yes -r "%{ptl_prefix}/fw/requirements.txt"
+
 %endif
 
 %changelog

--- a/openpbs.spec.in
+++ b/openpbs.spec.in
@@ -599,6 +599,10 @@ ${RPM_INSTALL_PREFIX:=%{pbs_prefix}}/libexec/pbs_posttrans \
 installed_pkg="$(pip3 list)"
 IFS=$'\n' required_pkg=($(cat %{ptl_prefix}/fw/requirements.txt))
 for i in "${required_pkg[@]}"; do
+	if echo $i | grep -E -q '^*#'
+	then
+		continue
+	fi
 	if [[ "$installed_pkg" =~ "$i" ]]; then
 		continue
 	else


### PR DESCRIPTION
#### Describe Bug or Feature
Installing the ptl rpm would result in a log of error messages.
This is because the script runs pip on every line of the requirements file, including the license header

#### Describe Your Change
Just feed pip the entire requirements file with the `-r` option.


#### Link to Design Doc
N/A


#### Attach Test and Valgrind Logs/Output
Before:
```
Updating / installing...
   1:openpbs-ptl-20.0.0-0             ################################# [ 33%]
DEPRECATION: The default format will switch to columns in the future. You can use --format=(legacy|columns) (or define a format=(legacy|columns) in your pip.conf under the [list] section) to disable this warning.
WARNING: Running pip install with root privileges is generally not a good idea. Try `pip3 install --user` instead.
Invalid requirement: '# Copyright (C) 1994-2021 Altair Engineering, Inc.'
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/pip/_vendor/packaging/requirements.py", line 92, in __init__
    req = REQUIREMENT.parseString(requirement_string)
  File "/usr/lib/python3.6/site-packages/pip/_vendor/pyparsing.py", line 1617, in parseString
    raise exc
  File "/usr/lib/python3.6/site-packages/pip/_vendor/pyparsing.py", line 1607, in parseString
    loc, tokens = self._parse( instring, 0 )
  File "/usr/lib/python3.6/site-packages/pip/_vendor/pyparsing.py", line 1379, in _parseNoCache
    loc,tokens = self.parseImpl( instring, preloc, doActions )
  File "/usr/lib/python3.6/site-packages/pip/_vendor/pyparsing.py", line 3376, in parseImpl
    loc, exprtokens = e._parse( instring, loc, doActions )
  File "/usr/lib/python3.6/site-packages/pip/_vendor/pyparsing.py", line 1379, in _parseNoCache
    loc,tokens = self.parseImpl( instring, preloc, doActions )
  File "/usr/lib/python3.6/site-packages/pip/_vendor/pyparsing.py", line 3698, in parseImpl
    return self.expr._parse( instring, loc, doActions, callPreParse=False )
  File "/usr/lib/python3.6/site-packages/pip/_vendor/pyparsing.py", line 1379, in _parseNoCache
    loc,tokens = self.parseImpl( instring, preloc, doActions )
  File "/usr/lib/python3.6/site-packages/pip/_vendor/pyparsing.py", line 3359, in parseImpl
    loc, resultlist = self.exprs[0]._parse( instring, loc, doActions, callPreParse=False )
  File "/usr/lib/python3.6/site-packages/pip/_vendor/pyparsing.py", line 1383, in _parseNoCache
    loc,tokens = self.parseImpl( instring, preloc, doActions )
  File "/usr/lib/python3.6/site-packages/pip/_vendor/pyparsing.py", line 2670, in parseImpl
    raise ParseException(instring, loc, self.errmsg, self)
pip._vendor.pyparsing.ParseException: Expected W:(abcd...) (at char 0), (line:1, col:1)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/pip/req/req_install.py", line 82, in __init__
    req = Requirement(req)
  File "/usr/lib/python3.6/site-packages/pip/_vendor/packaging/requirements.py", line 96, in __init__
    requirement_string[e.loc:e.loc + 8]))
pip._vendor.packaging.requirements.InvalidRequirement: Invalid requirement, parse error at "'# Copyri'"

Failed to install thirdparty package # Copyright (C) 1994-2021 Altair Engineering, Inc. required by PTL
...
on and on
```

After:
```
Updating / installing...
   1:openpbs-ptl-20.0.0-0             ################################# [ 33%]
WARNING: Running pip install with root privileges is generally not a good idea. Try `pip3 install --user` instead.
Collecting nose (from -r /opt/pbs/../ptl/fw/requirements.txt (line 38))
  Downloading https://files.pythonhosted.org/packages/15/d8/dd071918c040f50fa1cf80da16423af51ff8ce4a0f2399b7bf8de45ac3d9/nose-1.3.7-py3-none-any.whl (154kB)
    100% |████████████████████████████████| 163kB 7.4MB/s 
Collecting beautifulsoup4 (from -r /opt/pbs/../ptl/fw/requirements.txt (line 39))
  Downloading https://files.pythonhosted.org/packages/d1/41/e6495bd7d3781cee623ce23ea6ac73282a373088fcd0ddc809a047b18eae/beautifulsoup4-4.9.3-py3-none-any.whl (115kB)
    100% |████████████████████████████████| 122kB 23.9MB/s 
Collecting pexpect (from -r /opt/pbs/../ptl/fw/requirements.txt (line 40))
  Downloading https://files.pythonhosted.org/packages/39/7b/88dbb785881c28a102619d46423cb853b46dbccc70d3ac362d99773a78ce/pexpect-4.8.0-py2.py3-none-any.whl (59kB)
    100% |████████████████████████████████| 61kB 30.9MB/s 
Collecting defusedxml (from -r /opt/pbs/../ptl/fw/requirements.txt (line 41))
  Downloading https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl
Requirement already satisfied: soupsieve>1.2; python_version >= "3.0" in /usr/local/lib/python3.6/site-packages (from beautifulsoup4->-r /opt/pbs/../ptl/fw/requirements.txt (line 39))
Requirement already satisfied: ptyprocess>=0.5 in /usr/local/lib/python3.6/site-packages (from pexpect->-r /opt/pbs/../ptl/fw/requirements.txt (line 40))
Installing collected packages: nose, beautifulsoup4, pexpect, defusedxml
```

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
