### PR TITLE
Fixed resv overlap issue

### DIFF
--- a/src/scheduler/resv_info.cpp
+++ b/src/scheduler/resv_info.cpp
@@ -1182,27 +1182,20 @@ check_new_reservations(status *policy, int pbs_sd, resource_resv **resvs, server
 								nresv_copy->select = new selspec(*nresv_copy->resv->select_standing);
 							}
 						}
-						/* Duplication deep-copies node info array. This array gets
-						 * overwritten and needs to be freed. This is an alternative
-						 * to creating another duplication function that only duplicates
-						 * the required fields.
-						 */
-						release_nodes(nresv_copy);
-
-						nresv_copy->resv->orig_nspec_arr = parse_execvnode(occr_execvnodes_arr[j], sinfo, nresv_copy->select);
-						nresv_copy->nspec_arr = combine_nspec_array(nresv_copy->resv->orig_nspec_arr);
-						nresv_copy->ninfo_arr = create_node_array_from_nspec(nresv_copy->nspec_arr);
-						nresv_copy->resv->resv_nodes = create_resv_nodes(nresv_copy->nspec_arr, sinfo);
 					}
+					release_nodes(nresv_copy);
+
+					nresv_copy->resv->orig_nspec_arr = parse_execvnode(occr_execvnodes_arr[j], sinfo, nresv_copy->select);
+					nresv_copy->nspec_arr = combine_nspec_array(nresv_copy->resv->orig_nspec_arr);
+					nresv_copy->ninfo_arr = create_node_array_from_nspec(nresv_copy->nspec_arr);
+					nresv_copy->resv->resv_nodes = create_resv_nodes(nresv_copy->nspec_arr, sinfo);
 
 					/* Note that the sequence of occurrence dates and time are determined
 					 * during confirm_reservation and set to the reservation in the
 					 * simulated server
 					 */
 					nresv_copy->start = nresv->resv->occr_start_arr[j];
-
-					/* update start time, duration, and execvnodes of the occurrence */
-					nresv_copy->end = nresv_copy->start + nresv_copy->duration ;
+					nresv_copy->end = nresv_copy->start + nresv_copy->duration;
 
 					/* Only add the occurrence to the real universe if we are not
 					 * processing a degraded reservation as otherwise, the resources

--- a/test/tests/functional/pbs_reservations.py
+++ b/test/tests/functional/pbs_reservations.py
@@ -2446,22 +2446,24 @@ class TestReservations(TestFunctional):
         """
 
         self.common_config()
-
         a = {'scheduling': 'False'}
         self.server.manager(MGR_CMD_SET, SERVER, a)
 
-        start = int(time.time()) + 300
-        end = int(time.time()) + 1200
+        start1 = int(time.time()) + 3600
+        end1 = int(time.time()) + 7200
+        start2 = int(time.time()) + 1800
+        end2 = int(time.time()) + 5400
+
         srid = self.submit_reservation(user=TEST_USER,
                                        select='2:ncpus=4',
                                        rrule='FREQ=DAILY;COUNT=2',
-                                       start=start,
-                                       end=end)
+                                       start=start1,
+                                       end=end1)
 
         arid = self.submit_reservation(user=TEST_USER,
                                        select='2:ncpus=4',
-                                       start=start,
-                                       end=end)
+                                       start=start2,
+                                       end=end2)
         self.scheduler.run_scheduling_cycle()
         self.server.expect(RESV, {'reserve_state':
                                   (MATCH_RE, 'RESV_CONFIRMED|2')},


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
When multiple reservations were confirmed in the same cycle, it was possible for the scheduler to oversubscribe the same resources

#### Describe Your Change
When confirming a reservation, the scheduler creates a scratch universe to confirm the reservation.  When it has successfully confirmed the reservation, it copies the relevant data from the scratch reservation back to the real reservation.  The scheduler wasn't copying back the resv_nodes, so it would think the reservation didn't use any resources.  Since the scheduler didn't think it used any resources, those same resources could be used again to confirm another reservation.

Fix: copy back the resv_nodes (nspec array) to the real reservation.

#### Attach Test and Valgrind Logs/Output
I modified an existing test to show the bug.  I ran a full regression and it passed with no failures (including the modified test).