### PR TITLE
Reset the periodic hook when frequency changes

### DIFF
--- a/src/server/hook_func.c
+++ b/src/server/hook_func.c
@@ -2004,13 +2004,6 @@ mgr_hook_set(struct batch_request *preq)
 			if (phook->script != NULL)
 				(void)set_task(WORK_Timed, time_now + phook->freq,
 					run_periodic_hook, phook);
-			else {
-				log_event(PBSEVENT_ADMIN, PBS_EVENTCLASS_HOOK, LOG_INFO,
-					   hookname, "periodic hook is missing information, check hook frequency and script");
-				snprintf(hook_msg, sizeof(hook_msg),
-					"periodic hook is missing information, check hook frequency and script");
-				goto mgr_hook_set_error;
-			}
 		}
 	}
 

--- a/src/server/hook_func.c
+++ b/src/server/hook_func.c
@@ -2005,9 +2005,8 @@ mgr_hook_set(struct batch_request *preq)
 				(void)set_task(WORK_Timed, time_now + phook->freq,
 					run_periodic_hook, phook);
 			else {
-				sprintf(log_buffer, "periodic hook is missing information, check hook frequency and script");
-				log_event(PBSEVENT_ADMIN, PBS_EVENTCLASS_HOOK, LOG_INFO,
-					hookname, log_buffer);
+				log_eventf(PBSEVENT_ADMIN, PBS_EVENTCLASS_HOOK, LOG_INFO,
+					   hookname, "periodic hook is missing information, check hook frequency and script");
 				snprintf(hook_msg, sizeof(hook_msg),
 					"periodic hook is missing information, check hook frequency and script");
 				goto mgr_hook_set_error;

--- a/src/server/hook_func.c
+++ b/src/server/hook_func.c
@@ -2005,7 +2005,7 @@ mgr_hook_set(struct batch_request *preq)
 				(void)set_task(WORK_Timed, time_now + phook->freq,
 					run_periodic_hook, phook);
 			else {
-				log_eventf(PBSEVENT_ADMIN, PBS_EVENTCLASS_HOOK, LOG_INFO,
+				log_event(PBSEVENT_ADMIN, PBS_EVENTCLASS_HOOK, LOG_INFO,
 					   hookname, "periodic hook is missing information, check hook frequency and script");
 				snprintf(hook_msg, sizeof(hook_msg),
 					"periodic hook is missing information, check hook frequency and script");

--- a/src/server/hook_func.c
+++ b/src/server/hook_func.c
@@ -1781,7 +1781,7 @@ mgr_hook_set(struct batch_request *preq)
 					 *  2 - related to running the post processing function
 					 */
 					delete_task_by_parm1_func(phook, NULL, DELETE_ALL);
-					if ((phook->freq > 0) && (phook->script != NULL))
+					if (phook->script != NULL)
 						(void)set_task(WORK_Timed, time_now + phook->freq,
 								run_periodic_hook, phook);
 					else {
@@ -2001,7 +2001,7 @@ mgr_hook_set(struct batch_request *preq)
 		if ((phook->enabled == TRUE) && (phook->freq > 0)) {
 			/* Delete all existing hook related timed work tasks */
 			delete_task_by_parm1_func(phook, run_periodic_hook, DELETE_ALL);
-			if ((phook->freq > 0) && (phook->script != NULL))
+			if (phook->script != NULL)
 				(void)set_task(WORK_Timed, time_now + phook->freq,
 					run_periodic_hook, phook);
 			else {

--- a/src/server/hook_func.c
+++ b/src/server/hook_func.c
@@ -1998,6 +1998,21 @@ mgr_hook_set(struct batch_request *preq)
 			num_set++;
 		free(hook_freq_val);
 		hook_freq_val = NULL;
+		if ((phook->enabled == TRUE) && (phook->freq > 0)) {
+			/* Delete all existing hook related timed work tasks */
+			delete_task_by_parm1_func(phook, run_periodic_hook, DELETE_ALL);
+			if ((phook->freq > 0) && (phook->script != NULL))
+				(void)set_task(WORK_Timed, time_now + phook->freq,
+					run_periodic_hook, phook);
+			else {
+				sprintf(log_buffer, "periodic hook is missing information, check hook frequency and script");
+				log_event(PBSEVENT_ADMIN, PBS_EVENTCLASS_HOOK, LOG_INFO,
+					hookname, log_buffer);
+				snprintf(hook_msg, sizeof(hook_msg),
+					"periodic hook is missing information, check hook frequency and script");
+				goto mgr_hook_set_error;
+			}
+		}
 	}
 
 	if (num_set > 0) {


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
When a periodic hook's frequency changes, it does not affect the hook immediately. The new frequency takes effect after the hook runs.


#### Describe Your Change
When the frequency of a hook changes, check that the hook is enabled and if it is then reset the timed work task with the new frequency.


#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
Description: Rerun All Tests From #7633
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|7647|4176|0|0|0|0|4176|


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
