### PR TITLE
[WIP]Implement parallel tm_spawn (tm_spawn_multi)

### DIFF
--- a/doc/man1/pbsdsh.1B
+++ b/doc/man1/pbsdsh.1B
@@ -43,10 +43,10 @@
 
 .SH SYNOPSIS
 .B pbsdsh 
-[-c <copies>] [-s] [-v] [-o] -- <program> [<program args>]
+[-c <copies>] [-v] [-o] -- <program> [<program args>]
 .br
 .B pbsdsh 
-[-n <vnode index>] [-s] [-v] [-o] -- <program> [<program args>]
+[-n <vnode index>] [-v] [-o] -- <program> [<program args>]
 .br
 .B pbsdsh 
 --version
@@ -122,8 +122,6 @@ vnode allocated.  This option is mutually exclusive with
 .IP -o
 No obit request is made for spawned tasks.  The program does not wait for
 the tasks to finish.
-.IP -s
-Te program is run in turn on each vnode, one after the other.
 .IP -v
 Produces verbose output about error conditions and task exit status.
 

--- a/doc/man3/tm.3
+++ b/doc/man3/tm.3
@@ -38,7 +38,7 @@
 .\"
 .TH TM 3 "24 February 2015" Local "PBS Professional"
 .SH NAME
-tm_init, tm_nodeinfo, tm_poll, tm_notify, tm_spawn, tm_kill, tm_obit, tm_taskinfo, tm_atnode, tm_rescinfo, tm_publish, tm_subscribe, tm_finalize, tm_attach \- task management API
+tm_init, tm_nodeinfo, tm_poll, tm_notify, tm_spawn, tm_spawn_multi, tm_kill, tm_obit, tm_taskinfo, tm_atnode, tm_rescinfo, tm_publish, tm_subscribe, tm_finalize, tm_attach \- task management API
 .SH SYNOPSIS
 .B
 #include <tm.h>
@@ -89,6 +89,24 @@ char \(**\(**envp;
 tm_node_id where;
 .br
 tm_task_id \(**tid;
+.br
+tm_event_t \(**event;
+.RE
+.LP
+.B
+int tm_spawn_multi(argc, argv, envp, list_size, where, tids, event)
+.RS 6
+int argc;
+.br
+char \(**\(**argv;
+.br
+char \(**\(**envp;
+.br
+int list_size;
+.br
+tm_node_id where[];
+.br
+tm_task_id \(**tids;
 .br
 tm_event_t \(**event;
 .RE
@@ -355,10 +373,39 @@ is NULL terminated.  The argument
 .IR event
 points to a tm_event_t variable which is filled in with an event
 number.  When this event is returned by
-.B tm_poll ,
+.B tm_poll,
 the tm_task_id pointed to by
 .IR tid
 will contain the task id of the newly created task.
+.LP
+.B tm_spawn_multi(\|)
+sends a message to the MOMs to start a new task.  The array of node ids
+of the hosts to run the task is given by
+.IR where .
+The size of the array is specified in
+.IR list_size .
+The parameters
+.IR argc ,
+.IR argv
+and
+.IR envp
+specify the program to run and its arguments and environment very
+much like
+.B exec(\|).
+The full path of the program executable must be given by
+.IR argv[0]
+and the number of elements in the argv array is given by
+.IR argc .
+The array
+.IR envp
+is NULL terminated.  The argument
+.IR event
+points to a tm_event_t variable which is filled in with an event
+number.  When this event is returned by
+.B tm_poll,
+the tm_task_id pointed to by
+.IR tids
+will contain the task ids of the newly created tasks.
 .LP
 .B tm_kill(\|)
 sends a signal specified by

--- a/src/include/job.h
+++ b/src/include/job.h
@@ -296,6 +296,16 @@ typedef struct vmpiprocs {
 	long long	vn_accel_mem;	/* amt of accelerator memory wanted */
 } vmpiprocs;
 
+/* info needed to keep track of tasks for tm_multi_spawn/pbsdsh */
+struct job_multispawn_info {
+	int		ji_ident;
+	int		ji_num_sisters;
+	int		ji_taskid_index;
+	tm_task_id	*ji_taskid_list;
+	tm_node_id	*ji_nid_list;
+	struct job_multispawn_info *next;
+};
+
 /* the following enum defines if a node resource is to be reported by Mom */
 enum PBS_NodeRes_Status {
 	PBS_NODERES_ACTIVE,	/* resource reported from a non-released node */
@@ -492,6 +502,8 @@ struct job {
 	enum bg_hook_request ji_hook_running_bg_on; /* set when hook starts in the background*/
 	int		ji_msconnected; /* 0 - not connected, 1 - connected */
 	pbs_list_head	ji_multinodejobs;	/* links to recovered multinode jobs */
+	struct job_multispawn_info *ji_spawninfo;   /* pointer to information for multispawn */
+
 #else						    /* END Mom ONLY -  start Server ONLY */
 	struct batch_request *ji_pmt_preq; /* outstanding preempt job request for deleting jobs */
 	int ji_discarding;		   /* discarding job */
@@ -551,7 +563,6 @@ struct job {
 		char ji_fileprefix[PBS_JOBBASE + 1];  /* no longer used */
 		char ji_queue[PBS_MAXQUEUENAME + 1];  /* name of current queue */
 		char ji_destin[PBS_MAXROUTEDEST + 1]; /* dest from qmove/route, MomS for execution */
-
 		int ji_un_type;				 /* type of ji_un union */
 		union {					 /* depends on type of queue currently in */
 			struct {			 /* if in execution queue .. */
@@ -746,6 +757,7 @@ typedef struct	infoent {
 #define IM_PMIX			26
 #define IM_RECONNECT_TO_MS			27
 #define IM_JOIN_RECOV_JOB		28
+#define IM_SPAWN_MULTI		29	
 
 #define IM_ERROR		99
 #define IM_ERROR2		100

--- a/src/include/tm.h
+++ b/src/include/tm.h
@@ -105,7 +105,7 @@ tm_spawn_multi(int	 argc,
 	char		*envp[],
 	int		list_size,
 	tm_node_id	where[],
-	tm_task_id	*tids,
+	tm_task_id	tids[],
 	tm_event_t	*event);
 
 int

--- a/src/include/tm.h
+++ b/src/include/tm.h
@@ -100,6 +100,15 @@ tm_spawn(int		 argc,
 	tm_event_t	*event);
 
 int
+tm_spawn_multi(int	 argc,
+	char		*argv[],
+	char		*envp[],
+	int		list_size,
+	tm_node_id	where[],
+	tm_task_id	*tids,
+	tm_event_t	*event);
+
+int
 tm_kill(tm_task_id	tid,
 	int		sig,
 	tm_event_t	*event);

--- a/src/include/tm_.h
+++ b/src/include/tm_.h
@@ -78,6 +78,7 @@ typedef unsigned int	tm_task_id;
 #define	TM_ACK		111	/* tm_register event acknowledge */
 #define TM_FINALIZE	112	/* tm_finalize request, there is no reply */
 #define TM_ATTACH	113	/* tm_attach request */
+#define TM_SPAWN_MULTI	114	/* tm_spawn_multi request */
 #define TM_OKAY		  0
 
 

--- a/src/lib/Libifl/tm.c
+++ b/src/lib/Libifl/tm.c
@@ -815,7 +815,7 @@ tm_nodeinfo(tm_node_id **list, int *nnodes)
  */
 int
 tm_spawn_multi(int argc, char **argv, char **envp,
-		int list_size, tm_node_id where[], tm_task_id *tids,
+		int list_size, tm_node_id where[], tm_task_id tids[],
 		tm_event_t *event)
 {
 	char		*cp;

--- a/src/server/job_func.c
+++ b/src/server/job_func.c
@@ -590,6 +590,8 @@ job_free(job *pj)
 	tempinfo = pj->ji_spawninfo;
 	while (tempinfo != NULL) {
 		next = tempinfo->next;
+		free(tempinfo->ji_taskid_list);
+		free(tempinfo->ji_nid_list);
 		free(tempinfo);
 		tempinfo = next;
 	}

--- a/src/server/job_func.c
+++ b/src/server/job_func.c
@@ -357,6 +357,7 @@ job_alloc(void)
 	CLEAR_HEAD(pj->ji_multinodejobs);
 	pj->ji_extended.ji_ext.ji_stdout = 0;
 	pj->ji_extended.ji_ext.ji_stderr = 0;
+	pj->ji_spawninfo = NULL;
 #else	/* SERVER */
 	pj->ji_discarding = 0;
 	pj->ji_prunreq = NULL;
@@ -539,6 +540,8 @@ job_free(job *pj)
 
 #else	/* PBS_MOM  Mom Only */
 
+	struct job_multispawn_info	*tempinfo, *next; 
+
 	if (pj->ji_grpcache)
 		(void)free(pj->ji_grpcache);
 
@@ -584,6 +587,12 @@ job_free(job *pj)
 		job_free_extra(pj);
 
 	CLEAR_HEAD(pj->ji_multinodejobs);
+	tempinfo = pj->ji_spawninfo;
+	while (tempinfo != NULL) {
+		next = tempinfo->next;
+		free(tempinfo);
+		tempinfo = next;
+	}
 
 #ifdef WIN32
 	if (pj->ji_hJob) {


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
tm_spawn and pbsdsh can only start an executable on one mom at a time.  If an executable has to be sent to 10 moms, it would be sent one at a time.  We can speed things up and make things happen in parallel by sending to all of the moms at once using tm_spawn_multi.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Introducing tm_spawn_multi() that will multicast the execution request to all moms.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
https://openpbs.atlassian.net/wiki/spaces/PD/pages/2664988673/Proposal+for+tm+spawn+multi

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, WIN2K16
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|7667|4176|0|0|0|0|4176|

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
