### PR TITLE
skip test_preempt_requeue_exclhost on cpuset machines

### DIFF
--- a/test/tests/functional/pbs_preemption.py
+++ b/test/tests/functional/pbs_preemption.py
@@ -198,6 +198,7 @@ exit 1
         """
         self.submit_and_preempt_jobs(preempt_order='R')
 
+    @skipOnCpuSet
     def test_preempt_requeue_exclhost(self):
         """
         Test that a job is preempted by requeue on node


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
test_preempt_requeue_exclhost fails on a cpuset machine. It tries to create vnodes with number of vnode being '0'. This causes the create_vnode code to offline the cpuset vnode and keep the natural node. But the issue is that the natural vnode does not have any ncpu on it. Because of this scheduler is not able to find a valid node with an ncpu on it and the test fails.


#### Describe Your Change
Skip the test on cpuset machine.


#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
NA


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
