### PR TITLE
Fixing server crash due to setting the empty value to the custom resource.

### DIFF
--- a/src/lib/Libattr/attr_fn_l.c
+++ b/src/lib/Libattr/attr_fn_l.c
@@ -113,6 +113,9 @@ decode_l(attribute *patr, char *name, char *rescn, char *val)
 		}
 		post_attr_set(patr);
 		patr->at_val.at_long = strtol(val, &endp, 10);
+	} else if ((val != NULL) && (strlen(val) == 0)) {
+		patr->at_val.at_long = 0;
+		post_attr_set(patr);
 	} else {
 		ATR_UNSET(patr);
 		patr->at_val.at_long = 0;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
The server is getting crashed while resetting the valid value for the long custom resource once after setting the "empty" value. 

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
As part of setting the empty value to the long custom resource, also it is needed to set the ATR_VFLAG_SET Flag.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output

Before fix: 

```
JID=$(qsub -l select=1:ncpus=1:mpiprocs=1:ompthreads=1:mem=1gb:Qlist=aba_1c -q aba_1c -l aba_adm02_lic=6 -- /bin/sleep 1000)
2.osuse15

qalter -l "aba_adm02_lic =" $JID

qalter -l "aba_adm02_lic =7" $JID
qalter: End of File 2.osuse15
 
```

After fix:
```
(Server is not crashing while qalter the request)

root@science Uncategorized]# qalter -l "aba_adm02_lic =" $JID
[root@science Uncategorized]# qalter -l "aba_adm02_lic =7" $JID
[root@science Uncategorized]# qstat
Job id                 Name             User              Time Use S Queue
---------------------  ---------------- ----------------  -------- - -----
0.science              STDIN            root                     0 Q aba_1c          
[root@science Uncategorized]# 
```

<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, WIN2K16
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|7662|4176|1|2|0|0|4173|

Description: Rerun Only Failed Tests From #7662
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|7663|4|0|0|0|0|4|


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
