### PR TITLE
multi-server: jobs which span boundaries stay queued when it is eligible to run

### DIFF
--- a/src/include/server.h
+++ b/src/include/server.h
@@ -237,7 +237,7 @@ int connect_to_peersvr(void *);
 bool is_peersvr(void *);
 void mcast_resc_usage(psvr_ru_t *, int);
 int open_ps_mtfd(void);
-void send_nodestat_req(void);
+void send_nodestat_req(enum msvr_stats_type);
 void req_peer_svr_ack(int);
 void *pending_ack_svr(void);
 psvr_ru_t *init_psvr_ru(job *, int, char *, bool);

--- a/src/server/multi_svr.c
+++ b/src/server/multi_svr.c
@@ -613,8 +613,9 @@ connect_to_peersvr(void *psvr)
 	if (send_connect(psvr) < 0)
 		return -1;
 
-	if (resc_upd_reqd && svr_info->ps_pending_replies) {
-		mcast_resc_update_all(psvr);
+	if (resc_upd_reqd) {
+		if (svr_info->ps_pending_replies)
+			mcast_resc_update_all(psvr);
 		send_nodestat_req();
 	}
 

--- a/src/server/multi_svr.c
+++ b/src/server/multi_svr.c
@@ -613,8 +613,10 @@ connect_to_peersvr(void *psvr)
 	if (send_connect(psvr) < 0)
 		return -1;
 
-	if (resc_upd_reqd && svr_info->ps_pending_replies)
+	if (resc_upd_reqd && svr_info->ps_pending_replies) {
 		mcast_resc_update_all(psvr);
+		send_nodestat_req();
+	}
 
 	return 0;
 }
@@ -1028,6 +1030,10 @@ update_node_cache(int stream, struct batch_status *bstat)
 	clear_node_cache(psvr);
 
 	init_node_from_bstat(bstat, psvr);
+
+	/* Trigger default scheduler to schedule the job which has failed due
+	to missing vnode cache information */
+	set_scheduler_flag(SCH_SCHEDULE_NEW, dflt_scheduler);
 
 	return 0;
 }

--- a/src/server/multi_svr.c
+++ b/src/server/multi_svr.c
@@ -319,6 +319,9 @@ log_msvr_stat()
 void
 update_msvr_stat(ulong val, msvr_stat_type_t type)
 {
+	if (type < 0 || type >= END_OF_STAT)
+		return;
+		
 	msvr_stat.stat[type] += val;
 
 	log_msvr_stat();
@@ -616,7 +619,7 @@ connect_to_peersvr(void *psvr)
 	if (resc_upd_reqd) {
 		if (svr_info->ps_pending_replies)
 			mcast_resc_update_all(psvr);
-		send_nodestat_req();
+		send_nodestat_req(-1);
 	}
 
 	return 0;

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -6513,7 +6513,7 @@ set_nodes(void *pobj, int objtype, char *execvnod_in, char **execvnod_out, char 
 			*/
 			log_eventf(PBSEVENT_DEBUG, PBS_EVENTCLASS_JOB, LOG_INFO,
 				   pjob->ji_qs.ji_jobid, "Unknown node received");
-			send_nodestat_req();
+			send_nodestat_req(CACHE_MISS);
 			return PBSE_UNKNODE;
 		}
 
@@ -6589,7 +6589,7 @@ set_nodes(void *pobj, int objtype, char *execvnod_in, char **execvnod_out, char 
 						   presv->ri_qs.ri_resvID, "Unknown node %s received", vname);
 				free(execvncopy);
 				rc = PBSE_UNKNODE;
-				send_nodestat_req();
+				send_nodestat_req(CACHE_MISS);
 				goto end;
 			}
 
@@ -6681,7 +6681,7 @@ set_nodes(void *pobj, int objtype, char *execvnod_in, char **execvnod_out, char 
 							   pjob->ji_qs.ji_jobid, "Unknown node %s received", peh);
 						free(phowl);
 						free(execvncopy);
-						send_nodestat_req();
+						send_nodestat_req(CACHE_MISS);
 						return (PBSE_UNKNODE);
 					}
 					if ((phowl + ndindex)->hw_pnd->nd_moms)

--- a/src/server/req_jobobit.c
+++ b/src/server/req_jobobit.c
@@ -1621,7 +1621,7 @@ job_obit(ruu *pruu, int stream)
 				} else if (exitstatus == JOB_EXEC_JOINJOB) {
 					log_event(PBSEVENT_ERROR | PBSEVENT_JOB, PBS_EVENTCLASS_JOB, LOG_INFO,
 						  pjob->ji_qs.ji_jobid, "Mom rejected job due to join job error");
-					send_nodestat_req();
+					send_nodestat_req(CACHE_MISS);
 					exitstatus = JOB_EXEC_RETRY;
 				}
 RetryJob:

--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -303,7 +303,7 @@ need_to_run_elsewhere(struct batch_request *preq)
 		if ((pnode = find_alien_node(vname)))
 			svr_id = get_nattr_str(pnode, ND_ATR_server_inst_id);
 		else
-			send_nodestat_req();
+			send_nodestat_req(CACHE_MISS);
 	}
 
 	free(vname);
@@ -1485,7 +1485,7 @@ post_sendmom(struct work_task *pwt)
 			r = SEND_JOB_HOOK_REJECT_DELETEJOB;
 			break;
 		case PBSE_SISCOMM:
-			send_nodestat_req();
+			send_nodestat_req(CACHE_MISS);
 		default:
 			r = SEND_JOB_FATAL;
 			break;

--- a/src/server/svr_comm.c
+++ b/src/server/svr_comm.c
@@ -271,14 +271,14 @@ send_nodestat_req(void)
 
 	update_msvr_stat(1, CACHE_MISS);
 
+	if (mtfd == -1)
+		return;
+
 	/* Do not udate the cache too often */
 	if (time_now < time_last_sent + 2)
 		return;
 
 	time_last_sent = time_now;
-
-	if (mtfd == -1)
-		return;
 
 	log_eventf(PBSEVENT_DEBUG, PBS_EVENTCLASS_SERVER, LOG_DEBUG,
 		   __func__, "Sending node stat to peer servers");

--- a/src/server/svr_comm.c
+++ b/src/server/svr_comm.c
@@ -233,6 +233,8 @@ err:
  * @brief reply to connect message from peer server
  * sends all the resource update which needs to be updated
  * 
+ * @param[in] ptask - work task
+ * 
  */
 void
 replyhello_psvr(struct work_task *ptask)
@@ -257,19 +259,20 @@ replyhello_psvr(struct work_task *ptask)
  * stats only a few attributes. This request is asynchronous
  * and server will process when it gets a PS_STAT_RPLY.
  * 
+ * @param[in] type - msvr stat type
  */
 void
-send_nodestat_req(void)
+send_nodestat_req(enum msvr_stats_type type)
 {
 	struct attrl *pat;
 	struct attrl *head;
 	struct attrl *tail;
 	struct attrl *nxt;
 	int mtfd = open_ps_mtfd();
-	int rc;
 	static int time_last_sent = 0;
+	int rc;
 
-	update_msvr_stat(1, CACHE_MISS);
+	update_msvr_stat(1, type);
 
 	if (mtfd == -1)
 		return;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
multi-server: jobs which span boundaries stay queued when it is eligible to run as initially servers doesn't have the node cache. It will get in the next scheduling cycle.


#### Describe Your Change
Server will fetch the node cache when it comes up.
Server will inform the scheduler once it receives the cache to trigger another cycle.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[test.log](https://github.com/openpbs/openpbs/files/6541716/test.log)

Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, WIN2K16
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|7699|4178|1|5|0|15|4157|

Description: Rerun Only Failed Tests From #7699
Platforms: UBUNTU1804,SLES12
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|7712|6|0|0|0|0|6|


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
