### PR TITLE
group_info C++ refactor

### DIFF
--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -917,6 +917,7 @@ class fairshare_head
 	time_t last_decay;			/* last time tree was decayed */
 	fairshare_head();
 	fairshare_head(fairshare_head&);
+	fairshare_head operator=(fairshare_head&);
 	~fairshare_head();
 };
 

--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -879,7 +879,7 @@ class resdef
 class prev_job_info
 {
 	public:
-	const std::string name;	/* name of job */
+	std::string name;	/* name of job */
 	std::string entity_name;	/* fair share entity of job */
 	resource_req *resused;	/* resources used by the job */
 	prev_job_info(const std::string& pname, const std::string& ename, resource_req *rused);
@@ -917,7 +917,7 @@ class fairshare_head
 	time_t last_decay;			/* last time tree was decayed */
 	fairshare_head();
 	fairshare_head(fairshare_head&);
-	fairshare_head operator=(fairshare_head&);
+	fairshare_head& operator=(fairshare_head&);
 	~fairshare_head();
 };
 

--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -76,7 +76,7 @@ struct resource_req;
 struct resource_count;
 struct holiday;
 struct prev_job_info;
-struct group_info;
+class group_info;
 struct usage_info;
 struct counts;
 struct nspec;
@@ -90,7 +90,7 @@ class selspec;
 class resdef;
 struct event_list;
 struct status;
-struct fairshare_head;
+class fairshare_head;
 struct node_scratch;
 struct te_list;
 struct node_bucket;
@@ -112,7 +112,6 @@ typedef struct schd_resource schd_resource;
 typedef struct resource_req resource_req;
 typedef struct resource_count resource_count;
 typedef struct usage_info usage_info;
-typedef struct group_info group_info;
 typedef struct resv_info resv_info;
 typedef struct counts counts;
 typedef struct nspec nspec;
@@ -123,7 +122,6 @@ typedef struct np_cache np_cache;
 typedef struct chunk chunk;
 typedef struct timed_event timed_event;
 typedef struct event_list event_list;
-typedef struct fairshare_head fairshare_head;
 typedef struct node_scratch node_scratch;
 typedef struct resresv_set resresv_set;
 typedef struct te_list te_list;
@@ -884,7 +882,7 @@ class prev_job_info
 	const std::string name;	/* name of job */
 	std::string entity_name;	/* fair share entity of job */
 	resource_req *resused;	/* resources used by the job */
-	prev_job_info(const std::string& pname, char *ename, resource_req *rused);
+	prev_job_info(const std::string& pname, const std::string& ename, resource_req *rused);
 	prev_job_info(const prev_job_info &);
 	prev_job_info(prev_job_info &&) noexcept;
 	prev_job_info& operator=(const prev_job_info&);
@@ -912,23 +910,20 @@ struct resource_count
 /* global data types */
 
 /* fairshare head structure */
-struct fairshare_head
+class fairshare_head
 {
+	public:
 	group_info *root;			/* root of fairshare tree */
 	time_t last_decay;			/* last time tree was decayed */
+	fairshare_head();
+	fairshare_head(fairshare_head&);
+	~fairshare_head();
 };
 
-/* a path from the root to a group_info in the tree */
-struct group_path
+class group_info
 {
-	group_info *ginfo;
-	struct group_path *next;
-};
-
-
-struct group_info
-{
-	char *name;				/* name of user/group */
+	public:
+	const std::string name;				/* name of user/group */
 	int resgroup;				/* resgroup the group is in */
 	int cresgroup;				/* resgroup of the children of group */
 	int shares;				/* number of shares this group has */
@@ -944,11 +939,13 @@ struct group_info
 	usage_t temp_usage;			/* usage plus any temporary usage */
 	float usage_factor;			/* usage calculation taking parent's usage into account: number between 0 and 1 */
 
-	struct group_path *gpath;		/* path from the root of the tree */
+	std::vector<group_info *> gpath;	/* path from the root of the tree */
 
 	group_info *parent;			/* parent node */
 	group_info *sibling;			/* sibling node */
 	group_info *child;			/* child node */
+	group_info(const std::string& gname);
+	group_info(group_info&);
 };
 
 /**

--- a/src/scheduler/fairshare.cpp
+++ b/src/scheduler/fairshare.cpp
@@ -220,7 +220,7 @@ group_info::group_info(const std::string& gname) : name(gname)
 
 /**
  * @brief
- * 		parse the resource group fil
+ * 		parse the resource group file
  *
  * @param[in]	fname	-	name of the file
  * @param[in]	root	-	root of fairshare tree
@@ -344,13 +344,11 @@ preload_tree()
 	group_info *root;
 	group_info *unknown;		/* pointer to the "unknown" group */
 
-	if ((head = new fairshare_head) == NULL)
+	if ((head = new fairshare_head()) == NULL)
 		return 0;
 
-	if ((root = new group_info(FAIRSHARE_ROOT_NAME)) == NULL) {
-		delete head;
-		return 0;
-	}
+	root = new group_info(FAIRSHARE_ROOT_NAME);
+
 
 	head->root = root;
 
@@ -462,7 +460,7 @@ update_usage_on_run(resource_resv *resresv)
 
 	u = formula_evaluate(conf.fairshare_res.c_str(), resresv, resresv->resreq);
 	if (resresv->job->ginfo !=NULL) {
-		for (auto &g : resresv->job->ginfo->gpath)
+		for (auto& g : resresv->job->ginfo->gpath)
 			g->temp_usage += u;
 	}
 	else
@@ -919,13 +917,23 @@ fairshare_head::fairshare_head()
  * @param[in]	ofhead	-	fairshare_head to dup
  *
  * @return	duplicated fairshare_head
- * @retval	NULL	: fail
+ * @retval	NULL	: fail 
  */
 fairshare_head::fairshare_head(fairshare_head& ofhead)
 {
 	last_decay = ofhead.last_decay;
 	root = dup_fairshare_tree(ofhead.root, NULL);
+}
 
+/**
+ * @brief copy assignment operator for fairshare_head
+ */
+fairshare_head fairshare_head::operator=(fairshare_head& ofhead)
+{
+	free_fairshare_tree(root);
+	last_decay = ofhead.last_decay;
+	root = dup_fairshare_tree(ofhead.root, NULL);
+	return *this;
 }
 
 /**

--- a/src/scheduler/fairshare.cpp
+++ b/src/scheduler/fairshare.cpp
@@ -928,7 +928,7 @@ fairshare_head::fairshare_head(fairshare_head& ofhead)
 /**
  * @brief copy assignment operator for fairshare_head
  */
-fairshare_head fairshare_head::operator=(fairshare_head& ofhead)
+fairshare_head& fairshare_head::operator=(fairshare_head& ofhead)
 {
 	free_fairshare_tree(root);
 	last_decay = ofhead.last_decay;

--- a/src/scheduler/fairshare.cpp
+++ b/src/scheduler/fairshare.cpp
@@ -64,16 +64,9 @@
  * 	read_usage()
  * 	read_usage_v1()
  * 	read_usage_v2()
- * 	new_group_path()
- * 	free_group_path_list()
- * 	create_group_path()
  * 	over_fs_usage()
  * 	dup_fairshare_tree()
  * 	free_fairshare_tree()
- * 	free_fairshare_node()
- * 	new_fairshare_head()
- * 	dup_fairshare_head()
- * 	free_fairshare_head()
  * 	reset_temp_usage()
  *
  */
@@ -159,10 +152,10 @@ add_unknown(group_info *ginfo, group_info *root)
  *
  */
 group_info *
-find_group_info(const char *name, group_info *root)
+find_group_info(const std::string& name, group_info *root)
 {
 	group_info *ginfo;		/* the found group */
-	if (root == NULL || name == NULL || !strcmp(name, root->name))
+	if (root == NULL || name == root->name)
 		return root;
 
 	ginfo = find_group_info(name, root->sibling);
@@ -185,20 +178,19 @@ find_group_info(const char *name, group_info *root)
  *
  */
 group_info *
-find_alloc_ginfo(const char *name, group_info *root)
+find_alloc_ginfo(const std::string& name, group_info *root)
 {
 	group_info *ginfo;		/* the found group or allocated group */
 
-	if (name == NULL || root == NULL)
+	if (root == NULL)
 		return NULL;
 
 	ginfo = find_group_info(name, root);
 
 	if (ginfo == NULL) {
-		if ((ginfo = new_group_info()) == NULL)
+		if ((ginfo = new group_info(name)) == NULL)
 			return NULL;
 
-		ginfo->name = string_dup(name);
 		ginfo->shares = 1;
 		add_unknown(ginfo, root);
 	}
@@ -212,36 +204,23 @@ find_alloc_ginfo(const char *name, group_info *root)
  * @return	a ptr to the new group_info
  *
  */
-group_info *
-new_group_info()
+group_info::group_info(const std::string& gname) : name(gname)
 {
-	group_info *ngi;		/* the new group */
-
-	if ((ngi = static_cast<group_info *>(malloc(sizeof(group_info)))) == NULL) {
-		log_err(errno, __func__, MEM_ERR_MSG);
-		return NULL;
-	}
-
-	ngi->name = NULL;
-	ngi->resgroup = UNSPECIFIED;
-	ngi->cresgroup = UNSPECIFIED;
-	ngi->shares = UNSPECIFIED;
-	ngi->tree_percentage = 0.0;
-	ngi->group_percentage = 0.0;
-	ngi->usage = FAIRSHARE_MIN_USAGE;
-	ngi->temp_usage = FAIRSHARE_MIN_USAGE;
-	ngi->usage_factor = 0.0;
-	ngi->gpath = NULL;
-	ngi->parent = NULL;
-	ngi->sibling = NULL;
-	ngi->child = NULL;
-
-	return ngi;
-}
+	resgroup = UNSPECIFIED;
+	cresgroup = UNSPECIFIED;
+	shares = UNSPECIFIED;
+	tree_percentage = 0.0;
+	group_percentage = 0.0;
+	usage = FAIRSHARE_MIN_USAGE;
+	temp_usage = FAIRSHARE_MIN_USAGE;
+	usage_factor = 0.0;
+	parent = NULL;
+	sibling = NULL;
+	child = NULL;}
 
 /**
  * @brief
- * 		parse the resource group file
+ * 		parse the resource group fil
  *
  * @param[in]	fname	-	name of the file
  * @param[in]	root	-	root of fairshare tree
@@ -312,9 +291,8 @@ parse_group(const char *fname, group_info *root)
 					if (*endp == '\0') {
 						cgroup = strtol(cgrouptok, &endp, 10);
 						if (*endp == '\0') {
-							if ((new_ginfo = new_group_info()) == NULL)
+							if ((new_ginfo = new group_info(nametok)) == NULL)
 								return 0;
-							new_ginfo->name = string_dup(nametok);
 							new_ginfo->resgroup = ginfo->cresgroup;
 							new_ginfo->cresgroup = cgroup;
 							new_ginfo->shares = shares;
@@ -366,34 +344,25 @@ preload_tree()
 	group_info *root;
 	group_info *unknown;		/* pointer to the "unknown" group */
 
-	if ((head = new_fairshare_head()) == NULL)
+	if ((head = new fairshare_head) == NULL)
 		return 0;
 
-	if ((root = new_group_info()) == NULL) {
-		free_fairshare_head(head);
+	if ((root = new group_info(FAIRSHARE_ROOT_NAME)) == NULL) {
+		delete head;
 		return 0;
 	}
 
 	head->root = root;
 
-	if ((root->name = string_dup(FAIRSHARE_ROOT_NAME)) == NULL) {
-		free_fairshare_head(head);
-		return NULL;
-	}
-
 	root->resgroup = -1;
 	root->cresgroup = 0;
 	root->tree_percentage = 1.0;
 
-	if ((unknown = new_group_info()) == NULL) {
-		free_fairshare_head(head);
+	if ((unknown = new group_info(UNKNOWN_GROUP_NAME)) == NULL) {
+		delete head;
 		return NULL;
 	}
-	if ((unknown->name = string_dup(UNKNOWN_GROUP_NAME)) == NULL) {
-		free_fairshare_node(unknown);
-		free_fairshare_head(head);
-		return NULL;
-	}
+
 	unknown->shares = conf.unknown_shares;
 	unknown->resgroup = 0;
 	unknown->cresgroup = 1;
@@ -484,7 +453,6 @@ void
 update_usage_on_run(resource_resv *resresv)
 {
 	usage_t u;
-	struct group_path *gpath;
 
 	if (resresv == NULL)
 		return;
@@ -494,11 +462,8 @@ update_usage_on_run(resource_resv *resresv)
 
 	u = formula_evaluate(conf.fairshare_res.c_str(), resresv, resresv->resreq);
 	if (resresv->job->ginfo !=NULL) {
-		gpath = resresv->job->ginfo->gpath;
-		while (gpath != NULL) {
-			gpath->ginfo->temp_usage += u;
-			gpath = gpath->next;
-		}
+		for (auto &g : resresv->job->ginfo->gpath)
+			g->temp_usage += u;
 	}
 	else
 		log_event(PBSEVENT_JOB, PBS_EVENTCLASS_JOB, LOG_INFO, resresv->name,
@@ -531,8 +496,8 @@ decay_fairshare_tree(group_info *root)
 
 /**
  * @brief
- *		compare_path - compare two group_path's and see which is more
- *		       deserving to run
+ *		compare_path - compare two group paths and see which is more
+ *				deserving to run
  * @par
  *		comparison: usage / priority
  *
@@ -546,45 +511,34 @@ decay_fairshare_tree(group_info *root)
  *
  */
 int
-compare_path(struct group_path *gp1, struct group_path *gp2)
+compare_path(std::vector<group_info *>& gp1, std::vector<group_info *>& gp2)
 {
-	struct group_path *cur1, *cur2;
 	double curval1, curval2;
 	int rc = 0;
+	int len;
 
-	if (gp1 == NULL && gp2 == NULL)
-		return 0;
-
-	if (gp1 != NULL && gp2 == NULL)
-		return -1;
-
-	if (gp1 == NULL && gp2 != NULL)
-		return 1;
-
-
-	cur1 = gp1;
-	cur2 = gp2;
-
-	while (cur1 != NULL && cur2 != NULL && rc == 0  ) {
-		if (cur1 != cur2) {
-			if (cur1->ginfo->tree_percentage <= 0 && cur2->ginfo->tree_percentage> 0)
+	if (gp1.size() > gp2.size())
+		len = gp2.size();
+	else
+		len = gp1.size();
+	
+	for (int i = 0; rc == 0 && i < len; i++) {
+		if (gp1[i] != gp2[i]) {
+			if (gp1[i]->tree_percentage <= 0 && gp2[i]->tree_percentage > 0)
 				return 1;
-			if (cur1->ginfo->tree_percentage > 0 && cur2->ginfo->tree_percentage<= 0)
+			if (gp1[i]->tree_percentage > 0 && gp2[i]->tree_percentage <= 0)
 				return -1;
-			if (cur1->ginfo->tree_percentage <= 0 && cur2->ginfo->tree_percentage<= 0)
+			if (gp1[i]->tree_percentage <= 0 && gp2[i]->tree_percentage <= 0)
 				return 0;
 
-			curval1 = cur1->ginfo->temp_usage / cur1->ginfo->tree_percentage;
-			curval2 = cur2->ginfo->temp_usage / cur2->ginfo->tree_percentage;
+			curval1 = gp1[i]->temp_usage / gp1[i]->tree_percentage;
+			curval2 = gp2[i]->temp_usage / gp2[i]->tree_percentage;
 
 			if (curval1 < curval2)
 				rc = -1;
 			else if (curval2 < curval1)
 				rc = 1;
 		}
-
-		cur1 = cur1->next;
-		cur2 = cur2->next;
 	}
 
 	return rc;
@@ -665,10 +619,10 @@ rec_write_usage(group_info *root, FILE *fp)
 #ifdef NAS /* localmod 043 */
 	if (root->child == NULL) {
 #else
-	if (root->usage != 1 && root->child == NULL && strcmp(root->name, UNKNOWN_GROUP_NAME) != 0) {
+	if (root->usage != 1 && root->child == NULL && root->name != UNKNOWN_GROUP_NAME) {
 #endif /* localmod 043 */
 		memset(&grp, 0, sizeof(struct group_node_usage_v2));
-		snprintf(grp.name, sizeof(grp.name), "%s", root->name);
+		snprintf(grp.name, sizeof(grp.name), "%s", root->name.c_str());
 		grp.usage = root->usage;
 
 		fwrite(&grp, sizeof(struct group_node_usage_v2), 1, fp);
@@ -759,7 +713,6 @@ read_usage_v1(FILE *fp, group_info *root)
 {
 	struct group_node_usage_v1 grp;
 	group_info *ginfo;
-	struct group_path *gpath;
 
 	if (fp == NULL)
 		return 0;
@@ -771,12 +724,12 @@ read_usage_v1(FILE *fp, group_info *root)
 				ginfo->usage = grp.usage;
 				ginfo->temp_usage = grp.usage;
 				if (ginfo->child == NULL) {
-					gpath = ginfo->gpath;
 					/* add usage down the path from the root to our parent */
-					while (gpath->next != NULL) {
-						gpath->ginfo->usage += grp.usage;
-						gpath->ginfo->temp_usage += grp.usage;
-						gpath = gpath->next;
+					for (auto& g : ginfo->gpath) {
+						if (g == ginfo)
+							break;
+						g->usage += grp.usage;
+						g->temp_usage += grp.usage;
 					}
 				}
 			}
@@ -806,7 +759,6 @@ read_usage_v2(FILE *fp, int flags, group_info *root)
 {
 	struct group_node_usage_v2 grp;
 	group_info *ginfo;
-	struct group_path *gpath;
 
 	if (fp == NULL)
 		return 0;
@@ -826,12 +778,12 @@ read_usage_v2(FILE *fp, int flags, group_info *root)
 				ginfo->usage = grp.usage;
 				ginfo->temp_usage = grp.usage;
 				if (ginfo->child == NULL) {
-					gpath = ginfo->gpath;
 					/* add usage down the path from the root to our parent */
-					while (gpath->next != NULL) {
-						gpath->ginfo->usage += grp.usage;
-						gpath->ginfo->temp_usage += grp.usage;
-						gpath = gpath->next;
+					for (auto& g : ginfo->gpath) {
+						if (g == ginfo)
+							break;
+						g->usage += grp.usage;
+						g->temp_usage += grp.usage;
 					}
 				}
 			}
@@ -846,53 +798,6 @@ read_usage_v2(FILE *fp, int flags, group_info *root)
 
 /**
  * @brief
- *		new_group_path - create a new group_path structure and init it
- *
- * @return	the new group_pathj
- */
-struct group_path *new_group_path()
-{
-	struct group_path *ngp;
-
-	if ((ngp = static_cast<group_path *>(malloc(sizeof(struct group_path)))) == NULL) {
-		log_err(errno, __func__, MEM_ERR_MSG);
-		return NULL;
-	}
-
-	ngp->ginfo = NULL;
-	ngp->next = NULL;
-
-	return ngp;
-}
-
-/**
- * @brief
- *		free_group_path_list - free a entire group path list
- *
- * @param[in]	gp	-	the head of the group path list
- *
- * @return nothing
- */
-void
-free_group_path_list(struct group_path *gp)
-{
-	struct group_path *next;
-	struct group_path *cur;
-
-	if (gp == NULL)
-		return;
-
-	cur = gp;
-
-	while (cur != NULL) {
-		next = cur->next;
-		free(cur);
-		cur = next;
-	}
-}
-
-/**
- * @brief
  *		create_group_path - create a path from the root to the leaf of the tree
  *
  * @param[in]	ginfo - the group_root to create the path from
@@ -900,31 +805,18 @@ free_group_path_list(struct group_path *gp)
  * @return path
  *
  */
-struct group_path *create_group_path(group_info *ginfo)
+std::vector<group_info *> create_group_path(group_info *ginfo)
 {
-	struct group_path *ret;	/* what is returned from recursive call */
-	struct group_path *cur;	/* used to find the end of the path */
+	struct group_info *cur;
+	std::vector<group_info *> gpath;
 
 	if (ginfo == NULL)
-		return NULL;
+		return {};
 
-	ret = create_group_path(ginfo->parent);
+	for (cur = ginfo; cur != NULL; cur = cur->parent)
+		gpath.insert(gpath.begin(), cur);
 
-	if (ret != NULL) {
-		cur = ret;
-
-		while (cur->next != NULL)
-			cur = cur->next;
-
-		cur->next = new_group_path();
-		cur->next->ginfo = ginfo;
-	}
-	else {
-		ret = new_group_path();
-		ret->ginfo = ginfo;
-	}
-
-	return ret;
+	return gpath;
 }
 
 /**
@@ -944,7 +836,22 @@ struct group_path *create_group_path(group_info *ginfo)
 int
 over_fs_usage(group_info *ginfo)
 {
-	return ginfo->gpath->ginfo->usage * ginfo->tree_percentage < ginfo->usage;
+	return ginfo->gpath[0]->usage * ginfo->tree_percentage < ginfo->usage;
+}
+
+group_info::group_info(group_info& root) : name(root.name)
+{
+	resgroup = root.resgroup;
+	cresgroup = root.cresgroup;
+	shares = root.shares;
+	tree_percentage = root.tree_percentage;
+	group_percentage = root.group_percentage;
+	usage = root.usage;
+	usage_factor = root.usage_factor;
+	temp_usage = root.temp_usage;
+	sibling = NULL;
+	child = NULL;
+	parent = NULL;
 }
 
 /**
@@ -963,26 +870,10 @@ dup_fairshare_tree(group_info *root, group_info *nparent)
 	if (root == NULL)
 		return NULL;
 
-	nroot = new_group_info();
+	nroot = new group_info(*root);
 
 	if (nroot == NULL)
 		return NULL;
-
-
-	nroot->resgroup = root->resgroup;
-	nroot->cresgroup = root->cresgroup;
-	nroot->shares = root->shares;
-	nroot->tree_percentage = root->tree_percentage;
-	nroot->group_percentage = root->group_percentage;
-	nroot->usage = root->usage;
-	nroot->usage_factor = root->usage_factor;
-	nroot->temp_usage = root->temp_usage;
-	nroot->name = string_dup(root->name);
-
-	if (nroot->name == NULL) {
-		free_fairshare_node(nroot);
-		return NULL;
-	}
 
 	add_child(nroot, nparent);
 
@@ -1007,44 +898,18 @@ free_fairshare_tree(group_info *root)
 
 	free_fairshare_tree(root->sibling);
 	free_fairshare_tree(root->child);
-	free_fairshare_node(root);
-}
-
-/**
- * @brief
- *		free the data associated with a single fairshare tree node
- *
- * @param[in,out]	root	-	single fairshare tree node
- */
-void
-free_fairshare_node(group_info *node)
-{
-	if (node == NULL)
-		return;
-
-	free(node->name);
-	free_group_path_list(node->gpath);
-	free(node);
+	delete root;
 }
 
 /**
  * @brief
  * 		constructor for fairshare head
  */
-fairshare_head *
-new_fairshare_head()
+
+fairshare_head::fairshare_head()
 {
-	fairshare_head *fhead;
-
-	if ((fhead = static_cast<fairshare_head *>(malloc(sizeof(fairshare_head)))) == NULL) {
-		log_err(errno, __func__, MEM_ERR_MSG);
-		return NULL;
-	}
-
-	fhead->root = NULL;
-	fhead->last_decay = 0;
-
-	return fhead;
+	root = NULL;
+	last_decay = 0;
 }
 
 /**
@@ -1056,27 +921,11 @@ new_fairshare_head()
  * @return	duplicated fairshare_head
  * @retval	NULL	: fail
  */
-fairshare_head *
-dup_fairshare_head(fairshare_head *ofhead)
+fairshare_head::fairshare_head(fairshare_head& ofhead)
 {
-	fairshare_head *nfhead;
+	last_decay = ofhead.last_decay;
+	root = dup_fairshare_tree(ofhead.root, NULL);
 
-	if (ofhead == NULL)
-		return NULL;
-
-	nfhead = new_fairshare_head();
-
-	if (nfhead == NULL)
-		return NULL;
-
-	nfhead->last_decay = ofhead->last_decay;
-	nfhead->root = dup_fairshare_tree(ofhead->root, NULL);
-	if (nfhead->root == NULL) {
-		free_fairshare_head(nfhead);
-		return NULL;
-	}
-
-	return nfhead;
 }
 
 /**
@@ -1085,15 +934,9 @@ dup_fairshare_head(fairshare_head *ofhead)
  *
  * @param[in]	fhead	-	fairshare_head to be freed.
  */
-void
-free_fairshare_head(fairshare_head *fhead)
+fairshare_head::~fairshare_head()
 {
-	if (fhead == NULL)
-		return;
-
-	free_fairshare_tree(fhead->root);
-
-	free(fhead);
+	free_fairshare_tree(root);
 }
 
 /**

--- a/src/scheduler/fairshare.h
+++ b/src/scheduler/fairshare.h
@@ -50,24 +50,15 @@ void add_child(group_info *ginfo, group_info *parent);
  *      find_group_info - recursive function to find a ginfo in the
  resgroup tree
  */
-group_info *find_group_info(const char *name, group_info *root);
+group_info *find_group_info(const std::string& name, group_info *root);
 
 /*
  *      find_alloc_ginfo - trys to find a ginfo in the fair share tree.  If it
  *                        can not find the ginfo, then allocate a new one and
  *                        add it to the "unknown" group
  */
-group_info *find_alloc_ginfo(const char *name, group_info *root);
+group_info *find_alloc_ginfo(const std::string& name, group_info *root);
 
-
-/*
- *      new_group_info - allocate a new group_info struct and initalize it
- */
-#ifdef NAS /* localmod 005 */
-group_info * new_group_info(void);
-#else
-group_info * new_group_info();
-#endif /* localmod 005 */
 
 /*
  *
@@ -99,12 +90,7 @@ int parse_group(const char *fname, group_info *root);
  *	return new head and root of a fairshare tree
  *
  */
-#ifdef NAS /* localmod 005 */
 fairshare_head *preload_tree(void);
-#else
-fairshare_head *preload_tree();
-#endif /* localmod 005 */
-
 
 /*
  *      count_shares - count the shares in the current resource group
@@ -159,29 +145,15 @@ int read_usage_v1(FILE *fp, group_info *root);
 int read_usage_v2(FILE *fp, int flags, group_info *root);
 
 /*
- *      new_group_path - create a new group_path structure and init it
- */
-#ifdef NAS /* localmod 005 */
-struct group_path *new_group_path(void);
-#else
-struct group_path *new_group_path();
-#endif /* localmod 005 */
-
-/*
- *      free_group_path_list - free a entire group path list
- */
-void free_group_path_list(struct group_path *gp);
-
-/*
  *      create_group_path - create a path from the root to the leaf of the tree
  */
-struct group_path *create_group_path(group_info *ginfo);
+std::vector<group_info *> create_group_path(group_info *ginfo);
 
 /*
  *      compare_path - compare two group_path's and see which is more
  *                     deserving to run
  */
-int compare_path(struct group_path *gp1, struct group_path *gp2);
+int compare_path(std::vector<group_info *>& gp1, std::vector<group_info *>& gp2);
 
 /*
  *      over_fs_usage - return true of a entity has used more then their
@@ -205,35 +177,6 @@ group_info *dup_fairshare_tree(group_info *root, group_info *nparent);
  *	free_fairshare_tree - free the entire fairshare tree
  */
 void free_fairshare_tree(group_info *root);
-
-/*
- *	free_fairshare_node - free the data associated with
- *			      a single fairshare tree node
- */
-void free_fairshare_node(group_info *node);
-
-/*
- *	new_fairshare_head - constructor
- */
-#ifdef NAS /* localmod 005 */
-fairshare_head *new_fairshare_head(void);
-#else
-fairshare_head *new_fairshare_head();
-#endif /* localmod 005 */
-
-/*
- *	dup_fairshare_head - copy constructor for fairshare_head
- *
- *	  ofhead - fairshare_head to dup
- *
- *	return duplicated fairshare_head
- */
-fairshare_head *dup_fairshare_head(fairshare_head *ofead);
-
-/*
- *	free_fairshare_head - destructor for fairshare_head
- */
-void free_fairshare_head(fairshare_head *fhead);
 
 /*
  *

--- a/src/scheduler/fifo.cpp
+++ b/src/scheduler/fifo.cpp
@@ -144,7 +144,7 @@ schedinit(int nthreads)
 	parse_ded_file(DEDTIME_FILE);
 
 	if (fstree != NULL)
-		free_fairshare_head(fstree);
+		delete fstree;
 	/* preload the static members to the fairshare tree */
 	fstree = preload_tree();
 	if (fstree != NULL) {
@@ -357,8 +357,8 @@ init_scheduling_cycle(status *policy, int pbs_sd, server_info *sinfo)
 						delta = IF_NEG_THEN_ZERO(delta);
 
 						;
-						for (auto gpath = user->gpath; gpath != NULL; gpath = gpath->next)
-							gpath->ginfo->usage += delta;
+						for (auto& g : user->gpath)
+							g->usage += delta;
 
 						resort = 1;
 					}
@@ -2023,7 +2023,7 @@ add_job_to_calendar(int pbs_sd, status *policy, server_info *sinfo,
 			 */
 			update_usage_on_run(bjob);
 			log_eventf(PBSEVENT_DEBUG, PBS_EVENTCLASS_JOB, LOG_DEBUG, bjob->name,
-				"Fairshare usage of entity %s increased due to job becoming a top job.", bjob->job->ginfo->name);
+				"Fairshare usage of entity %s increased due to job becoming a top job.", bjob->job->ginfo->name.c_str());
 		}
 
 		sprintf(log_buf, "Job is a top job and will run at %s",

--- a/src/scheduler/pbsfs.cpp
+++ b/src/scheduler/pbsfs.cpp
@@ -312,7 +312,7 @@ print_fairshare_entity(group_info *ginfo)
 		ginfo->tree_percentage == 0 ? -1 : ginfo->usage / ginfo->tree_percentage);
 
 	printf("Path from root: \n");
-	for (auto& gp : ginfo->gpath) {
+	for (const auto& gp : ginfo->gpath) {
 		printf("%-10s: %5d %10.0f / %5.3f = %.0f\n",
 			gp->name.c_str(), gp->cresgroup,
 			gp->usage, gp->tree_percentage,

--- a/src/scheduler/pbsfs.cpp
+++ b/src/scheduler/pbsfs.cpp
@@ -249,15 +249,15 @@ main(int argc, char *argv[])
 			}
 			switch (compare_path(ginfo->gpath, ginfo2->gpath)) {
 				case -1:
-					printf("%s\n", ginfo->name);
+					printf("%s\n", ginfo->name.c_str());
 					break;
 
 				case 0:
-					printf("%s == %s\n", ginfo->name, ginfo2->name);
+					printf("%s == %s\n", ginfo->name.c_str(), ginfo2->name.c_str());
 					break;
 
 				case 1:
-					printf("%s\n", ginfo2->name);
+					printf("%s\n", ginfo2->name.c_str());
 			}
 		}
 		else if (flags & FS_GET)
@@ -293,7 +293,6 @@ main(int argc, char *argv[])
 static void
 print_fairshare_entity(group_info *ginfo)
 {
-	struct group_path *gp;
 	printf(
 		"fairshare entity: %s\n"
 		"Resgroup		: %d\n"
@@ -303,7 +302,7 @@ print_fairshare_entity(group_info *ginfo)
 		"fairshare_tree_usage	: %f\n"
 		"usage			: %.0lf (%s)\n"
 		"usage/perc		: %.0lf\n",
-		ginfo->name,
+		ginfo->name.c_str(),
 		ginfo->resgroup,
 		ginfo->cresgroup,
 		ginfo->shares,
@@ -313,12 +312,12 @@ print_fairshare_entity(group_info *ginfo)
 		ginfo->tree_percentage == 0 ? -1 : ginfo->usage / ginfo->tree_percentage);
 
 	printf("Path from root: \n");
-	for (gp = ginfo->gpath; gp != NULL; gp = gp->next) {
+	for (auto& gp : ginfo->gpath) {
 		printf("%-10s: %5d %10.0f / %5.3f = %.0f\n",
-			gp->ginfo->name, gp->ginfo->cresgroup,
-			gp->ginfo->usage, gp->ginfo->tree_percentage,
-			gp->ginfo->tree_percentage == 0 ? -1 :
-			gp->ginfo->usage / gp->ginfo->tree_percentage);
+			gp->name.c_str(), gp->cresgroup,
+			gp->usage, gp->tree_percentage,
+			gp->tree_percentage == 0 ? -1 :
+			gp->usage / gp->tree_percentage);
 	}
 }
 
@@ -343,11 +342,11 @@ print_fairshare(group_info *root, int level)
 		printf(
 			"%-10s: Grp: %-5d  cgrp: %-5d"
 			"Shares: %-6d Usage: %-6.0lf Perc: %6.3f%%\n",
-			root->name, root->resgroup, root->cresgroup, root->shares,
+			root->name.c_str(), root->resgroup, root->cresgroup, root->shares,
 			root->usage, (root->tree_percentage * 100));
 	}
 	else
-		printf("%*s%s(%d)\n", level, " ", root->name, root->cresgroup);
+		printf("%*s%s(%d)\n", level, " ", root->name.c_str(), root->cresgroup);
 
 	print_fairshare(root->child, level >= 0 ? level + 5 : -1);
 	print_fairshare(root->sibling, level);

--- a/src/scheduler/prev_job_info.cpp
+++ b/src/scheduler/prev_job_info.cpp
@@ -90,15 +90,13 @@ create_prev_job_info(resource_resv **jobs)
 	}
 }
 
-prev_job_info::prev_job_info(const std::string& pname, char *ename, resource_req *rused): name(pname)
+prev_job_info::prev_job_info(const std::string& pname, const std::string& ename, resource_req *rused): name(pname), entity_name(ename)
 {
-	entity_name = ename;
 	resused = rused;
 }
 
-prev_job_info::prev_job_info(const prev_job_info& opj): name(opj.name)
+prev_job_info::prev_job_info(const prev_job_info& opj): name(opj.name), entity_name(opj.entity_name)
 {
-	entity_name = opj.entity_name;
 	resused = dup_resource_req_list(opj.resused);
 }
 

--- a/src/scheduler/prev_job_info.cpp
+++ b/src/scheduler/prev_job_info.cpp
@@ -108,7 +108,11 @@ prev_job_info::prev_job_info(prev_job_info&& opj) noexcept: name(std::move(opj.n
 
 prev_job_info& prev_job_info::operator=(const prev_job_info& opj)
 {
-	return *this = prev_job_info(opj);
+	name = opj.name;
+	entity_name = opj.entity_name;
+	resused = dup_resource_req_list(opj.resused);
+	
+	return *this;
 }
 
 /**

--- a/src/scheduler/server_info.cpp
+++ b/src/scheduler/server_info.cpp
@@ -1088,7 +1088,7 @@ free_server_info(server_info *sinfo)
 	if (sinfo->policy != NULL)
 		delete sinfo->policy;
 	if (sinfo->fstree != NULL)
-		free_fairshare_head(sinfo->fstree);
+		delete sinfo->fstree;
 	if (sinfo->liminfo != NULL) {
 		lim_free_liminfo(sinfo->liminfo);
 		sinfo->liminfo = NULL;
@@ -2226,10 +2226,10 @@ dup_server_info(server_info *osinfo)
 
 	/* duplicate the server information */
 	if ((nsinfo = new_server_info(0)) == NULL)
-		return NULL;                /* error */
+		return NULL;
 
 	if (osinfo->fstree != NULL) {
-		nsinfo->fstree = dup_fairshare_head(osinfo->fstree);
+		nsinfo->fstree = new fairshare_head(*osinfo->fstree);
 		if (nsinfo->fstree == NULL) {
 			free_server(nsinfo);
 			return NULL;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Refactor the fairshare structures into C++

#### Describe Your Change
Refactor fairshare_head and group_info into C++.  Eliminate group_path in favor of a vector.

#### Attach Test and Valgrind Logs/Output
Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, WIN2K16
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|7689|4178|0|0|0|15|4163|
