### PR TITLE
put nslookup mutex for getnameinfo

### DIFF
--- a/src/lib/Libtpp/tpp_platform.c
+++ b/src/lib/Libtpp/tpp_platform.c
@@ -667,8 +667,18 @@ tpp_sock_resolve_ip(tpp_addr_t *addr, char *host, int len)
 		sa->sa_family = AF_INET6;
 	} else
 		return -1;
-
+#ifndef WIN32
+	/* 
+	 * introducing a new mutex to prevent child process from 
+	 * inheriting getnameinfo mutex using pthread_atfork handlers
+	 */
+	tpp_lock(&tpp_nslookup_mutex);
+#endif
 	rc = getnameinfo(sa, salen, host, len, NULL, 0, 0);
+	/* unlock nslookup mutex */
+#ifndef WIN32
+		tpp_unlock(&tpp_nslookup_mutex);
+#endif
 	if (rc != 0) {
 		TPP_DBPRT("Error: %s", gai_strerror(rc));
 	}


### PR DESCRIPTION

#### Describe Bug or Feature
* Same as #2299 , this time lock introduced by getnameinfo method.

#### Describe Your Change
* Apply the nslookup_mutex around getnameinfo call also.


#### Attach Test and Valgrind Logs/Output
Description: Tests from given sources on platforms SUSE15, CENTOS8, CENTOS7
Platforms: SUSE15,CENTOS8,CENTOS7
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|7707|2050|0|1|0|0|2049|

After rerun for error test, it got passed:
Description: Rerun Only Failed Tests From #7707
Platforms: SUSE15,CENTOS8,CENTOS7
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|7708|1|0|0|0|0|1|


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
