### PR TITLE
Change sched to not consider prerunning job as running

### DIFF
--- a/src/scheduler/constant.h
+++ b/src/scheduler/constant.h
@@ -327,6 +327,9 @@ enum resv_conf {
 /* job substate meaning node is provisioning */
 #define PROVISIONING_SUBSTATE "71"
 
+/* job substate meaning job is pre-running state */
+#define PRERUNNING_SUBSTATE "41"
+
 /* TRUE_FALSE indicates both true and false for collections of resources */
 enum { FALSE, TRUE, TRUE_FALSE };
 

--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -570,6 +570,7 @@ struct job_info
 
 	bool is_provisioning:1;	/* job is provisioning */
 	bool is_preempted:1;	/* job is preempted */
+	bool is_prerunning:1		/* Job in prerunning substate */
 	bool topjob_ineligible:1;	/* Job is ineligible to be a top job */
 
 	char *job_name;			/* job name attribute (qsub -N) */

--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -570,7 +570,7 @@ struct job_info
 
 	bool is_provisioning:1;	/* job is provisioning */
 	bool is_preempted:1;	/* job is preempted */
-	bool is_prerunning:1		/* Job in prerunning substate */
+	bool is_prerunning:1;		/* Job in prerunning substate */
 	bool topjob_ineligible:1;	/* Job is ineligible to be a top job */
 
 	char *job_name;			/* job name attribute (qsub -N) */

--- a/src/scheduler/fifo.cpp
+++ b/src/scheduler/fifo.cpp
@@ -349,7 +349,7 @@ init_scheduling_cycle(status *policy, int pbs_sd, server_info *sinfo)
 				if (user != NULL) {
 					auto rj = find_resource_resv(sinfo->running_jobs, lj.name);
 
-					if (rj != NULL && rj->job != NULL && rj->job->is_prerunning != 1) {
+					if (rj != NULL && rj->job != NULL && !rj->job->is_prerunning) {
 						/* just in case the delta is negative just add 0 */
 						delta = formula_evaluate(conf.fairshare_res.c_str(), rj, rj->job->resused) -
 							formula_evaluate(conf.fairshare_res.c_str(), rj, lj.resused);

--- a/src/scheduler/fifo.cpp
+++ b/src/scheduler/fifo.cpp
@@ -349,7 +349,7 @@ init_scheduling_cycle(status *policy, int pbs_sd, server_info *sinfo)
 				if (user != NULL) {
 					auto rj = find_resource_resv(sinfo->running_jobs, lj.name);
 
-					if (rj != NULL && rj->job != NULL) {
+					if (rj != NULL && rj->job != NULL && rj->job->is_prerunning != 1) {
 						/* just in case the delta is negative just add 0 */
 						delta = formula_evaluate(conf.fairshare_res.c_str(), rj, rj->job->resused) -
 							formula_evaluate(conf.fairshare_res.c_str(), rj, lj.resused);

--- a/src/scheduler/job_info.cpp
+++ b/src/scheduler/job_info.cpp
@@ -1255,6 +1255,8 @@ query_job(struct batch_status *job, server_info *sinfo, schd_error *err)
 				resresv->job->is_susp_sched = 1;
 			if (!strcmp(attrp->value, PROVISIONING_SUBSTATE))
 				resresv->job->is_provisioning = 1;
+			if (!strcmp(attrp->value, PRERUNNING_SUBSTATE))
+				resresv->job->is_prerunning = 1;
 		}
 		else if (!strcmp(attrp->name, ATTR_sched_preempted)) {
 			count = strtol(attrp->value, &endp, 10);
@@ -1403,7 +1405,6 @@ query_job(struct batch_status *job, server_info *sinfo, schd_error *err)
 
 		attrp = attrp->next;
 	}
-
 	return resresv;
 }
 
@@ -1449,6 +1450,7 @@ new_job_info()
 
 	jinfo->is_provisioning = 0;
 	jinfo->is_preempted = 0;
+	jinfo->is_prerunning = 0;
 
 	jinfo->job_name = NULL;
 	jinfo->comment = NULL;

--- a/src/scheduler/job_info.cpp
+++ b/src/scheduler/job_info.cpp
@@ -2736,6 +2736,7 @@ dup_job_info(job_info *ojinfo, queue_info *nqinfo, server_info *nsinfo)
 	njinfo->is_susp_sched = ojinfo->is_susp_sched;
 	njinfo->is_array = ojinfo->is_array;
 	njinfo->is_subjob = ojinfo->is_subjob;
+	njinfo->is_prerunning = ojinfo->is_prerunning;
 	njinfo->can_not_preempt = ojinfo->can_not_preempt;
 	njinfo->topjob_ineligible = ojinfo->topjob_ineligible;
 	njinfo->is_checkpointed = ojinfo->is_checkpointed;

--- a/src/scheduler/server_info.cpp
+++ b/src/scheduler/server_info.cpp
@@ -2056,7 +2056,8 @@ int
 check_run_job(resource_resv *job, const void *arg)
 {
 	if (job->is_job && job->job != NULL)
-		return job->job->is_running;
+		if ((job->job->is_running == 1 && (job->job->is_prerunning != 1))
+			return 1;
 
 	return 0;
 }

--- a/src/scheduler/server_info.cpp
+++ b/src/scheduler/server_info.cpp
@@ -2056,8 +2056,7 @@ int
 check_run_job(resource_resv *job, const void *arg)
 {
 	if (job->is_job && job->job != NULL)
-		if ((job->job->is_running == 1) && (job->job->is_prerunning != 1))
-			return 1;
+		return job->job->is_running;
 
 	return 0;
 }

--- a/src/scheduler/server_info.cpp
+++ b/src/scheduler/server_info.cpp
@@ -2056,7 +2056,7 @@ int
 check_run_job(resource_resv *job, const void *arg)
 {
 	if (job->is_job && job->job != NULL)
-		if ((job->job->is_running == 1 && (job->job->is_prerunning != 1))
+		if ((job->job->is_running == 1) && (job->job->is_prerunning != 1))
 			return 1;
 
 	return 0;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Scheduler does not differentiate between pre-running and running jobs and considers them all as running. This works fine for most cases but in the case of finding the fairshare usage of jobs, it causes trouble. Since prerunning jobs don't have any resources_used.<res> attribute set on them, scheduler ends up using the resources_list (requested resources) attributes.
This results in a sudden jump in the resource usage on an entity thereby depleting the entity's chances of running a job.


#### Describe Your Change
A pre-running job should ideally not be considered a running job. This change ensures that jobs in pre-running substate don't make it into running_jobs list.


#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, WIN2K16
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|7760|4178|1|0|0|0|4177|

The test that failed in regression is not related to fairshare.