### PR TITLE
Use pbs_sleep inside PTL tests

### DIFF
--- a/test/tests/functional/pbs_hooksmoketest.py
+++ b/test/tests/functional/pbs_hooksmoketest.py
@@ -54,7 +54,7 @@ class TestHookSmokeTest(TestFunctional):
 
         self.script = []
         self.script += ['echo Hello World\n']
-        self.script += ['/bin/sleep 30\n']
+        self.script += ['pbs_sleep 30\n']
         if self.du.get_platform() == "cray" or \
            self.du.get_platform() == "craysim":
             self.script += ['aprun -b -B /bin/sleep 10']

--- a/test/tests/functional/pbs_job_array.py
+++ b/test/tests/functional/pbs_job_array.py
@@ -990,7 +990,7 @@ e.accept()
                                 'bin', 'qsub')
 
         cmd = [qsub_cmd, '-J1-4%2', '-Wmax_run_subjobs=4', '--',
-               '/bin/sleep 100']
+               self.mom.sleep_cmd, '100']
         rv = self.du.run_cmd(self.server.hostname, cmd=cmd)
         self.assertNotEqual(rv['rc'], 0, 'qsub must fail')
         msg = "qsub: multiple max_run_subjobs values found"

--- a/test/tests/functional/pbs_job_script.py
+++ b/test/tests/functional/pbs_job_script.py
@@ -58,7 +58,7 @@ class TestPbsJobScript(TestFunctional):
 
         scr = []
         scr += [selstr + '\n']
-        scr += ['/bin/sleep 100\n']
+        scr += ['pbs_sleep 100\n']
 
         j = Job()
         j.create_script(scr)

--- a/test/tests/functional/pbs_node_rampdown.py
+++ b/test/tests/functional/pbs_node_rampdown.py
@@ -348,10 +348,7 @@ class TestPbsNodeRampDown(TestFunctional):
         self.n9 = '%s[2]' % (self.hostB,)
         self.n10 = '%s[3]' % (self.hostB,)
 
-        if sys.platform in ('cygwin', 'win32'):
-            SLEEP_CMD = "pbs-sleep"
-        else:
-            SLEEP_CMD = "/bin/sleep"
+        SLEEP_CMD = "pbs_sleep"
 
         self.pbs_release_nodes_cmd = os.path.join(
             self.server.pbs_conf['PBS_EXEC'], 'bin', 'pbs_release_nodes')

--- a/test/tests/functional/pbs_qsub_opts_args.py
+++ b/test/tests/functional/pbs_qsub_opts_args.py
@@ -152,7 +152,7 @@ bhtiusabsdlg' % (os.environ['HOME'])
         """
         submit a job with a script and executable
         """
-        cmd = [self.qsub_cmd, self.fn, '--', self.mom.sleep_cmd,'10']
+        cmd = [self.qsub_cmd, self.fn, '--', self.mom.sleep_cmd, '10']
         rv = self.du.run_cmd(self.server.hostname, cmd=cmd)
         failed = rv['rc'] == 2 and rv['err'][0].split(' ')[0] == 'usage:'
         self.assertTrue(failed, 'qsub should have failed, but did not fail')

--- a/test/tests/functional/pbs_qsub_opts_args.py
+++ b/test/tests/functional/pbs_qsub_opts_args.py
@@ -152,7 +152,7 @@ bhtiusabsdlg' % (os.environ['HOME'])
         """
         submit a job with a script and executable
         """
-        cmd = [self.qsub_cmd, self.fn, '--', '/bin/sleep 10']
+        cmd = [self.qsub_cmd, self.fn, '--', self.mom.sleep_cmd,'10']
         rv = self.du.run_cmd(self.server.hostname, cmd=cmd)
         failed = rv['rc'] == 2 and rv['err'][0].split(' ')[0] == 'usage:'
         self.assertTrue(failed, 'qsub should have failed, but did not fail')
@@ -187,7 +187,7 @@ bhtiusabsdlg' % (os.environ['HOME'])
         """
         submit a job with only an executable
         """
-        cmd = [self.qsub_cmd, '--', '/bin/sleep 10']
+        cmd = [self.qsub_cmd, '--', self.mom.sleep_cmd, '10']
         rv = self.du.run_cmd(self.server.hostname, cmd=cmd)
         self.assertEqual(rv['rc'], 0, 'qsub failed')
 
@@ -195,7 +195,7 @@ bhtiusabsdlg' % (os.environ['HOME'])
         """
         submit a job with an option and executable
         """
-        cmd = [self.qsub_cmd, '-V', '--', '/bin/sleep', '10']
+        cmd = [self.qsub_cmd, '-V', '--', self.mom.sleep_cmd, '10']
         rv = self.du.run_cmd(self.server.hostname, cmd=cmd)
         self.assertEqual(rv['rc'], 0, 'qsub failed')
 

--- a/test/tests/functional/pbs_qsub_remove_files.py
+++ b/test/tests/functional/pbs_qsub_remove_files.py
@@ -238,7 +238,7 @@ class TestQsub_remove_files(TestFunctional):
         """
         script = \
             "#!/bin/sh\n"\
-            "/bin/sleep 3;\n"\
+            "pbs_sleep 3;\n"\
             "if [ $PBS_ARRAY_INDEX -eq 2 ]; then\n"\
             "exit 1; fi; exit 0;"
         j = Job(TEST_USER, attrs={ATTR_R: 'oe', ATTR_J: '1-3'},
@@ -267,7 +267,7 @@ class TestQsub_remove_files(TestFunctional):
         """
         script = \
             "#!/bin/sh\n"\
-            "/bin/sleep 3;\n"\
+            "pbs_sleep 3;\n"\
             "if [ $PBS_ARRAY_INDEX -eq 2 ]; then\n"\
             "exit 1; fi; exit 0;"
         tmp_dir = self.du.create_temp_dir(asuser=TEST_USER)

--- a/test/tests/functional/pbs_root_owned_script.py
+++ b/test/tests/functional/pbs_root_owned_script.py
@@ -174,7 +174,7 @@ class Test_RootOwnedScript(TestFunctional):
         # Job script
         test = []
         test += ['#PBS -l select=ncpus=1\n']
-        test += ['%s -j $PBS_JOBID -P -s /bin/sleep 30\n' % pbs_attach]
+        test += ['%s -j $PBS_JOBID -P -s pbs_sleep 30\n' % pbs_attach]
 
         # Submit a job
         j = Job(ROOT_USER)

--- a/test/tests/functional/pbs_support_linux_hook_event_phase1_2.py
+++ b/test/tests/functional/pbs_support_linux_hook_event_phase1_2.py
@@ -90,8 +90,8 @@ else:
         test = []
         test += ['#PBS -l select=vnode=%s+vnode=%s\n' %
                  (self.hostA, self.hostB)]
-        test += ['%s -j $PBS_JOBID /bin/sleep 30\n' % self.pbs_attach]
-        test += ['%s %s %s /bin/sleep 30\n' %
+        test += ['%s -j $PBS_JOBID pbs_sleep 30\n' % self.pbs_attach]
+        test += ['%s %s %s pbs_sleep 30\n' %
                  (self.pbs_tmrsh, self.momB.hostname, self.pbs_attach)]
 
         # Submit a job
@@ -177,8 +177,8 @@ e.accept()
         test = []
         test += ['#PBS -l select=vnode=%s+vnode=%s\n' %
                  (self.hostA, self.hostB)]
-        test += ['%s -j $PBS_JOBID /bin/sleep 30\n' % self.pbs_attach]
-        test += ['%s %s %s /bin/sleep 30\n' %
+        test += ['%s -j $PBS_JOBID pbs_sleep 30\n' % self.pbs_attach]
+        test += ['%s %s %s pbs_sleep 30\n' %
                  (self.pbs_tmrsh, self.momB.hostname, self.pbs_attach)]
 
         # Submit a job


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
PTL framework already uses pbs_sleep in job submission. Doing the same for tests which uses sleep in job scripts or as executable inside them

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Replacing /bin/sleep in PTL tests with pbs_sleep.
The job scripts doesn't require full path of pbs_sleep but the tests which use sleep as executable, they require full path. Hence using full path of pbs_sleep from MoM class to make it platform independent.

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Description: Rerun All Tests From #7694
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|7719|173|0|0|0|2|171|


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
