### PR TITLE
Access registry in user hook and job

### DIFF
--- a/src/resmom/mom_hook_func.c
+++ b/src/resmom/mom_hook_func.c
@@ -1363,7 +1363,9 @@ run_hook_exit:
 					bld_env_variables(&hook_env, "PBS_HOOK_CONFIG_FILE", pbs_hook_conf);
 				env_string = make_envp(hook_env.v_envp);
 			}
+			wloaduserprofile(pwdp);
 			run_exit = wsystem(cmdline, pwdp->pw_userlogin, env_string);
+			wunloaduserprofile(pwdp);
 			free(env_string);
 			(void)win_alarm(0, NULL);
 			free_string_array(hook_env.v_envp);

--- a/src/server/job_func.c
+++ b/src/server/job_func.c
@@ -1096,6 +1096,9 @@ job_purge(job *pjob)
 	/* if open, close 5th pipes to/from Mom starter process */
 	if (pjob->ji_parent2child_moms_status_pipe != -1)
 		(void)close(pjob->ji_parent2child_moms_status_pipe);
+#else
+	if (pjob->ji_user)
+		wunloaduserprofile(pjob->ji_user);
 #endif
 #else	/* not PBS_MOM */
 	if ((!check_job_substate(pjob, JOB_SUBSTATE_TRANSIN)) &&


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
* Jobs and user hooks cannot access registry hive and any operation of accessing/modifying it from the user hook and job script always fails.

#### Describe Your Change
* Loading user profile before creating process as user


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[Attaching Soon]


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
