### PR TITLE
Multi-Server: Discard job for job spanning boundaries

### DIFF
--- a/src/include/job.h
+++ b/src/include/job.h
@@ -797,6 +797,7 @@ task_find	(job		*pjob,
  */
 #define JOB_SVFLG_AdmSuspd 0x200000 /* Job is suspended for maintenance */
 #define JOB_SVFLG_RescUpdt_Rqd 0x400000 /* Broadcast of rsc usage is required */
+#define JOB_SVFLG_AlienJob 0x800000 /* Job is an alien and live its lifecycle in some other server */
 
 #define MAIL_NONE  (int)'n'
 #define MAIL_ABORT (int)'a'

--- a/src/include/job.h
+++ b/src/include/job.h
@@ -797,7 +797,7 @@ task_find	(job		*pjob,
  */
 #define JOB_SVFLG_AdmSuspd 0x200000 /* Job is suspended for maintenance */
 #define JOB_SVFLG_RescUpdt_Rqd 0x400000 /* Broadcast of rsc usage is required */
-#define JOB_SVFLG_AlienJob 0x800000 /* Job is an alien and live its lifecycle in some other server */
+#define JOB_SVFLG_AlienJob 0x800000 /* job is owned by another server in a msvr setup */
 
 #define MAIL_NONE  (int)'n'
 #define MAIL_ABORT (int)'a'

--- a/src/include/net_connect.h
+++ b/src/include/net_connect.h
@@ -125,6 +125,7 @@ typedef unsigned long pbs_net_t;        /* for holding host addresses */
 #define PS_RSC_UPDATE		3 /* Peer server resource update */
 #define PS_RSC_UPDATE_ACK	4 /* Reply for peer server resource update */
 #define PS_STAT_RPLY		5 /* Asynchronous status reply */
+#define PS_DISCARD_JOB		6 /* asks peer server to discard jobs */
 
 /* return codes for client_to_svr() */
 

--- a/src/include/net_connect.h
+++ b/src/include/net_connect.h
@@ -125,7 +125,7 @@ typedef unsigned long pbs_net_t;        /* for holding host addresses */
 #define PS_RSC_UPDATE		3 /* Peer server resource update */
 #define PS_RSC_UPDATE_ACK	4 /* Reply for peer server resource update */
 #define PS_STAT_RPLY		5 /* Asynchronous status reply */
-#define PS_DISCARD_JOB		6 /* asks peer server to discard jobs */
+#define PS_DISCARD_JOB	6 /* asks peer server to discard jobs */
 
 /* return codes for client_to_svr() */
 

--- a/src/include/server.h
+++ b/src/include/server.h
@@ -255,6 +255,7 @@ int process_status_reply(int);
 void *get_peersvr_from_svrid(char *);
 void update_msvr_stat(unsigned long, msvr_stat_type_t);
 int ps_send_discard(char *, char *, char *, int);
+int open_ps_mtfd_for_execvnode(char *);
 
 /* end of multi-svr functions */
 

--- a/src/include/server.h
+++ b/src/include/server.h
@@ -254,6 +254,7 @@ void clean_saved_rsc(void*);
 int process_status_reply(int);
 void *get_peersvr_from_svrid(char *);
 void update_msvr_stat(unsigned long, msvr_stat_type_t);
+int ps_send_discard(char *, char *, char *, int);
 
 /* end of multi-svr functions */
 

--- a/src/server/multi_svr.c
+++ b/src/server/multi_svr.c
@@ -878,6 +878,7 @@ open_ps_mtfd_for_execvnode(char *exec_vnode)
 		if (parse_node_resc(chunk, &noden, &nelem, &pkvp) == 0) {
 			if ((pnode = find_nodebyname(noden)) == NULL &&
 			    (pnode = find_alien_node(noden)) == NULL) {
+				/* Broadcast when we dont have the node cache */
 				close_streams(mtfd, rc);
 				mtfd = open_ps_mtfd();
 				return mtfd;

--- a/src/server/multi_svr.c
+++ b/src/server/multi_svr.c
@@ -320,7 +320,7 @@ update_msvr_stat(ulong val, msvr_stat_type_t type)
 {
 	if (type < 0 || type >= END_OF_STAT)
 		return;
-		
+
 	msvr_stat.stat[type] += val;
 
 	log_msvr_stat();
@@ -851,6 +851,42 @@ req_resc_update(int stream, pbs_list_head *ru_head, void *psvr)
 	*/
 	if (op == INCR)
 		send_command(stream, PS_RSC_UPDATE_ACK);
+}
+
+/**
+ * @brief open a multicast fd for peer servers corresponds to execvnode
+ * 
+ * @param[in] exec_vnode - exec vnode
+ * 
+ * @return int
+ * @retval -1 : for failure
+ */
+int
+open_ps_mtfd_for_execvnode(char *exec_vnode)
+{
+	int mtfd = -1;
+	char *chunk;
+	int rc = 0;
+	char *noden;
+	int nelem;
+	struct key_value_pair *pkvp;
+	struct pbsnode *pnode;
+
+	for (chunk = parse_plus_spec(exec_vnode, &rc);
+	     chunk && !rc; chunk = parse_plus_spec(NULL, &rc)) {
+
+		if (parse_node_resc(chunk, &noden, &nelem, &pkvp) == 0) {
+			if ((pnode = find_nodebyname(noden)) == NULL &&
+			    (pnode = find_alien_node(noden)) == NULL) {
+				close_streams(mtfd, rc);
+				mtfd = open_ps_mtfd();
+				return mtfd;
+			} else
+				mcast_add(get_peersvr_from_svrid(get_nattr_str(pnode, ND_ATR_server_inst_id)), &mtfd, TRUE);
+		}
+	}
+
+	return mtfd;
 }
 
 /**

--- a/src/server/multi_svr.c
+++ b/src/server/multi_svr.c
@@ -876,8 +876,11 @@ open_ps_mtfd_for_execvnode(char *exec_vnode)
 	     chunk && !rc; chunk = parse_plus_spec(NULL, &rc)) {
 
 		if (parse_node_resc(chunk, &noden, &nelem, &pkvp) == 0) {
-			if ((pnode = find_nodebyname(noden)) == NULL &&
-			    (pnode = find_alien_node(noden)) == NULL) {
+
+			if ((pnode = find_nodebyname(noden)))
+				continue;
+
+			if ((pnode = find_alien_node(noden)) == NULL) {
 				/* Broadcast when we dont have the node cache */
 				close_streams(mtfd, rc);
 				mtfd = open_ps_mtfd();

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -2394,6 +2394,7 @@ discard_job(job *pjob, char *txt, int noack)
 	struct pbsnode *pnode;
 	int	 rc;
 	int	 rver;
+	int	broadcast = 0;
 
 	/* We're about to discard the job, reply to a preemption.
 	 * This serves as a catch all just incase the code doesn't reply on its own.
@@ -2462,7 +2463,8 @@ discard_job(job *pjob, char *txt, int noack)
 				}
 				nmom++;
 			}
-		}
+		} else
+			broadcast = 1;
 		pn = parse_plus_spec(NULL, &rc);
 	}
 
@@ -2470,7 +2472,7 @@ discard_job(job *pjob, char *txt, int noack)
 	rver = get_jattr_long(pjob, JOB_ATR_run_version);
 
 	/* ask each peer server to handle discard job for its share of moms running the job */
-	if (!(pjob->ji_qs.ji_svrflags & JOB_SVFLG_AlienJob))
+	if (broadcast && !(pjob->ji_qs.ji_svrflags & JOB_SVFLG_AlienJob))
 		ps_send_discard(pjob->ji_qs.ji_jobid,
 				get_jattr_str(pjob, JOB_ATR_exec_vnode),
 				get_jattr_str(pjob, JOB_ATR_exec_host), rver);

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -2394,7 +2394,7 @@ discard_job(job *pjob, char *txt, int noack)
 	struct pbsnode *pnode;
 	int	 rc;
 	int	 rver;
-	
+
 	/* We're about to discard the job, reply to a preemption.
 	 * This serves as a catch all just incase the code doesn't reply on its own.
 	 */
@@ -2469,6 +2469,7 @@ discard_job(job *pjob, char *txt, int noack)
 	/* Get run version of this job */
 	rver = get_jattr_long(pjob, JOB_ATR_run_version);
 
+	/* ask each peer server to handle discard job for its share of moms running the job */
 	if (!(pjob->ji_qs.ji_svrflags & JOB_SVFLG_AlienJob))
 		ps_send_discard(pjob->ji_qs.ji_jobid,
 				get_jattr_str(pjob, JOB_ATR_exec_vnode),

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -2470,14 +2470,8 @@ discard_job(job *pjob, char *txt, int noack)
 		pn = parse_plus_spec(NULL, &rc);
 	}
 
-	/* Get run vervion of this job */
+	/* Get run version of this job */
 	rver = get_jattr_long(pjob, JOB_ATR_run_version);
-
-	if ((mom_superior->mi_dmn_info->dmn_state & INUSE_DOWN) &&
-	    !(pjob->ji_qs.ji_svrflags & JOB_SVFLG_AlienJob))
-		ps_send_discard(pjob->ji_qs.ji_jobid,
-				get_jattr_str(pjob, JOB_ATR_exec_vnode),
-				get_jattr_str(pjob, JOB_ATR_exec_host), rver);
 
 	/* unless "noack", attach discard array to the job */
 	if (noack == 0)
@@ -2496,6 +2490,12 @@ discard_job(job *pjob, char *txt, int noack)
 		} else
 			(pdsc + i)->jdcd_state = JDCD_DOWN;
 	}
+
+	if ((mom_superior->mi_dmn_info->dmn_state & INUSE_DOWN) &&
+	    !(pjob->ji_qs.ji_svrflags & JOB_SVFLG_AlienJob))
+		ps_send_discard(pjob->ji_qs.ji_jobid,
+				get_jattr_str(pjob, JOB_ATR_exec_vnode),
+				get_jattr_str(pjob, JOB_ATR_exec_host), rver);
 
 	/*
 	 * at this point unless "noack", we call post_discard_job() to see if

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -2394,7 +2394,8 @@ discard_job(job *pjob, char *txt, int noack)
 	struct pbsnode *pnode;
 	int	 rc;
 	int	 rver;
-
+	mominfo_t *mom_superior = NULL;
+	
 	/* We're about to discard the job, reply to a preemption.
 	 * This serves as a catch all just incase the code doesn't reply on its own.
 	 */
@@ -2448,6 +2449,9 @@ discard_job(job *pjob, char *txt, int noack)
 		/* had better be the "natural" vnode with only the one parent */
 		if (pnode != NULL) {
 
+			if (!mom_superior)
+				mom_superior = pnode->nd_moms[0];
+
 			for (i = 0; i < nmom; ++i) {
 				if ((pdsc + i)->jdcd_mom == pnode->nd_moms[0])
 					break;		/* already have this Mom */
@@ -2466,14 +2470,20 @@ discard_job(job *pjob, char *txt, int noack)
 		pn = parse_plus_spec(NULL, &rc);
 	}
 
+	/* Get run vervion of this job */
+	rver = get_jattr_long(pjob, JOB_ATR_run_version);
+
+	if ((mom_superior->mi_dmn_info->dmn_state & INUSE_DOWN) &&
+	    !(pjob->ji_qs.ji_svrflags & JOB_SVFLG_AlienJob))
+		ps_send_discard(pjob->ji_qs.ji_jobid,
+				get_jattr_str(pjob, JOB_ATR_exec_vnode),
+				get_jattr_str(pjob, JOB_ATR_exec_host), rver);
+
 	/* unless "noack", attach discard array to the job */
 	if (noack == 0)
 		pjob->ji_discard = pdsc;
 	else
 		pjob->ji_discard = NULL;
-
-	/* Get run vervion of this job */
-	rver = get_jattr_long(pjob, JOB_ATR_run_version);
 
 	/* Send discard message to each Mom that is up or mark the entry down */
 	for (i = 0; i < nmom; i++) {

--- a/src/server/svr_comm.c
+++ b/src/server/svr_comm.c
@@ -382,8 +382,6 @@ ps_process_discard_job(int c)
 	long rver;
 	job *pjob = NULL;
 
-	log_errf(-1, __func__, "received discard job");
-
 	jid = disrcs(c, &sz, &rc);
 	if (rc)
 		goto end;

--- a/src/server/svr_comm.c
+++ b/src/server/svr_comm.c
@@ -311,6 +311,112 @@ send_nodestat_req(enum msvr_stats_type type)
 }
 
 /**
+ * @brief broadcast discard job request to peer servers
+ * 
+ * @param[in] jobid - job id
+ * @param execvnode - job's exec vnode
+ * @param exechost - job's exec host
+ * @param rver - job run version
+ * 
+ * @return int 
+ * @retval 0: success
+ * @retval !0: failure
+ */
+int
+ps_send_discard(char *jobid, char *execvnode, char *exechost, int rver)
+{
+	int mtfd = -1;
+	int rc;
+
+	if (!exechost)
+		return -1;
+
+	mtfd = open_ps_mtfd();
+	if (mtfd == -1)
+		return -1;
+
+	rc = ps_compose(mtfd, PS_DISCARD_JOB);
+	if (rc != DIS_SUCCESS)
+		goto err;
+
+	if ((rc = diswcs(mtfd, jobid, strlen(jobid))) != 0)
+		goto err;
+
+	if ((rc = diswcs(mtfd, execvnode, strlen(execvnode))) != 0)
+		goto err;
+
+	if ((rc = diswcs(mtfd, exechost, strlen(exechost))) != 0)
+		goto err;
+
+	if ((rc = diswsi(mtfd, rver)) != 0)
+		goto err;
+
+	if ((rc = dis_flush(mtfd)) != DIS_SUCCESS)
+		goto err;
+
+	return 0;
+
+err:
+	log_errf(pbs_errno, __func__, "%s from stream %d",
+		 dis_emsg[rc], mtfd);
+	stream_eof(mtfd, rc, "write_err");
+	return PBSE_PROTOCOL;
+}
+
+/**
+ * @brief process the discard job request from peer server
+ * 
+ * @param[in] c - connection stream.
+ * @return int
+ * @retval 0 : success
+ * @reval !0 : DIS error
+ */
+static int
+ps_process_discard_job(int c)
+{
+	size_t sz;
+	int rc;
+	char *jid = NULL;
+	char *execvnode = NULL;
+	char *exechost = NULL;
+	long rver;
+	job *pjob = NULL;
+
+	jid = disrcs(c, &sz, &rc);
+	if (rc)
+		goto end;
+
+	execvnode = disrcs(c, &sz, &rc);
+	if (rc)
+		goto end;
+
+	exechost = disrcs(c, &sz, &rc);
+	if (rc)
+		goto end;
+
+	rver = disrsi(c, &rc);
+	if (rc)
+		goto end;
+
+	pjob = calloc(1, sizeof(job));
+	pbs_strncpy(pjob->ji_qs.ji_jobid, jid, sizeof(pjob->ji_qs.ji_jobid));
+	pjob->ji_qs.ji_svrflags |= JOB_SVFLG_AlienJob;
+	set_jattr_str_slim(pjob, JOB_ATR_exec_vnode, execvnode, NULL);
+	set_jattr_str_slim(pjob, JOB_ATR_exec_host, exechost, NULL);
+	set_jattr_l_slim(pjob, JOB_ATR_run_version, rver, SET);
+
+	discard_job(pjob, "", 1);
+
+end:
+	free(pjob);
+	free(exechost);
+	free(execvnode);
+	free(jid);
+
+	return rc;
+}
+
+/**
  * @brief
  * 		Input is coming from peer server over a TPP stream.
  *
@@ -416,6 +522,12 @@ found:
 
 	case PS_STAT_RPLY:
 		rc = process_status_reply(stream);
+		if (rc != 0)
+			goto err;
+		break;
+	
+	case PS_DISCARD_JOB:
+		rc = ps_process_discard_job(stream);
 		if (rc != 0)
 			goto err;
 		break;

--- a/src/server/svr_comm.c
+++ b/src/server/svr_comm.c
@@ -331,7 +331,7 @@ ps_send_discard(char *jobid, char *execvnode, char *exechost, int rver)
 	if (!exechost)
 		return -1;
 
-	mtfd = open_ps_mtfd();
+	mtfd = open_ps_mtfd_for_execvnode(execvnode);
 	if (mtfd == -1)
 		return -1;
 
@@ -381,6 +381,8 @@ ps_process_discard_job(int c)
 	char *exechost = NULL;
 	long rver;
 	job *pjob = NULL;
+
+	log_errf(-1, __func__, "received discard job");
 
 	jid = disrcs(c, &sz, &rc);
 	if (rc)

--- a/src/server/svr_comm.c
+++ b/src/server/svr_comm.c
@@ -405,7 +405,7 @@ ps_process_discard_job(int c)
 	set_jattr_str_slim(pjob, JOB_ATR_exec_host, exechost, NULL);
 	set_jattr_l_slim(pjob, JOB_ATR_run_version, rver, SET);
 
-	discard_job(pjob, "", 1);
+	discard_job(pjob, "Discard request for non local job", 1);
 
 end:
 	free(pjob);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
qdel -Wforce / qrerun -Wforce does not delete the job on mom's belongs to other partitions when mother superior is down


#### Describe Your Change
Discard job is a special message by the server to discard a job from all moms participating in that job. In multi-server cases, some of those moms can belong to other partitions. The server will not be able to contact those moms and hence the job won't get discarded.

This change will broadcast the discard job request to peer servers if it cannot reach the target mother superior.


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[test.log](https://github.com/openpbs/openpbs/files/6611496/test.log)


Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, WIN2K16
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|7768|4178|2|0|0|0|4176|

Description: Rerun Only Failed Tests From #7768
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|7778|3|0|0|0|0|3|


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
