### PR TITLE
Multi-server partition tolerance part 2: jobs spanning servers

### DIFF
--- a/src/include/attribute.h
+++ b/src/include/attribute.h
@@ -471,45 +471,47 @@ extern char *return_internal_value(char *name, char *val);
 
 /* other associated funtions */
 
-extern int   acl_check(attribute *, char *canidate, int type);
-extern int   check_duplicates(struct array_strings *strarr);
+extern int acl_check(attribute *, char *canidate, int type);
+extern int check_duplicates(struct array_strings *strarr);
 
 extern char *arst_string(char *str, attribute *pattr);
-extern void  attrl_fixlink(pbs_list_head *svrattrl);
-extern int   save_attr_fs(attribute_def *, attribute *, int);
+extern void attrl_fixlink(pbs_list_head *svrattrl);
+extern int save_attr_fs(attribute_def *, attribute *, int);
 
-extern int      encode_state(const attribute *, pbs_list_head *, char *,
-	char *, int, svrattrl **rtnl);
-extern int      encode_props(const attribute*, pbs_list_head*, char*,
-	char*, int, svrattrl **rtnl);
-extern int      encode_jobs  (const attribute*, pbs_list_head*, char*,
-	char*, int, svrattrl **rtnl);
-extern int      encode_resvs(const attribute*, pbs_list_head*, char*,
-	char*, int, svrattrl **rtnl);
-extern int      encode_ntype(const attribute*, pbs_list_head*, char*,
-	char*, int, svrattrl **rtnl);
-extern int      encode_sharing(const attribute*, pbs_list_head*, char*,
-	char*, int, svrattrl **rtnl);
-extern int      decode_state(attribute*, char*, char*, char*);
-extern int      decode_props(attribute*, char*, char*, char*);
-extern int      decode_ntype(attribute*, char*, char*, char*);
-extern int	decode_sharing(attribute*, char*, char*, char*);
-extern int      decode_null  (attribute*, char*, char*, char*);
-extern int      comp_null(attribute*, attribute*);
-extern int      count_substrings(char*, int*);
-extern int      set_resources_min_max(attribute *, attribute*, enum batch_op);
-extern int      set_node_state  (attribute*, attribute*, enum batch_op);
-extern int      set_node_ntype  (attribute*, attribute*, enum batch_op);
-extern int      set_node_props  (attribute*, attribute*, enum batch_op);
-extern int      set_null	(attribute*, attribute*, enum batch_op);
-extern int      node_state      (attribute*, void*, int);
-extern int      node_np_action  (attribute*, void*, int);
-extern int      node_ntype(attribute*, void*, int);
-extern int      node_prop_list(attribute*, void*, int);
-extern int      node_comment(attribute *, void *, int);
-extern int	is_true_or_false(char *val);
+extern int encode_state(const attribute *, pbs_list_head *, char *,
+			char *, int, svrattrl **rtnl);
+extern int encode_props(const attribute *, pbs_list_head *, char *,
+			char *, int, svrattrl **rtnl);
+extern int encode_jobs(const attribute *, pbs_list_head *, char *,
+		       char *, int, svrattrl **rtnl);
+extern int encode_msvr_rmtjobs(const attribute *, pbs_list_head *, char *,
+		       char *, int, svrattrl **rtnl);
+extern int encode_resvs(const attribute *, pbs_list_head *, char *,
+			char *, int, svrattrl **rtnl);
+extern int encode_ntype(const attribute *, pbs_list_head *, char *,
+			char *, int, svrattrl **rtnl);
+extern int encode_sharing(const attribute *, pbs_list_head *, char *,
+			  char *, int, svrattrl **rtnl);
+extern int decode_state(attribute *, char *, char *, char *);
+extern int decode_props(attribute *, char *, char *, char *);
+extern int decode_ntype(attribute *, char *, char *, char *);
+extern int decode_sharing(attribute *, char *, char *, char *);
+extern int decode_null(attribute *, char *, char *, char *);
+extern int comp_null(attribute *, attribute *);
+extern int count_substrings(char *, int *);
+extern int set_resources_min_max(attribute *, attribute *, enum batch_op);
+extern int set_node_state(attribute *, attribute *, enum batch_op);
+extern int set_node_ntype(attribute *, attribute *, enum batch_op);
+extern int set_node_props(attribute *, attribute *, enum batch_op);
+extern int set_null(attribute *, attribute *, enum batch_op);
+extern int node_state(attribute *, void *, int);
+extern int node_np_action(attribute *, void *, int);
+extern int node_ntype(attribute *, void *, int);
+extern int node_prop_list(attribute *, void *, int);
+extern int node_comment(attribute *, void *, int);
+extern int is_true_or_false(char *val);
 extern void unset_entlim_resc(attribute *, char *);
-extern int      action_node_partition(attribute *, void *, int);
+extern int action_node_partition(attribute *, void *, int);
 
 /* Action routines for OS provisioning */
 extern int	node_prov_enable_action(attribute *, void *, int);

--- a/src/include/pbs_ifl.h
+++ b/src/include/pbs_ifl.h
@@ -122,6 +122,7 @@ extern "C" {
 
 /* additional job and general attribute names */
 #define ATTR_server_inst_id "server_instance_id"
+#define ATTR_msvr_remote_jobs "msvr_remote_jobs"
 #define ATTR_ctime	"ctime"
 #define ATTR_estimated  "estimated"
 #define ATTR_exechost	"exec_host"

--- a/src/include/pbs_internal.h
+++ b/src/include/pbs_internal.h
@@ -169,6 +169,9 @@ extern "C" {
 #define	ESC_CHAR	'\\'
 #endif
 
+/* prefix for any remote job occupying resources locally, used for the 'jobs' attribute */
+#define MSVR_REMOTE_JOB_MARKER	'r'
+
 /* set of characters that are not allowed in a queue name */
 #define INVALID_QUEUE_NAME_CHARS "`~!$%^&*()+=<>?;'\"|"
 

--- a/src/include/pbs_internal.h
+++ b/src/include/pbs_internal.h
@@ -169,9 +169,6 @@ extern "C" {
 #define	ESC_CHAR	'\\'
 #endif
 
-/* prefix for any remote job occupying resources locally, used for the 'jobs' attribute */
-#define MSVR_REMOTE_JOB_MARKER	'r'
-
 /* set of characters that are not allowed in a queue name */
 #define INVALID_QUEUE_NAME_CHARS "`~!$%^&*()+=<>?;'\"|"
 

--- a/src/include/pbs_nodes.h
+++ b/src/include/pbs_nodes.h
@@ -206,10 +206,11 @@ struct	prop {
 };
 
 struct	jobinfo {
-	char		*jobid;
-	int		has_cpu;
-	size_t		mem;
-	struct	jobinfo	*next;
+	char *jobid;
+	int has_cpu;
+	int remotejob;
+	size_t mem;
+	struct jobinfo *next;
 };
 
 struct	resvinfo {
@@ -443,7 +444,7 @@ extern	int	chk_vnode_pool(attribute *, void *, int);
 extern	void	free_pnode(struct pbsnode *);
 extern	int	save_nodes_db(int, void *);
 extern void	propagate_socket_licensing(mominfo_t *);
-extern void	update_jobs_on_node(char *, char *, int, int);
+extern void	update_jobs_on_node(char *, char *, int, int, int);
 extern int	mcast_add(mominfo_t *, int *, bool);
 void		stream_eof(int, int, char *);
 
@@ -508,6 +509,8 @@ int is_nattr_set(const struct pbsnode *pnode, int attr_idx);
 void free_nattr(struct pbsnode *pnode, int attr_idx);
 void clear_nattr(struct pbsnode *pnode, int attr_idx);
 void set_nattr_jinfo(struct pbsnode *pnode, int attr_idx, struct pbsnode *val);
+
+struct jobinfo *create_jobinfo(char *jobid, int has_cpu, int remotejob);
 
 #ifdef	__cplusplus
 }

--- a/src/lib/Libattr/attr_node_func.c
+++ b/src/lib/Libattr/attr_node_func.c
@@ -525,10 +525,15 @@ encode_jobs(const attribute *pattr, pbs_list_head *ph, char *aname, char *rname,
 	for (psubn = pnode->nd_psn; psubn; psubn = psubn->next) {
 		for (jip = psubn->jobs; jip; jip = jip->next) {
 			jobcnt++;
+			/* msvr: space for remote job marker */
+			if (jip->remotejob)
+				strsize += 1;
+
 			/* add 3 to length of node name for slash, comma, and space */
 			/* plus one for the cpu index				   */
 			strsize += strlen(jip->jobid) + 4;
 			i = psubn->index;
+
 			/* now add additional space needed for the cpu index */
 			while ((i = i/10) != 0)
 				strsize++;
@@ -553,8 +558,11 @@ encode_jobs(const attribute *pattr, pbs_list_head *ph, char *aname, char *rname,
 			} else
 				i++;
 
-			sprintf(job_str + offset, "%s/%ld",
-				jip->jobid, psubn->index);
+			if (jip->remotejob)	/* For remote jobs, add 'r' prefix to the id */
+				sprintf(job_str + offset, "%c%s/%ld",
+					MSVR_REMOTE_JOB_MARKER, jip->jobid, psubn->index);
+			else
+				sprintf(job_str + offset, "%s/%ld", jip->jobid, psubn->index);
 			offset += strlen(jip->jobid) + 1;
 			j = psubn->index;
 			while ((j = j/10) != 0)

--- a/src/lib/Libattr/attr_node_func.c
+++ b/src/lib/Libattr/attr_node_func.c
@@ -492,7 +492,7 @@ encode_ntype(const attribute *pattr, pbs_list_head *ph, char *aname, char *rname
  * @param[out]  rtnl - the return value, a pointer to svrattrl
  *
  * @return	int
- * @retval	<0	an error encountered; value is negative of an error code
+ * @retval	<0 or PBSE_SYSTEM	an error encountered; value is negative of an error code
  * @retval	 0	ok, encode happened and svrattrl created and linked in,
  *			or nothing to encode
  *
@@ -593,7 +593,7 @@ encode_jobs(const attribute *pattr, pbs_list_head *ph, char *aname, char *rname,
  * @param[out]  rtnl - the return value, a pointer to svrattrl
  *
  * @return	int
- * @retval	<0	an error encountered; value is negative of an error code
+ * @retval	<0 or PBSE_SYSTEM	an error encountered; value is negative of an error code
  * @retval	 0	ok, encode happened and svrattrl created and linked in,
  *			or nothing to encode
  *

--- a/src/lib/Libattr/master_node_attr_def.xml
+++ b/src/lib/Libattr/master_node_attr_def.xml
@@ -779,14 +779,14 @@
   <attributes>
       <member_index>ND_ATR_msvr_remote_jobs</member_index>
       <member_name>ATTR_msvr_remote_jobs</member_name>
-      <member_at_decode>decode_arst</member_at_decode>
+      <member_at_decode>decode_null</member_at_decode>
       <member_at_encode>encode_msvr_rmtjobs</member_at_encode>
-      <member_at_set>set_arst</member_at_set>
-      <member_at_comp>comp_arst</member_at_comp>
-      <member_at_free>free_arst</member_at_free>
+      <member_at_set>set_null</member_at_set>
+      <member_at_comp>comp_null</member_at_comp>
+      <member_at_free>free_null</member_at_free>
       <member_at_action>NULL_FUNC</member_at_action>
       <member_at_flags>ATR_DFLAG_SvRD | ATR_DFLAG_SvWR</member_at_flags>
-      <member_at_type>ATR_TYPE_ARST</member_at_type>
+      <member_at_type>ATR_TYPE_JINFOP</member_at_type>
       <member_at_parent>PARENT_TYPE_NODE</member_at_parent>
       <member_verify_function>
          <ECL>NULL_VERIFY_DATATYPE_FUNC</ECL>

--- a/src/lib/Libattr/master_node_attr_def.xml
+++ b/src/lib/Libattr/master_node_attr_def.xml
@@ -776,6 +776,23 @@
          <ECL>NULL_VERIFY_VALUE_FUNC</ECL>
       </member_verify_function>
    </attributes>
+  <attributes>
+      <member_index>ND_ATR_msvr_remote_jobs</member_index>
+      <member_name>ATTR_msvr_remote_jobs</member_name>
+      <member_at_decode>decode_arst</member_at_decode>
+      <member_at_encode>encode_msvr_rmtjobs</member_at_encode>
+      <member_at_set>set_arst</member_at_set>
+      <member_at_comp>comp_arst</member_at_comp>
+      <member_at_free>free_arst</member_at_free>
+      <member_at_action>NULL_FUNC</member_at_action>
+      <member_at_flags>ATR_DFLAG_SvRD | ATR_DFLAG_SvWR</member_at_flags>
+      <member_at_type>ATR_TYPE_ARST</member_at_type>
+      <member_at_parent>PARENT_TYPE_NODE</member_at_parent>
+      <member_verify_function>
+         <ECL>NULL_VERIFY_DATATYPE_FUNC</ECL>
+         <ECL>NULL_VERIFY_VALUE_FUNC</ECL>
+      </member_verify_function>
+   </attributes>
    <tail>
    <SVR>};</SVR>
    <ECL>};

--- a/src/lib/Libifl/pbsD_statsrv.c
+++ b/src/lib/Libifl/pbsD_statsrv.c
@@ -88,7 +88,7 @@ PBSD_server_ready(int c)
 {
 	if (!msvr_mode())
 		return 0;
-		
+
 	PBSD_status_aggregate(c, PBS_BATCH_ServerReady, NULL, NULL, NULL, MGR_OBJ_SERVER, NULL);
 	return pbs_errno;
 }

--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -673,6 +673,7 @@ struct node_info
 	char *mom;			/* host name on which mom resides */
 
 	char **jobs;			/* the name of the jobs currently on the node */
+	std::unordered_set<std::string> msvr_rmt_jobs;	/* ids of remote jobs running on this node in a msvr setup */
 	char **resvs;			/* the name of the reservations currently on the node */
 	resource_resv **job_arr;	/* ptrs to structs of the jobs on the node */
 	resource_resv **run_resvs_arr;	/* ptrs to structs of resvs holding resources on the node */

--- a/src/scheduler/node_info.cpp
+++ b/src/scheduler/node_info.cpp
@@ -112,6 +112,7 @@
  *
  */
 
+#include <sstream>
 #include <unordered_map>
 
 #include <pbs_config.h>
@@ -491,16 +492,12 @@ query_node_info(struct batch_status *node, server_info *sinfo)
 		else if (!strcmp(attrp->name, ATTR_NODE_jobs))
 			ninfo->jobs = break_comma_list(attrp->value);
 		else if (!strcmp(attrp->name, ATTR_msvr_remote_jobs)) {
-			char *ptr = NULL;
-			char *jidptr = attrp->value;
-
-			for (ptr = strchr(attrp->value, ','); ptr != NULL; jidptr = ptr + 1, ptr = strchr(ptr + 1, ',')) {
-				*ptr = '\0';
-				ninfo->msvr_rmt_jobs.insert(jidptr);
-				*ptr = ',';
+			std::string rmtjid;
+			std::istringstream ss(attrp->value);
+			while (ss) {
+				std::getline(ss, rmtjid, ',');
+				ninfo->msvr_rmt_jobs.insert(rmtjid);
 			}
-			/* insert the last jid */
-			ninfo->msvr_rmt_jobs.insert(jidptr);
 		}
 		else if (!strcmp(attrp->name, ATTR_maxrun)) {
 			count = strtol(attrp->value, &endp, 10);

--- a/src/scheduler/node_info.cpp
+++ b/src/scheduler/node_info.cpp
@@ -494,10 +494,8 @@ query_node_info(struct batch_status *node, server_info *sinfo)
 		else if (!strcmp(attrp->name, ATTR_msvr_remote_jobs)) {
 			std::string rmtjid;
 			std::istringstream ss(attrp->value);
-			while (ss) {
-				std::getline(ss, rmtjid, ',');
+			while (std::getline(ss, rmtjid, ','))
 				ninfo->msvr_rmt_jobs.insert(rmtjid);
-			}
 		}
 		else if (!strcmp(attrp->name, ATTR_maxrun)) {
 			count = strtol(attrp->value, &endp, 10);

--- a/src/scheduler/node_info.cpp
+++ b/src/scheduler/node_info.cpp
@@ -1613,8 +1613,6 @@ collect_jobs_on_nodes(node_info **ninfo_arr, resource_resv **resresv_arr, int si
 	}
 
 	for (i = 0; ninfo_arr[i] != NULL; i++) {
-		int count_ghost_jobs = 0;
-
 		if (ninfo_arr[i]->jobs != NULL) {
 			for (j = 0, k = 0; ninfo_arr[i]->jobs[j] != NULL && k < size; j++) {
 				/* If one/more servers is down, jobs from down servers consuming resources on other servers'

--- a/src/scheduler/pbs_sched_utils.cpp
+++ b/src/scheduler/pbs_sched_utils.cpp
@@ -186,6 +186,7 @@ sigfunc_pipe(int sig)
 {
 	log_record(PBSEVENT_SYSTEM, PBS_EVENTCLASS_SERVER, LOG_INFO, "sigfunc_pipe", "We've received a sigpipe: The server probably died.");
 	got_sigpipe = 1;
+	part_tolerance = true;
 }
 
 /**
@@ -778,10 +779,10 @@ reconnect_servers(void)
 			rets = getsockopt(sec_conn[i]->sd, SOL_SOCKET, SO_ERROR, &errs, &error_sz);
 		if (retp || rets || errp || errs
 			|| prim_conn[i]->state == SVR_CONN_STATE_DOWN
-			|| sec_conn[i]->state == SVR_CONN_STATE_DOWN) {
-			if (reconnect_msvr_conn(prim_conn[i], sec_conn[i]) != 0)
-				num_down += 1;
-		}
+			|| sec_conn[i]->state == SVR_CONN_STATE_DOWN)
+			reconnect_msvr_conn(prim_conn[i], sec_conn[i]);
+		if (prim_conn[i]->sd < 0 || sec_conn[i]->sd < 0)
+			num_down += 1;
 	}
 	pthread_mutex_unlock(&cleanup_lock);
 

--- a/src/scheduler/server_info.cpp
+++ b/src/scheduler/server_info.cpp
@@ -197,6 +197,8 @@ query_server(status *pol, int pbs_sd)
 		return NULL;
 
 	PBSD_server_ready(pbs_sd);
+	if (got_sigpipe)
+		return NULL;
 
 	if (allres.empty())
 		if (update_resource_defs(pbs_sd) == false)

--- a/src/server/multi_svr.c
+++ b/src/server/multi_svr.c
@@ -108,9 +108,7 @@ get_peersvr_from_svrid(char *sv_id)
 			 "Failed to parse server instance id %s", sv_id);
 
 	for (psvr = GET_NEXT(peersvrl); psvr; psvr = GET_NEXT(psvr->mi_link)) {
-		
-		if (is_same_host(psi.name, psvr->mi_host) &&
-		    psi.port == psvr->mi_port)
+		if (is_same_host(psi.name, psvr->mi_host) && psi.port == psvr->mi_port)
 			return psvr;
 	}
 
@@ -355,7 +353,7 @@ free_psvr_ru(psvr_ru_t *ru_head)
  * @param[in] op - operation performed - INCR/DECR
  * @param[in] exec_vnode - exec_vnode string
  * @param[in] broadcast - whether request needs to be broadcasted
- * @return psvr_ru_t* 
+ * @return psvr_ru_t*
  * @retval NULL - on failure
  */
 psvr_ru_t *
@@ -388,11 +386,11 @@ err:
 
 /**
  * @brief reverse any resource update in the resource usage list
- * 
+ *
  * This happens when we receive a full update from one of the peer server.
- * We need to reverse any udate from that server before applying
+ * We need to reverse any update from that server before applying
  * to avoid duplicate updates.
- * 
+ *
  * @param[in] ru_head - head of the resource update object list
  */
 static void
@@ -405,7 +403,7 @@ reverse_resc_update(psvr_ru_t *ru_head)
 	     ru_cur = GET_NEXT(ru_cur->ru_link)) {
 		log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_JOB, LOG_DEBUG, ru_cur->jobid,
 			   "Reversing resc update op=%d, execvnode=%s", ru_cur->op, ru_cur->execvnode);
-		update_jobs_on_node(ru_cur->jobid, ru_cur->execvnode, DECR, ru_cur->share_job);
+		update_jobs_on_node(ru_cur->jobid, ru_cur->execvnode, DECR, ru_cur->share_job, 0);
 		job_attr_def[JOB_ATR_exec_vnode].at_decode(&pexech, job_attr_def[JOB_ATR_exec_vnode].at_name, NULL, ru_cur->execvnode);
 		update_node_rassn(&pexech, DECR);
 	}
@@ -806,7 +804,7 @@ save_resc_update(void *pobj, psvr_ru_t *ru_new)
 
 /**
  * @brief handler for resource update from a peer server
- * 
+ *
  * @param[in] stream - connection stream
  * @param[in] ru_head - head of resource update list
  * @param[in,out] psvr - peer server object
@@ -833,7 +831,7 @@ req_resc_update(int stream, pbs_list_head *ru_head, void *psvr)
 		if (rc == PBSE_DUPRESC)
 			continue;
 
-		update_jobs_on_node(ru_cur->jobid, ru_cur->execvnode, ru_cur->op, ru_cur->share_job);
+		update_jobs_on_node(ru_cur->jobid, ru_cur->execvnode, ru_cur->op, ru_cur->share_job, 1);
 		job_attr_def[JOB_ATR_exec_vnode].at_decode(&pexech, job_attr_def[JOB_ATR_exec_vnode].at_name,
 							   NULL, ru_cur->execvnode);
 		update_node_rassn(&pexech, ru_cur->op);
@@ -920,7 +918,7 @@ open_ps_mtfd(void)
 /**
  * @brief multicast single job's resource usage
  * to all peer servers
- * 
+ *
  * @param[in] psvr_ru - resource usage structure
  * @param[in] mtfd - mutlicast fd
  */

--- a/src/server/node_func.c
+++ b/src/server/node_func.c
@@ -338,6 +338,7 @@ initialize_pbsnode(struct pbsnode *pnode, char *pname, int ntype)
 
 	set_nattr_jinfo(pnode, ND_ATR_jobs, pnode);
 	set_nattr_jinfo(pnode, ND_ATR_resvs, pnode);
+	set_nattr_jinfo(pnode, ND_ATR_msvr_remote_jobs, pnode);
 
 	set_nattr_l_slim(pnode, ND_ATR_ResvEnable, 1, SET);
 	(get_nattr(pnode, ND_ATR_ResvEnable))->at_flags |= ATR_VFLAG_DEFLT;

--- a/src/server/process_request.c
+++ b/src/server/process_request.c
@@ -308,7 +308,7 @@ req_register_sched(conn_t *conn, struct batch_request *preq)
 			goto rerr;
 		}
 	}
-	
+
 	if (sched->sc_primary_conn != -1 && sched->sc_secondary_conn != -1) {
 		rc = PBSE_SCHEDCONNECTED;
 		goto rerr;
@@ -608,7 +608,7 @@ process_request(int sfds)
 		request->rq_perm = ATR_DFLAG_USRD | ATR_DFLAG_USWR |
 				   ATR_DFLAG_OPRD | ATR_DFLAG_OPWR |
 				   ATR_DFLAG_MGRD | ATR_DFLAG_MGWR |
-				   ATR_DFLAG_SvWR;
+				   ATR_DFLAG_SvRD | ATR_DFLAG_SvWR;
 
 	} else {
 

--- a/src/server/req_stat.c
+++ b/src/server/req_stat.c
@@ -599,7 +599,6 @@ req_stat_node(struct batch_request *preq)
 		rc = status_node(pnode, preq, &preply->brp_un.brp_status);
 
 	} else {			/* get status of all nodes */
-	
 		for (i = 0; i < svr_totnodes; i++) {
 			pnode = pbsndlist[i];
 

--- a/src/server/svr_comm.c
+++ b/src/server/svr_comm.c
@@ -58,7 +58,7 @@ static int mtfd_replyhello_psvr = -1;
 
 /**
  * @brief send a command using peer server protocol
- * 
+ *
  * @param[in] c - connection stream
  * @param[in] command - command which needs to be sent
  * @return int
@@ -425,7 +425,7 @@ end:
  *
  * @param[in] stream  - TPP stream on which the request is arriving
  * @param[in] version - Version of protocol.
- * 
+ *
  * @see is_request
  *
  * @return none

--- a/src/server/svr_func.c
+++ b/src/server/svr_func.c
@@ -240,7 +240,7 @@ encode_svrstate(const attribute *pattr, pbs_list_head *phead, char *atname, char
 
 /**
  * @brief
- * 		set_resc_assigned - updates server and/or queue resources_assigned
+ * 		set_resc_assigned - updates node, server and/or queue resources_assigned
  *		attribute depending on to what kind of object the first argument
  *		points and possibly on what value of "state" the object has
  *


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
This adds the ability for PBS to work with one/more servers down even when there are jobs spanning across servers. Specifically, it handles the following scenario:
- Job from a down server consumes resources on nodes of an up server: Scheduler should not identify these jobs as ghost jobs. To make this happen, I'm adding a new hidden attribute to vnodes which will list the jobids of any remote jobs which run on them.  When the scheduler analyzes ghost jobs, it will ignore any jobs which are listed in the remote jobs attribute, if it's operating under partition tolerant mode. That way, it'll not oversubscribe the node's resources.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Added a prefix to jobids in the jobs attribute for non-local jobs. The scheduler uses this to dismiss remote jobs as potential ghost jobs when it's working with partition tolerance.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
```
[ragrawal@m1 sched_logs]$ qstat
Job id            Name             User              Time Use S Queue
----------------  ---------------- ----------------  -------- - -----
1300.m1           STDIN            ragrawal          00:00:00 R workq           
[ragrawal@m1 sched_logs]$ pbsnodes -av
m1
     Mom = m1
     ntype = PBS
     state = free
     pcpus = 4
     jobs = 1300.m1/0, 1300.m1/1
     resources_available.arch = linux
     resources_available.host = m1
     resources_available.mem = 16409428kb
     resources_available.ncpus = 4
     resources_available.vnode = m1
     resources_assigned.accelerator_memory = 0kb
     resources_assigned.hbmem = 0kb
     resources_assigned.mem = 0kb
     resources_assigned.naccelerators = 0
     resources_assigned.ncpus = 2
     resources_assigned.vmem = 0kb
     resv_enable = True
     sharing = default_shared
     license = l
     last_state_change_time = Fri Jun 11 02:15:57 2021
     last_used_time = Fri Jun 11 01:37:37 2021

m2
     Mom = m2
     ntype = PBS
     state = free
     pcpus = 4
     jobs = 1300.m1/0, 1300.m1/1
     resources_available.arch = linux
     resources_available.host = m2
     resources_available.mem = 16410880kb
     resources_available.ncpus = 4
     resources_available.vnode = m2
     resources_assigned.accelerator_memory = 0kb
     resources_assigned.hbmem = 0kb
     resources_assigned.mem = 0kb
     resources_assigned.naccelerators = 0
     resources_assigned.ncpus = 2
     resources_assigned.vmem = 0kb
     resv_enable = True
     sharing = default_shared
     license = l
     last_state_change_time = Fri Jun 11 02:16:06 2021

[ragrawal@m1 sched_logs]$ ps -ef | grep pbs_server
root       54866       1  0 02:15 ?        00:00:00 /opt/pbs/sbin/pbs_server.bin
root       55077       1  0 02:16 ?        00:00:00 /opt/pbs/sbin/pbs_server.bin
ragrawal   55251    1501  0 02:18 pts/0    00:00:00 grep --color=auto pbs_server
[ragrawal@m1 sched_logs]$ sudo kill 54866
[ragrawal@m1 sched_logs]$ ps -ef | grep pbs_server
root       55077       1  0 02:16 ?        00:00:00 /opt/pbs/sbin/pbs_server.bin
ragrawal   55364    1501  0 02:18 pts/0    00:00:00 grep --color=auto pbs_server
[ragrawal@m1 ~]$ qstat
qstat: cannot connect to server m1 runs on port 18000 (errno=111)
[ragrawal@m1 ~]$ pbsnodes -av
pbsnodes: cannot connect to server m1 runs on port 18000 (errno=111)
m2
     Mom = m2
     ntype = PBS
     state = free
     pcpus = 4
     jobs = 1300.m1/0, 1300.m1/1
     resources_available.arch = linux
     resources_available.host = m2
     resources_available.mem = 16410880kb
     resources_available.ncpus = 4
     resources_available.vnode = m2
     resources_assigned.accelerator_memory = 0kb
     resources_assigned.hbmem = 0kb
     resources_assigned.mem = 0kb
     resources_assigned.naccelerators = 0
     resources_assigned.ncpus = 2
     resources_assigned.vmem = 0kb
     resv_enable = True
     sharing = default_shared
     license = l
     last_state_change_time = Fri Jun 11 02:16:06 2021

[ragrawal@m1 ~]$ 
[ragrawal@m1 ~]$ qsub -lselect=1:ncpus=2 -lplace=scatter -- /bin/sleep 10000
1101.m1
[ragrawal@m1 ~]$ qsub -lselect=1:ncpus=2 -lplace=scatter -- /bin/sleep 10000
1201.m1
[ragrawal@m1 ~]$ qstat
qstat: cannot connect to server m1 runs on port 18000 (errno=111)
Job id            Name             User              Time Use S Queue
----------------  ---------------- ----------------  -------- - -----
1101.m1           STDIN            ragrawal          00:00:00 R workq           
1201.m1           STDIN            ragrawal                 0 Q workq           
[ragrawal@m1 ~]$ pbsnodes -av
pbsnodes: cannot connect to server m1 runs on port 18000 (errno=111)
m2
     Mom = m2
     ntype = PBS
     state = job-busy
     pcpus = 4
     jobs = 1300.m1/0, 1300.m1/1, 1101.m1/2, 1101.m1/3
     resources_available.arch = linux
     resources_available.host = m2
     resources_available.mem = 16410880kb
     resources_available.ncpus = 4
     resources_available.vnode = m2
     resources_assigned.accelerator_memory = 0kb
     resources_assigned.hbmem = 0kb
     resources_assigned.mem = 0kb
     resources_assigned.naccelerators = 0
     resources_assigned.ncpus = 4
     resources_assigned.vmem = 0kb
     resv_enable = True
     sharing = default_shared
     license = l
     last_state_change_time = Fri Jun 11 02:21:07 2021
```


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
