### PR TITLE
Addressed timing issue in dyn-res test

### DIFF
--- a/test/tests/functional/pbs_svr_dyn_res.py
+++ b/test/tests/functional/pbs_svr_dyn_res.py
@@ -420,6 +420,10 @@ class TestServerDynRes(TestFunctional):
         a = {'job_state': 'R', 'Resource_List.foobar': '95gb'}
         self.server.expect(JOB, a, id=jid)
 
+        # Turn off scheduling. There is a race where scheduler could
+        # already be inside a cycle because of previous expect call and
+        # read the old dynamic resource script.
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
         # Change script during job run
         tmp_file = self.du.create_temp_file(body="echo 50gb")
         self.du.run_copy(src=tmp_file, dest=filenames[0], sudo=True,
@@ -428,6 +432,8 @@ class TestServerDynRes(TestFunctional):
         # Rerun job
         self.server.rerunjob(jid)
 
+        # Turn on scheduling
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
         # The job shouldn't run
         job_comment = "Can Never Run: Insufficient amount of server resource:"
         job_comment += " foobar (R: 95gb A: 50gb T: 50gb)"


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
There is a problem in test_res_size_runtime test that causes it to fail because of a race condition.
The test creates a dynamic resource script and submits a job that request the dynamic resource. Scheduler runs this job because there are enough resources available in the system.
The test then overwrites the dynamic resource script to cut the resource value to half. It then qrerun the job assuming that now scheduler will not be able to run the job due to lack of resources.
The problem occurs when the scheduler is already in a cycle when the script is overwritten. In such a case there is a chance that the scheduler reads the value from the old script and by the time it comes around to query jobs from server, the job is already re-queued. This results in the scheduler running the job again.


#### Describe Your Change
Added a change to turn off scheduling before script is overwritten and turn it on after test re-queues the job.


#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
[test.txt](https://github.com/openpbs/openpbs/files/6594821/test.txt)
