### PR TITLE
Put absolute path for pbs_sleep

### DIFF
--- a/test/tests/functional/pbs_hooksmoketest.py
+++ b/test/tests/functional/pbs_hooksmoketest.py
@@ -54,7 +54,7 @@ class TestHookSmokeTest(TestFunctional):
 
         self.script = []
         self.script += ['echo Hello World\n']
-        self.script += ['pbs_sleep 30\n']
+        self.script += ['%s 30\n' % (self.mom.sleep_cmd)]
         if self.du.get_platform() == "cray" or \
            self.du.get_platform() == "craysim":
             self.script += ['aprun -b -B /bin/sleep 10']

--- a/test/tests/functional/pbs_job_script.py
+++ b/test/tests/functional/pbs_job_script.py
@@ -58,7 +58,7 @@ class TestPbsJobScript(TestFunctional):
 
         scr = []
         scr += [selstr + '\n']
-        scr += ['pbs_sleep 100\n']
+        scr += ['%s 100\n' % (self.mom.sleep_cmd)]
 
         j = Job()
         j.create_script(scr)

--- a/test/tests/functional/pbs_node_rampdown.py
+++ b/test/tests/functional/pbs_node_rampdown.py
@@ -348,7 +348,7 @@ class TestPbsNodeRampDown(TestFunctional):
         self.n9 = '%s[2]' % (self.hostB,)
         self.n10 = '%s[3]' % (self.hostB,)
 
-        SLEEP_CMD = "pbs_sleep"
+        SLEEP_CMD = self.mom.sleep_cmd
 
         self.pbs_release_nodes_cmd = os.path.join(
             self.server.pbs_conf['PBS_EXEC'], 'bin', 'pbs_release_nodes')

--- a/test/tests/functional/pbs_qsub_remove_files.py
+++ b/test/tests/functional/pbs_qsub_remove_files.py
@@ -238,9 +238,9 @@ class TestQsub_remove_files(TestFunctional):
         """
         script = \
             "#!/bin/sh\n"\
-            "pbs_sleep 3;\n"\
+            "%s 3;\n"\
             "if [ $PBS_ARRAY_INDEX -eq 2 ]; then\n"\
-            "exit 1; fi; exit 0;"
+            "exit 1; fi; exit 0;" % (self.mom.sleep_cmd)
         j = Job(TEST_USER, attrs={ATTR_R: 'oe', ATTR_J: '1-3'},
                 jobname='JOB_NAME')
         j.create_script(script)
@@ -267,9 +267,9 @@ class TestQsub_remove_files(TestFunctional):
         """
         script = \
             "#!/bin/sh\n"\
-            "pbs_sleep 3;\n"\
+            "%s 3;\n"\
             "if [ $PBS_ARRAY_INDEX -eq 2 ]; then\n"\
-            "exit 1; fi; exit 0;"
+            "exit 1; fi; exit 0;" % (self.mom.sleep_cmd)
         tmp_dir = self.du.create_temp_dir(asuser=TEST_USER)
         j = Job(TEST_USER, attrs={ATTR_e: tmp_dir, ATTR_o: tmp_dir,
                                   ATTR_R: 'oe', ATTR_J: '1-3'})

--- a/test/tests/functional/pbs_root_owned_script.py
+++ b/test/tests/functional/pbs_root_owned_script.py
@@ -174,7 +174,8 @@ class Test_RootOwnedScript(TestFunctional):
         # Job script
         test = []
         test += ['#PBS -l select=ncpus=1\n']
-        test += ['%s -j $PBS_JOBID -P -s pbs_sleep 30\n' % pbs_attach]
+        test += ['%s -j $PBS_JOBID -P -s %s 30\n' %
+                 (pbs_attach, self.mom.sleep_cmd)]
 
         # Submit a job
         j = Job(ROOT_USER)

--- a/test/tests/functional/pbs_support_linux_hook_event_phase1_2.py
+++ b/test/tests/functional/pbs_support_linux_hook_event_phase1_2.py
@@ -90,9 +90,11 @@ else:
         test = []
         test += ['#PBS -l select=vnode=%s+vnode=%s\n' %
                  (self.hostA, self.hostB)]
-        test += ['%s -j $PBS_JOBID pbs_sleep 30\n' % self.pbs_attach]
-        test += ['%s %s %s pbs_sleep 30\n' %
-                 (self.pbs_tmrsh, self.momB.hostname, self.pbs_attach)]
+        test += ['%s -j $PBS_JOBID %s 30\n' %
+                 (self.pbs_attach, self.mom.sleep_cmd)]
+        test += ['%s %s %s %s 30\n' %
+                 (self.pbs_tmrsh, self.momB.hostname, self.pbs_attach,
+                  self.mom.sleep_cmd)]
 
         # Submit a job
         j = Job(TEST_USER)
@@ -177,9 +179,11 @@ e.accept()
         test = []
         test += ['#PBS -l select=vnode=%s+vnode=%s\n' %
                  (self.hostA, self.hostB)]
-        test += ['%s -j $PBS_JOBID pbs_sleep 30\n' % self.pbs_attach]
-        test += ['%s %s %s pbs_sleep 30\n' %
-                 (self.pbs_tmrsh, self.momB.hostname, self.pbs_attach)]
+        test += ['%s -j $PBS_JOBID %s 30\n' %
+                 (self.pbs_attach, self.mom.sleep_cmd)]
+        test += ['%s %s %s %s 30\n' %
+                 (self.pbs_tmrsh, self.momB.hostname, self.pbs_attach,
+                  self.mom.sleep_cmd)]
 
         # Submit a job
         j = Job(TEST_USER)


### PR DESCRIPTION
#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Tests were failing on few test machines as PBS path was not added to the system path. 

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Adding full path of pbs_sleep.


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|7781|68|0|0|0|2|66|


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
