### PR TITLE
TestReservations.test_ASAP_resv_with_multivnode_job is failing intermittently

### DIFF
--- a/test/tests/functional/pbs_reservations.py
+++ b/test/tests/functional/pbs_reservations.py
@@ -2090,7 +2090,7 @@ class TestReservations(TestFunctional):
         jids = [jid1, jid2]
         for job in jids:
             self.server.expect(JOB, 'queue', op=UNSET, id=job)
-        exp_attrib = {'job_state': 'F', 'substate': '91'}
+        exp_attrib = {'job_state': 'F'}
         for jid in jids:
             self.server.expect(JOB, exp_attrib, id=jid, extend='x')
         # Verify all the PBS daemons are up and running upon resv completion


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
TestReservations.test_ASAP_resv_with_multivnode_job is failing intermittently on few platforms.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
For ASAP reservation, there could be scenario, when job finishes earlier than the reservation and the corresponding mom sends the server obit before the server could send TermJob signal to mom.
So in that scenario, PTL test fails as it keep checking for "job_state = F && substate = 91".

This PR is for checking for "job_state = F" (irrespective of substate is 91 or 92).

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

Description: Tests from given sources on platforms SUSE15, CENTOS8, CENTOS7
Platforms: SUSE15,CENTOS8,CENTOS7
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|7807|2050|0|1|0|0|2049|

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
