### PR TITLE
Allow all nodes delete from setup on cpuset nodes

### DIFF
--- a/test/fw/ptl/lib/ptl_server.py
+++ b/test/fw/ptl/lib/ptl_server.py
@@ -580,7 +580,8 @@ class Server(Wrappers):
         Remove all the nodes from PBS
         """
         try:
-            self.manager(MGR_CMD_DELETE, VNODE, id="@default")
+            self.manager(MGR_CMD_DELETE, VNODE, id="@default",
+                         runas=ROOT_USER)
         except PbsManagerError as e:
             if "Unknown node" not in e.msg[0]:
                 raise

--- a/test/fw/ptl/lib/ptl_wrappers.py
+++ b/test/fw/ptl/lib/ptl_wrappers.py
@@ -2245,7 +2245,7 @@ class Wrappers(PBSService):
         :raises: PbsManagerError
         """
 
-        if cmd == MGR_CMD_DELETE and obj_type == NODE:
+        if cmd == MGR_CMD_DELETE and obj_type == NODE and id != '@default':
             for cmom, momobj in self.moms.items():
                 if momobj.is_cpuset_mom():
                     self.skipTest("Do not delete nodes on cpuset moms")
@@ -2254,7 +2254,7 @@ class Wrappers(PBSService):
                 id is not None and obj_type == NODE):
             for cmom, momobj in self.moms.items():
                 cpuset_nodes = []
-                if momobj.is_cpuset_mom():
+                if momobj.is_cpuset_mom() and attrib:
                     momobj.check_mem_request(attrib)
                     if len(attrib) == 0:
                         return True

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -1566,7 +1566,8 @@ class PBSTestSuite(unittest.TestCase):
         if enabled_cpuset:
             time.sleep(4)
         a = {'state': 'free'}
-        self.server.manager(MGR_CMD_CREATE, NODE, None, mom.shortname)
+        self.server.manager(MGR_CMD_CREATE, NODE, None, mom.shortname,
+                            runas=ROOT_USER)
         if enabled_cpuset:
             # In order to avoid intermingling CF/HK/PY file copies from the
             # create node and those caused by the following call, wait

--- a/test/tests/functional/pbs_calendaring.py
+++ b/test/tests/functional/pbs_calendaring.py
@@ -190,7 +190,6 @@ class TestCalendaring(TestFunctional):
         msg = jid3 + ';Job is a top job and will run at'
         self.scheduler.log_match(msg)
 
-    @skipOnCpuSet
     def test_topjob_bucket(self):
         """
         In this test we test that a bucket job will be calendared to start
@@ -199,7 +198,7 @@ class TestCalendaring(TestFunctional):
 
         self.scheduler.set_sched_config({'strict_ordering': 'true all'})
         a = {'resources_available.ncpus': 2}
-        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
+        self.mom.create_vnodes(a, 1)
 
         res_req = {'Resource_List.select': '1:ncpus=1',
                    'Resource_List.walltime': 30}

--- a/test/tests/functional/pbs_fairshare.py
+++ b/test/tests/functional/pbs_fairshare.py
@@ -378,7 +378,6 @@ class TestFairshare(TestFunctional):
         self.assertEqual(fs_usage, 1,
                          "Fairshare usage %d not equal to 1" % fs_usage)
 
-    @skipOnCpuSet
     def test_fairshare_topjob(self):
         """
         Test that jobs are run in the augmented fairshare order after a topjob
@@ -390,10 +389,8 @@ class TestFairshare(TestFunctional):
         self.scheduler.add_to_resource_group(TEST_USER, 11, 'root', 10)
         self.scheduler.add_to_resource_group(TEST_USER1, 12, 'root', 10)
         self.scheduler.add_to_resource_group(TEST_USER2, 13, 'root', 10)
-
-        self.server.manager(MGR_CMD_SET, NODE,
-                            {'resources_available.ncpus': 5},
-                            id=self.mom.shortname)
+        a = {'resources_available.ncpus': 5}
+        self.mom.create_vnodes(a, 1)
         a = {'Resource_List.select': '5:ncpus=1'}
         j1 = Job(TEST_USER, attrs=a)
         jid1 = self.server.submit(j1)

--- a/test/tests/functional/pbs_hook_exechost_periodic.py
+++ b/test/tests/functional/pbs_hook_exechost_periodic.py
@@ -67,6 +67,7 @@ class TestHookExechostPeriodic(TestFunctional):
     """
     Tests to test exechost_periodic hook
     """
+
     def test_multiple_exechost_periodic_hooks(self):
         """
         This test sets two exechost_periodic hooks and restarts the mom,
@@ -96,6 +97,7 @@ class TestHookExechostPeriodic(TestFunctional):
         self.mom.log_match("exechost_periodic hook2",
                            max_attempts=5, interval=5)
 
+    @skipOnCpuSet
     @requirements(num_moms=2)
     def test_exechost_periodic_accept(self):
         """
@@ -141,6 +143,7 @@ class TestHookExechostPeriodic(TestFunctional):
         node_attribs = {'resources_available.mem': "90gb"}
         self.server.expect(NODE, node_attribs, id=self.momB.shortname)
 
+    @skipOnCpuSet
     @requirements(num_moms=2)
     def test_exechost_periodic_alarm(self):
         """
@@ -163,6 +166,7 @@ class TestHookExechostPeriodic(TestFunctional):
             for msg in exp_msg:
                 mom.log_match(msg)
 
+    @skipOnCpuSet
     @requirements(num_moms=2)
     def test_exechost_periodic_error(self):
         """
@@ -185,6 +189,7 @@ class TestHookExechostPeriodic(TestFunctional):
             for msg in exp_msg:
                 mom.log_match(msg)
 
+    @skipOnCpuSet
     @requirements(num_moms=2)
     def test_exechost_periodic_custom_resc(self):
         """

--- a/test/tests/functional/pbs_hook_modifyvnode_state_changes.py
+++ b/test/tests/functional/pbs_hook_modifyvnode_state_changes.py
@@ -287,6 +287,7 @@ class TestPbsModifyvnodeStateChanges(TestFunctional):
             previous_state = line_dict['v.state_hex']
             previous_lsct = line_dict['v.lsct']
 
+    @skipOnCpuSet
     def test_hook_state_changes_00(self):
         """
         Test: induce a variety of vnode state changes with debug turned on
@@ -342,7 +343,7 @@ class TestPbsModifyvnodeStateChanges(TestFunctional):
             start_time = time.time()
             self.logger.debug("    ***offline mom:%s" % mom)
             self.server.manager(MGR_CMD_SET, NODE, {'state': (INCR,
-                                'offline')},
+                                                              'offline')},
                                 id=mom.shortname)
             self.checkLog(start_time, mom.fqdn, check_up=False,
                           check_down=False)
@@ -351,7 +352,7 @@ class TestPbsModifyvnodeStateChanges(TestFunctional):
             start_time = time.time()
             self.logger.debug("    ***online mom:%s" % mom)
             self.server.manager(MGR_CMD_SET, NODE, {'state': (DECR,
-                                'offline')},
+                                                              'offline')},
                                 id=mom.shortname)
             self.checkLog(start_time, mom.fqdn, check_up=False,
                           check_down=False)
@@ -367,7 +368,7 @@ class TestPbsModifyvnodeStateChanges(TestFunctional):
             }
             self.logger.debug("    ***reserve & release mom:%s" % mom)
             rid = self.server.submit(Reservation(ROOT_USER, attrs,
-                                     hosts=[mom.shortname]))
+                                                 hosts=[mom.shortname]))
             self.logger.debug("rid=%s" % rid)
             self.checkLog(start_time, mom.fqdn, check_up=False,
                           check_down=False)
@@ -442,6 +443,7 @@ class TestPbsModifyvnodeStateChanges(TestFunctional):
                                       starttime=start_time)
         self.logger.debug("---- %s TEST ENDED ----" % get_method_name(self))
 
+    @skipOnCpuSet
     @tags('smoke')
     def test_hook_state_changes_01(self):
         """
@@ -485,6 +487,7 @@ class TestPbsModifyvnodeStateChanges(TestFunctional):
 
         self.logger.debug("---- %s TEST ENDED ----" % get_method_name(self))
 
+    @skipOnCpuSet
     def test_hook_state_changes_02(self):
         """
         Test:  stop and start the pbs server; look for proper log messages

--- a/test/tests/functional/pbs_job_array.py
+++ b/test/tests/functional/pbs_job_array.py
@@ -762,7 +762,6 @@ e.accept()
         else:
             self.server.expect(JOB, {ATTR_state: 'B'}, id=j_id)
 
-    @skipOnCpuSet
     def test_max_run_subjobs_basic(self):
         """
         Test that if a job is submitted with 'max_run_subjobs' attribute
@@ -770,7 +769,7 @@ e.accept()
         """
 
         a = {'resources_available.ncpus': 8}
-        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
+        self.mom.create_vnodes(a, 1)
         j = Job(attrs={ATTR_J: '1-20%2'})
         j_id = self.server.submit(j)
         self.server.expect(JOB, {ATTR_state: 'B'}, id=j_id)
@@ -782,7 +781,6 @@ e.accept()
         msg = "Number of concurrent running subjobs limit reached"
         self.scheduler.log_match(j_id + ';' + msg)
 
-    @skipOnCpuSet
     def test_max_run_subjobs_calendar(self):
         """
         Test that if a job is submitted with 'max_run_subjobs' attribute
@@ -790,7 +788,7 @@ e.accept()
         """
 
         a = {'resources_available.ncpus': 8}
-        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
+        self.mom.create_vnodes(a, 1)
         a = {'backfill_depth': '2'}
         self.server.manager(MGR_CMD_SET, SERVER, a)
         self.scheduler.set_sched_config({'strict_ordering': 'True'})
@@ -817,13 +815,12 @@ e.accept()
                                         fmt="%a %b %d %H:%M:%S %Y")
         self.assertAlmostEqual(stime + 300, est, 1)
 
-    @skipOnCpuSet
     def test_max_run_subjobs_queuejob_hook(self):
         """
         Test that a queuejob hook is able to set max_run_subjobs attribute.
         """
         a = {'resources_available.ncpus': 8}
-        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
+        self.mom.create_vnodes(a, 1)
 
         self.create_max_run_subjobs_hook(3, "queuejob", "h1", self.qjh)
         j1 = Job(attrs={ATTR_J: '1-20'})
@@ -839,14 +836,13 @@ e.accept()
         self.assertIn("Attribute has to be set on an array job",
                       e.exception.msg[0])
 
-    @skipOnCpuSet
     def test_max_run_subjobs_modifyjob_hook(self):
         """
         Submit array job with large max_run_subjobs limit see if modifyjob
         modifies it.
         """
         a = {'resources_available.ncpus': 20}
-        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
+        self.mom.create_vnodes(a, 1)
 
         self.create_max_run_subjobs_hook(3, "modifyjob", "h1", self.mjh)
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
@@ -868,7 +864,6 @@ e.accept()
         self.assertIn("Attribute has to be set on an array job",
                       e.exception.msg[0])
 
-    @skipOnCpuSet
     def test_max_run_subjobs_preemption(self):
         """
         Submit array job with max_run_subjobs limit and see if such a job
@@ -881,7 +876,7 @@ e.accept()
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, "wq2")
 
         a = {'resources_available.ncpus': 8}
-        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
+        self.mom.create_vnodes(a, 1)
 
         a = {'Resource_List.select': 'ncpus=2'}
         j = Job(attrs=a)
@@ -896,14 +891,13 @@ e.accept()
         self.server.expect(JOB, {'job_state=R': 4}, extend='t')
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid)
 
-    @skipOnCpuSet
     def test_max_run_subjobs_qrun(self):
         """
         Submit array job with max_run_subjobs limit and see if such a job
         is run using qrun, max_run_subjobs limit is ignored.
         """
         a = {'resources_available.ncpus': 8}
-        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
+        self.mom.create_vnodes(a, 1)
 
         a = {'Resource_List.select': 'ncpus=2'}
         j = Job(attrs=a)
@@ -924,7 +918,6 @@ e.accept()
         self.server.expect(JOB, {ATTR_state: 'S'}, id=jid)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=subjid_4)
 
-    @skipOnCpuSet
     def test_max_run_subjobs_suspend(self):
         """
         Submit array job with max_run_subjobs limit and see if such a job
@@ -933,7 +926,7 @@ e.accept()
         """
 
         a = {'resources_available.ncpus': 8}
-        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
+        self.mom.create_vnodes(a, 1)
 
         a = {ATTR_J: '1-20%3', 'Resource_List.select': 'ncpus=2'}
         j_arr = Job(attrs=a)
@@ -948,7 +941,6 @@ e.accept()
         subjid_4 = j_arr.create_subjob_id(jid_arr, 4)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=subjid_4)
 
-    @skipOnCpuSet
     def test_max_run_subjobs_eligible_time(self):
         """
         Test that array jobs hitting max_run_subjobs limit still
@@ -956,7 +948,7 @@ e.accept()
         """
 
         a = {'resources_available.ncpus': 8}
-        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
+        self.mom.create_vnodes(a, 1)
 
         a = {'eligible_time_enable': 'True'}
         self.server.manager(MGR_CMD_SET, SERVER, a)

--- a/test/tests/functional/pbs_offline_vnodes.py
+++ b/test/tests/functional/pbs_offline_vnodes.py
@@ -121,7 +121,7 @@ class TestOfflineVnode(TestFunctional):
             elif nd.is_cpuset_mom() is True:
                 vnl = self.server.status(NODE)
                 vlist = [x['id'] for x in vnl if x['id'] !=
-                         vn.shortname]
+                         self.mom.shortname]
             else:
                 vlist = [vn + "[0]", vn + "[1]"]
             for v1 in vlist:


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Tests were skipped if tests tried to delete node on cpuset. But as PTL setup tries delete all node and recreate for fresh setup all tests were skipped.

#### Describe Your Change
Allow setup to delete and recreate nodes.
Delete node and create node are done before adding current user as manager so run them as root.
pbs_job_array.py, pbs_fairshare.py,pbs_preemption.py tests were under skipcpuset decorator and were trying to modify ncpus on natural node. Instead create_vnodes with ncpus will return one vnode as required. So modified it and removed cpuset decorator.
TestHookExechostPeriodic hook was modifying vnodes so skip them on cpuset
TestPbsModifyvnodeStateChanges modifies vnode states from hook so skip them on cpuset


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[removedecorator.txt](https://github.com/openpbs/openpbs/files/6618122/removedecorator.txt)
[cpuset_fix.txt](https://github.com/openpbs/openpbs/files/6618982/cpuset_fix.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
