### PR TITLE
fixed tests from TestSupportLinuxHookEventPhase1_2 and TestAcctlogRescUsedWithTwoMomHooks when mom is cpuset machine.

### DIFF
--- a/test/tests/functional/pbs_support_linux_hook_event_phase1_2.py
+++ b/test/tests/functional/pbs_support_linux_hook_event_phase1_2.py
@@ -225,7 +225,8 @@ e.accept()
                     "---------------------->",
                     "Hook;pbs_python;Event is: EXECJOB_ATTACH",
                     "Hook;pbs_python;Requestor is: pbs_mom",
-                    "Hook;pbs_python;Requestor_host is: %s" % self.hostA,
+                    "Hook;pbs_python;Requestor_host is: %s" %
+                    self.momA.shortname,
                     "Hook;pbs_python;Vnode: [%s]-------------->" % self.hostA,
                     "Job;%s;PID =" % jid,
                     "Hook;pbs_python;Vnode: [%s]-------------->" % self.hostB,

--- a/test/tests/functional/pbs_two_mom_hooks_resources_used.py
+++ b/test/tests/functional/pbs_two_mom_hooks_resources_used.py
@@ -74,20 +74,18 @@ class TestAcctlogRescUsedWithTwoMomHooks(TestFunctional):
 
         self.momA = self.moms.values()[0]
         self.momB = self.moms.values()[1]
-        self.momA.delete_vnode_defs()
-        self.momB.delete_vnode_defs()
 
-        self.hostA = self.momA.shortname
-        self.hostB = self.momB.shortname
+        if self.momA.is_cpuset_mom() or self.momB.is_cpuset_mom():
+            node_status = self.server.status(NODE)
 
-        rc = self.server.manager(MGR_CMD_DELETE, NODE, None, "")
-        self.assertEqual(rc, 0)
-
-        rc = self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostA)
-        self.assertEqual(rc, 0)
-
-        rc = self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostB)
-        self.assertEqual(rc, 0)
+        if self.momA.is_cpuset_mom():
+            self.hostA = node_status[1]['id']
+        else:
+            self.hostA = self.momA.shortname
+        if self.momB.is_cpuset_mom():
+            self.hostB = node_status[-1]['id']
+        else:
+            self.hostB = self.momB.shortname
 
     def test_Rrecord(self):
         """


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
fixed tests from TestSupportLinuxHookEventPhase1_2 and TestAcctlogRescUsedWithTwoMomHooks when mom is cpuset machine.
Tests are failed on cpuset machine during job submission and log match.

#### Describe Your Change
* Update code for job submission such that first check if mom is cpuset or not and on that basis use vnode value.
* update log match host name with actual host value.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Before Fix:
[res_before_fix_test_Rrecord.txt](https://github.com/openpbs/openpbs/files/6631054/res_before_fix_test_Rrecord.txt)
[before_fix_test_execjob_attach_hook_with_accept.txt](https://github.com/openpbs/openpbs/files/6631055/before_fix_test_execjob_attach_hook_with_accept.txt)


After Fix:
* On normal machine:
[res_test_Rrecord_normal_machine.txt](https://github.com/openpbs/openpbs/files/6631009/res_test_Rrecord_normal_machine.txt)
[res_test_execjob_attach_hook_with_accept_on_normal_machine.txt](https://github.com/openpbs/openpbs/files/6631011/res_test_execjob_attach_hook_with_accept_on_normal_machine.txt)

* One MoM is cpuset:
[res_test_Rrecord_one_cpuset_machine.txt](https://github.com/openpbs/openpbs/files/6631014/res_test_Rrecord_one_cpuset_machine.txt)
[res_test_execjob_attach_hook_with_accept_one_mom_cpuset.txt](https://github.com/openpbs/openpbs/files/6631016/res_test_execjob_attach_hook_with_accept_one_mom_cpuset.txt)

* Both MoM is cpuset:
[res_test_Rrecord_one_cpuset_machine.txt](https://github.com/openpbs/openpbs/files/6631021/res_test_Rrecord_one_cpuset_machine.txt)
[res_test_execjob_attach_hook_with_accept_both_cpuset_mom.txt](https://github.com/openpbs/openpbs/files/6631023/res_test_execjob_attach_hook_with_accept_both_cpuset_mom.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
