### PR TITLE
Fixing the server crash while moving job across queue

### DIFF
--- a/src/server/accounting.c
+++ b/src/server/accounting.c
@@ -587,7 +587,7 @@ acct_job(const job *pjob, int type, char *buf, int len)
 		len -= i;
 	} else if (is_jattr_set(pjob, JOB_ATR_depend)) {
 		pbs_list_head phead;
-		svrattrl *svrattrl_list;
+		svrattrl *svrattrl_list = NULL;
 		CLEAR_HEAD(phead);
 		job_attr_def[JOB_ATR_depend].at_encode(get_jattr(pjob, JOB_ATR_depend),
 			&phead, job_attr_def[JOB_ATR_depend].at_name, NULL, ATR_ENCODE_CLIENT, &svrattrl_list);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Server crashes when jobs are moved across queue with differing priority.


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
The dangling pointer is causing the server to walk into unintended code and causing it core dump. Setting the NULL to an uninitialized pointer would stave off the crash.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Steps to reproduce:

1) Run the server in Valgrind, submit a job that spans across 2 nodes.
2) Submit 2 more jobs that depend on the last submitted job.
3) Delete the first dependent job.
4) Make the mom down and that causes the parent's job to requeue.
5) Once requeued, move the parent job across the queue.
6) Move the second dependent job across the queue, which causes the job state to change from "H" to "Q" state.
7) Move back the second dependent job to the first submitted queue, which causes the below crash at the accounting function.

[Test_logs.txt](https://github.com/openpbs/openpbs/files/6639273/Test_logs.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
