### PR TITLE
fixed few test suites failed on cpuset machine.

### DIFF
--- a/test/tests/functional/pbs_pbsnodes.py
+++ b/test/tests/functional/pbs_pbsnodes.py
@@ -183,11 +183,21 @@ class TestPbsnodes(TestFunctional):
         j.set_sleep_time(1)
         jid = self.server.submit(j)
         self.server.accounting_match("E;%s;" % jid)
-        prev = self.server.status(NODE, 'last_used_time')[0]['last_used_time']
+        if self.mom.is_cpuset_mom():
+            prev = self.server.status(NODE,
+                                      'last_used_time')[1]['last_used_time']
+        else:
+            prev = self.server.status(NODE,
+                                      'last_used_time')[0]['last_used_time']
         self.logger.info("Restarting server")
         self.server.restart()
         self.assertTrue(self.server.isUp(), 'Failed to restart Server Daemon')
-        now = self.server.status(NODE, 'last_used_time')[0]['last_used_time']
+        if self.mom.is_cpuset_mom():
+            now = self.server.status(NODE,
+                                     'last_used_time')[1]['last_used_time']
+        else:
+            now = self.server.status(NODE,
+                                     'last_used_time')[0]['last_used_time']
         self.logger.info("Before: " + prev + ". After: " + now + ".")
         self.assertEqual(prev.strip(), now.strip(),
                          'Last used time mismatch after server restart')

--- a/test/tests/functional/pbs_pbsnodes.py
+++ b/test/tests/functional/pbs_pbsnodes.py
@@ -184,20 +184,16 @@ class TestPbsnodes(TestFunctional):
         jid = self.server.submit(j)
         self.server.accounting_match("E;%s;" % jid)
         if self.mom.is_cpuset_mom():
-            prev = self.server.status(NODE,
-                                      'last_used_time')[1]['last_used_time']
+            i = 1
         else:
-            prev = self.server.status(NODE,
-                                      'last_used_time')[0]['last_used_time']
+            i = 0
+
+        prev = self.server.status(NODE, 'last_used_time')[i]['last_used_time']
         self.logger.info("Restarting server")
         self.server.restart()
         self.assertTrue(self.server.isUp(), 'Failed to restart Server Daemon')
-        if self.mom.is_cpuset_mom():
-            now = self.server.status(NODE,
-                                     'last_used_time')[1]['last_used_time']
-        else:
-            now = self.server.status(NODE,
-                                     'last_used_time')[0]['last_used_time']
+
+        now = self.server.status(NODE, 'last_used_time')[i]['last_used_time']
         self.logger.info("Before: " + prev + ". After: " + now + ".")
         self.assertEqual(prev.strip(), now.strip(),
                          'Last used time mismatch after server restart')

--- a/test/tests/functional/pbs_snapshot_unittest.py
+++ b/test/tests/functional/pbs_snapshot_unittest.py
@@ -58,10 +58,11 @@ class TestPBSSnapshot(TestFunctional):
     def setUp(self):
         TestFunctional.setUp(self)
 
-        # Create a custom resource called 'ngpus'
+        # Create a custom resource called 'ngpus_snapshot'
         # This will help us test parts of PBSSnapUtils which handle resources
         attr = {"type": "long", "flag": "nh"}
-        self.server.manager(MGR_CMD_CREATE, RSC, attr, id="ngpus", sudo=True)
+        self.server.manager(MGR_CMD_CREATE, RSC, attr, id="ngpus_snapshot",
+                            sudo=True)
 
         # Check whether pbs_snapshot is accessible
         try:

--- a/test/tests/functional/pbs_snapshot_unittest.py
+++ b/test/tests/functional/pbs_snapshot_unittest.py
@@ -58,12 +58,6 @@ class TestPBSSnapshot(TestFunctional):
     def setUp(self):
         TestFunctional.setUp(self)
 
-        # Create a custom resource called 'ngpus_snapshot'
-        # This will help us test parts of PBSSnapUtils which handle resources
-        attr = {"type": "long", "flag": "nh"}
-        self.server.manager(MGR_CMD_CREATE, RSC, attr, id="ngpus_snapshot",
-                            sudo=True)
-
         # Check whether pbs_snapshot is accessible
         try:
             self.pbs_snapshot_path = os.path.join(


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Fixed following test suites failed on cpuset machine.

- TestPbsnodes 
- TestPBSSnapshot 

#### Describe Your Change
* TestPbsnodes - test 'test_pbsnodes_av' got failed on cpuset machine with error 'KeyError: 'last_used_time'. The reason behind this in test we are checking for 'last_used_time' attribute on physical node, we should check it on vnode.
Update code such that check for vnode value instead of physical node. 

* TestPBSSnapshot - all tests are failing on setup with error 'qmgr obj=ngpus svr=default: Duplicate entry in list ', 'qmgr: Error (15055) returned from server'. on cpuset machine custom resource 'ngpus' is already present due to while creating same name resource PTL got failed. 
Update resource name ngpus_snapshot in test suite setup.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Before Fix:
[res_before_fix.txt](https://github.com/openpbs/openpbs/files/6664412/res_before_fix.txt)
[res_TestPbsnodes_before_fix.txt](https://github.com/openpbs/openpbs/files/6664417/res_TestPbsnodes_before_fix.txt)

After Fix:
[res_after_fix.txt](https://github.com/openpbs/openpbs/files/6664418/res_after_fix.txt)
[res_on_normal_machine.txt](https://github.com/openpbs/openpbs/files/6664419/res_on_normal_machine.txt)
[res_TestPbsnodes_on_normal_machine.txt](https://github.com/openpbs/openpbs/files/6664424/res_TestPbsnodes_on_normal_machine.txt)
[res_TestPbsnodes_after_fix.txt](https://github.com/openpbs/openpbs/files/6664426/res_TestPbsnodes_after_fix.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
