### PR TITLE
Addressed static code analysis issues

### DIFF
--- a/src/scheduler/check.h
+++ b/src/scheduler/check.h
@@ -197,17 +197,6 @@ enum sched_error_code check_prime_boundary(status *policy, resource_resv *resres
 int check_node_resources(resource_resv *resresv, node_info **ninfo_arr);
 
 /*
- *
- *	should_check_resvs - do some simple checks to see if it is possible
- *			     for a job to interfere with reservations.
- *			     This function is called for two cases.  One we
- *			     are checking for reseservations on a specific
- *			     node, and the other is a more simple case of just
- *			     checking for reservations on the entire server
- */
-int should_check_resvs(server_info *sinfo, node_info *ninfo, resource_resv *resresv);
-
-/*
  *	false_res - return a static struct of resource which is a boolean
  *		    set to false
  */

--- a/src/scheduler/constant.h
+++ b/src/scheduler/constant.h
@@ -53,10 +53,10 @@
 #define IF_NEG_THEN_ZERO(a) (((a)>=(0))?(a):(0))
 
 /* multipliers [bw] means either btye or word */
-#define KILO		1024UL		/* number of [bw] in a kilo[bw] */
-#define MEGATOKILO	1024UL		/* number of mega[bw] in a kilo[bw] */
-#define GIGATOKILO	1048576UL	/* number of giga[bw] in a kilo[bw] */
-#define TERATOKILO	1073741824UL	/* number of tera[bw] in a kilo[bw] */
+#define KILO		1024L		/* number of [bw] in a kilo[bw] */
+#define MEGATOKILO	1024L		/* number of mega[bw] in a kilo[bw] */
+#define GIGATOKILO	1048576L	/* number of giga[bw] in a kilo[bw] */
+#define TERATOKILO	1073741824L	/* number of tera[bw] in a kilo[bw] */
 
 /* extra constants */
 #define FREE_DEEP 1		/* constant to pass to free_*_list */

--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -303,6 +303,7 @@ class selspec
 	chunk **chunks;
 	selspec();
 	selspec(selspec&);
+	selspec& operator=(selspec&);
 	~selspec();
 };
 
@@ -537,7 +538,7 @@ class queue_info
 	int backfill_depth;		/* total allowable topjobs in this queue*/
 	char *partition;		/* partition to which queue belongs to */
 
-	queue_info(char *);
+	explicit queue_info(const char *);
 	queue_info(queue_info&, server_info *);
 	~queue_info();
 };
@@ -723,7 +724,7 @@ struct node_info
 	node_partition **np_arr;	/* array of node partitions node is in */
 	char *svr_inst_id;
 
-	node_info(const std::string& name);
+	explicit node_info(const std::string& name);
 	~node_info();
 };
 
@@ -815,7 +816,7 @@ class resource_resv
 	timed_event *run_event;		   /* run event in calendar */
 	timed_event *end_event;		   /* end event in calendar */
 
-	resource_resv(const std::string& rname);
+	explicit resource_resv(const std::string& rname);
 	~resource_resv();
 };
 

--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -302,8 +302,8 @@ class selspec
 	std::unordered_set<resdef *> defs;			/* the resources requested by this select spec*/
 	chunk **chunks;
 	selspec();
-	selspec(selspec&);
-	selspec& operator=(selspec&);
+	selspec(const selspec&);
+	selspec& operator=(const selspec&);
 	~selspec();
 };
 

--- a/src/scheduler/fairshare.cpp
+++ b/src/scheduler/fairshare.cpp
@@ -648,7 +648,6 @@ read_usage(const char *filename, int flags, fairshare_head *fhead)
 	FILE *fp;				/* file pointer to usage file */
 	struct group_node_header head;		/* usage file header */
 	time_t last;				/* read the last sync from the file */
-	int error = 0;				/* error reading in usage header */
 
 	if (fhead == NULL || fhead->root == NULL)
 		return;
@@ -666,6 +665,8 @@ read_usage(const char *filename, int flags, fairshare_head *fhead)
 	/* read header */
 	if (fread(&head, sizeof(struct group_node_header), 1, fp) != 0) {
 		if (!strcmp(head.tag, USAGE_MAGIC)) { /* this is a header */
+			int error = 0;
+
 			if (head.version == 2) {
 				if (fread(&last, sizeof(time_t), 1, fp) != 0) {
 					/* 946713600 = 1/1/2000 00:00 - before usage version 2 existed */
@@ -676,16 +677,14 @@ read_usage(const char *filename, int flags, fairshare_head *fhead)
 				}
 				if (!error)
 					read_usage_v2(fp, flags, fhead->root);
-			}
-			else
+			} else
 				error = 1;
 
 			if (error)
 				log_event(PBSEVENT_SCHED, PBS_EVENTCLASS_FILE, LOG_WARNING,
 					  "fairshare usage", "Invalid usage file header");
 
-		}
-		else	 { /* original headerless usage file */
+		} else { /* original headerless usage file */
 			rewind(fp);
 			read_usage_v1(fp, fhead->root);
 		}

--- a/src/scheduler/fifo.cpp
+++ b/src/scheduler/fifo.cpp
@@ -115,7 +115,6 @@ int
 schedinit(int nthreads)
 {
 	char zone_dir[MAXPATHLEN];
-	struct tm *tmptr;
 
 #ifdef PYTHON
 	const char *errstr;
@@ -135,7 +134,7 @@ schedinit(int nthreads)
 		init_non_prime_time(&cstat, NULL);
 
 	if (conf.holiday_year != 0) {
-		tmptr = localtime(&cstat.current_time);
+		auto tmptr = localtime(&cstat.current_time);
 		if ((tmptr != NULL) && ((tmptr->tm_year + 1900) > conf.holiday_year))
 			log_event(PBSEVENT_ADMIN, PBS_EVENTCLASS_FILE, LOG_NOTICE, HOLIDAYS_FILE,
 				"The holiday file is out of date; please update it.");
@@ -226,8 +225,6 @@ update_cycle_status(status& policy, time_t current_time)
 {
 	bool dedtime;			/* is it dedtime? */
 	enum prime_time prime;		/* current prime time status */
-	struct tm *ptm;
-	struct tm *tmptr;
 	const char *primetime;
 
 	if (current_time == 0)
@@ -256,7 +253,7 @@ update_cycle_status(status& policy, time_t current_time)
 		init_non_prime_time(&policy, NULL);
 
 	if (conf.holiday_year != 0) {
-		tmptr = localtime(&policy.current_time);
+		auto tmptr = localtime(&policy.current_time);
 		if ((tmptr != NULL) && ((tmptr->tm_year + 1900) > conf.holiday_year))
 			log_event(PBSEVENT_ADMIN, PBS_EVENTCLASS_FILE, LOG_NOTICE,
 				  HOLIDAYS_FILE, "The holiday file is out of date; please update it.");
@@ -267,7 +264,7 @@ update_cycle_status(status& policy, time_t current_time)
 	if (policy.prime_status_end == SCHD_INFINITY)
 		log_eventf(PBSEVENT_DEBUG2, PBS_EVENTCLASS_SERVER, LOG_DEBUG, "", "It is %s.  It will never end", primetime);
 	else {
-		ptm = localtime(&(policy.prime_status_end));
+		auto ptm = localtime(&(policy.prime_status_end));
 		if (ptm != NULL) {
 			log_eventf(PBSEVENT_DEBUG2, PBS_EVENTCLASS_SERVER, LOG_DEBUG, "",
 				"It is %s.  It will end in %ld seconds at %02d/%02d/%04d %02d:%02d:%02d",
@@ -314,11 +311,7 @@ int
 init_scheduling_cycle(status *policy, int pbs_sd, server_info *sinfo)
 {
 	group_info *user = NULL;	/* the user for the running jobs of the last cycle */
-	char decayed = 0;		/* boolean: have we decayed usage? */
-	time_t t;			/* used in decaying fair share */
-	usage_t delta;			/* the usage between last sch cycle and now */
 	static schd_error *err;
-	int i;
 
 	if (err == NULL) {
 		err = new_schd_error();
@@ -328,7 +321,8 @@ init_scheduling_cycle(status *policy, int pbs_sd, server_info *sinfo)
 
 	if ((policy->fair_share || sinfo->job_sort_formula != NULL) && sinfo->fstree != NULL) {
 		FILE *fp;
-		int resort = 0;
+		bool decayed = false;
+		bool resort = false;
 		if ((fp = fopen(USAGE_TOUCH, "r")) != NULL) {
 			fclose(fp);
 			reset_usage(fstree->root);
@@ -336,7 +330,7 @@ init_scheduling_cycle(status *policy, int pbs_sd, server_info *sinfo)
 			if (fstree->last_decay == 0)
 				fstree->last_decay = policy->current_time;
 			remove(USAGE_TOUCH);
-			resort = 1;
+			resort = true;
 		}
 		if (!last_running.empty() && sinfo->running_jobs != NULL) {
 			/* add the usage which was accumulated between the last cycle and this
@@ -351,7 +345,7 @@ init_scheduling_cycle(status *policy, int pbs_sd, server_info *sinfo)
 
 					if (rj != NULL && rj->job != NULL && !rj->job->is_prerunning) {
 						/* just in case the delta is negative just add 0 */
-						delta = formula_evaluate(conf.fairshare_res.c_str(), rj, rj->job->resused) -
+						auto delta = formula_evaluate(conf.fairshare_res.c_str(), rj, rj->job->resused) -
 							formula_evaluate(conf.fairshare_res.c_str(), rj, lj.resused);
 
 						delta = IF_NEG_THEN_ZERO(delta);
@@ -360,7 +354,7 @@ init_scheduling_cycle(status *policy, int pbs_sd, server_info *sinfo)
 						for (auto& g : user->gpath)
 							g->usage += delta;
 
-						resort = 1;
+						resort = true;
 					}
 				}
 			}
@@ -371,7 +365,7 @@ init_scheduling_cycle(status *policy, int pbs_sd, server_info *sinfo)
 		 * passed.  If this is the case, perform as many decays as necessary
 		 */
 
-		t = policy->current_time;
+		auto t = policy->current_time;
 		while (conf.decay_time != SCHD_INFINITY &&
 			(t - sinfo->fstree->last_decay) > conf.decay_time) {
 			log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_SERVER, LOG_DEBUG,
@@ -379,8 +373,8 @@ init_scheduling_cycle(status *policy, int pbs_sd, server_info *sinfo)
 			if (fstree != NULL)
 				decay_fairshare_tree(sinfo->fstree->root);
 			t -= conf.decay_time;
-			decayed = 1;
-			resort = 1;
+			decayed = true;
+			resort = true;
 		}
 
 		if (decayed) {
@@ -411,13 +405,13 @@ init_scheduling_cycle(status *policy, int pbs_sd, server_info *sinfo)
 	 * is updated for all running jobs
 	 */
 	if ((sinfo->running_jobs != NULL) && (policy->preempting)) {
-		for (i = 0; sinfo->running_jobs[i] != NULL; i++) {
+		for (int i = 0; sinfo->running_jobs[i] != NULL; i++) {
 			if (sinfo->running_jobs[i]->job->resv_id == NULL)
 				update_soft_limits(sinfo, sinfo->running_jobs[i]->job->queue, sinfo->running_jobs[i]);
 		}
 	}
 	if (sinfo->jobs != NULL) {
-		for (i = 0; sinfo->jobs[i] != NULL; i++) {
+		for (int i = 0; sinfo->jobs[i] != NULL; i++) {
 			resource_resv *resresv = sinfo->jobs[i];
 			if (resresv->job != NULL) {
 				if (policy->preempting) {
@@ -816,7 +810,6 @@ get_high_prio_cmd(int *is_conn_lost, sched_cmd *high_prior_cmd)
 int
 main_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rerr)
 {
-	queue_info *qinfo;		/* ptr to queue that job is in */
 	resource_resv *njob;		/* ptr to the next job to see if it can run */
 	int rc = 0;			/* return code to the function */
 	int num_topjobs = 0;		/* number of jobs we've added to the calendar */
@@ -862,6 +855,7 @@ main_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rerr)
 		(njob = next_job(policy, sinfo, sort_again)) != NULL; i++) {
 		int should_use_buckets;		/* Should use node buckets for a job */
 		unsigned int flags = NO_FLAGS;	/* flags to is_ok_to_run @see is_ok_to_run() */
+		auto qinfo = njob->job->queue;
 
 #ifdef NAS /* localmod 030 */
 		if (check_for_cycle_interrupt(1)) {
@@ -872,7 +866,6 @@ main_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rerr)
 		rc = 0;
 		comment[0] = '\0';
 		log_msg[0] = '\0';
-		qinfo = njob->job->queue;
 		sort_again = SORTED;
 
 		clear_schd_error(err);
@@ -947,14 +940,13 @@ main_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rerr)
 			log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_JOB, LOG_WARNING, njob->name, "Leaving scheduling cycle because of an internal error.");
 		}
 		else if (rc != SUCCESS && rc != RUN_FAILURE) {
-			int cal_rc;
 #ifdef NAS /* localmod 034 */
 			int bf_rc;
-			if ((bf_rc = site_should_backfill_with_job(policy, sinfo, njob, num_topjobs, num_topjobs_per_queues, err)))
+			if ((bf_rc = site_should_backfill_with_job(policy, sinfo, njob, num_topjobs, num_topjobs_per_queues, err))) {
 #else
 			if (should_backfill_with_job(policy, sinfo, njob, num_topjobs) != 0) {
 #endif
-				cal_rc = add_job_to_calendar(sd, policy, sinfo, njob, should_use_buckets);
+				auto cal_rc = add_job_to_calendar(sd, policy, sinfo, njob, should_use_buckets);
 
 				if (cal_rc > 0) { /* Success! */
 #ifdef NAS /* localmod 034 */
@@ -1181,11 +1173,10 @@ update_job_can_not_run(int pbs_sd, resource_resv *job, schd_error *err)
 	char log_buf[MAX_LOG_SIZE];		/* buffer for log message */
 	int ret = 1;				/* return code for function */
 
-
-	job->can_not_run = 1;
-
 	if ((job == NULL) || (err == NULL) || (job->job == NULL))
 		return ret;
+
+	job->can_not_run = 1;
 
 	if (translate_fail_code(err, comment_buf, log_buf)) {
 		/* don't attempt to update the comment on a remote job and on an array job */
@@ -1234,8 +1225,6 @@ update_job_can_not_run(int pbs_sd, resource_resv *job, schd_error *err)
 int
 run_job(int pbs_sd, resource_resv *rjob, char *execvnode, int has_runjob_hook, schd_error *err)
 {
-	char buf[100];	/* used to assemble queue@localserver */
-	const char *errbuf;		/* comes from pbs_geterrmsg() */
 	int rc = 0;
 
 	if (rjob == NULL || rjob->job == NULL || err == NULL)
@@ -1248,6 +1237,8 @@ run_job(int pbs_sd, resource_resv *rjob, char *execvnode, int has_runjob_hook, s
 	}
 
 	if (rjob->is_peer_ob) {
+		char buf[100]; /* used to assemble queue@localserver */
+
 		if (strchr(rjob->server->name, (int) ':') == NULL) {
 #ifdef NAS /* localmod 005 */
 			sprintf(buf, "%s@%s:%u", rjob->job->queue->name.c_str(),
@@ -1292,7 +1283,9 @@ run_job(int pbs_sd, resource_resv *rjob, char *execvnode, int has_runjob_hook, s
 	}
 
 	if (rc) {
+		const char *errbuf; /* comes from pbs_geterrmsg() */
 		char buf[MAX_LOG_SIZE];
+
 		set_schd_error_codes(err, NOT_RUN, RUN_FAILURE);
 		errbuf = pbs_geterrmsg(get_svr_inst_fd(pbs_sd, rjob->svr_inst_id));
 		if (errbuf == NULL)
@@ -1373,26 +1366,24 @@ run_update_resresv(status *policy, int pbs_sd, server_info *sinfo,
 {
 	int ret = 0;				/* return code */
 	int pbsrc;				/* return codes from pbs IFL calls */
-	char buf[COMMENT_BUF_SIZE] = {'\0'};		/* generic buffer - comments & logging*/
-	int num_nspec;
 
 	/* used for jobs with nodes resource */
 	nspec **ns = NULL;
 	nspec **orig_ns = NULL;
 	char *execvnode = NULL;
-	int i;
 
 	/* used for resresv array */
 	resource_resv *array = NULL;		/* used to hold array ptr */
 
 	unsigned int eval_flags = NO_FLAGS;	/* flags to pass to eval_selspec() */
-	timed_event *te;			/* used to create timed events */
 	resource_resv *rr;
-	const char *err_txt = NULL;
 	char old_state = 0;
 
-	if (resresv == NULL || sinfo == NULL)
-		ret = -1;
+	if (resresv == NULL || sinfo == NULL) {
+		clear_schd_error(err);
+		set_schd_error_codes(err, NOT_RUN, SCHD_ERROR);
+		return -1;
+	}
 
 	if (resresv->is_job && qinfo == NULL)
 		ret = -1;
@@ -1416,7 +1407,8 @@ run_update_resresv(status *policy, int pbs_sd, server_info *sinfo,
 			if (!pbsrc)
 				ret = 1;
 			else {
-				err_txt = pbse_to_txt(pbsrc);
+				char buf[COMMENT_BUF_SIZE] = {'\0'}; /* generic buffer - comments & logging*/
+				const char *err_txt = pbse_to_txt(pbsrc);
 				if (err_txt == NULL)
 					err_txt = "";
 				clear_schd_error(err);
@@ -1494,7 +1486,7 @@ run_update_resresv(status *policy, int pbs_sd, server_info *sinfo,
 			}
 #endif
 
-			num_nspec = count_array(orig_ns);
+			auto num_nspec = count_array(orig_ns);
 			if (num_nspec > 1)
 				qsort(orig_ns, num_nspec, sizeof(nspec *), cmp_nspec);
 
@@ -1521,7 +1513,7 @@ run_update_resresv(status *policy, int pbs_sd, server_info *sinfo,
 					printf("%04d-%02d-%02d %02d:%02d:%02d %s %s %s\n",
 						ptm->tm_year+1900, ptm->tm_mon+1, ptm->tm_mday,
 						ptm->tm_hour, ptm->tm_min, ptm->tm_sec,
-						"Running", resresv->name,
+						"Running", resresv->name.c_str(),
 						execvnode != NULL ? execvnode : "(NULL)");
 					fflush(stdout);
 #endif /* localmod 031 */
@@ -1593,7 +1585,7 @@ run_update_resresv(status *policy, int pbs_sd, server_info *sinfo,
 		update_resresv_on_run(rr, ns);
 
 		if ((flags & RURR_ADD_END_EVENT)) {
-			te = create_event(TIMED_END_EVENT, rr->end, rr, NULL, NULL);
+			auto te = create_event(TIMED_END_EVENT, rr->end, rr, NULL, NULL);
 			if (te == NULL) {
 				set_schd_error_codes(err, NOT_RUN, SCHD_ERROR);
 				return -1;
@@ -1618,12 +1610,11 @@ run_update_resresv(status *policy, int pbs_sd, server_info *sinfo,
 
 		if (ns != NULL) {
 			int sort_nodepart = 0;
-			for (i = 0; ns[i] != NULL; i++) {
-				int j;
+			for (int i = 0; ns[i] != NULL; i++) {
 				update_node_on_run(ns[i], rr, &old_state);
 				if (ns[i]->ninfo->np_arr != NULL) {
 					node_partition **npar = ns[i]->ninfo->np_arr;
-					for (j = 0; npar[j] != NULL; j++) {
+					for (int j = 0; npar[j] != NULL; j++) {
 						modify_resource_list(npar[j]->res, ns[i]->resreq, SCHD_INCR);
 						if (!ns[i]->ninfo->is_free)
 							npar[j]->free_nodes--;
@@ -1862,12 +1853,6 @@ add_job_to_calendar(int pbs_sd, status *policy, server_info *sinfo,
 	resource_resv *bjob;		/* job pointer which becomes the topjob*/
 	resource_resv *tjob;		/* temporary job pointer for job arrays */
 	time_t start_time;		/* calculated start time of topjob */
-	char *exec;			/* used to hold execvnode for topjob */
-	timed_event *te_start;	/* start event for topjob */
-	timed_event *te_end;		/* end event for topjob */
-	timed_event *nexte;
-	char log_buf[MAX_LOG_SIZE];
-	int i;
 
 	if (policy == NULL || sinfo == NULL ||
 		topjob == NULL || topjob->job == NULL)
@@ -1877,7 +1862,7 @@ add_job_to_calendar(int pbs_sd, status *policy, server_info *sinfo,
 		/* if the job is in the calendar, then there is nothing to do
 		 * Note: We only ever look from now into the future
 		 */
-		nexte = get_next_event(sinfo->calendar);
+		auto nexte = get_next_event(sinfo->calendar);
 		if (find_timed_event(nexte, topjob->name, IGNORE_DISABLED_EVENTS, TIMED_NOEVENT, 0) != NULL)
 			return 1;
 	}
@@ -1903,6 +1888,9 @@ add_job_to_calendar(int pbs_sd, status *policy, server_info *sinfo,
 		start_time = calc_run_time(njob->name, nsinfo, SIM_RUN_JOB);
 
 	if (start_time > 0) {
+		char *exec;	       /* used to hold execvnode for topjob */
+		char log_buf[MAX_LOG_SIZE];
+
 		/* If our top job is a job array, we don't backfill around the
 		 * parent array... rather a subjob.  Normally subjobs don't actually
 		 * exist until they are started.  In our case here, we need to create
@@ -1940,7 +1928,7 @@ add_job_to_calendar(int pbs_sd, status *policy, server_info *sinfo,
 			printf("%04d-%02d-%02d %02d:%02d:%02d %s %s %s\n",
 				ptm->tm_year+1900, ptm->tm_mon+1, ptm->tm_mday,
 				ptm->tm_hour, ptm->tm_min, ptm->tm_sec,
-				"Backfill", njob->name, exec);
+				"Backfill", njob->name.c_str(), exec);
 #endif /* localmod 068 */
 			if (bjob->nspec_arr != NULL)
 				free_nspecs(bjob->nspec_arr);
@@ -1973,14 +1961,14 @@ add_job_to_calendar(int pbs_sd, status *policy, server_info *sinfo,
 		bjob->start = start_time;
 		bjob->end = start_time + bjob->duration;
 
-		te_start = create_event(TIMED_RUN_EVENT, bjob->start, bjob, NULL, NULL);
+		auto te_start = create_event(TIMED_RUN_EVENT, bjob->start, bjob, NULL, NULL);
 		if (te_start == NULL) {
 			free_server(nsinfo);
 			return 0;
 		}
 		add_event(sinfo->calendar, te_start);
 
-		te_end = create_event(TIMED_END_EVENT, bjob->end, bjob, NULL, NULL);
+		auto te_end = create_event(TIMED_END_EVENT, bjob->end, bjob, NULL, NULL);
 		if (te_end == NULL) {
 			free_server(nsinfo);
 			return 0;
@@ -1994,7 +1982,7 @@ add_job_to_calendar(int pbs_sd, status *policy, server_info *sinfo,
 		}
 
 
-		for (i = 0; bjob->nspec_arr[i] != NULL; i++) {
+		for (int i = 0; bjob->nspec_arr[i] != NULL; i++) {
 			int ind = bjob->nspec_arr[i]->ninfo->node_ind;
 			add_te_list(&(bjob->nspec_arr[i]->ninfo->node_events), te_start);
 
@@ -2141,36 +2129,6 @@ find_non_normal_job_ind(resource_resv **jobs, int start_index) {
 	return -1;
 }
 
-#ifdef NAS
-/**
- * @return
- *		find_susp_job - find a suspended job
- *
- * @param[in]	jobs	-	the array of jobs
- *
- * @return	first suspended job or NULL if there aren't any.
- *
- */
-resource_resv *
-find_susp_job(resource_resv **jobs) {
-	int i;
-
-	if (jobs == NULL)
-		return NULL;
-
-	for(i = 0; jobs[i] != NULL; i++) {
-		if (jobs[i]->job != NULL) {
-			if (jobs[i]->job->is_suspended) {
-				return jobs[i];
-			}
-		}
-	}
-	return NULL;
-}
-#endif
-
-
-
 /**
  * @brief
  * 		find the next job to be considered to run by the scheduler
@@ -2210,10 +2168,6 @@ next_job(status *policy, server_info *sinfo, int flag)
 	static int sort_status = MAY_RESORT_JOBS; /* to decide whether to sort jobs or not */
 	static int queue_list_size; /* Count of number of priority levels in queue_list */
 	resource_resv *rjob = NULL;		/* the job to return */
-	int i = 0;
-	int queues_finished = 0;
-	int queue_index_size = 0;
-	int j = 0;
 	int ind = -1;
 
 	if ((policy == NULL) || (sinfo == NULL))
@@ -2286,11 +2240,14 @@ next_job(status *policy, server_info *sinfo, int flag)
 		/* last_index refers to a priority level as shown in diagram
 		 * above.
 		 */
-		i = last_queue_index;
+		int i = last_queue_index;
+
 		while((rjob == NULL) && (i < queue_list_size)) {
 			/* Calculating number of queues at this priority level */
-			queue_index_size = count_array(sinfo->queue_list[i]);
-			for (j = last_queue; j < queue_index_size; j++) {
+			int queue_index_size = count_array(sinfo->queue_list[i]);
+			int queues_finished = 0;
+
+			for (int j = last_queue; j < queue_index_size; j++) {
 				ind = find_runnable_resresv_ind(sinfo->queue_list[i][j]->jobs, 0);
 				if(ind != -1)
 					rjob = sinfo->queue_list[i][j]->jobs[ind];
@@ -2666,9 +2623,9 @@ parse_sched_obj(int connector, struct batch_status *status)
 		}
 
 		if (validate_priv_dir) {
-			int c = -1;
+			int c;
 #if !defined(DEBUG) && !defined(NO_SECURITY_CHECK)
-				c  = chk_file_sec_user(tmp_priv_dir, 1, 0, S_IWGRP|S_IWOTH, 1, getuid());
+				c = chk_file_sec_user(tmp_priv_dir, 1, 0, S_IWGRP|S_IWOTH, 1, getuid());
 				c |= chk_file_sec_user(pbs_conf.pbs_environment, 0, 0, S_IWGRP|S_IWOTH, 0, getuid());
 				if (c != 0) {
 					log_eventf(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__,
@@ -2676,7 +2633,9 @@ parse_sched_obj(int connector, struct batch_status *status)
 					strcpy(comment, "PBS failed validation checks for sched_priv directory");
 					priv_dir_update_fail = 1;
 				}
-#endif  /* not DEBUG and not NO_SECURITY_CHECK */
+#else  /* not DEBUG and not NO_SECURITY_CHECK */
+			c = 0;
+#endif
 			if (c == 0) {
 				if (chdir(tmp_priv_dir) == -1) {
 					strcpy(comment, "PBS failed validation checks for sched_priv directory");
@@ -2708,7 +2667,6 @@ parse_sched_obj(int connector, struct batch_status *status)
 					}
 				}
 			}
-
 		}
 
 

--- a/src/scheduler/job_info.cpp
+++ b/src/scheduler/job_info.cpp
@@ -562,10 +562,7 @@ query_jobs_chunk(th_data_query_jinfo *data)
 		resource_req *req;
 		resource_req *walltime_req = NULL;
 		resource_req *soft_walltime_req = NULL;
-		char fairshare_name[100];
 		long duration;
-		time_t start;
-		time_t end;
 
 		if ((resresv = query_job(cur_job, sinfo, err)) == NULL) {
 			data->error = 1;
@@ -711,7 +708,8 @@ query_jobs_chunk(th_data_query_jinfo *data)
 		if (resresv->job->stime != UNSPECIFIED &&
 			!(resresv->job->is_queued || resresv->job->is_suspended) &&
 			resresv->ninfo_arr != NULL) {
-			start = resresv->job->stime;
+			auto start = resresv->job->stime;
+			time_t end;
 
 			/* if a job is exiting, then its end time can be more closely
 			 * estimated by setting it to now + EXITING_TIME
@@ -764,7 +762,8 @@ query_jobs_chunk(th_data_query_jinfo *data)
 		 * of something most likely unique - egroup:euser
 		 */
 
-		if (resresv->job->ginfo ==NULL) {
+		if (resresv->job->ginfo == NULL) {
+			char fairshare_name[100];
 #ifdef NAS /* localmod 058 */
 			sprintf(fairshare_name, "%s:%s:%s", resresv->group, resresv->user,
 				(qinfo->name != NULL ? qinfo->name : ""));
@@ -856,7 +855,7 @@ static inline th_data_query_jinfo *
 alloc_tdata_jquery(status *policy, int pbs_sd, struct batch_status *jobs, queue_info *qinfo,
 		int sidx, int eidx)
 {
-	th_data_query_jinfo *tdata = NULL;
+	th_data_query_jinfo *tdata;
 
 	tdata = static_cast<th_data_query_jinfo *>(malloc(sizeof(th_data_query_jinfo)));
 	if (tdata == NULL) {
@@ -905,7 +904,6 @@ query_jobs(status *policy, int pbs_sd, queue_info *qinfo, resource_resv **pjobs,
 	static struct attropl opl2[2] = { { &opl2[1], const_cast<char *>(ATTR_state), NULL, const_cast<char *>("Q"), EQ},
 		{ NULL, const_cast<char *>(ATTR_array), NULL, const_cast<char *>("True"), NE} };
 	static struct attrl *attrib = NULL;
-	int i;
 
 	/* linked list of jobs returned from pbs_selstat() */
 	struct batch_status *jobs;
@@ -922,21 +920,23 @@ query_jobs(status *policy, int pbs_sd, queue_info *qinfo, resource_resv **pjobs,
 	int num_prev_jobs;
 	int num_new_jobs;
 
-	/* used for pbs_geterrmsg() */
-	const char *errmsg;
-
 	/* for multi-threading */
-	int chunk_size;
-	int j;
 	int jidx;
 	th_data_query_jinfo *tdata = NULL;
 	th_task_info *task = NULL;
-	int num_tasks;
-	int th_err = 0;
 	resource_resv ***jinfo_arrs_tasks;
 	int tid;
 
-	const char *jobattrs[] = {
+	if (policy == NULL || qinfo == NULL || queue_name.empty())
+		return pjobs;
+
+	opl.value = const_cast<char *>(queue_name.c_str());
+
+	if (qinfo->is_peer_queue)
+		opl.next = &opl2[0];
+
+	if (attrib == NULL) {
+		const char *jobattrs[] = {
 			ATTR_p,
 			ATTR_qtime,
 			ATTR_qrank,
@@ -973,20 +973,10 @@ query_jobs(status *policy, int pbs_sd, queue_info *qinfo, resource_resv **pjobs,
 			ATTR_A,
 			ATTR_max_run_subjobs,
 			ATTR_server_inst_id,
-			NULL
-	};
+			NULL};
 
-	if (policy == NULL || qinfo == NULL || queue_name.empty())
-		return pjobs;
-
-	opl.value = const_cast<char *>(queue_name.c_str());
-
-	if (qinfo->is_peer_queue)
-		opl.next = &opl2[0];
-
-	if (attrib == NULL) {
-		for (i = 0; jobattrs[i] != NULL; i++) {
-			struct attrl *temp_attrl = NULL;
+		for (int i = 0; jobattrs[i] != NULL; i++) {
+			struct attrl *temp_attrl;
 
 			temp_attrl = new_attrl();
 			temp_attrl->name = strdup(jobattrs[i]);
@@ -999,7 +989,7 @@ query_jobs(status *policy, int pbs_sd, queue_info *qinfo, resource_resv **pjobs,
 	/* get jobs from PBS server */
 	if ((jobs = send_selstat(pbs_sd, &opl, attrib, const_cast<char *>("S"))) == NULL) {
 		if (pbs_errno > 0) {
-			errmsg = pbs_geterrmsg(pbs_sd);
+			const char *errmsg = pbs_geterrmsg(pbs_sd);
 			if (errmsg == NULL)
 				errmsg = "";
 			log_eventf(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_NOTICE, "job_info",
@@ -1050,17 +1040,21 @@ query_jobs(status *policy, int pbs_sd, queue_info *qinfo, resource_resv **pjobs,
 			return NULL;
 		}
 
-		for (j = 0, jidx = num_prev_jobs; tdata->oarr[j] != NULL; j++) {
+		jidx = num_prev_jobs;
+		for (int j = 0; tdata->oarr[j] != NULL; j++) {
 			resresv_arr[jidx++] = tdata->oarr[j];
 		}
 		free(tdata->oarr);
 		free(tdata);
 		resresv_arr[jidx] = NULL;
 	} else {
-		chunk_size = num_new_jobs / num_threads;
+		int chunk_size = num_new_jobs / num_threads;
+		int th_err = 0;
+		int num_tasks = 0;
+
 		chunk_size = (chunk_size > MT_CHUNK_SIZE_MIN) ? chunk_size : MT_CHUNK_SIZE_MIN;
 		chunk_size = (chunk_size < MT_CHUNK_SIZE_MAX) ? chunk_size : MT_CHUNK_SIZE_MAX;
-		for (j = 0, num_tasks = 0; num_new_jobs > 0;
+		for (int j = 0; num_new_jobs > 0;
 				num_tasks++, j += chunk_size, num_new_jobs -= chunk_size) {
 			tdata = alloc_tdata_jquery(policy, pbs_sd, jobs, qinfo, j, j + chunk_size - 1);
 			if (tdata == NULL) {
@@ -1089,13 +1083,13 @@ query_jobs(status *policy, int pbs_sd, queue_info *qinfo, resource_resv **pjobs,
 			th_err = 1;
 		}
 		/* Get results from worker threads */
-		for (i = 0; i < num_tasks;) {
+		for (int i = 0; i < num_tasks;) {
 			pthread_mutex_lock(&result_lock);
 			while (ds_queue_is_empty(result_queue))
 				pthread_cond_wait(&result_cond, &result_lock);
 			while (!ds_queue_is_empty(result_queue)) {
-				task = (th_task_info*) ds_dequeue(result_queue);
-				tdata = (th_data_query_jinfo*) task->thread_data;
+				task = static_cast<th_task_info *>(ds_dequeue(result_queue));
+				tdata = static_cast<th_data_query_jinfo *>(task->thread_data);
 				if (tdata->error)
 					th_err = 1;
 				jinfo_arrs_tasks[task->task_id] = tdata->oarr;
@@ -1112,9 +1106,10 @@ query_jobs(status *policy, int pbs_sd, queue_info *qinfo, resource_resv **pjobs,
 			return NULL;
 		}
 		/* Assemble job info objects from various threads into the resresv_arr */
-		for (i = 0, jidx = num_prev_jobs; i < num_tasks; i++) {
+		jidx = num_prev_jobs;
+		for (int i = 0; i < num_tasks; i++) {
 			if (jinfo_arrs_tasks[i] != NULL) {
-				for (j = 0; jinfo_arrs_tasks[i][j] != NULL; j++) {
+				for (int j = 0; jinfo_arrs_tasks[i][j] != NULL; j++) {
 					resresv_arr[jidx++] = jinfo_arrs_tasks[i][j];
 				}
 				free(jinfo_arrs_tasks[i]);
@@ -1942,7 +1937,6 @@ int
 translate_fail_code(schd_error *err, char *comment_msg, char *log_msg)
 {
 	int rc = 1;
-	const char *pbse;
 	char commentbuf[MAX_LOG_SIZE];
 	const char *arg1;
 	const char *arg2;
@@ -1961,6 +1955,8 @@ translate_fail_code(schd_error *err, char *comment_msg, char *log_msg)
 	}
 
 	if (err->error_code < RET_BASE) {
+		const char *pbse;
+
 		if (err->specmsg != NULL)
 			pbse = err->specmsg;
 		else
@@ -2649,7 +2645,6 @@ create_resresv_sets(status *policy, server_info *sinfo)
 {
 	int i;
 	int j = 0;
-	int cur_ind;
 	int len;
 	int rset_len;
 	resource_resv **resresvs;
@@ -2672,7 +2667,7 @@ create_resresv_sets(status *policy, server_info *sinfo)
 	rsets[0] = NULL;
 
 	for (i = 0; resresvs[i] != NULL; i++) {
-		cur_ind = find_resresv_set_by_resresv(policy, rsets, resresvs[i]);
+		auto cur_ind = find_resresv_set_by_resresv(policy, rsets, resresvs[i]);
 
 		/* Didn't find the set, create it.*/
 		if (cur_ind == -1) {
@@ -2957,7 +2952,6 @@ find_and_preempt_jobs(status *policy, int pbs_sd, resource_resv *hjob, server_in
 	int i = 0;
 	int *jobs = NULL;
 	resource_resv *job = NULL;
-	int ret = -1;
 	int done = 0;
 	int rc = 1;
 	int *preempted_list = NULL;
@@ -3087,7 +3081,7 @@ find_and_preempt_jobs(status *policy, int pbs_sd, resource_resv *hjob, server_in
 
 	if (done) {
 		clear_schd_error(err);
-		ret = run_update_resresv(policy, pbs_sd, sinfo, hjob->job->queue, hjob, NULL, RURR_ADD_END_EVENT, err);
+		auto ret = run_update_resresv(policy, pbs_sd, sinfo, hjob->job->queue, hjob, NULL, RURR_ADD_END_EVENT, err);
 
 		/* oops... we screwed up.. the high priority job didn't run.  Forget about
 		 * running it now and resume preempted work
@@ -3603,7 +3597,6 @@ select_index_to_preempt(status *policy, resource_resv *hjob,
 	int i, j, k;
 	int good = 1;		/* good boolean: Is job eligible to be preempted */
 	struct preempt_ordering *po;
-	resdef **rdtc_non_consumable = NULL;
 
 	if ( err == NULL || hjob == NULL || hjob->job == NULL ||
 		rjobs == NULL || rjobs[0] == NULL)
@@ -3766,8 +3759,6 @@ select_index_to_preempt(status *policy, resource_resv *hjob,
 		if (good)
 			break;
 	}
-	if (rdtc_non_consumable != NULL)
-		free (rdtc_non_consumable);
 
 	if (good && rjobs[i] != NULL)
 		return i;
@@ -3938,16 +3929,16 @@ create_subjob_from_array(resource_resv *array, int index, const std::string& sub
 
 	subjob = dup_resource_resv(array, array->server, array->job->queue, subjob_name);
 
+	if (subjob == NULL) {
+		free_schd_error(err);
+		return NULL;
+	}
+
 	/* make a copy of dependent jobs */
 	subjob->job->depend_job_str = string_dup(array->job->depend_job_str);
 	subjob->job->dependent_jobs = (resource_resv **) dup_array(array->job->dependent_jobs);
 
 	array->job->queued_subjobs = tmp;
-
-	if (subjob == NULL) {
-		free_schd_error(err);
-		return NULL;
-	}
 
 	subjob->job->is_begin = 0;
 	subjob->job->is_array = 0;
@@ -4203,9 +4194,7 @@ formula_evaluate(const char *formula, resource_resv *resresv, resource_req *resr
 	char buf[1024];
 	char *globals;
 	int globals_size = 1024;  /* initial size... will grow if needed */
-	resource_req *req;
 	sch_resource_t ans = 0;
-	const char *str;
 	char *formula_buf;
 	int formula_buf_len;
 
@@ -4241,7 +4230,7 @@ formula_evaluate(const char *formula, resource_resv *resresv, resource_req *resr
 
 
 	for (const auto& cr : consres) {
-		req = find_resource_req(resreq, cr);
+		auto req = find_resource_req(resreq, cr);
 
 		if (req != NULL)
 			sprintf(buf, "\'%s\':%.*f,", cr->name.c_str(),
@@ -4299,7 +4288,7 @@ formula_evaluate(const char *formula, resource_resv *resresv, resource_req *resr
 
 	obj = PyMapping_GetItemString(dict, "_PBS_PYTHON_EXCEPTIONSTR_");
 	if (obj != NULL) {
-		str = PyUnicode_AsUTF8(obj);
+		auto str = PyUnicode_AsUTF8(obj);
 		if (str != NULL) {
 			if (strlen(str) > 0) { /* exception happened */
 				log_eventf(PBSEVENT_DEBUG2, PBS_EVENTCLASS_JOB, LOG_DEBUG, resresv->name,
@@ -4511,13 +4500,12 @@ char*
 getaoename(selspec *select)
 {
 	int i = 0;
-	resource_req *req;
 
 	if (select == NULL)
 		return NULL;
 
 	for (i = 0; select->chunks[i] != NULL; i++) {
-		req = find_resource_req(select->chunks[i]->req, allres["aoe"]);
+		auto req = find_resource_req(select->chunks[i]->req, allres["aoe"]);
 		if (req != NULL)
 			return string_dup(req->res_str);
 	}
@@ -4870,7 +4858,6 @@ void create_res_released(status *policy, resource_resv *pjob)
 nspec **create_res_released_array(status *policy, resource_resv *resresv)
 {
 	nspec **nspec_arr = NULL;
-	int i = 0;
 	resource_req *req;
 
 	if ((resresv == NULL) || (resresv->nspec_arr == NULL) || (resresv->ninfo_arr == NULL))
@@ -4880,7 +4867,7 @@ nspec **create_res_released_array(status *policy, resource_resv *resresv)
 	if (nspec_arr == NULL)
 		return NULL;
 	if (!policy->rel_on_susp.empty()) {
-		for (i = 0; nspec_arr[i] != NULL; i++) {
+		for (int i = 0; nspec_arr[i] != NULL; i++) {
 			for (req = nspec_arr[i]->resreq; req != NULL; req = req->next) {
 				auto ros = policy->rel_on_susp;
 				if (req->type.is_consumable == 1 && ros.find(req->def) == ros.end())
@@ -4993,7 +4980,6 @@ extend_soft_walltime(resource_resv *resresv, time_t server_time)
 static int cull_preemptible_jobs(resource_resv *job, const void *arg)
 {
 	struct resresv_filter *inp;
-	int index;
 	resource_req *req_scan;
 
 	if (arg == NULL || job == NULL)
@@ -5120,7 +5106,7 @@ static int cull_preemptible_jobs(resource_resv *job, const void *arg)
 					 */
 					return 1;
 				}
-				for (index = 0; job->select->chunks[index] != NULL; index++)
+				for (int index = 0; job->select->chunks[index] != NULL; index++)
 				{
 					for (req_scan = job->select->chunks[index]->req; req_scan != NULL; req_scan = req_scan->next)
 					{
@@ -5252,8 +5238,6 @@ static char **parse_runone_job_list(char *depend_val) {
 	char *r;
 	char **ret = NULL;
 	char *depend_str = NULL;
-	int  job_delim = 0;
-	int  svr_delim = 0;
 
 	if (depend_val == NULL)
 		return NULL;
@@ -5278,9 +5262,9 @@ static char **parse_runone_job_list(char *depend_val) {
 		return NULL;
 	}
 	for (i = 0;  i < len; i++) {
-		job_delim = strcspn(r, ":");
+		auto job_delim = strcspn(r, ":");
 		r[job_delim] = '\0';
-		svr_delim = strcspn(r, "@");
+		auto svr_delim = strcspn(r, "@");
 		r[svr_delim] = '\0';
 		ret[i] = string_dup(r);
 		if (ret[i] == NULL) {
@@ -5316,7 +5300,7 @@ void associate_dependent_jobs(server_info *sinfo) {
 				sinfo->jobs[i]->job->dependent_jobs = static_cast<resource_resv **>(calloc((len + 1), sizeof(resource_resv *)));
 				sinfo->jobs[i]->job->dependent_jobs[len] = NULL;
 				for (j = 0; job_arr[j] != NULL; j++) {
-					resource_resv *jptr = NULL;
+					resource_resv *jptr;
 					jptr = find_resource_resv(sinfo->jobs, job_arr[j]);
 					if (jptr != NULL)
 						sinfo->jobs[i]->job->dependent_jobs[j] = jptr;

--- a/src/scheduler/job_info.cpp
+++ b/src/scheduler/job_info.cpp
@@ -2679,9 +2679,7 @@ create_resresv_sets(status *policy, server_info *sinfo)
 			cur_ind = j;
 			rsets[j++] = cur_rset;
 			rsets[j] = NULL;
-		} else
-			cur_rset = rsets[cur_ind];
-
+		}
 		resresvs[i]->ec_index = cur_ind;
 	}
 

--- a/src/scheduler/limits.cpp
+++ b/src/scheduler/limits.cpp
@@ -1073,8 +1073,7 @@ check_limits(server_info *si, queue_info *qi, resource_resv *rr, schd_error *err
 				return SE_NONE;
 			}
 		}
-	}
-	else if ((flags & CHECK_CUMULATIVE_LIMIT)) {
+	} else if ((flags & CHECK_CUMULATIVE_LIMIT)) {
 		if (!si->has_hard_limit && !qi->has_hard_limit)
 			return SE_NONE;
 		server_lim = make_limcounts(si->total_user_counts,
@@ -2532,8 +2531,8 @@ check_server_max_res_soft(server_info *si, queue_info *qi, resource_resv *rr)
 		return (0);
 
 	for (res = limres; res != NULL; res = res->next) {
-		resource_req *req;
-		if ((req = find_resource_req(rr->resreq, res->def)) == NULL)
+		/* If the job is not requesting the limit resource, it is not over its soft limit*/
+		if (find_resource_req(rr->resreq, res->def) == NULL)
 			continue;
 
 		if ((reskey = entlim_mk_reskey(LIM_OVERALL, allparam,
@@ -2601,8 +2600,8 @@ check_queue_max_res_soft(server_info *si, queue_info *qi, resource_resv *rr)
 		return (0);
 
 	for (res = limres; res != NULL; res = res->next) {
-		resource_req *req;
-		if ((req = find_resource_req(rr->resreq, res->def)) == NULL)
+		/* If the job is not requesting the limit resource, it is not over its soft limit*/
+		if (find_resource_req(rr->resreq, res->def) == NULL)
 			continue;
 
 		if ((reskey = entlim_mk_reskey(LIM_OVERALL, allparam,
@@ -2752,8 +2751,8 @@ check_max_group_res_soft(resource_resv *rr, counts *cts_list, void *limitctx, in
 	group = rr->group;
 
 	for (res = limres; res != NULL; res = res->next) {
-		resource_req *req;
-		if ((req = find_resource_req(rr->resreq, res->def)) == NULL)
+		/* If the job is not requesting the limit resource, it is not over its soft limit*/
+		if (find_resource_req(rr->resreq, res->def) == NULL)
 			continue;
 
 		/* individual group limit check */
@@ -2923,8 +2922,8 @@ check_max_user_res_soft(resource_resv **rr_arr, resource_resv *rr,
 	user = rr->user;
 
 	for (res = limres; res != NULL; res = res->next) {
-		resource_req *req;
-		if ((req = find_resource_req(rr->resreq, res->def)) == NULL)
+		/* If the job is not requesting the limit resource, it is not over its soft limit*/
+		if (find_resource_req(rr->resreq, res->def) == NULL)
 			continue;
 
 		/* individual user limit check */
@@ -3554,8 +3553,8 @@ check_max_project_res_soft(resource_resv *rr, counts *cts_list, void *limitctx, 
 
 	project = rr->project;
 	for (res = limres; res != NULL; res = res->next) {
-		resource_req *req;
-		if ((req = find_resource_req(rr->resreq, res->def)) == NULL)
+		/* If the job is not requesting the limit resource, it is not over its soft limit*/
+		if (find_resource_req(rr->resreq, res->def) == NULL)
 			continue;
 
 		/* individual project limit check */

--- a/src/scheduler/misc.h
+++ b/src/scheduler/misc.h
@@ -102,11 +102,6 @@ filter_array(void **ptrarr, int (*filter_func)(void*, void*),
 int calc_time_left_STF(resource_resv *resresv, sch_resource_t* min_time_left);
 
 /*
- *      string_array_verify - verify two string arrays are equal
- */
-unsigned string_array_verify(char **sa1, char **sa2);
-
-/*
  *
  *	match_string_array - match two NULL terminated string arrays
  *
@@ -117,15 +112,6 @@ unsigned string_array_verify(char **sa1, char **sa2);
  *
  */
 enum match_string_array_ret match_string_array(const char * const *strarr1, const char * const *strarr2);
-
-/*
- *
- *	match_string_to_array - see if a string array contains a single string
- *
- *	returns value from match_string_array()
- *
- */
-enum match_string_array_ret match_string_to_array(const char *str, const char * const *strarr);
 
 /*
  * convert a string array into a printable string
@@ -181,17 +167,6 @@ int remove_ptr_from_array(void *arr, void *ptr);
  * @retval NULL on error
  */
 void *add_ptr_to_array(void *ptr_arr, void *ptr);
-
-/*
- *	remove_str_from_array - remove a string from a ptr list and move
- *				the rest of the pointers up to fill the hole
- *				Pointer array size will not change - an extra
- *				NULL is added to the end
- *
- *	returns non-zero if the str was successfully removed from the array
- *		zero if the array has not been modified
- */
-int remove_str_from_array(char **arr, char *str);
 
 /*
  *      is_valid_pbs_name - is str a valid pbs username (POSIX.1 + ' ')

--- a/src/scheduler/multi_threading.cpp
+++ b/src/scheduler/multi_threading.cpp
@@ -262,37 +262,37 @@ worker(void *tid)
 			case TS_IS_ND_ELIGIBLE:
 				snprintf(buf, sizeof(buf), "Thread %d calling check_node_eligibility_chunk()", ntid);
 				log_event(PBSEVENT_DEBUG3, PBS_EVENTCLASS_SCHED, LOG_DEBUG, __func__, buf);
-				check_node_eligibility_chunk((th_data_nd_eligible *) work->thread_data);
+				check_node_eligibility_chunk(static_cast<th_data_nd_eligible *>(work->thread_data));
 				break;
 			case TS_DUP_ND_INFO:
 				snprintf(buf, sizeof(buf), "Thread %d calling dup_node_info_chunk()", ntid);
 				log_event(PBSEVENT_DEBUG3, PBS_EVENTCLASS_SCHED, LOG_DEBUG, __func__, buf);
-				dup_node_info_chunk((th_data_dup_nd_info *) work->thread_data);
+				dup_node_info_chunk(static_cast<th_data_dup_nd_info *>(work->thread_data));
 				break;
 			case TS_QUERY_ND_INFO:
 				snprintf(buf, sizeof(buf), "Thread %d calling query_node_info_chunk()", ntid);
 				log_event(PBSEVENT_DEBUG3, PBS_EVENTCLASS_SCHED, LOG_DEBUG, __func__, buf);
-				query_node_info_chunk((th_data_query_ninfo *) work->thread_data);
+				query_node_info_chunk(static_cast<th_data_query_ninfo *>(work->thread_data));
 				break;
 			case TS_FREE_ND_INFO:
 				snprintf(buf, sizeof(buf), "Thread %d calling free_node_info_chunk()", ntid);
 				log_event(PBSEVENT_DEBUG3, PBS_EVENTCLASS_SCHED, LOG_DEBUG, __func__, buf);
-				free_node_info_chunk((th_data_free_ninfo *) work->thread_data);
+				free_node_info_chunk(static_cast<th_data_free_ninfo *>(work->thread_data));
 				break;
 			case TS_DUP_RESRESV:
 				snprintf(buf, sizeof(buf), "Thread %d calling dup_resource_resv_array_chunk()", ntid);
 				log_event(PBSEVENT_DEBUG3, PBS_EVENTCLASS_SCHED, LOG_DEBUG, __func__, buf);
-				dup_resource_resv_array_chunk((th_data_dup_resresv *) work->thread_data);
+				dup_resource_resv_array_chunk(static_cast<th_data_dup_resresv *>(work->thread_data));
 				break;
 			case TS_QUERY_JOB_INFO:
 				snprintf(buf, sizeof(buf), "Thread %d calling query_jobs_chunk()", ntid);
 				log_event(PBSEVENT_DEBUG3, PBS_EVENTCLASS_SCHED, LOG_DEBUG, __func__, buf);
-				query_jobs_chunk((th_data_query_jinfo *) work->thread_data);
+				query_jobs_chunk(static_cast<th_data_query_jinfo *>(work->thread_data));
 				break;
 			case TS_FREE_RESRESV:
 				snprintf(buf, sizeof(buf), "Thread %d calling free_resource_resv_array_chunk()", ntid);
 				log_event(PBSEVENT_DEBUG3, PBS_EVENTCLASS_SCHED, LOG_DEBUG, __func__, buf);
-				free_resource_resv_array_chunk((th_data_free_resresv *) work->thread_data);
+				free_resource_resv_array_chunk(static_cast<th_data_free_resresv *>(work->thread_data));
 				break;
 			default:
 				log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__,

--- a/src/scheduler/node_info.cpp
+++ b/src/scheduler/node_info.cpp
@@ -90,13 +90,10 @@
  * 	ok_break_chunk()
  * 	is_excl()
  * 	alloc_rest_nodepart()
- * 	set_res_on_host()
  * 	can_fit_on_vnode()
- * 	is_aoe_avail_on_vnode()
  * 	is_provisionable()
  * 	node_up_event()
  * 	node_down_event()
- * 	node_in_str()
  * 	create_node_array_from_str()
  * 	find_node_by_rank()
  * 	new_node_scratch()
@@ -223,7 +220,7 @@ query_node_info_chunk(th_data_query_ninfo *data)
 static inline th_data_query_ninfo *
 alloc_tdata_nd_query(struct batch_status *nodes, server_info *sinfo, int sidx, int eidx)
 {
-	th_data_query_ninfo *tdata = NULL;
+	th_data_query_ninfo *tdata;
 
 	tdata = static_cast<th_data_query_ninfo *>(malloc(sizeof(th_data_query_ninfo)));
 	if (tdata == NULL) {
@@ -256,20 +253,16 @@ query_nodes(int pbs_sd, server_info *sinfo)
 	struct batch_status *nodes;		/* nodes returned from the server */
 	struct batch_status *cur_node;	/* used to cycle through nodes */
 	node_info **ninfo_arr;		/* array of nodes for scheduler's use */
-	char *err;				/* used with pbs_geterrmsg() */
 	int num_nodes = 0;			/* the number of nodes */
-	int i;
-	int j;
 	int nidx = 0;
 	static struct attrl *attrib = NULL;
-	int chunk_size;
 	th_data_query_ninfo *tdata = NULL;
 	th_task_info *task = NULL;
-	int num_tasks;
-	int th_err = 0;
 	node_info ***ninfo_arrs_tasks = NULL;
 	int tid;
-	const char *nodeattrs[] = {
+
+	if (attrib == NULL) {
+		const char *nodeattrs[] = {
 			ATTR_NODE_state,
 			ATTR_NODE_Mom,
 			ATTR_NODE_Port,
@@ -296,12 +289,10 @@ query_nodes(int pbs_sd, server_info *sinfo)
 			ATTR_NODE_last_used_time,
 			ATTR_NODE_resvs,
 			ATTR_server_inst_id,
-			NULL
-	};
+			NULL};
 
-	if (attrib == NULL) {
-		for (i = 0; nodeattrs[i] != NULL; i++) {
-			struct attrl *temp_attrl = NULL;
+		for (int i = 0; nodeattrs[i] != NULL; i++) {
+			struct attrl *temp_attrl;
 
 			temp_attrl = new_attrl();
 			temp_attrl->name = strdup(nodeattrs[i]);
@@ -313,7 +304,7 @@ query_nodes(int pbs_sd, server_info *sinfo)
 
 	/* get nodes from PBS server */
 	if ((nodes = send_statvnode(pbs_sd, NULL, attrib, NULL)) == NULL) {
-		err = pbs_geterrmsg(pbs_sd);
+		auto err = pbs_geterrmsg(pbs_sd);
 		log_eventf(PBSEVENT_SCHED, PBS_EVENTCLASS_NODE, LOG_INFO, "", "Error getting nodes: %s", err);
 		return NULL;
 	}
@@ -341,13 +332,16 @@ query_nodes(int pbs_sd, server_info *sinfo)
 
 		ninfo_arr[nidx] = NULL;
 	} else {
+		int chunk_size = num_nodes / num_threads;
+		int th_err = 0;
+		int j;
+		int num_tasks;
 		if ((ninfo_arr = static_cast<node_info **>(malloc((num_nodes + 1) * sizeof(node_info *)))) == NULL) {
 			log_err(errno, __func__, MEM_ERR_MSG);
 			pbs_statfree(nodes);
 			return NULL;
 		}
 		ninfo_arr[0] = NULL;
-		chunk_size = num_nodes / num_threads;
 		chunk_size = (chunk_size > MT_CHUNK_SIZE_MIN) ? chunk_size : MT_CHUNK_SIZE_MIN;
 		for (j = 0, num_tasks = 0; num_nodes > 0;
 				j += chunk_size, num_tasks++, num_nodes -= chunk_size) {
@@ -375,13 +369,13 @@ query_nodes(int pbs_sd, server_info *sinfo)
 			th_err = 1;
 		}
 		/* Get results from worker threads */
-		for (i = 0; i < num_tasks;) {
+		for (int i = 0; i < num_tasks;) {
 			pthread_mutex_lock(&result_lock);
 			while (ds_queue_is_empty(result_queue))
 				pthread_cond_wait(&result_cond, &result_lock);
 			while (!ds_queue_is_empty(result_queue)) {
-				task = (th_task_info *) ds_dequeue(result_queue);
-				tdata = (th_data_query_ninfo *) task->thread_data;
+				task = static_cast<th_task_info *>(ds_dequeue(result_queue));
+				tdata = static_cast<th_data_query_ninfo *>(task->thread_data);
 				if (tdata->error)
 					th_err = 1;
 				ninfo_arrs_tasks[task->task_id] = tdata->oarr;
@@ -397,11 +391,11 @@ query_nodes(int pbs_sd, server_info *sinfo)
 			return NULL;
 		}
 		/* Assemble node info objects from various threads into the ninfo_arr */
-		for (i = 0; i < num_tasks; i++) {
+		for (int i = 0; i < num_tasks; i++) {
 			if (ninfo_arrs_tasks[i] != NULL) {
 				node_info *ninfo;
 
-				for (j = 0; (ninfo = ninfo_arrs_tasks[i][j]) != NULL; j++) {
+				for (int j = 0; (ninfo = ninfo_arrs_tasks[i][j]) != NULL; j++) {
 					ninfo->rank = get_sched_rank();
 					ninfo_arr[nidx++] = ninfo;
 				}
@@ -744,7 +738,7 @@ free_node_info_chunk(th_data_free_ninfo *data)
 static inline th_data_free_ninfo *
 alloc_tdata_free_nodes(node_info **ninfo_arr, int sidx, int eidx)
 {
-	th_data_free_ninfo *tdata = NULL;
+	th_data_free_ninfo *tdata;
 
 	tdata = static_cast<th_data_free_ninfo *>(malloc(sizeof(th_data_free_ninfo)));
 	if (tdata == NULL) {
@@ -870,11 +864,11 @@ node_info::~node_info()
 int
 set_node_info_state(node_info *ninfo, const char *state)
 {
-	char statebuf[256];			/* used to strtok() node states */
-	char *tok;				/* used with strtok() */
-	char *saveptr;
-
 	if (ninfo != NULL && state != NULL) {
+		char statebuf[256]; /* used to strtok() node states */
+		char *tok;	    /* used with strtok() */
+		char *saveptr;
+
 		/* clear all states */
 		ninfo->is_down = ninfo->is_free = ninfo->is_unknown = 0;
 		ninfo->is_sharing = ninfo->is_busy = ninfo->is_job_busy = 0;
@@ -891,7 +885,7 @@ set_node_info_state(node_info *ninfo, const char *state)
 
 			if (add_node_state(ninfo, tok) == 1)
 				log_eventf(PBSEVENT_SCHED, PBS_EVENTCLASS_NODE, LOG_INFO,
-					ninfo->name, "Unknown Node State: %s", tok);
+					   ninfo->name, "Unknown Node State: %s", tok);
 
 			tok = strtok_r(NULL, ",", &saveptr);
 		}
@@ -1139,13 +1133,12 @@ node_info *
 find_node_by_host(node_info **ninfo_arr, char *host)
 {
 	int i;
-	schd_resource *res;
 
 	if (ninfo_arr == NULL || host == NULL)
 		return NULL;
 
 	for (i = 0; ninfo_arr[i] != NULL; i++) {
-		res = find_resource(ninfo_arr[i]->res, allres["host"]);
+		auto res = find_resource(ninfo_arr[i]->res, allres["host"]);
 		if (res != NULL) {
 			if (compare_res_to_str(res, host, CMP_CASELESS))
 				break;
@@ -1208,7 +1201,7 @@ static inline th_data_dup_nd_info *
 alloc_tdata_dup_nodes(unsigned int flags, server_info *nsinfo, node_info **onodes, node_info **nnodes,
 		int sidx, int eidx)
 {
-	th_data_dup_nd_info *tdata = NULL;
+	th_data_dup_nd_info *tdata;
 
 	tdata = static_cast<th_data_dup_nd_info *>(malloc(sizeof(th_data_dup_nd_info)));
 	if (tdata == NULL) {
@@ -1244,16 +1237,12 @@ dup_nodes(node_info **onodes, server_info *nsinfo, unsigned int flags)
 	node_info **nnodes;
 	int num_nodes;
 	int thread_node_ct_left;
-	int i, j;
 	schd_resource *nres = NULL;
 	schd_resource *ores = NULL;
 	schd_resource *tres = NULL;
 	node_info *ninfo = NULL;
-	char namebuf[1024];
-	int chunk_size;
 	th_data_dup_nd_info *tdata = NULL;
 	th_task_info *task = NULL;
-	int num_tasks;
 	int th_err = 0;
 	int tid;
 
@@ -1281,8 +1270,9 @@ dup_nodes(node_info **onodes, server_info *nsinfo, unsigned int flags)
 		th_err = tdata->error;
 		free(tdata);
 	} else { /* We are multithreading */
-		j = 0;
-		chunk_size = num_nodes / num_threads;
+		int j;
+		int num_tasks;
+		int chunk_size = num_nodes / num_threads;
 		chunk_size = (chunk_size > MT_CHUNK_SIZE_MIN) ? chunk_size : MT_CHUNK_SIZE_MIN;
 		for (j = 0, num_tasks = 0; thread_node_ct_left > 0;
 				num_tasks++, j+= chunk_size, thread_node_ct_left -= chunk_size) {
@@ -1306,13 +1296,13 @@ dup_nodes(node_info **onodes, server_info *nsinfo, unsigned int flags)
 		}
 
 		/* Get results from worker threads */
-		for (i = 0; i < num_tasks;) {
+		for (int i = 0; i < num_tasks;) {
 			pthread_mutex_lock(&result_lock);
 			while (ds_queue_is_empty(result_queue))
 				pthread_cond_wait(&result_cond, &result_lock);
 			while (!ds_queue_is_empty(result_queue)) {
-				task = (th_task_info *) ds_dequeue(result_queue);
-				tdata = (th_data_dup_nd_info *) task->thread_data;
+				task = static_cast<th_task_info *>(ds_dequeue(result_queue));
+				tdata = static_cast<th_data_dup_nd_info *>(task->thread_data);
 				if (tdata->error)
 					th_err = 1;
 				free(tdata);
@@ -1331,7 +1321,7 @@ dup_nodes(node_info **onodes, server_info *nsinfo, unsigned int flags)
 
 
 	if (!(flags & DUP_INDIRECT)) {
-		for (i = 0; nnodes[i] != NULL; i++) {
+		for (int i = 0; nnodes[i] != NULL; i++) {
 			/* since the node list we're duplicating may have indirect resources
 			 * which point to resources not in our node list, we need to detect it
 			 * if we are in this case, we'll redirect them locally
@@ -1348,8 +1338,10 @@ dup_nodes(node_info **onodes, server_info *nsinfo, unsigned int flags)
 						ninfo = find_node_info(onodes, nnodes[i]->name);
 						ores = find_resource(ninfo->res, nres->def);
 						if (ores->indirect_res != NULL) {
+							char namebuf[1024];
+
 							sprintf(namebuf, "@%s", nnodes[i]->name.c_str());
-							for (j = i+1; nnodes[j] != NULL; j++) {
+							for (int j = i + 1; nnodes[j] != NULL; j++) {
 								tres = find_resource(nnodes[j]->res, nres->def);
 								if (tres != NULL) {
 									if (tres->indirect_vnode_name != NULL &&
@@ -2432,25 +2424,14 @@ eval_placement(status *policy, selspec *spec, node_info **ninfo_arr, place *pl,
 {
 	np_cache		*npc = NULL;
 	node_partition		**hostsets = NULL;
-	const char		*host_arr[2] = {"host", NULL};
-	int			i = 0;
-	int			k = 0;
 	int			tot = 0;
-	int			c = -1;
 	nspec			**nsa = NULL;
 	nspec			**ns_head = NULL;
-	char			reason[MAX_LOG_SIZE] = {0};
 	resource_req		*req = NULL;
 	schd_resource		*res = NULL;
 	selspec			*dselspec = NULL;
-	int			do_exclhost = 0;
 	node_info		**nptr = NULL;
 	static schd_error	*failerr = NULL;
-
-
-	int rc = 0; /* true if current chunk was successfully allocated */
-	/* true if any vnode is allocated from a host - used in exclhost allocation */
-	int any_succ_rc = 0;
 
 	if (spec == NULL || ninfo_arr == NULL || pl == NULL || resresv == NULL || nspec_arr == NULL)
 		return 0;
@@ -2495,12 +2476,15 @@ eval_placement(status *policy, selspec *spec, node_info **ninfo_arr, place *pl,
 		hostsets = resresv->server->hostsets;
 
 	if (hostsets == NULL) {
+		const char *host_arr[2] = {"host", NULL};
+
 		npc = find_alloc_np_cache(policy, &resresv->server->npc_arr, host_arr, nptr, NULL);
 		if (npc != NULL)
 			hostsets = npc->nodepart;
 	}
 
 	if (hostsets != NULL) {
+
 		nsa = *nspec_arr;
 		ns_head = *nspec_arr;
 
@@ -2510,26 +2494,28 @@ eval_placement(status *policy, selspec *spec, node_info **ninfo_arr, place *pl,
 				return 0;
 		}
 
-		for (i = 0; hostsets[i] != NULL && tot != spec->total_chunks; i++) {
+		for (int i = 0; hostsets[i] != NULL && tot != spec->total_chunks; i++) {
 			/* if one vnode on a host is set to force/dflt exclhost
 			 * then they all are.  The mom makes sure of this
 			 */
 			node_info **dninfo_arr = hostsets[i]->ninfo_arr;
 			enum vnode_sharing sharing = VNS_DFLT_SHARED;
+			bool do_exclhost = false;
+			int rc = 0; /* true if current chunk was successfully allocated */
+			/* true if any vnode is allocated from a host - used in exclhost allocation */
+			int any_succ_rc = 0;
 
 			if (dninfo_arr[0] != NULL)
 				sharing = dninfo_arr[0]->sharing;
 
-			do_exclhost = 0;
 			flags &= ~EVAL_EXCLSET;
 			if (sharing == VNS_FORCE_EXCLHOST ||
 				(sharing == VNS_DFLT_EXCLHOST && pl->excl == 0 && pl->share ==0)||
 				pl->exclhost) {
-				do_exclhost = 1;
+				do_exclhost = true;
 				flags |= EVAL_EXCLSET;
 			}
 
-			rc = any_succ_rc = 0;
 			log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_NODE, LOG_DEBUG,
 				resresv->name, "Evaluating host %s", hostsets[i]->res_val);
 
@@ -2566,7 +2552,7 @@ eval_placement(status *policy, selspec *spec, node_info **ninfo_arr, place *pl,
 			 * vnode from dninfo_arr[] so we don't allocate it again.
 			 */
 			else if (pl->vscatter) {
-				for (c = 0; dselspec->chunks[c] != NULL; c++) {
+				for (int c = 0; dselspec->chunks[c] != NULL; c++) {
 					/* setting rc=1 forces at least 1 loop of the while.  This should be
 					 * be rewritten in the do/while() style seen in the free block below
 					 */
@@ -2574,7 +2560,7 @@ eval_placement(status *policy, selspec *spec, node_info **ninfo_arr, place *pl,
 					if ((hostsets[i]->free_nodes > 0)
 						&& (check_avail_resources(hostsets[i]->res,
 						dselspec->chunks[c]->req, UNSET_RES_ZERO, INSUFFICIENT_RESOURCE, err))) {
-						for (k = 0; dninfo_arr[k] != NULL; k++)
+						for (int k = 0; dninfo_arr[k] != NULL; k++)
 							dninfo_arr[k]->nscr &= ~NSCR_VISITED;
 						while (rc > 0 && dselspec->chunks[c]->num_chunks > 0) {
 							rc = eval_simple_selspec(policy, spec->chunks[c], dninfo_arr, pl,
@@ -2601,6 +2587,8 @@ eval_placement(status *policy, selspec *spec, node_info **ninfo_arr, place *pl,
 						}
 					}
 					else {
+						char reason[MAX_LOG_SIZE] = {0};
+
 						if (hostsets[i]->free_nodes == 0)
 							strcpy(reason, "No free nodes available");
 						else
@@ -2635,12 +2623,12 @@ eval_placement(status *policy, selspec *spec, node_info **ninfo_arr, place *pl,
 			* If it returns success (i.e. rc=1) we are done for this host
 			*/
 			else if (pl->scatter) {
-				for (c = 0; dselspec->chunks[c] != NULL && rc == 0; c++) {
+				for (int c = 0; dselspec->chunks[c] != NULL && rc == 0; c++) {
 					if ((hostsets[i]->free_nodes > 0)
 						&& (check_avail_resources(hostsets[i]->res,
 						dselspec->chunks[c]->req, UNSET_RES_ZERO, INSUFFICIENT_RESOURCE, err))) {
 						if (dselspec->chunks[c]->num_chunks > 0) {
-							for (k = 0; dninfo_arr[k] != NULL; k++)
+							for (int k = 0; dninfo_arr[k] != NULL; k++)
 								dninfo_arr[k]->nscr &= ~NSCR_VISITED;
 
 							rc = eval_simple_selspec(policy, spec->chunks[c],
@@ -2666,6 +2654,8 @@ eval_placement(status *policy, selspec *spec, node_info **ninfo_arr, place *pl,
 						}
 					}
 					else {
+						char reason[MAX_LOG_SIZE] = {0};
+
 						if (hostsets[i]->free_nodes == 0)
 							strcpy(reason, "No free nodes available");
 						else
@@ -2712,12 +2702,12 @@ eval_placement(status *policy, selspec *spec, node_info **ninfo_arr, place *pl,
 					return 0;
 				}
 
-				for (c = 0; dselspec->chunks[c] != NULL; c++) {
+				for (int c = 0; dselspec->chunks[c] != NULL; c++) {
 					if ((hostsets[i]->free_nodes > 0)
 						&& (check_avail_resources(hostsets[i]->res,
 						dselspec->chunks[c]->req, UNSET_RES_ZERO, INSUFFICIENT_RESOURCE, err))) {
 						if (dselspec->chunks[c]->num_chunks >0) {
-							for (k = 0; dup_ninfo_arr[k] != NULL; k++)
+							for (int k = 0; dup_ninfo_arr[k] != NULL; k++)
 								dup_ninfo_arr[k]->nscr &= ~NSCR_VISITED;
 							do {
 								rc = eval_simple_selspec(policy, dselspec->chunks[c], dup_ninfo_arr,
@@ -2762,7 +2752,9 @@ eval_placement(status *policy, selspec *spec, node_info **ninfo_arr, place *pl,
 						}
 					}
 					else {
-						if (hostsets[i]->free_nodes ==0)
+						char reason[MAX_LOG_SIZE] = {0};
+
+						if (hostsets[i]->free_nodes == 0)
 							strcpy(reason, "No free nodes available");
 						else
 							translate_fail_code(err, NULL, reason);
@@ -2856,7 +2848,7 @@ eval_complex_selspec(status *policy, selspec *spec, node_info **ninfo_arr, place
 	resource_req *req;
 	schd_resource *res;
 
-	if (spec == NULL || ninfo_arr == NULL)
+	if (spec == NULL || ninfo_arr == NULL || nspec_arr == NULL)
 		return 0;
 
 	/* we have a simple selspec... just pass it along */
@@ -3437,7 +3429,6 @@ is_vnode_eligible_chunk(resource_req *specreq, node_info *node,
 int
 is_powerok(node_info *node, resource_resv *resresv, schd_error *err)
 {
-	int i;
 	int ret = NO_PROVISIONING_NEEDED;
 
 	if (!resresv->is_job)
@@ -3469,7 +3460,7 @@ is_powerok(node_info *node, resource_resv *resresv, schd_error *err)
 	 * and job with EOE
 	 */
 	if (node->run_resvs_arr) {
-		for (i = 0; node->run_resvs_arr[i]; i++) {
+		for (int i = 0; node->run_resvs_arr[i]; i++) {
 			if (node->run_resvs_arr[i]->eoename == NULL) {
 				err->error_code = PROV_RESRESV_CONFLICT;
 				return NOT_PROVISIONABLE;
@@ -3508,10 +3499,6 @@ resources_avail_on_vnode(resource_req *specreq_cons, node_info *node,
 	resource_req tmpreq = {0};
 	resource_req *req;
 	resource_req *newreq, *aoereq;
-	schd_resource *res;
-	sch_resource_t num;
-	sch_resource_t amount;
-	int allocated = 0;
 	long long num_chunks = 0;
 	int is_p;
 
@@ -3520,10 +3507,11 @@ resources_avail_on_vnode(resource_req *specreq_cons, node_info *node,
 		return 0;
 
 	if (flags & EVAL_OKBREAK) {
+		int allocated = 0;
 		/* req is the first consumable resource at this point */
 		for (req = specreq_cons; req != NULL; req = req->next) {
 			if (req->type.is_consumable) {
-				num = req->amount;
+				auto num = req->amount;
 				tmpreq.amount = 1;
 
 				tmpreq.name = req->name;
@@ -3571,14 +3559,12 @@ resources_avail_on_vnode(resource_req *specreq_cons, node_info *node,
 					if (num_chunks > num)
 						num_chunks = num;
 
-					amount = num_chunks;
-
 					if (ns != NULL) {
 						newreq = dup_resource_req(req);
 						if (newreq == NULL)
 							return 0;
 
-						newreq->amount = amount;
+						newreq->amount = num_chunks;
 
 						if (ns->ninfo == NULL) /* check if this is the first res */
 							ns->ninfo = node;
@@ -3590,18 +3576,18 @@ resources_avail_on_vnode(resource_req *specreq_cons, node_info *node,
 					/* now that we have allocated some resources to this node, we need
 					 * to remove them from the requested amount
 					 */
-					req->amount -= amount;
+					req->amount -= num_chunks;
 
-					res = find_resource(node->res, req->def);
+					auto res = find_resource(node->res, req->def);
 					if (res != NULL) {
 						if (res->indirect_res != NULL)
-							res->indirect_res->assigned += amount;
+							res->indirect_res->assigned += num_chunks;
 						else
-							res->assigned += amount;
+							res->assigned += num_chunks;
 					}
 
 					/* use tmpreq to wrap the amount so we can use res_to_str */
-					tmpreq.amount = amount;
+					tmpreq.amount = num_chunks;
 
 					log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_NODE, LOG_DEBUG, node->name,
 						"vnode allocated %s=%s", req->name, res_to_str(&tmpreq, RF_REQUEST));
@@ -3623,8 +3609,7 @@ resources_avail_on_vnode(resource_req *specreq_cons, node_info *node,
 				pbs_strncpy(last_node_name, node->name.c_str(), sizeof(last_node_name));
 			return 1;
 		}
-	}
-	else {
+	} else {
 		num_chunks = check_resources_for_node(specreq_cons, node, resresv, err);
 		if (num_chunks > 0) {
 			is_p = is_provisionable(node, resresv, err);
@@ -3703,28 +3688,15 @@ check_resources_for_node(resource_req *resreq, node_info *ninfo,
 	 */
 	long long min_chunks = UNSPECIFIED;
 	long long chunks = UNSPECIFIED;   /*number of chunks which can be satisfied*/
-	int resresv_excl = 0;
-	resource_req *req;
-	schd_resource *nres;
-	schd_resource *cur_res;
-	event_list *calendar;
 
-	schd_resource *noderes;
-
-	time_t event_time = 0;
-	time_t cur_time;
 	time_t end_time;
-	int is_run_event;
 
-	nspec *ns;
 	timed_event *event;
-	unsigned int event_mask;
-	int i;
 
 	if (resreq == NULL || ninfo == NULL || err == NULL || resresv == NULL)
 		return -1;
 
-	noderes = ninfo->res;
+	auto noderes = ninfo->res;
 
 	min_chunks = check_avail_resources(noderes, resreq,
 		CHECK_ALL_BOOLS|UNSET_RES_ZERO, INSUFFICIENT_RESOURCE, err);
@@ -3732,8 +3704,8 @@ check_resources_for_node(resource_req *resreq, node_info *ninfo,
 	if (chunks != UNSPECIFIED && (min_chunks == SCHD_INFINITY || chunks < min_chunks))
 		min_chunks = chunks;
 
-	calendar = ninfo->server->calendar;
-	cur_time = ninfo->server->server_time;
+	auto calendar = ninfo->server->calendar;
+	auto cur_time = ninfo->server->server_time;
 	if(resresv->duration != resresv->hard_duration &&
 	   exists_resv_event(calendar, cur_time + resresv->hard_duration))
 		end_time = cur_time + calc_time_left(resresv, 1);
@@ -3755,25 +3727,24 @@ check_resources_for_node(resource_req *resreq, node_info *ninfo,
 		 * from t1 to t2, then the resources should be taken out at t1 and returned
 		 * at t2.
 		 */
-		nres = dup_ind_resource_list(noderes);
-		resresv_excl = is_excl(resresv->place_spec, ninfo->sharing);
+		auto nres = dup_ind_resource_list(noderes);
+		auto resresv_excl = is_excl(resresv->place_spec, ninfo->sharing);
 
 		if (nres != NULL) {
-			resource_resv *resc_resv;
-
 			/* Walk the event list by time such that the start of an event always
 			 * precedes the end of it. The event type (start or end event) is
 			 * determined, and the resources are consumed if a start event, and
 			 * released if an end event.
 			 */
 			event = get_next_event(calendar);
-			event_mask = TIMED_RUN_EVENT | TIMED_END_EVENT;
+			const auto event_mask = TIMED_RUN_EVENT | TIMED_END_EVENT;
 
 			for (event = find_init_timed_event(event, IGNORE_DISABLED_EVENTS, event_mask);
 				event != NULL && min_chunks > 0;
 				event = find_next_timed_event(event, IGNORE_DISABLED_EVENTS, event_mask)) {
-				event_time = event->event_time;
-				resc_resv = (resource_resv *) event->event_ptr;
+				auto event_time = event->event_time;
+				auto resc_resv = static_cast<resource_resv *>(event->event_ptr);
+				nspec *ns;
 
 				if (event_time < cur_time)
 					continue;
@@ -3781,18 +3752,18 @@ check_resources_for_node(resource_req *resreq, node_info *ninfo,
 					continue;
 
 				if (resc_resv->nspec_arr != NULL) {
+					int i;
 					for (i = 0; resc_resv->nspec_arr[i] != NULL &&
-						resc_resv->nspec_arr[i]->ninfo->rank != ninfo->rank; i++)
+							resc_resv->nspec_arr[i]->ninfo->rank != ninfo->rank; i++)
 						;
 					ns = resc_resv->nspec_arr[i];
-				}
-				else {
+				} else {
 					ns = NULL;
 					log_eventf(PBSEVENT_SCHED, PBS_EVENTCLASS_SCHED, LOG_WARNING, resresv->name,
 						"Event %s is a run/end event w/o nspec array, ignoring event", event->name.c_str());
 				}
 
-				is_run_event = (event->event_type == TIMED_RUN_EVENT);
+				auto is_run_event = (event->event_type == TIMED_RUN_EVENT);
 
 				if ((event_time < end_time) && resresv != resc_resv && ns != NULL) {
 					/* One event will need provisioning while the other will not,
@@ -3807,15 +3778,13 @@ check_resources_for_node(resource_req *resreq, node_info *ninfo,
 					if (is_excl(resc_resv->place_spec, ninfo->sharing) || resresv_excl) {
 						min_chunks = 0;
 					} else {
-						cur_res = nres;
-						while (cur_res != NULL) {
+						for (auto cur_res = nres; cur_res  != NULL; cur_res = cur_res->next) {
 							if (cur_res->type.is_consumable) {
-								req = find_resource_req(ns->resreq, cur_res->def);
+								auto req = find_resource_req(ns->resreq, cur_res->def);
 								if (req != NULL) {
 									cur_res->assigned += is_run_event ? req->amount : -req->amount;
 								}
 							}
-							cur_res = cur_res->next;
 						}
 						if (is_run_event) {
 							chunks = check_avail_resources(nres, resreq,
@@ -4004,7 +3973,6 @@ parse_selspec(const std::string& sspec)
 	resource_req *req_head = NULL;
 	resource_req *req_end = NULL;
 	resource_req *req;
-	int ret;
 	int invalid = 0;
 
 	int num_kv;
@@ -4045,9 +4013,9 @@ parse_selspec(const std::string& sspec)
 	while (tok != NULL && !invalid) {
 		tmpptr = string_dup(tok);
 #ifdef NAS /* localmod 082 */
-		ret = parse_chunk_r(tok, 0, &num_chunks, &num_kv, &nkvelements, &kv, NULL);
+		auto ret = parse_chunk_r(tok, 0, &num_chunks, &num_kv, &nkvelements, &kv, NULL);
 #else
-		ret = parse_chunk_r(tok, &num_chunks, &num_kv, &nkvelements, &kv, NULL);
+		auto ret = parse_chunk_r(tok, &num_chunks, &num_kv, &nkvelements, &kv, NULL);
 #endif /* localmod 082 */
 
 		if (!ret) {
@@ -4152,7 +4120,6 @@ int compare_chunk(chunk *c1, chunk *c2) {
  *	@retval 0 if not equal
  */
 int compare_selspec(selspec *s1, selspec *s2) {
-	int i;
 	int ret = 1;
 
 	if(s1 == NULL && s2 == NULL)
@@ -4164,7 +4131,7 @@ int compare_selspec(selspec *s1, selspec *s2) {
 		return 0;
 
 	if (s1->chunks != NULL && s2->chunks != NULL) {
-		for (i = 0; ret && s1->chunks[i] != NULL; i++) {
+		for (int i = 0; ret && s1->chunks[i] != NULL; i++) {
 			if (compare_chunk(s1->chunks[i], s2->chunks[i]) == 0)
 				ret = 0;
 		}
@@ -4334,8 +4301,10 @@ parse_execvnode(char *execvnode, server_info *sinfo, selspec *sel)
 		return NULL;
 	}
 
-	if ((excvndup = string_dup(execvnode)) == NULL)
+	if ((excvndup = string_dup(execvnode)) == NULL) {
+		free(nspec_arr);
 		return NULL;
+	}
 
 	simplespec = parse_plus_spec_r(excvndup, &tailptr, &hp);
 	if (hp > 0) /* simplespec starts with '(' but doesn't close */
@@ -4840,8 +4809,7 @@ is_excl(place *pl, enum vnode_sharing sharing)
 int
 alloc_rest_nodepart(nspec **nsa, node_info **ninfo_arr)
 {
-	nspec *ns;
-	int i, j;
+	int j;
 	int max_seq_num = 0;
 	if (nsa == NULL || ninfo_arr == NULL)
 		return 0;
@@ -4855,8 +4823,8 @@ alloc_rest_nodepart(nspec **nsa, node_info **ninfo_arr)
 			max_seq_num = nsa[j]->seq_num;
 	}
 
-	for (i = 0; ninfo_arr[i] != NULL; i++) {
-		ns = find_nspec(nsa, ninfo_arr[i]);
+	for (int i = 0; ninfo_arr[i] != NULL; i++) {
+		const auto ns = find_nspec(nsa, ninfo_arr[i]);
 
 		/* node not part of solution */
 		if (ns == NULL) {
@@ -4878,54 +4846,6 @@ alloc_rest_nodepart(nspec **nsa, node_info **ninfo_arr)
 
 	return 1;
 }
-
-/**
- * @brief
- *		set_res_on_host - set a resource on all the vnodes of a host
- *
- * @param[in]	res_name	-	name of the res to set
- * param[in]	res_value	-	value to set the res
- * param[in]	host	-	name of the host
- * param[in]	exclude	-	node to exclude being set
- * param[in,out]	ninfo_arr	-	array to search through
- *
- * @return	int
- * @retval	1	: on success
- * @retval	0	: on error
- *
- */
-int
-set_res_on_host(char *res_name, char *res_value,
-	char *host, node_info *exclude, node_info **ninfo_arr)
-{
-	int i;
-	schd_resource *hostres;
-	schd_resource *res;
-	int rc = 1;
-
-	if (res_name == NULL || res_value == NULL || host == NULL || ninfo_arr == NULL)
-		return 0;
-
-	for (i = 0; ninfo_arr[i] != NULL && rc; i++) {
-		if (ninfo_arr[i] != exclude) {
-			hostres = find_resource(ninfo_arr[i]->res, allres["host"]);
-
-			if (hostres != NULL) {
-				if (compare_res_to_str(hostres, host, CMP_CASELESS)) {
-					res = find_alloc_resource_by_str(ninfo_arr[i]->res, res_name);
-					if (res != NULL) {
-						if (ninfo_arr[i]->res == NULL)
-							ninfo_arr[i]->res = res;
-
-						rc = set_resource(res, res_value, RF_AVAIL);
-					}
-				}
-			}
-		}
-	}
-	return rc;
-}
-
 
 /**
  * @brief
@@ -4972,43 +4892,6 @@ can_fit_on_vnode(resource_req *req, node_info **ninfo_arr)
 				return 1;
 		}
 	}
-
-	return 0;
-}
-
-/**
- * @brief
- *		Checks if an AOE is available on a vnode
- *
- * @par Functionality:
- *		This function checks if an AOE is available on a vnode.
- *
- * @param[in]	ninfo		-	pointer to node_info
- * @param[in]	resresv		-	pointer to resource_resv
- *
- * @return	int
- * @retval	 0 : AOE not available
- * @retval	 1 : AOE available
- *
- * @par Side Effects:
- *		Unknown
- *
- * @par MT-safe: No
- *
- */
-int
-is_aoe_avail_on_vnode(node_info *ninfo, resource_resv *resresv)
-{
-	schd_resource *resp;
-
-	if (ninfo == NULL || resresv == NULL)
-		return 0;
-
-	if (resresv->aoename == NULL)
-		return 0;
-
-	if ((resp = find_resource(ninfo->res, allres["aoe"])) != NULL)
-		return is_string_in_arr(resp->str_avail, resresv->aoename);
 
 	return 0;
 }
@@ -5229,8 +5112,6 @@ node_up_event(node_info *node, void *arg)
 int
 node_down_event(node_info *node, void *arg)
 {
-	int i;
-	const char *job_state;
 	server_info *sinfo;
 
 	if (node == NULL)
@@ -5238,7 +5119,9 @@ node_down_event(node_info *node, void *arg)
 
 	sinfo = node->server;
 	if (node->job_arr != NULL) {
-		for (i = 0; node->job_arr[i] != NULL; i++) {
+		for (int i = 0; node->job_arr[i] != NULL; i++) {
+			const char *job_state;
+
 			if (node->job_arr[i]->job->can_requeue)
 				job_state = "Q";
 			else
@@ -5257,31 +5140,6 @@ node_down_event(node_info *node, void *arg)
 	update_all_nodepart(sinfo->policy, sinfo, NO_ALLPART);
 
 	return 1;
-}
-
-/**
- * @brief
- * 		filter function to check if node is in a string array of node names
- *
- * @see	node_filter
- *
- * @param[in]	node	- node to check
- * @param[in] 	strarr	- array of node names
- *
- * @returns	int
- * @retval	1	: include node in array
- * @retval	0	: don't include node in array
- */
-int
-node_in_str(node_info *node, void *strarr)
-{
-	if (node == NULL || strarr == NULL)
-		return 0;
-
-	if (is_string_in_arr((char **)strarr, node->name.c_str()))
-		return 1;
-
-	return 0;
 }
 
 /**
@@ -5452,9 +5310,9 @@ sim_exclhost_func(timed_event *te, void *arg1, void *arg2)
 	if (te == NULL || arg1 == NULL || arg2 == NULL)
 		return 0;
 
-	resresv = (resource_resv*) arg1;
-	ninfo = (node_info*) arg2;
-	future_resresv = (resource_resv*) te->event_ptr;
+	resresv = static_cast<resource_resv *>(arg1);
+	ninfo = static_cast<node_info *>(arg2);
+	future_resresv = static_cast<resource_resv *>(te->event_ptr);
 	if (find_nspec_by_rank(future_resresv->nspec_arr, ninfo->rank) ==NULL)
 		return 0; /* event does not affect the node */
 
@@ -5638,7 +5496,7 @@ static inline th_data_nd_eligible *
 alloc_tdata_nd_eligible(place *pl, resource_resv *resresv, node_info **ninfo_arr,
 		int sidx, int eidx)
 {
-	th_data_nd_eligible *tdata = NULL;
+	th_data_nd_eligible *tdata;
 
 	tdata = static_cast<th_data_nd_eligible *>(malloc(sizeof(th_data_nd_eligible)));
 	if (tdata == NULL)  {
@@ -5674,11 +5532,8 @@ void
 check_node_array_eligibility(node_info **ninfo_arr, resource_resv *resresv, place *pl,
 		int num_nodes, schd_error *err)
 {
-	int i, j;
 	th_data_nd_eligible *tdata = NULL;
 	th_task_info *task = NULL;
-	int chunk_size;
-	int num_tasks;
 	int tid;
 
 	if (ninfo_arr == NULL || resresv == NULL || pl == NULL || err == NULL)
@@ -5698,7 +5553,9 @@ check_node_array_eligibility(node_info **ninfo_arr, resource_resv *resresv, plac
 		free_schd_error(tdata->err);
 		free(tdata);
 	} else {	 /* We are multithreading */
-		chunk_size = num_nodes / num_threads;
+		int j;
+		int num_tasks;
+		int chunk_size = num_nodes / num_threads;
 		chunk_size = (chunk_size > MT_CHUNK_SIZE_MIN) ? chunk_size : MT_CHUNK_SIZE_MIN;
 		for (j = 0, num_tasks = 0; num_nodes > 0;
 				num_tasks++, j += chunk_size, num_nodes -= chunk_size) {
@@ -5719,13 +5576,13 @@ check_node_array_eligibility(node_info **ninfo_arr, resource_resv *resresv, plac
 		}
 
 		/* Get results from worker threads */
-		for (i = 0; i < num_tasks;) {
+		for (int i = 0; i < num_tasks;) {
 			pthread_mutex_lock(&result_lock);
 			while (ds_queue_is_empty(result_queue))
 				pthread_cond_wait(&result_cond, &result_lock);
 			while (!ds_queue_is_empty(result_queue)) {
-				task = (th_task_info *) ds_dequeue(result_queue);
-				tdata = (th_data_nd_eligible *) task->thread_data;
+				task = static_cast<th_task_info *>(ds_dequeue(result_queue));
+				tdata = static_cast<th_data_nd_eligible *>(task->thread_data);
 				if (err->status_code == SCHD_UNKWN && tdata->err->status_code != SCHD_UNKWN)
 					copy_schd_error(err, tdata->err);
 
@@ -5770,29 +5627,6 @@ node_in_partition(node_info *ninfo, char *partition)
 }
 
 /**
- * @brief
- *		node_partition_cmp - used with node_filter to filter nodes attached to a
- *		   specific partition
- *
- * @param[in]	node	-	the node we're currently filtering
- * @param[in]	arg	-	the name of the partition
- *
- * @return	int
- * @return	1	: keep the node
- * @return	0	: don't keep the node
- *
- */
-int
-node_partition_cmp(node_info *ninfo, void *arg)
-{
-	if (ninfo->partition != NULL)
-		if (!strcmp(ninfo->partition,  (char *) arg))
-			return 1;
-
-	return 0;
-}
-
-/**
  * @brief add an event to all the nodes associated to a calendar event
  * @param te - event
  * @param nspecs - nspecs[i]->node is the node to add the event to
@@ -5834,7 +5668,7 @@ int add_event_to_nodes(timed_event *te, nspec **nspecs) {
 int add_node_events(timed_event *te, void *arg1, void *arg2) {
 	if (!te->disabled) {
 		nspec **nspecs;
-		nspecs = ((resource_resv *) te->event_ptr)->nspec_arr;
+		nspecs = (static_cast<resource_resv *>(te->event_ptr))->nspec_arr;
 
 		if (add_event_to_nodes(te, nspecs) == 0)
 			return -1;

--- a/src/scheduler/node_info.cpp
+++ b/src/scheduler/node_info.cpp
@@ -478,6 +478,7 @@ query_node_info(struct batch_status *node, server_info *sinfo)
 			ninfo->partition = string_dup(attrp->value);
 			if (ninfo->partition == NULL) {
 				log_err(errno, __func__, MEM_ERR_MSG);
+				delete ninfo;
 				return NULL;
 			}
 		}
@@ -2585,8 +2586,7 @@ eval_placement(status *policy, selspec *spec, node_info **ninfo_arr, place *pl,
 								clear_schd_error(err);
 							}
 						}
-					}
-					else {
+					} else {
 						char reason[MAX_LOG_SIZE] = {0};
 
 						if (hostsets[i]->free_nodes == 0)
@@ -3976,7 +3976,7 @@ parse_selspec(const std::string& sspec)
 	int invalid = 0;
 
 	int num_kv;
-	struct key_value_pair *kv;
+	struct key_value_pair *kv = NULL;
 	int nkvelements = 0;
 
 	int num_chunks;
@@ -3999,10 +3999,12 @@ parse_selspec(const std::string& sspec)
 	if ((spec->chunks = static_cast<chunk **>(calloc(num_plus + 2, sizeof(chunk *)))) == NULL) {
 		log_err(errno, __func__, MEM_ERR_MSG);
 		delete spec;
+		return 0;
 	}
 
 	specbuf = string_dup(select_spec);
 	if (specbuf == NULL) {
+		delete spec;
 		log_err(errno, __func__, MEM_ERR_MSG);
 		return 0;
 	}

--- a/src/scheduler/node_info.h
+++ b/src/scheduler/node_info.h
@@ -156,12 +156,6 @@ void update_node_on_run(nspec *ns, resource_resv *resresv, const char *job_state
 int node_queue_cmp(node_info *ninfo, void *arg);
 
 /*
- *      node_partition_cmp - used with node_filter to filter nodes attached to a
- *                           specific partition
- */
-int node_partition_cmp(node_info *ninfo, void *arg);
-
-/*
  *      update_node_on_end - update a node when a job ends
  */
 void update_node_on_end(node_info *ninfo, resource_resv *resresv, const char *job_state);
@@ -488,22 +482,6 @@ int is_exclhost(place *pl, enum vnode_sharing sharing);
 int alloc_rest_nodepart(nspec **nsa, node_info **ninfo_arr);
 
 /*
- *	set_res_on_host - set a resource on all the vnodes of a host
- *
- *	  res_name  - name of the res to set
- *	  res_value - value to set the res
- *	  host      - name of the host
- *	  exclude   - node to exclude from being set
- *	  ninfo_arr - array to search through
- *
- *	returns 1 on success 0 on error
- */
-int
-set_res_on_host(char *res_name, char *res_value,
-	char *host, node_info *exclude, node_info **ninfo_arr);
-
-
-/*
  *	can_fit_on_vnode - see if a chunk fit on one vnode in node list
  *
  *	  req - requested resources to compare to nodes
@@ -513,17 +491,6 @@ set_res_on_host(char *res_name, char *res_value,
  *		0: chunk can not fit / error
  */
 int can_fit_on_vnode(resource_req *req,  node_info **ninfo_arr);
-
-
-/*
- *      is_aoe_avail_on_vnode - it first finds if aoe is available in node's
- *                              available list
- *
- *      return : 0 if aoe not available on node
- *             : 1 if aoe available
- *
- */
-int is_aoe_avail_on_vnode(node_info *ninfo, resource_resv *resresv);
 
 /*
  *      is_eoe_avail_on_vnode - it first finds if eoe is available in node's

--- a/src/scheduler/node_partition.h
+++ b/src/scheduler/node_partition.h
@@ -216,7 +216,7 @@ int resresv_can_fit_nodepart(status *policy, node_partition *np, resource_resv *
  */
 node_partition *create_specific_nodepart(status *policy, const char *name, node_info **nodes, int flags );
 /* create the placement sets for the server and queues */
-int create_placement_sets(status *policy, server_info *sinfo);
+bool create_placement_sets(status *policy, server_info *sinfo);
 
 /* Update placement sets and allparts */
 void update_all_nodepart(status *policy, server_info *sinfo, unsigned int flags);

--- a/src/scheduler/pbs_bitmap.cpp
+++ b/src/scheduler/pbs_bitmap.cpp
@@ -61,7 +61,7 @@ pbs_bitmap_alloc(pbs_bitmap *pbm, unsigned long num_bits)
 	unsigned long *tmp_bits;
 	long prev_longs;
 
-	if(num_bits <= 0)
+	if(num_bits == 0)
 		return NULL;
 
 	if(pbm == NULL) {

--- a/src/scheduler/prev_job_info.cpp
+++ b/src/scheduler/prev_job_info.cpp
@@ -90,9 +90,8 @@ create_prev_job_info(resource_resv **jobs)
 	}
 }
 
-prev_job_info::prev_job_info(const std::string& pname, const std::string& ename, resource_req *rused): name(pname), entity_name(ename)
+prev_job_info::prev_job_info(const std::string& pname, const std::string& ename, resource_req *rused): name(pname), entity_name(ename), resused(rused)
 {
-	resused = rused;
 }
 
 prev_job_info::prev_job_info(const prev_job_info& opj): name(opj.name), entity_name(opj.entity_name)

--- a/src/scheduler/prime.cpp
+++ b/src/scheduler/prime.cpp
@@ -185,7 +185,7 @@ enum prime_time check_prime(enum days d, struct tm *t)
 	 *  in which case the current time is NONPRIME only between NP and P
 	 *  This case also captures the setting of identical Prime and Nonprime times in the "holidays" file
 	 */
-	else if (npt <= pt) {
+	else if (npt < pt) {
 		if (npt <= ct && ct < pt)
 			prime = NON_PRIME;
 		else prime = PRIME;
@@ -488,11 +488,6 @@ parse_holidays(const char *fname)
 int
 load_day(enum days d, enum prime_time pr, const char *tok)
 {
-	int num;		/* used to convert string -> integer */
-	int hours;		/* used to convert 4 digit HHMM into hours */
-	int mins;		/* used to convert 4 digit HHMM into minutes */
-	char *endp;		/* used wtih strtol() */
-
 	if (tok != NULL) {
 		if (!strcmp(tok, "all") || !strcmp(tok, "ALL")) {
 			if (pr == NON_PRIME && conf.prime[d][PRIME].all == TRUE) {
@@ -515,11 +510,12 @@ load_day(enum days d, enum prime_time pr, const char *tok)
 			conf.prime[d][pr].min = static_cast<unsigned int>(UNSPECIFIED);
 			conf.prime[d][pr].none = TRUE;
 		} else {
-			num = strtol(tok, &endp, 10);
+			char *endp; /* used wtih strtol() */
+			auto num = strtol(tok, &endp, 10);
 			if (*endp == '\0') {
 				/* num is a 4 digit number of the time HHMM */
-				mins = num % 100;
-				hours = num / 100;
+				auto mins = num % 100;
+				auto hours = num / 100;
 				conf.prime[d][pr].hour = hours;
 				conf.prime[d][pr].min = mins;
 			}

--- a/src/scheduler/queue.cpp
+++ b/src/scheduler/queue.cpp
@@ -59,7 +59,7 @@
 ds_queue *
 new_ds_queue(void)
 {
-	ds_queue *ret_obj = NULL;
+	ds_queue *ret_obj;
 
 	ret_obj = static_cast<ds_queue *>(malloc(sizeof(ds_queue)));
 	if (ret_obj == NULL) {

--- a/src/scheduler/resource.cpp
+++ b/src/scheduler/resource.cpp
@@ -430,10 +430,9 @@ std::unordered_set<resdef *>
 resstr_to_resdef(const std::unordered_set<std::string>& resstr)
 {
 	std::unordered_set<resdef *> defs;
-	resdef *def;
 
 	for (const auto& str : resstr) {
-		def = find_resdef(str);
+		auto def = find_resdef(str);
 		if (def != NULL)
 			defs.insert(def);
 		else {
@@ -448,10 +447,9 @@ std::unordered_set<resdef *>
 resstr_to_resdef(const char * const* resstr)
 {
 	std::unordered_set<resdef *> defs;
-	resdef *def;
 
 	for (int i = 0; resstr[i] != NULL; i++) {
-		def = find_resdef(resstr[i]);
+		auto def = find_resdef(resstr[i]);
 		if (def != NULL)
 			defs.insert(def);
 		else {

--- a/src/scheduler/resource_resv.cpp
+++ b/src/scheduler/resource_resv.cpp
@@ -303,7 +303,7 @@ free_resource_resv_array(resource_resv **resresv_arr)
 }
 
 /**
- * @brie& 
+ * @brief
  *		resource_resv destructor
  *
  */
@@ -2037,7 +2037,7 @@ new_chunk()
  * @return	duplicate chunk array.
  */
 chunk **
-dup_chunk_array(chunk **old_chunk_arr)
+dup_chunk_array(const chunk * const *old_chunk_arr)
 {
 	int i;
 	int ct;
@@ -2080,7 +2080,7 @@ dup_chunk_array(chunk **old_chunk_arr)
  * @return	duplicate chunk structure.
  */
 chunk *
-dup_chunk(chunk *ochunk)
+dup_chunk(const chunk *ochunk)
 {
 	chunk *nchunk;
 
@@ -2188,7 +2188,7 @@ selspec::selspec()
  *
  * @param[in]	oldspec	-	old selspec to be copied
  */
-selspec::selspec(selspec& oldspec)
+selspec::selspec(const selspec& oldspec)
 {
 	total_chunks = oldspec.total_chunks;
 	total_cpus = oldspec.total_cpus;
@@ -2196,7 +2196,7 @@ selspec::selspec(selspec& oldspec)
 	defs = oldspec.defs;
 }
 
-selspec& selspec::operator=(selspec& oldspec)
+selspec& selspec::operator=(const selspec& oldspec)
 {
 	total_chunks = oldspec.total_chunks;
 	total_cpus = oldspec.total_cpus;

--- a/src/scheduler/resource_resv.cpp
+++ b/src/scheduler/resource_resv.cpp
@@ -52,8 +52,6 @@
  * 	find_resource_resv()
  * 	find_resource_resv_by_indrank()
  * 	find_resource_resv_by_time()
- * 	find_resource_resv_func()
- * 	cmp_job_arrays()
  * 	is_resource_resv_valid()
  * 	dup_resource_req_list()
  * 	dup_resource_req()
@@ -217,7 +215,7 @@ free_resource_resv_array_chunk(th_data_free_resresv *data)
 static inline th_data_free_resresv *
 alloc_tdata_free_rr_arr(resource_resv **resresv_arr, int sidx, int eidx)
 {
-	th_data_free_resresv *tdata = NULL;
+	th_data_free_resresv *tdata;
 
 	tdata = static_cast<th_data_free_resresv *>(malloc(sizeof(th_data_free_resresv)));
 	if (tdata == NULL) {
@@ -305,7 +303,7 @@ free_resource_resv_array(resource_resv **resresv_arr)
 }
 
 /**
- * @brief
+ * @brie& 
  *		resource_resv destructor
  *
  */
@@ -398,7 +396,7 @@ static inline th_data_dup_resresv *
 alloc_tdata_dup_nodes(resource_resv **oresresv_arr, resource_resv **nresresv_arr, server_info *nsinfo,
 		queue_info *nqinfo, int sidx, int eidx)
 {
-	th_data_dup_resresv *tdata = NULL;
+	th_data_dup_resresv *tdata;
 
 	tdata = static_cast<th_data_dup_resresv *>(malloc(sizeof(th_data_dup_resresv)));
 	if (tdata == NULL) {
@@ -433,11 +431,8 @@ dup_resource_resv_array(resource_resv **oresresv_arr,
 	server_info *nsinfo, queue_info *nqinfo)
 {
 	resource_resv **nresresv_arr;
-	int i, j;
-	int chunk_size;
 	th_data_dup_resresv *tdata = NULL;
 	th_task_info *task = NULL;
-	int num_tasks;
 	int num_resresv;
 	int thread_job_ct_left;
 	int th_err = 0;
@@ -466,10 +461,11 @@ dup_resource_resv_array(resource_resv **oresresv_arr,
 			free(tdata);
 		}
 	} else { /* We are multithreading */
-		chunk_size = num_resresv / num_threads;
+		int num_tasks = 0;
+		int chunk_size = num_resresv / num_threads;
 		chunk_size = (chunk_size > MT_CHUNK_SIZE_MIN)? chunk_size: MT_CHUNK_SIZE_MIN;
 		chunk_size = (chunk_size < MT_CHUNK_SIZE_MAX)? chunk_size: MT_CHUNK_SIZE_MAX;
-		for (j = 0, num_tasks = 0; thread_job_ct_left > 0;
+		for (int j = 0; thread_job_ct_left > 0;
 				num_tasks++, j += chunk_size, thread_job_ct_left -= chunk_size) {
 			tdata = alloc_tdata_dup_nodes(oresresv_arr, nresresv_arr, nsinfo, nqinfo, j, j + chunk_size - 1);
 			if (tdata == NULL) {
@@ -485,13 +481,13 @@ dup_resource_resv_array(resource_resv **oresresv_arr,
 		}
 
 		/* Get results from worker threads */
-		for (i = 0; i < num_tasks;) {
+		for (int i = 0; i < num_tasks;) {
 			pthread_mutex_lock(&result_lock);
 			while (ds_queue_is_empty(result_queue))
 				pthread_cond_wait(&result_cond, &result_lock);
 			while (!ds_queue_is_empty(result_queue)) {
-				task = (th_task_info *) ds_dequeue(result_queue);
-				tdata = (th_data_dup_resresv *) task->thread_data;
+				task = static_cast<th_task_info *>(ds_dequeue(result_queue));
+				tdata = static_cast<th_data_dup_resresv *>(task->thread_data);
 				if (tdata->error)
 					th_err = 1;
 				free(tdata);
@@ -723,62 +719,6 @@ find_resource_resv_by_time(resource_resv **resresv_arr, const std::string& name,
 	}
 
 	return resresv_arr[i];
-}
-
-/**
- * @brief
- * 		find a resource resv by calling a caller provided comparison function
- *
- * @param[in]	resresv_arr - array of resource_resvs to search
- * @param[in]	fn int cmp_func(resource_resv *rl, void *cmp_arg)
- * @param[in]	cmp_arg - opaque argument for cmp_func()
- *
- * @return found resource_resv or NULL
- *
- */
-resource_resv *
-find_resource_resv_func(resource_resv **resresv_arr,
-	int (*cmp_func)(resource_resv*, void*), void *cmp_arg)
-{
-	int i;
-	if (resresv_arr == NULL || cmp_func == NULL || cmp_arg == NULL)
-		return NULL;
-
-	for (i = 0; resresv_arr[i] != NULL &&
-		cmp_func(resresv_arr[i], cmp_arg) == 0; i++)
-		;
-	return resresv_arr[i];
-}
-
-/**
- * @brief
- * 		function used by find_resource_resv_func to see if two subjobs are
- *	 	 part of the same job array (e.g., 1234[])
- *
- * @param[in]	resresv	-	resource_resv structure
- * @param[in]	arg	-	argument resource reservation.
- */
-int
-cmp_job_arrays(resource_resv *resresv, void *arg)
-{
-	resource_resv *argresv;
-
-	if (resresv == NULL || arg == NULL)
-		return 0;
-
-	argresv = (resource_resv *) arg;
-
-	if (resresv->job == NULL || argresv->job ==NULL)
-		return 0;
-
-	/* if one is not a subjob = no match */
-	if (resresv->job->array_id.empty() || argresv->job->array_id.empty())
-		return 0;
-
-	if (resresv->job->array_id == argresv->job->array_id)
-		return 1;
-
-	return 0;
 }
 
 /**
@@ -1391,11 +1331,11 @@ set_resource_req(resource_req *req, const char *val)
 void
 free_resource_req_list(resource_req *list)
 {
-	resource_req *resreq, *tmp;
+	resource_req *resreq;
 
 	resreq = list;
 	while (resreq != NULL) {
-		tmp = resreq;
+		auto tmp = resreq;
 		resreq = resreq->next;
 		free_resource_req(tmp);
 	}
@@ -1412,11 +1352,11 @@ free_resource_req_list(resource_req *list)
 void
 free_resource_count_list(resource_count *list)
 {
-	resource_count *rcount, *tmp;
+	resource_count *rcount;
 
 	rcount = list;
 	while (rcount != NULL) {
-		tmp = rcount;
+		auto tmp = rcount;
 		rcount = rcount->next;
 		free_resource_count(tmp);
 	}
@@ -1469,7 +1409,7 @@ compare_resource_req(resource_req *req1, resource_req *req2) {
 
 	if (req1 == NULL && req2 == NULL)
 		return 1;
-	else if (req1 == NULL || req1 == NULL)
+	else if (req1 == NULL || req2 == NULL)
 		return 0;
 
 	if (req1->type.is_consumable || req1->type.is_boolean)
@@ -1546,17 +1486,15 @@ compare_resource_req_list(resource_req *req1, resource_req *req2, std::unordered
 void
 update_resresv_on_run(resource_resv *resresv, nspec **nspec_arr)
 {
-	int ns_size;
 	queue_info *resv_queue;
 	int ret;
-	int i;
 
 	if (resresv == NULL || nspec_arr == NULL)
 		return;
 
 	if (resresv->is_job) {
 		if (resresv->job->is_suspended) {
-			for (ns_size = 0; nspec_arr[ns_size] != NULL; ns_size++)
+			for (int ns_size = 0; nspec_arr[ns_size] != NULL; ns_size++)
 				nspec_arr[ns_size]->ninfo->num_susp_jobs--;
 			if (resresv->job->resreleased != NULL) {
 				free_nspecs(resresv->job->resreleased);
@@ -1579,7 +1517,7 @@ update_resresv_on_run(resource_resv *resresv, nspec **nspec_arr)
 		resresv->job->accrue_type = JOB_RUNNING;
 
 		if (resresv->aoename != NULL) {
-			for (i = 0; nspec_arr[i] != NULL; i++) {
+			for (int i = 0; nspec_arr[i] != NULL; i++) {
 				if (nspec_arr[i]->go_provision) {
 					resresv->job->is_provisioning = 1;
 					break;
@@ -1592,7 +1530,7 @@ update_resresv_on_run(resource_resv *resresv, nspec **nspec_arr)
 			resresv->execselect = parse_selspec(selectspec);
 		}
 		if (resresv->job->dependent_jobs != NULL) {
-			for (i = 0; resresv->job->dependent_jobs[i] != NULL; i++) {
+			for (int i = 0; resresv->job->dependent_jobs[i] != NULL; i++) {
 				/* Mark all runone jobs as "can not run" */
 				resresv->job->dependent_jobs[i]->can_not_run = 1;
 			}
@@ -2256,6 +2194,15 @@ selspec::selspec(selspec& oldspec)
 	total_cpus = oldspec.total_cpus;
 	chunks = dup_chunk_array(oldspec.chunks);
 	defs = oldspec.defs;
+}
+
+selspec& selspec::operator=(selspec& oldspec)
+{
+	total_chunks = oldspec.total_chunks;
+	total_cpus = oldspec.total_cpus;
+	chunks = dup_chunk_array(oldspec.chunks);
+	defs = oldspec.defs;
+	return *this;
 }
 
 /**

--- a/src/scheduler/resource_resv.cpp
+++ b/src/scheduler/resource_resv.cpp
@@ -2301,7 +2301,7 @@ compare_non_consumable(schd_resource *res, resource_req *req)
 	 * req:   *   res: TRUE_FALSE
 	 */
 	if (req->type.is_boolean) {
-		if (!req->amount  && res == NULL)
+		if (!req->amount && res == NULL)
 			return 1;
 		else if (req->amount && res == NULL)
 			return 0;

--- a/src/scheduler/resource_resv.h
+++ b/src/scheduler/resource_resv.h
@@ -296,12 +296,12 @@ chunk *new_chunk();
 /*
  *	dup_chunk_array - array copy constructor for array of chunk ptrs
  */
-chunk **dup_chunk_array(chunk **old_chunk_arr);
+chunk **dup_chunk_array(const chunk * const *old_chunk_arr);
 
 /*
  *	dup_chunk - copy constructor for chunk
  */
-chunk *dup_chunk(chunk *ochunk);
+chunk *dup_chunk(const chunk *ochunk);
 
 /*
  *	free_chunk_array - array destructor for array of chunk ptrs

--- a/src/scheduler/resource_resv.h
+++ b/src/scheduler/resource_resv.h
@@ -314,28 +314,6 @@ void free_chunk_array(chunk **chunk_arr);
 void free_chunk(chunk *ch);
 
 /*
- *
- * find a resource resv by calling a caller provided comparison function
- *
- *	resresv_arr - array of resource_resvs to search
- *	int cmp_func(resource_resv *rl, void *cmp_arg)
- *	cmp_arg - opaque argument for cmp_func()
- *
- * return found resource_resv or NULL
- *
- */
-resource_resv *
-find_resource_resv_func(resource_resv **resresv_arr,
-	int (*cmp_func)(resource_resv*, void*), void *cmp_arg);
-/*
- *
- * function used by find_resource_resv_func to see if two subjobs are
- * part of the same job array (e.g., 1234[])
- *
- */
-int cmp_job_arrays(resource_resv *resresv, void *arg);
-
-/*
  * create_resource_req - create a new resource_req
  *
  *	return new resource_req or NULL

--- a/src/scheduler/resv_info.cpp
+++ b/src/scheduler/resv_info.cpp
@@ -101,13 +101,10 @@ struct batch_status *
 stat_resvs(int pbs_sd)
 {
 	struct batch_status *resvs;
-	/* used for pbs_geterrmsg() */
-	const char *errmsg;
-
 	/* get the reservation info from the PBS server */
 	if ((resvs = send_statresv(pbs_sd, NULL, NULL, NULL)) == NULL) {
 		if (pbs_errno) {
-			errmsg = pbs_geterrmsg(pbs_sd);
+			const char *errmsg = pbs_geterrmsg(pbs_sd);
 			if (errmsg == NULL)
 				errmsg = "";
 			log_eventf(PBSEVENT_SCHED, PBS_EVENTCLASS_RESV, LOG_NOTICE, "resv_info",
@@ -194,7 +191,6 @@ query_reservations(int pbs_sd, server_info *sinfo, struct batch_status *resvs)
 		int ignore_resv = 0;
 		clear_schd_error(err);
 		struct attrl	*attrp = NULL;
-		resource_resv **jobs_in_reservations;
 		/* Check if this reservation belongs to this scheduler */
 		for (attrp = cur_resv->attribs; attrp != NULL; attrp = attrp->next) {
 			if (strcmp(attrp->name, ATTR_partition) == 0) {
@@ -366,7 +362,7 @@ query_reservations(int pbs_sd, server_info *sinfo, struct batch_status *resvs)
 						}
 					}
 				}
-				jobs_in_reservations = resource_resv_filter(resresv->resv->resv_queue->jobs,
+				auto jobs_in_reservations = resource_resv_filter(resresv->resv->resv_queue->jobs,
 									    count_array(resresv->resv->resv_queue->jobs),
 									    check_running_job_in_reservation, NULL, 0);
 				collect_jobs_on_nodes(resresv->resv->resv_nodes, jobs_in_reservations,
@@ -402,19 +398,17 @@ query_reservations(int pbs_sd, server_info *sinfo, struct batch_status *resvs)
 		if (resresv->resv->is_standing &&
 			(resresv->resv->resv_state != RESV_UNCONFIRMED)) {
 			resource_resv *resresv_ocr = NULL; /* the occurrence's resource_resv */
-			char *execvnodes_seq = NULL; /* confirmed execvnodes sequence string */
+			char *execvnodes_seq; /* confirmed execvnodes sequence string */
 			char **execvnode_ptr = NULL;
 			char **tofree = NULL;
 			resource_resv **tmp = NULL;
 			time_t dtstart;
-			time_t next;
 			char *rrule = NULL;
 			char *tz = NULL;
-			struct tm* loc_time;
 			char start_time[128];
 			int count = 0;
 			int occr_count; /* occurrences count as reported by execvnodes_seq */
-			int occr_idx = 1; /* the occurrence index of a standing reservation */
+			int occr_idx; /* the occurrence index of a standing reservation */
 			int degraded_idx; /* index corrected to account for reconfirmation */
 
 			/* occr_idx refers to the soonest occurrence to run or currently running
@@ -501,7 +495,7 @@ query_reservations(int pbs_sd, server_info *sinfo, struct batch_status *resvs)
 				 * The last argument (j+1) indicates the occurrence index from dtstart
 				 * starting at 1. Returns dtstart if it's an advance reservation.
 				 */
-				next = get_occurrence(rrule, dtstart, tz, j + 1);
+				auto next = get_occurrence(rrule, dtstart, tz, j + 1);
 
 				/* Duplicate the "master" resv only for subsequent occurrences */
 				if (j == 0)
@@ -571,7 +565,7 @@ query_reservations(int pbs_sd, server_info *sinfo, struct batch_status *resvs)
 				resresv_arr[idx++] = resresv_ocr;
 				resresv_arr[idx] = NULL;
 
-				loc_time = localtime(&resresv_ocr->start);
+				auto loc_time = localtime(&resresv_ocr->start);
 				strftime(start_time, sizeof(start_time), "%Y%m%d-%H:%M:%S", loc_time);
 
 				log_eventf(PBSEVENT_DEBUG2, PBS_EVENTCLASS_RESV, LOG_DEBUG, resresv->name,
@@ -765,15 +759,13 @@ query_resv(struct batch_status *resv, server_info *sinfo)
 	 *
 	 */
 	if (advresv->resv->select_orig != NULL) {
-		int i;
 		int j = 0;
-		int sel_orig_num, sel_num;
 		char *sel_orig_str, *sel_str;
-		sel_num = strtol(advresv->select->chunks[j]->str_chunk, &sel_str, 10);
+		auto sel_num = strtol(advresv->select->chunks[j]->str_chunk, &sel_str, 10);
 
-		for (i = 0; advresv->resv->select_orig->chunks[i] != NULL; i++) {
+		for (int i = 0; advresv->resv->select_orig->chunks[i] != NULL; i++) {
 			chunk *chk = advresv->resv->select_orig->chunks[i];
-			sel_orig_num = strtol(chk->str_chunk, &sel_orig_str, 10);
+			auto sel_orig_num = strtol(chk->str_chunk, &sel_orig_str, 10);
 			if (strcmp(sel_orig_str, sel_str) == 0 && sel_num <= sel_orig_num) {
 				advresv->select->chunks[j++]->seq_num = chk->seq_num;
 				if (advresv->select->chunks[j] != NULL)
@@ -1352,12 +1344,11 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 {
 	time_t sim_time;			/* time in simulation */
 	unsigned int simrc = TIMED_NOEVENT;	/* ret code from simulate_events() */
-	schd_error *err = NULL;
+	schd_error *err;
 	int pbsrc = 0;				/* return code from pbs_confirmresv() */
 	enum resv_conf rconf = RESV_CONFIRM_SUCCESS; /* assume reconf success */
 	char logmsg[MAX_LOG_SIZE];
 	char logmsg2[MAX_LOG_SIZE];
-	const char *errmsg;
 
 	nspec **ns = NULL;
 	resource_resv *nresv = unconf_resv;
@@ -1367,11 +1358,9 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 	resource_resv *nresv_parent = nresv;	/* the "original" / parent reservation */
 
 	int confirmd_occr = 0;			/* the number of confirmed occurrence(s) */
-	int j, cur_count;
+	int cur_count;
 
-	int tot_vnodes = 0;			/* total number of vnodes associated to the reservation */
 	int vnodes_down = 0;			/* the number of vnodes that are down */
-	char names_of_down_vnodes[MAXVNODELIST] = "";  /* the list of down vnodes */
 
 	/* resv_start_time is used both for calculating the time of an ASAP
 	 * reservation and to keep track of the start time of the first occurrence
@@ -1438,8 +1427,9 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 	 * be added to the server info such that the duplicated server info has up to
 	 * date information.
 	 */
-	for (j = 0, cur_count = 0; j < occr_count && rconf == RESV_CONFIRM_SUCCESS;
-		j++, cur_count = j) {
+	cur_count = 0;
+	for (int j = 0; j < occr_count && rconf == RESV_CONFIRM_SUCCESS;
+	     j++, cur_count = j) {
 		/* Get the start time of the next occurrence.
 		 * See call to same function in query_reservations for a more in-depth
 		 * description.
@@ -1642,7 +1632,6 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 	/* Finished simulating occurrences now time to confirm if ok. Currently
 	 * the confirmation is an all or nothing process but may come to change. */
 	if (confirmd_occr == occr_count) {
-		char confirm_msg[LOG_BUF_SIZE] = {0};
 		/* We either confirm a standing or advance reservation, the standing
 		 * has a special sequence of execvnodes while the advance has a single
 		 * execvnode. The sequence of execvnodes is created by concatenating
@@ -1657,6 +1646,7 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 			log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_RESV, LOG_DEBUG, nresv_parent->name, "Invalid execvnode_seq while confirming reservation");
 			rconf = RESV_CONFIRM_RETRY;
 		} else {
+			char confirm_msg[LOG_BUF_SIZE] = {0};
 
 			log_eventf(PBSEVENT_RESV, PBS_EVENTCLASS_RESV, LOG_INFO, nresv_parent->name,
 				"Confirming %d Occurrences", occr_count);
@@ -1691,7 +1681,7 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 			log_eventf(PBSEVENT_RESV, PBS_EVENTCLASS_RESV, LOG_INFO, nresv_parent->name,
 				"PBS Failed to confirm resv: %s", logmsg);
 		else {
-			errmsg = pbs_geterrmsg(pbs_sd);
+			const char *errmsg = pbs_geterrmsg(pbs_sd);
 			if (errmsg == NULL)
 				errmsg = "";
 			log_eventf(PBSEVENT_RESV, PBS_EVENTCLASS_RESV, LOG_INFO, nresv_parent->name,
@@ -1702,8 +1692,7 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 		if (nresv_parent->resv->resv_substate == RESV_DEGRADED) {
 			if (vnodes_down >= 0)
 				log_eventf(PBSEVENT_RESV, PBS_EVENTCLASS_RESV, LOG_INFO, nresv_parent->name,
-					"Reservation is in degraded mode, %d out of %d vnodes are unavailable; %s",
-					vnodes_down, tot_vnodes, names_of_down_vnodes);
+					"Reservation is in degraded mode");
 
 			/* we failed to confirm the degraded reservation but we still need to
 			 * set the remaining occurrences start time to avoid looking at them
@@ -1897,9 +1886,9 @@ ralter_reduce_chunks(resource_resv *resv)
 				return -1;
 
 		} else {
-			int tot_num_chunks = 0;
 			int chk_diff = chks_orig[i]->num_chunks - chks[j]->num_chunks;
 			if (chk_diff > 0) {
+				int tot_num_chunks = 0;
 				/* First remove nodes that are unavailable */
 				num_chks = ralter_remove_nodes(resv, start_of_chunk, chks_orig[i]->seq_num, chk_diff, -1);
 				if (num_chks == -1)
@@ -2091,12 +2080,12 @@ create_resv_nodes(nspec **nspec_arr, server_info *sinfo)
 	node_info **nodes = NULL;
 	schd_resource *res;
 	resource_req *req;
-	int i;
 
 	if (nspec_arr != NULL) {
+		int i;
 		for (i = 0; nspec_arr[i] != NULL; i++)
 			;
-		nodes = static_cast<node_info **>(malloc((i+1) * sizeof(node_info *)));
+		nodes = static_cast<node_info **>(malloc((i + 1) * sizeof(node_info *)));
 		if (nodes != NULL) {
 			for (i = 0; nspec_arr[i] != NULL; i++) {
 				/* please note - the new duplicated nodes will NOT be part
@@ -2136,29 +2125,6 @@ create_resv_nodes(nspec **nspec_arr, server_info *sinfo)
 }
 
 /**
- * @brief end a running reservation on its nodes.  This is used so we can assign
- * 		them back to a running reservation when reconfirming it.
- *
- * @param[in] resv - the reservation
- * @param[in] all_nodes - The server's nodes list
- *
- * @return void
- */
-void
-end_resv_on_nodes(resource_resv *resv, node_info **all_nodes)
-{
-	node_info **resv_nodes = NULL;
-	node_info *ninfo = NULL;
-	int i;
-
-	resv_nodes = resv->ninfo_arr;
-	for (i = 0; resv_nodes[i] != NULL; i++) {
-		ninfo = find_node_by_indrank(all_nodes, resv_nodes[i]->node_ind, resv_nodes[i]->rank);
-		update_node_on_end(ninfo, resv, NULL);
-	}
-}
-
-/**
  * @brief - adjust resources on nodes belonging to a reservation that is
  *	    running and is either degraded or being altered.  We need to free
  * 	    the resources on these nodes so the resources are available for
@@ -2172,16 +2138,12 @@ end_resv_on_nodes(resource_resv *resv, node_info **all_nodes)
 void
 release_running_resv_nodes(resource_resv *resv, server_info *sinfo)
 {
-	int i = 0;
-	node_info **resv_nodes = NULL;
-	node_info *ninfo = NULL;
-
 	if (resv == NULL || sinfo == NULL )
 		return;
 	if (resv->resv->is_running && (resv->resv->resv_substate == RESV_DEGRADED || resv->resv->resv_state == RESV_BEING_ALTERED)) {
-		resv_nodes = resv->ninfo_arr;
-		for (i = 0; resv_nodes[i] != NULL; i++) {
-			ninfo = find_node_by_indrank(sinfo->nodes, resv_nodes[i]->node_ind, resv_nodes[i]->rank);
+		auto resv_nodes = resv->ninfo_arr;
+		for (int i = 0; resv_nodes[i] != NULL; i++) {
+			auto ninfo = find_node_by_indrank(sinfo->nodes, resv_nodes[i]->node_ind, resv_nodes[i]->rank);
 			update_node_on_end(ninfo, resv, NULL);
 		}
 		sinfo->pset_metadata_stale = 1;

--- a/src/scheduler/sched_ifl_wrappers.cpp
+++ b/src/scheduler/sched_ifl_wrappers.cpp
@@ -256,9 +256,7 @@ send_confirmresv(int virtual_sd, resource_resv *resv, const char *location, unsi
 struct batch_status *
 send_selstat(int virtual_fd, struct attropl *attrib, struct attrl *rattrib, char *extend)
 {
-	struct batch_status *ret = NULL;
-
-	ret = pbs_selstat(virtual_fd, attrib, rattrib, extend);
+	auto ret = pbs_selstat(virtual_fd, attrib, rattrib, extend);
 	if (handle_part_tolerance(ret) == NULL) {
 		pbs_statfree(ret);
 		return NULL;
@@ -282,9 +280,7 @@ send_selstat(int virtual_fd, struct attropl *attrib, struct attrl *rattrib, char
 struct batch_status *
 send_statvnode(int virtual_fd, char *id, struct attrl *attrib, char *extend)
 {
-	struct batch_status *ret = NULL;
-
-	ret = pbs_statvnode(virtual_fd, id, attrib, extend);
+	auto ret = pbs_statvnode(virtual_fd, id, attrib, extend);
 	if (handle_part_tolerance(ret) == NULL) {
 		pbs_statfree(ret);
 		return NULL;
@@ -307,9 +303,7 @@ send_statvnode(int virtual_fd, char *id, struct attrl *attrib, char *extend)
 struct batch_status *
 send_statsched(int virtual_fd, struct attrl *attrib, char *extend)
 {
-	struct batch_status *ret = NULL;
-
-	ret = pbs_statsched(virtual_fd, attrib, extend);
+	auto ret = pbs_statsched(virtual_fd, attrib, extend);
 	if (handle_part_tolerance(ret) == NULL) {
 		pbs_statfree(ret);
 		return NULL;
@@ -333,9 +327,7 @@ send_statsched(int virtual_fd, struct attrl *attrib, char *extend)
 struct batch_status *
 send_statqueue(int virtual_fd, char *id, struct attrl *attrib, char *extend)
 {
-	struct batch_status *ret = NULL;
-
-	ret = pbs_statque(virtual_fd, id, attrib, extend);
+	auto ret = pbs_statque(virtual_fd, id, attrib, extend);
 	if (handle_part_tolerance(ret) == NULL) {
 		pbs_statfree(ret);
 		return NULL;
@@ -358,9 +350,7 @@ send_statqueue(int virtual_fd, char *id, struct attrl *attrib, char *extend)
 struct batch_status *
 send_statserver(int virtual_fd, struct attrl *attrib, char *extend)
 {
-	struct batch_status *ret = NULL;
-
-	ret = pbs_statserver(virtual_fd, attrib, extend);
+	auto ret = pbs_statserver(virtual_fd, attrib, extend);
 	if (handle_part_tolerance(ret) == NULL) {
 		pbs_statfree(ret);
 		return NULL;
@@ -384,9 +374,7 @@ send_statserver(int virtual_fd, struct attrl *attrib, char *extend)
 struct batch_status *
 send_statrsc(int virtual_fd, char *id, struct attrl *attrib, char *extend)
 {
-	struct batch_status *ret = NULL;
-
-	ret = pbs_statrsc(virtual_fd, id, attrib, extend);
+	auto ret = pbs_statrsc(virtual_fd, id, attrib, extend);
 	if (handle_part_tolerance(ret) == NULL) {
 		pbs_statfree(ret);
 		return NULL;
@@ -410,9 +398,7 @@ send_statrsc(int virtual_fd, char *id, struct attrl *attrib, char *extend)
 struct batch_status *
 send_statresv(int virtual_fd, char *id, struct attrl *attrib, char *extend)
 {
-	struct batch_status *ret = NULL;
-
-	ret = pbs_statresv(virtual_fd, id, attrib, extend);
+	auto ret = pbs_statresv(virtual_fd, id, attrib, extend);
 	if (handle_part_tolerance(ret) == NULL) {
 		pbs_statfree(ret);
 		return NULL;

--- a/src/scheduler/server_info.h
+++ b/src/scheduler/server_info.h
@@ -152,12 +152,6 @@ int copy_server_arrays(server_info *nsinfo, server_info *osinfo);
 int check_exit_job(resource_resv *job, const void *arg);
 
 /*
- *      check_run_resv - function used by resv_filter to filter out
- *                       non-running reservations
- */
-int check_run_resv(resource_resv *resv, const void *arg);
-
-/*
  *
  *	check_susp_job - function used by job_filter to filter out jobs
  *			   which are suspended
@@ -418,12 +412,6 @@ update_total_counts(server_info *si, queue_info* qi,
 void
 update_total_counts_on_end(server_info *si, queue_info* qi,
 	resource_resv *rr, int mode);
-
-/*
- * Refreshes total counts list for server & queue by deleting the
- * old structures and duplicating new one from running counts
- */
-void refresh_total_counts(server_info *sinfo);
 
 /**
  * @brief - get a unique rank to uniquely identify an object

--- a/src/scheduler/sort.cpp
+++ b/src/scheduler/sort.cpp
@@ -1196,11 +1196,6 @@ cmp_resv_state(const void *r1, const void *r2)
 void
 sort_jobs(status *policy, server_info *sinfo)
 {
-	int i = 0;
-	int job_index = 0;
-	int index = 0;
-	int count = 0;
-
 	/** sort jobs in such a way that Higher Priority jobs come on top
 	 * followed by preempted jobs and then normal jobs
 	 */
@@ -1209,17 +1204,18 @@ sort_jobs(status *policy, server_info *sinfo)
 		 * to select the next job.
 		 */
 		if (policy->by_queue || policy->round_robin) {
+			int job_index = 0;
 			/* cycle through queues and sort them on the basis of preemption priority,
 			 * preempted jobs, and fairshare usage
 			 */
-			for (; i < sinfo->num_queues; i++) {
+			for (int i = 0; i < sinfo->num_queues; i++) {
 				if (sinfo->queues[i]->sc.total > 0) {
 					qsort(sinfo->queues[i]->jobs, sinfo->queues[i]->sc.total,
 						sizeof(resource_resv*), cmp_sort);
 				}
 			}
-			for (count = 0; count != sinfo->num_queues; count++) {
-				for (index = 0; index < sinfo->queues[count]->sc.total; index++) {
+			for (int count = 0; count != sinfo->num_queues; count++) {
+				for (int index = 0; index < sinfo->queues[count]->sc.total; index++) {
 					sinfo->jobs[job_index] = sinfo->queues[count]->jobs[index];
 					job_index++;
 				}
@@ -1232,7 +1228,7 @@ sort_jobs(status *policy, server_info *sinfo)
 		}
 	}
 	else if (policy->by_queue) {
-		for (i = 0; i < sinfo->num_queues; i++) {
+		for (int i = 0; i < sinfo->num_queues; i++) {
 			qsort(sinfo->queues[i]->jobs, count_array(sinfo->queues[i]->jobs), sizeof(resource_resv *), cmp_sort);
 		}
 		qsort(sinfo->jobs, count_array(sinfo->jobs), sizeof(resource_resv*), cmp_sort);
@@ -1240,14 +1236,13 @@ sort_jobs(status *policy, server_info *sinfo)
 	else if (policy->round_robin) {
 		if (sinfo -> queue_list != NULL) {
 			int queue_list_size = count_array(sinfo->queue_list);
-			int i,j;
-			for (i = 0; i < queue_list_size; i++)
+			for (int i = 0; i < queue_list_size; i++)
 			{
 				int queue_index_size = count_array(sinfo->queue_list[i]);
-				for (j = 0; j < queue_index_size; j++)
+				for (int j = 0; j < queue_index_size; j++)
 				{
-				    qsort(sinfo->queue_list[i][j]->jobs, count_array(sinfo->queue_list[i][j]->jobs),
-					    sizeof(resource_resv *), cmp_sort);
+					qsort(sinfo->queue_list[i][j]->jobs, count_array(sinfo->queue_list[i][j]->jobs),
+						sizeof(resource_resv *), cmp_sort);
 				}
 			}
 

--- a/src/scheduler/state_count.cpp
+++ b/src/scheduler/state_count.cpp
@@ -102,10 +102,8 @@ init_state_count(state_count *sc)
 void
 count_states(resource_resv **jobs, state_count *sc)
 {
-	int i;
-
 	if (jobs != NULL) {
-		for (i = 0; jobs[i] != NULL; i++) {
+		for (int i = 0; jobs[i] != NULL; i++) {
 			if (jobs[i]->job != NULL) {
 				if (jobs[i]->job->is_queued)
 					sc->queued++;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
I ran cppcheck and clang's static code analyzer on the scheduler and addressed the findings.
[report.txt](https://github.com/openpbs/openpbs/files/6666160/report.txt)

Here is cppcheck's report.  I'm not attaching clang's because it was filled with false positives.  I only addressed the real issues.  Some of cppcheck's issues were false positives, but not many.


#### Describe Your Change
Addressed issues reported by static code analyzers

A lot of minor fixes.  I moved a lot of variables closer to their use.  There were 3 actual bugs:
1) If we compiled with DEBUG mode, we wouldn't chdir() into our priv dir
2) There was a path through the STF code where if a job needed to shrink close to its min_walltime, it could cause a FPE.
3) for the daemon service user, we called setuid() and setgid() without checking their return value.  It turned out that setgid() was failing.  I believe this is because we set the uid first, and then we no longer have the privilege to set the gid.  I now set the gid first. 

#### Attach Test and Valgrind Logs/Output
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16,UBUNTU2004
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|7916|4177|2|5|0|0|4170|

I reran the failed/error tests and they passed.