### PR TITLE
Fix test_run_count_subjob_in_x of Test_run_count

### DIFF
--- a/test/tests/functional/pbs_test_run_count.py
+++ b/test/tests/functional/pbs_test_run_count.py
@@ -156,14 +156,14 @@ class Test_run_count(TestFunctional):
         j = Job(TEST_USER, a)
         j.set_sleep_time(20)
         jid = self.server.submit(j)
-        time.sleep(15)
+        self.logger.info("Waiting for second subjob to go in R state")
         self.server.expect(JOB, {ATTR_state: "R"},
-                           id=j.create_subjob_id(jid, 2))
+                           id=j.create_subjob_id(jid, 2), offset=15)
         # Create an execjob_begin hook that rejects the job
         self.create_reject_begin_hook()
-        time.sleep(15)
+        self.logger.info("Waiting for subjob to finish")
         self.server.expect(JOB, {ATTR_state: "X"},
-                           id=j.create_subjob_id(jid, 2))
+                           id=j.create_subjob_id(jid, 2), offset=15)
 
         self.subjob_check(jid=jid, sjid=j.create_subjob_id(jid, 3))
 

--- a/test/tests/functional/pbs_test_run_count.py
+++ b/test/tests/functional/pbs_test_run_count.py
@@ -154,14 +154,14 @@ class Test_run_count(TestFunctional):
 
         a = {ATTR_J: '1-6'}
         j = Job(TEST_USER, a)
-        j.set_sleep_time(10)
+        j.set_sleep_time(20)
         jid = self.server.submit(j)
-        time.sleep(9)
+        time.sleep(15)
         self.server.expect(JOB, {ATTR_state: "R"},
                            id=j.create_subjob_id(jid, 2))
         # Create an execjob_begin hook that rejects the job
         self.create_reject_begin_hook()
-        time.sleep(8)
+        time.sleep(15)
         self.server.expect(JOB, {ATTR_state: "X"},
                            id=j.create_subjob_id(jid, 2))
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
test_run_count_subjob_in_x  was failing with Job not in 'H' state after execjob_begin hook with reject request is created.
Test is submitting an array of jobs and while second subjob is in running state, creating execjob_begin hook with reject. On few machines, hook create and import was taking little longer time that third subjob would also get finished by the time test checks for 'H' state of third subjob.


#### Describe Your Change
Increased sleep time of Array jobs such that second subjob would run for longer time and third subjob would start executing after hook has imported.


#### Attach Test and Valgrind Logs/Output
[test_run_count_subjob_in_x_before_fix.txt](https://github.com/openpbs/openpbs/files/6675381/test_run_count_subjob_in_x_before_fix.txt)
[test_run_count_subjob_in_x_after_fix.txt](https://github.com/openpbs/openpbs/files/6676426/test_run_count_subjob_in_x_after_fix.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
