### PR TITLE
Fix for the test failure to validate a long string set to customer resource

### DIFF
--- a/test/tests/functional/pbs_acct_log.py
+++ b/test/tests/functional/pbs_acct_log.py
@@ -57,20 +57,6 @@ class TestAcctLog(TestFunctional):
         in the job's resources_used attr or the accounting log at job end
         """
 
-        # Make sure emails are not truncated
-        try:
-            mailfile = os.environ['MAIL']
-        except KeyError:
-            self.skip_test(
-                "mail is not setup. " +
-                "Hence this step would be skipped. " +
-                "Please setup the mail.")
-        if not os.path.isfile(mailfile):
-            self.skip_test(
-                "Mail file does not exist. " +
-                "Hence this step would be skipped. " +
-                "Please check manually.")
-
         self.server.manager(MGR_CMD_SET, SERVER,
                             {'job_history_enable': 'True'})
 
@@ -106,18 +92,6 @@ class TestAcctLog(TestFunctional):
         # Make sure the server log hasn't been truncated
         log_match = 'resources_used.foo_str=' + hstr
         self.server.log_match("%s;.*%s.*" % (jid, log_match), regexp=True)
-
-        mailpass = 0
-        for x in range(1, 5):
-            fo = open(mailfile, 'r')
-            maillog = fo.readlines()[-10:]
-            fo.close()
-            if (log_match in str(maillog)):
-                self.logger.info("Message found in " + mailfile)
-                mailpass = 1
-                break
-
-        self.assertTrue(mailpass, "Message not found in " + mailfile)
 
     def test_long_resource_reque(self):
         """

--- a/test/tests/functional/pbs_acct_log.py
+++ b/test/tests/functional/pbs_acct_log.py
@@ -62,10 +62,8 @@ class TestAcctLog(TestFunctional):
 
         # Create a very long string - the truncation was 2048 characters
         # 4096 is plenty big to show it
-        hstr = ""
-        for i in range(4096):
-            hstr += "1"
 
+        hstr = '1'*4096
         hook_body = "import pbs\n"
         hook_body += "e = pbs.event()\n"
         hook_body += "hstr=\'" + hstr + "\'\n"
@@ -75,7 +73,6 @@ class TestAcctLog(TestFunctional):
         self.server.create_import_hook("ep", a, hook_body)
 
         J = Job()
-        J.set_attributes({ATTR_m: 'e'})
         J.set_sleep_time(1)
         jid = self.server.submit(J)
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
The test is setting a string custom resource for 4096 long value and validating this long resource value in accounting logs, server logs, and mail. Seems the sendmail has a limitation that it can't have a single line with more than 2048 characters, this truncating it. 
(For reference: https://www.cs.ait.ac.th/~on/O/oreilly/tcpip/sendmail/ch18_08.htm)
<html>
<body>
<!--StartFragment-->

MAXLINE | 2048 | conf.h | Length of an input line
-- | -- | -- | --


<!--EndFragment-->
</body>
</html>

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
It's not an expected behavior to see 4096 bytes long string in the mail, thus removing this invalid validation. 

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[testlog.txt](https://github.com/openpbs/openpbs/files/6693650/testlog.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
