### PR TITLE
DBPRT to log file

### DIFF
--- a/src/cmds/qsub.c
+++ b/src/cmds/qsub.c
@@ -113,6 +113,7 @@
 #undef DEBUG
 #endif /* localmod 004 */
 
+#undef DBPRT
 #ifdef DEBUG
 #ifdef NAS /* localmod 004 */
 #define DBPRT(x)	fprintf x;

--- a/src/include/log.h
+++ b/src/include/log.h
@@ -92,7 +92,7 @@ extern "C" {
 #define STRIP_PARENS(...) __VA_ARGS__
 #undef DBPRT
 #define	DBPRT(x) \
-	if (will_log_event(PBSEVENT_DEBUG3)) { \
+	if (will_log_event(PBSEVENT_DEBUGPRT)) { \
 		char * msg_; \
 		int msg_len_; \
 		int save_errno_ = errno; \
@@ -101,7 +101,7 @@ extern "C" {
 			if (msg_len_ > 0 && msg_[msg_len_ - 1] == '\n') { \
 				msg_[msg_len_ - 1] = '\0'; \
 			} \
-			log_record(PBSEVENT_DEBUG3, 0, LOG_DEBUG, __func__, msg_); \
+			log_record(PBSEVENT_DEBUGPRT, 0, LOG_DEBUG, __func__, msg_); \
 			free(msg_); \
 		} \
 		errno = save_errno_; \
@@ -178,6 +178,9 @@ extern void log_supported_auth_methods(char **supported_auth_methods);
 #define PBSEVENT_RESV		0x0200		/* reservation related msgs */
 #define PBSEVENT_DEBUG3		0x0400		/* less needed debug messages */
 #define PBSEVENT_DEBUG4		0x0800		/* rarely needed debugging */
+#ifndef PBSEVENT_DEBUGPRT
+#define PBSEVENT_DEBUGPRT	0x1000		/* messages from the DBPRT macro */
+#endif
 #define PBSEVENT_FORCE		0x8000		/* set to force a message */
 #define SVR_LOG_DFLT		PBSEVENT_ERROR | PBSEVENT_SYSTEM | PBSEVENT_ADMIN | PBSEVENT_JOB \
 				| PBSEVENT_JOB_USAGE | PBSEVENT_SECURITY | PBSEVENT_SCHED \

--- a/src/lib/Libifl/tm.c
+++ b/src/lib/Libifl/tm.c
@@ -67,20 +67,6 @@
  * @file	tm.c
  */
 
-/*
- ** Set up a debug print macro.
- */
-#ifdef  DEBUG
-#define DBPRT(x) \
-{ \
-	int	err = errno; \
-	printf x; \
-	errno = err; \
-}
-#else
-#define DBPRT(x)
-#endif
-
 #ifndef	MIN
 #define	MIN(a, b)	(((a) < (b)) ? (a) : (b))
 #endif

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -243,7 +243,7 @@ tinsert2(const u_long key1, const u_long key2, mominfo_t *momp, struct tree **ro
 	struct	tree	*q;
 
 	DBPRT(("tinsert2: %lu|%lu %s stream %d\n", key1, key2,
-		momp->mi_host, momp->mi_dmn_info->dmn_stream))
+		momp->mi_host, momp->mi_dmn_info ? momp->mi_dmn_info->dmn_stream : -1))
 
 	if (rootp == NULL)
 		return;

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -1449,7 +1449,7 @@ main(int argc, char **argv)
 			state = SV_STATE_DOWN;
 		}
 	}
-	DBPRT(("Server out of main loop, state is %ld\n", *state))
+	DBPRT(("Server out of main loop, state is %ld\n", state))
 
 	/* set the current seq id to the last id before final save */
 	server.sv_qs.sv_lastid = server.sv_qs.sv_jobidnumber;

--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -1405,7 +1405,7 @@ post_sendmom(struct work_task *pwt)
 		return;
 	}
 
-	DBPRT(("post_sendmom: %s substate is %d", jobp->ji_qs.ji_jobid, get_job_substate(jobp)))
+	DBPRT(("post_sendmom: %s substate is %ld", jobp->ji_qs.ji_jobid, get_job_substate(jobp)))
 
 	if (jobp->ji_prunreq)
 		jobp->ji_prunreq = NULL;	/* set in svr_strtjob2() */

--- a/src/server/svr_comm.c
+++ b/src/server/svr_comm.c
@@ -474,7 +474,7 @@ ps_request(int stream, int version)
 		pdmn_info = psvr->mi_dmn_info;
 		if (pdmn_info->dmn_stream >= 0 && pdmn_info->dmn_stream != stream) {
 			DBPRT(("%s: stream %d from %s:%d already open on %d\n",
-			       __func__, stream, pmom->mi_host,
+			       __func__, stream, psvr->mi_host,
 			       ntohs(addr->sin_port), pdmn_info->dmn_stream))
 			tpp_close(pdmn_info->dmn_stream);
 			tdelete2((u_long) pdmn_info->dmn_stream, 0ul, &streams);


### PR DESCRIPTION
At times, it is useful to have the debugging printf (DBPRT) messages sent to the log files rather than stdout so that they are interspersed with the other log messages.

This pull request defines an alternative implementation of the DBPRT macro when DBPRT_LOG is defined.  This implementation uses the logging module to log the message at the PBSEVENT_DEBUG3 level.  A few fixes to code using DBPRT are also included.
