### PR TITLE
Fixed possible memory leak when querying resources

### DIFF
--- a/src/scheduler/resource.cpp
+++ b/src/scheduler/resource.cpp
@@ -115,11 +115,10 @@ query_resources(int pbs_sd)
 	for (cur_bs = bs; cur_bs != NULL; cur_bs = cur_bs->next) {
 		int flags = NO_FLAGS;
 		resource_type rtype;
-		char *endp;
-
-		attrp = cur_bs->attribs;
 
 		for (attrp = cur_bs->attribs; attrp != NULL; attrp = attrp->next) {
+			char *endp;
+			
 			if (!strcmp(attrp->name, ATTR_RESC_TYPE)) {
 				int num = strtol(attrp->value, &endp, 10);
 				rtype = conv_rsc_type(num);

--- a/src/scheduler/resource.cpp
+++ b/src/scheduler/resource.cpp
@@ -116,27 +116,20 @@ query_resources(int pbs_sd)
 		int flags = NO_FLAGS;
 		resource_type rtype;
 		char *endp;
-		resdef *def;
 
 		attrp = cur_bs->attribs;
 
-		while (attrp != NULL) {
+		for (attrp = cur_bs->attribs; attrp != NULL; attrp = attrp->next) {
 			if (!strcmp(attrp->name, ATTR_RESC_TYPE)) {
 				int num = strtol(attrp->value, &endp, 10);
 				rtype = conv_rsc_type(num);
 			} else if (!strcmp(attrp->name, ATTR_RESC_FLAG)) {
 				flags = strtol(attrp->value, &endp, 10);
 			}
-			attrp = attrp->next;
 		}
-		def = new resdef(cur_bs->name, flags, rtype);
-		if (def == NULL) {
-			for (auto& d : tmpres)
-				delete d.second;
-			return {};
-		}
-		tmpres[def->name] = def;
+		tmpres[cur_bs->name] = new resdef(cur_bs->name, flags, rtype);
 	}
+	pbs_statfree(bs);
 
 	/**
 	 * @par Make sure all the well known resources are sent to us.
@@ -150,8 +143,6 @@ query_resources(int pbs_sd)
 			return {};
 		}
 	}
-
-	pbs_statfree(bs);
 
 	return tmpres;
 }


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Possible memory leak if some built-in resources aren't sent to the scheduler.

#### Describe Your Change
Moved pbs_statfree() to the point when we are done with it.

Also, new can't return NULL.  No reason to check for it.

#### Attach Test and Valgrind Logs/Output
Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, WIN2K16, UBUNTU2004
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16,UBUNTU2004
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|7966|4177|1|3|0|0|4173|

I reran the failed/error tests.  All but 1 failed which is a known test bug in master.