### PR TITLE
Add a host id to mom name when handling multiple mom hosts and change PBS_START_COMM to 0

### DIFF
--- a/test/fw/ptl/lib/ptl_server.py
+++ b/test/fw/ptl/lib/ptl_server.py
@@ -1912,7 +1912,10 @@ class Server(Wrappers):
                     attrib['port'] = port
                     if name is None:
                         name = hostname.split('.')[0]
-                    _n = name + str(momnum) + '-' + str(i)
+                    if momnum == 1:
+                        _n = name + '-' + str(i)
+                    else:
+                        _n = name + str(momnum) + '-' + str(i)
                     rc = self.manager(MGR_CMD_CREATE, NODE, attrib, id=_n)
                     if rc != 0:
                         self.logger.error("error creating node " + _n)

--- a/test/fw/ptl/lib/ptl_server.py
+++ b/test/fw/ptl/lib/ptl_server.py
@@ -1870,7 +1870,9 @@ class Server(Wrappers):
             attrib = {}
 
         error = False
+        momnum = 0
         for hostname in momhosts:
+            momnum += 1
             _pconf = self.du.parse_pbs_config(hostname)
             if 'PBS_HOME' in _pconf:
                 _hp = _pconf['PBS_HOME']
@@ -1882,6 +1884,7 @@ class Server(Wrappers):
             _np_conf = _pconf
             _np_conf['PBS_START_SERVER'] = '0'
             _np_conf['PBS_START_SCHED'] = '0'
+            _np_conf['PBS_START_COMM'] = '0'
             _np_conf['PBS_START_MOM'] = '1'
             for i in range(0, num * step_port, step_port):
                 _np = os.path.join(_hp, home_prefix + str(i))
@@ -1909,7 +1912,7 @@ class Server(Wrappers):
                     attrib['port'] = port
                     if name is None:
                         name = hostname.split('.')[0]
-                    _n = name + '-' + str(i)
+                    _n = name + str(momnum) + '-' + str(i)
                     rc = self.manager(MGR_CMD_CREATE, NODE, attrib, id=_n)
                     if rc != 0:
                         self.logger.error("error creating node " + _n)


### PR DESCRIPTION
Add a host id to mom name when handling multiple mom hosts and change PBS_START_COMM to 0
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
When creating moms on multiple hosts, node name would be same on both hosts and error out
PBS_START_COMM was not made to 0 which was causing errors on PTL comm_startup failed error message


#### Describe Your Change
Added a host id index to mom name to differentiate between different hosts.
Made PBS_START_COMM=0 in mom_config


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[multimom.txt](https://github.com/openpbs/openpbs/files/6782489/multimom.txt)
[multimom_pbsnodes.txt](https://github.com/openpbs/openpbs/files/6782491/multimom_pbsnodes.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
