### PR TITLE
Fixed preemption by checkpointing to fail if it is not enabled

### DIFF
--- a/test/tests/functional/pbs_preemption.py
+++ b/test/tests/functional/pbs_preemption.py
@@ -189,6 +189,11 @@ exit 1
         """
         Test that when checkpoint fails, a job is correctly requeued
         """
+        # no checkpoint script, should requeue
+        self.submit_and_preempt_jobs(preempt_order='CR')
+        self.server.cleanup_jobs()
+
+        # checkpoint script fails, should requeue
         self.mom.add_checkpoint_abort_script(body=self.chk_script_fail)
         self.submit_and_preempt_jobs(preempt_order='CR')
 
@@ -821,3 +826,8 @@ exit 3
         self.server.expect(JOB, {'job_state': 'R'}, id=hjid)
         self.server.expect(JOB, {'job_state=R': 5})
         self.server.expect(JOB, {'job_state=S': 1})
+    
+    def test_chkpt_restart(self):
+        """
+        Test that if checkpointing is not set up, that the job is requeued
+        """

--- a/test/tests/functional/pbs_preemption.py
+++ b/test/tests/functional/pbs_preemption.py
@@ -826,8 +826,3 @@ exit 3
         self.server.expect(JOB, {'job_state': 'R'}, id=hjid)
         self.server.expect(JOB, {'job_state=R': 5})
         self.server.expect(JOB, {'job_state=S': 1})
-    
-    def test_chkpt_restart(self):
-        """
-        Test that if checkpointing is not set up, that the job is requeued
-        """


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
If checkpoint is in the preempt_order, but it is not enabled (no checkpoint_abort script), the checkpoint preempt method will "succeed", but the job will remain in the running state.  This will cause the scheduler to think it has been preempted, and will run the high priority job.  This oversubscribes resources.

#### Describe Your Change
If there is no checkpoint_abort script, the mom returns PBSE_NOSUSP.  In post_hold() on the server side, it ignores PBSE_NOSUSP when checking for the error code.  This would then fall into the case for successful preemption.

The fix is to fail preemption if the pbs error code returned from mom is not PBSE_NONE, regardless if it is PBSE_NOSUSP or not.

I also refactored the if statement in post_hold() a little to make it more clear what was going on.

#### Attach Test and Valgrind Logs/Output
Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, WIN2K16, UBUNTU2004
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16,UBUNTU2004
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|8018|4177|1|109|0|0|4067|

And the rerun:
Description: Rerun Only Failed Tests From #8018
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16,UBUNTU2004
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|8030|110|0|0|0|0|110|

So all tests passed.