### PR TITLE
fix tpp crash and simplify locks to avoid races

### DIFF
--- a/src/lib/Libtpp/tpp_em.c
+++ b/src/lib/Libtpp/tpp_em.c
@@ -927,6 +927,8 @@ int
 tpp_mbox_init(tpp_mbox_t *mbox, char *name, int size)
 {
 	tpp_init_lock(&mbox->mbox_mutex);
+	tpp_lock(&mbox->mbox_mutex);
+
 	TPP_QUE_CLEAR(&mbox->mbox_queue);
 
 	snprintf(mbox->mbox_name, sizeof(mbox->mbox_name), "%s", name);
@@ -936,6 +938,7 @@ tpp_mbox_init(tpp_mbox_t *mbox, char *name, int size)
 #ifdef HAVE_SYS_EVENTFD_H
 	if ((mbox->mbox_eventfd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK)) == -1) {
 		tpp_log(LOG_CRIT, __func__, "eventfd() error, errno=%d", errno);
+		tpp_unlock(&mbox->mbox_mutex);
 		return -1;
 	}
 #else
@@ -948,6 +951,7 @@ tpp_mbox_init(tpp_mbox_t *mbox, char *name, int size)
 	 */
 	if (tpp_pipe_cr(mbox->mbox_pipe) != 0) {
 		tpp_log(LOG_CRIT, __func__, "pipe() error, errno=%d", errno);
+		tpp_unlock(&mbox->mbox_mutex);
 		return -1;
 	}
 	/* set the cmd pipe to nonblocking now
@@ -958,6 +962,7 @@ tpp_mbox_init(tpp_mbox_t *mbox, char *name, int size)
 	tpp_set_close_on_exec(mbox->mbox_pipe[0]);
 	tpp_set_close_on_exec(mbox->mbox_pipe[1]);
 #endif
+	tpp_unlock(&mbox->mbox_mutex);
 	return 0;
 }
 

--- a/src/lib/Libtpp/tpp_router.c
+++ b/src/lib/Libtpp/tpp_router.c
@@ -258,8 +258,7 @@ send_leaves_to_router(tpp_router_t *parent, tpp_router_t *target)
 		}
 	}
 	pbs_idx_free_ctx(idx_ctx);
-	tpp_unlock_rwlock(&router_lock);
-
+	
 	while ((pkt = (tpp_packet_t *) tpp_deque(&leaf_packets))) {
 		if (tpp_transport_vsend(target->conn_fd, pkt) != 0) {
 			tpp_log(LOG_ERR, __func__, "Send leaves to pbs_comm %s failed", target->router_name);
@@ -273,7 +272,6 @@ send_leaves_to_router(tpp_router_t *parent, tpp_router_t *target)
 err:
 	/* we jump to the error block only before starting to send, so safe to clear the queue */
 	tpp_log(LOG_CRIT, __func__, "Error sending leaves to router %s", target->router_name);
-	tpp_unlock_rwlock(&router_lock);
 
 	pbs_idx_free_ctx(idx_ctx);
 
@@ -297,8 +295,8 @@ err:
  * @retval  0 - Success
  *
  * @par Side Effects:
- *	This routine expects to be called with the "router_lock" locked and
- *	will unlock the router_lock before exiting.
+ *	This function is not guarded by an lock around it. So it should be called 
+ *  under a lock
  *
  * @par MT-safe: No
  *
@@ -319,12 +317,10 @@ broadcast_to_my_routers(tpp_chunk_t *chunks, int count, int origin_tfd)
 		if (tpp_enque(&router_list, r) == NULL) {
 			tpp_log(LOG_CRIT, __func__, "Out of memory enqueuing to router_list");
 			pbs_idx_free_ctx(idx_ctx);
-			tpp_unlock_rwlock(&router_lock);
 			goto err;
 		}
 	}
 	pbs_idx_free_ctx(idx_ctx);
-	tpp_unlock_rwlock(&router_lock);
 
 	while ((r = (tpp_router_t *) tpp_deque(&router_list))) {
 		int j;
@@ -374,8 +370,8 @@ err:
  *	None
  *
  * @note
- *   This function is not guarded by an lock around it. So it could get invoked
- *   concurrently by multiple threads.
+ *   This function is not guarded by an lock around it. So it should be called 
+ *   under a lock
  *
  * @par MT-safe: No
  *
@@ -395,7 +391,6 @@ broadcast_to_my_leaves(tpp_chunk_t *chunks, int count, int origin_tfd, int type)
 	else
 		traverse_idx = this_router->my_leaves_idx;
 
-	tpp_read_lock(&router_lock);
 	while (pbs_idx_find(traverse_idx, NULL, (void **)&l, &idx_ctx) == PBS_IDX_RET_OK) {
 		/*
 		 * leaf directly connected to me? and not myself
@@ -410,13 +405,11 @@ broadcast_to_my_leaves(tpp_chunk_t *chunks, int count, int origin_tfd, int type)
 			if (tpp_enque(&leaf_list, l) == NULL) {
 				tpp_log(LOG_CRIT, __func__, "Out of memory enqueuing to leaf_list");
 				pbs_idx_free_ctx(idx_ctx);
-				tpp_unlock_rwlock(&router_lock);
 				goto err;
 			}
 		}
 	}
 	pbs_idx_free_ctx(idx_ctx);
-	tpp_unlock_rwlock(&router_lock);
 
 	while ((l = (tpp_leaf_t *) tpp_deque(&leaf_list))) {
 		int j;
@@ -484,6 +477,8 @@ router_send_ctl_join(int tfd, void *data, void *c)
 			tpp_log(LOG_CRIT, NULL, "tfd=%d, pbs_comm %s accepted connection", tfd, r->router_name);
 
 			rc = send_leaves_to_router(this_router, r);
+
+			tpp_unlock_rwlock(&router_lock);
 		} else {
 			tpp_log(LOG_CRIT, __func__, "Failed to send JOIN packet/send leaves to pbs_comm %s", this_router->router_name);
 			tpp_transport_close(r->conn_fd);
@@ -663,8 +658,9 @@ router_close_handler_inner(int tfd, int error, void *c, int hop)
 			 * broadcast leave pkt to other routers,
 			 * except from where it came from
 			 */
-			tpp_read_lock(&router_lock); /* below routine expects to be called under lock */
-			broadcast_to_my_routers(chunks, 2, tfd); /* this routine unlocks the lock */
+			tpp_read_lock(&router_lock);
+			broadcast_to_my_routers(chunks, 2, tfd);
+			tpp_unlock_rwlock(&router_lock);
 
 			tpp_log(LOG_CRIT, NULL, "tfd=%d, Connection from leaf %s down", tfd, tpp_netaddr(&l->leaf_addrs[0]));
 		}
@@ -682,10 +678,6 @@ router_close_handler_inner(int tfd, int error, void *c, int hop)
 			tpp_log(LOG_CRIT, __func__, "tfd=%d, Failed to delete address from my_leaves %s", tfd, tpp_netaddr(&l->leaf_addrs[0]));
 			tpp_unlock_rwlock(&router_lock);
 			return -1;
-		}
-
-		if (hop == 1) {
-			l->conn_fd = -1; /* reset my direct connection fd to -1 since its closing */
 		}
 
 		if (l->num_routers > 0) {
@@ -713,19 +705,12 @@ router_close_handler_inner(int tfd, int error, void *c, int hop)
 			pbs_idx_delete(my_leaves_notify_idx, &l->leaf_addrs[0]);
 		}
 
-		tpp_unlock_rwlock(&router_lock);
-
 		/* broadcast to all self connected leaves */
-		/*
-		 * Its okay to call this function without being under a lock, since when a TPP_CTL_LEAVE
-		 * arrives the downed leaf's traces (IP addresses etc) are removed from the indexes
-		 * under lock before this function is called to propagate this information.
-		 * Another concurrent TPP_CTL_LEAVE will not find anything in the indexes to remove
-		 * and will be ignored early itself.
-		 */
 		broadcast_to_my_leaves(chunks, 2, tfd, 0);
 
 		free_leaf(l);
+
+		tpp_unlock_rwlock(&router_lock);
 
 		return 0;
 
@@ -811,8 +796,6 @@ router_close_handler_inner(int tfd, int error, void *c, int hop)
 			r->conn_fd = -1;
 			r->state = TPP_ROUTER_STATE_DISCONNECTED;
 
-			tpp_unlock_rwlock(&router_lock);
-
 			chunks[0].data = (void *) &hdr;
 			chunks[0].len = sizeof(tpp_leave_pkt_hdr_t);
 
@@ -827,17 +810,11 @@ router_close_handler_inner(int tfd, int error, void *c, int hop)
 				chunks[1].len = l->num_addrs * sizeof(tpp_addr_t);
 
 				/* broadcast to all self connected leaves */
-				/*
-				 * Its okay to call this function without being under a lock, since when a TPP_CTL_LEAVE
-				 * arrives the downed leaf's traces (IP addresses etc) are removed from the indexes
-				 * under lock before this function is called to propagate this information.
-				 * Another concurrent TPP_CTL_LEAVE will not find anything in the indexes to remove
-				 * and will be ignored early itself. Besides we do not want to hold a lock across
-				 * a IO call (inside this function).
-				 */
 				broadcast_to_my_leaves(chunks, 2, tfd, 0);
 				free_leaf(l);
 			}
+
+			tpp_unlock_rwlock(&router_lock);
 		}
 
 		if (r->initiator == 1) {
@@ -1001,7 +978,9 @@ router_timer_handler(time_t now)
 		chunks[0].len = len;
 
 		/* broadcast to self connected leaves asking for notification */
+		tpp_read_lock(&router_lock);
 		broadcast_to_my_leaves(chunks, 1, -1, 1);
+		tpp_unlock_rwlock(&router_lock);
 	}
 
 	return ret;
@@ -1330,7 +1309,9 @@ again:
 				tpp_transport_set_conn_ctx(tfd, ctx);
 
 				/* now send new router info about all leaves I have */
-				send_leaves_to_router(this_router, r); /* this call will unlock the router_lock */
+				send_leaves_to_router(this_router, r);
+
+				tpp_unlock_rwlock(&router_lock);
 				return 0;
 
 			} else if (node_type == TPP_LEAF_NODE || node_type == TPP_LEAF_NODE_LISTEN) {
@@ -1524,10 +1505,10 @@ again:
 					 * broadcast JOIN pkt to other routers,
 					 * except from where it came from
 					 */
-					broadcast_to_my_routers(chunks, 1, tfd); /* this call will unlock the router_lock */
-				} else {
-					tpp_unlock_rwlock(&router_lock); /* unlock router_lock explicitly */
+					broadcast_to_my_routers(chunks, 1, tfd);
 				}
+				
+				tpp_unlock_rwlock(&router_lock);
 				return 0;
 			}
 			return 0;

--- a/src/lib/Libtpp/tpp_router.c
+++ b/src/lib/Libtpp/tpp_router.c
@@ -856,14 +856,16 @@ router_close_handler_inner(int tfd, int error, void *c, int hop)
 			 * ie, remove from routers_idx tree
 			 **/
 			tpp_write_lock(&router_lock);
+			
 			pbs_idx_delete(routers_idx, &r->router_addr);
-			tpp_unlock_rwlock(&router_lock);
-
 			/*
 			 * context will be freed and deleted by router_close_handler
 			 * so just free router structure itself
 			 */
 			free_router(r);
+
+			tpp_unlock_rwlock(&router_lock);
+
 		}
 
 		return 0;

--- a/src/lib/Libtpp/tpp_transport.c
+++ b/src/lib/Libtpp/tpp_transport.c
@@ -947,23 +947,17 @@ static int
 tpp_post_cmd(int tfd, char cmd, tpp_packet_t *pkt)
 {
 	int rc;
+	int slot_state;
 	phy_conn_t *conn = NULL;
 	thrd_data_t *td = NULL;
 
 	errno = 0;
 
-	if (tpp_read_lock(&cons_array_lock))
-		return -1;
+	conn = get_transport_atomic(tfd, &slot_state);
+	if (conn)
+		td = conn->td;
 
-	if (tfd >= 0 && tfd < conns_array_size) {
-		if (conns_array[tfd].conn && conns_array[tfd].slot_state == TPP_SLOT_BUSY) {
-			conn = conns_array[tfd].conn;
-			td = conn->td;
-		}
-	}
-
-	if (!td || !conn) {
-		tpp_unlock_rwlock(&cons_array_lock);
+	if (!conn || slot_state != TPP_SLOT_BUSY || !td) {
 		errno = EBADF;
 		return -1;
 	}
@@ -980,8 +974,6 @@ tpp_post_cmd(int tfd, char cmd, tpp_packet_t *pkt)
 
 	/* write to worker threads send pipe, to wakeup thread */
 	rc = tpp_mbox_post(&td->mbox, tfd, cmd, NULL, 0);
-	tpp_unlock_rwlock(&cons_array_lock);
-
 	return rc;
 }
 
@@ -1724,6 +1716,8 @@ handle_disconnect(phy_conn_t *conn)
 	conn->net_state = TPP_CONN_DISCONNECTED;
 	conn->lasterr = error;
 
+	tfd = conn->sock_fd; /* store this since close_handler could unset this */
+
 	if (the_close_handler)
 		the_close_handler(conn->sock_fd, error, conn->ctx, conn->extra);
 
@@ -1739,16 +1733,15 @@ handle_disconnect(phy_conn_t *conn)
 	 *
 	 */
 	n = NULL;
-	while (tpp_mbox_clear(&conn->td->mbox, &n, conn->sock_fd, &cmd, (void **) &pkt) == 0)
+	while (tpp_mbox_clear(&conn->td->mbox, &n, tfd, &cmd, (void **) &pkt) == 0)
 		tpp_free_pkt(pkt);
 
-	conns_array[conn->sock_fd].slot_state = TPP_SLOT_FREE;
-	conns_array[conn->sock_fd].conn = NULL;
+	conns_array[tfd].slot_state = TPP_SLOT_FREE;
+	conns_array[tfd].conn = NULL;
 
 	tpp_unlock_rwlock(&cons_array_lock);
 
 	/* free old connection */
-	tfd = conn->sock_fd;
 	free_phy_conn(conn);
 	tpp_sock_close(tfd);
 

--- a/src/lib/Libtpp/tpp_transport.c
+++ b/src/lib/Libtpp/tpp_transport.c
@@ -966,10 +966,8 @@ tpp_post_cmd(int tfd, char cmd, tpp_packet_t *pkt)
 		/* data associated that needs to be sent out, put directly into target mbox */
 		/* write to worker threads send pipe */
 		rc = tpp_mbox_post(&conn->send_mbox, tfd, cmd, (void*) pkt, pkt->totlen);
-		if (rc != 0) {
-			tpp_unlock_rwlock(&cons_array_lock);
+		if (rc != 0)
 			return rc;
-		}
 	}
 
 	/* write to worker threads send pipe, to wakeup thread */


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
1. The comm router code incorrectly accesses a fd which has been set to -1 earlier and indexes on it and crashes. The stack trace is as follows:
`#0 0x0000000000409155 in handle_disconnect (conn=conn@entry=0x7efef8002500) at /home/pbsbuild/ramdisk/workspace/build/openpbs/src/lib/Libtpp/tpp_transport.c:1745
#1 0x0000000000409274 in add_pkt (conn=conn@entry=0x7efef8002500) at /home/pbsbuild/ramdisk/workspace/build/openpbs/src/lib/Libtpp/tpp_transport.c:1892
#2 0x0000000000409378 in handle_incoming_data (conn=conn@entry=0x7efef8002500)
at /home/pbsbuild/ramdisk/workspace/build/openpbs/src/lib/Libtpp/tpp_transport.c:1850
#3 0x000000000040a1e0 in work (v=0x24d5e20) at /home/pbsbuild/ramdisk/workspace/build/openpbs/src/lib/Libtpp/tpp_transport.c:1576
#4 0x00007eff06943e65 in start_thread () from /lib64/libpthread.so.0
#5 0x00007eff0601b88d in clone () from /lib64/libc.so.6`

The change to fix this it to not set the conn_fd = -1 in function router_close_handler_inner(). Also the caller, handle_disconnect() has been modified to deal with it, in case the handler reset the fd to -1. 

2. While walking the leaves tree in the comm router, the locks are released too early, and another thread could remove the leaves in between the time the index walk happened, and the usage. Moved the lock/unlocks to a more consistent around the entire functions of "broadcast_to_my_leaves" "broadcast_to_my_routers" and "send_leaves_to_router" functions (instead of inside them)

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

Helgrind test logs
[comm.log](https://github.com/openpbs/openpbs/files/6740473/comm.log)
BTW, the single stack trace listed by helgrind is well understood and is a false positive. 

Description: Rerun All Tests From #8037
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16,UBUNTU2004
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|8040|4175|1|2|0|1|4171|

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
