### PR TITLE
Test 'test_resv_conf_soft' of TestSoftwalltime was failing while submitting resv due to bad time

### DIFF
--- a/test/tests/functional/pbs_soft_walltime.py
+++ b/test/tests/functional/pbs_soft_walltime.py
@@ -471,13 +471,13 @@ e.accept()
         a = {'resources_available.ncpus': 4}
         self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom.shortname)
 
-        now = int(time.time())
         J = Job(TEST_USER, attrs={'Resource_List.ncpus': 4})
         jid = self.server.submit(J)
         self.server.alterjob(jid, {'Resource_List.soft_walltime': 5})
 
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
 
+        now = time.time()
         a = {'Resource_List.ncpus': 1, 'reserve_start': now + 10,
              'reserve_end': now + 130}
         R = Reservation(TEST_USER, attrs=a)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature

- Test 'test_resv_conf_soft' of TestSoftwalltime was failing while submitting resv due to bad time


#### Describe Your Change

- The test is submitting reservation with starting time of the reservation as "now+10" .The value of now is current time and is taken before the job submission. Reservation submission happens  after a while (submitting job and other operations) due to which by the time test submits the reservation, the start time has already exceeded and hence the bad time specification error.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
[Execution_logs_TestSoftwalltime.txt](https://github.com/openpbs/openpbs/files/6748280/Execution_logs_TestSoftwalltime.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
