### PR TITLE
Test 'test_exechost_periodic_accept' of TestHookExechostPeriodic is failing intermittently while verifying server-logs

### DIFF
--- a/test/tests/functional/pbs_hook_exechost_periodic.py
+++ b/test/tests/functional/pbs_hook_exechost_periodic.py
@@ -49,6 +49,7 @@ node = ''
 for k in vn.keys():
     if host in k:
         node = k
+        break
 vn[node].resources_available["mem"] = pbs.size("90gb")
 other_node = "invalid_node"
 if other_node not in vn:
@@ -118,18 +119,15 @@ class TestHookExechostPeriodic(TestFunctional):
         common_msg = " as it is owned by a different mom"
         common_msg2 = "resources_available.mem=9gb per mom hook request"
 
-        exp_msg1 = "autocreated vnode %s" % other_node
+        exp_msg1 = "autocreated vnode %s" % (other_node)
         msg1 = "%s;Updated vnode %s's resource " % (self.momA.hostname,
                                                     other_node)
         exp_msg2 = msg1 + common_msg2
-        msg2 = "%s;Updated vnode %s's resource " % (self.momA.hostname,
-                                                    other_node)
-        exp_msg3 = msg2 + common_msg2
-        msg3 = "%s;Not allowed to update vnode '%s'," % (self.momB.hostname,
+        msg2 = "%s;Not allowed to update vnode '%s'," % (self.momB.hostname,
                                                          other_node)
-        exp_msg4 = msg3 + common_msg
+        exp_msg3 = msg2 + common_msg
 
-        for msg in [exp_msg1, exp_msg2, exp_msg3, exp_msg4]:
+        for msg in [exp_msg1, exp_msg2, exp_msg3]:
             self.server.log_match(msg)
 
         node_attribs = {'resources_available.mem': "90gb"}

--- a/test/tests/functional/pbs_hook_exechost_periodic.py
+++ b/test/tests/functional/pbs_hook_exechost_periodic.py
@@ -43,19 +43,13 @@ from tests.functional import *
 
 common_periodic_hook_script = """import pbs
 pbs.logmsg(pbs.LOG_DEBUG, "In exechost_periodic hook")
-server_node = pbs.server().name
-pbs.logmsg(pbs.LOG_DEBUG, "server name is %s" % server_node)
-
 vn = pbs.event().vnode_list
-vnodes = pbs.server().vnodes()
-for node in vnodes:
-    if node.name != server_node:
-        remote_node = node.name
-        pbs.logmsg(pbs.LOG_DEBUG, "remote node is %s" % node.name)
-vn = pbs.event().vnode_list
-if remote_node not in vn:
-    vn[remote_node] = pbs.vnode(remote_node)
-vn[remote_node].resources_available["mem"] = pbs.size("90gb")
+host = pbs.get_local_nodename()
+node = ''
+for k in vn.keys():
+    if host in k:
+        node = k
+vn[node].resources_available["mem"] = pbs.size("90gb")
 other_node = "invalid_node"
 if other_node not in vn:
     vn[other_node] = pbs.vnode(other_node)
@@ -67,6 +61,8 @@ class TestHookExechostPeriodic(TestFunctional):
     """
     Tests to test exechost_periodic hook
     """
+    def setUp(self):
+        TestFunctional.setUp(self)
 
     def test_multiple_exechost_periodic_hooks(self):
         """
@@ -122,21 +118,18 @@ class TestHookExechostPeriodic(TestFunctional):
         common_msg = " as it is owned by a different mom"
         common_msg2 = "resources_available.mem=9gb per mom hook request"
 
-        msg1 = "%s;Not allowed to update vnode '%s'," % (self.momA.hostname,
-                                                         self.hostB)
-        exp_msg1 = msg1 + common_msg
-        exp_msg2 = "autocreated vnode %s" % other_node
+        exp_msg1 = "autocreated vnode %s" % other_node
+        msg1 = "%s;Updated vnode %s's resource " % (self.momA.hostname,
+                                                    other_node)
+        exp_msg2 = msg1 + common_msg2
         msg2 = "%s;Updated vnode %s's resource " % (self.momA.hostname,
                                                     other_node)
         exp_msg3 = msg2 + common_msg2
-        msg3 = "%s;Updated vnode %s's resource " % (self.momA.hostname,
-                                                    other_node)
-        exp_msg4 = msg3 + common_msg2
-        msg4 = "%s;Not allowed to update vnode '%s'," % (self.momB.hostname,
+        msg3 = "%s;Not allowed to update vnode '%s'," % (self.momB.hostname,
                                                          other_node)
-        exp_msg5 = msg4 + common_msg
+        exp_msg4 = msg3 + common_msg
 
-        for msg in [exp_msg1, exp_msg2, exp_msg3, exp_msg4, exp_msg5]:
+        for msg in [exp_msg1, exp_msg2, exp_msg3, exp_msg4]:
             self.server.log_match(msg)
 
         node_attribs = {'resources_available.mem': "90gb"}

--- a/test/tests/functional/pbs_hook_exechost_periodic.py
+++ b/test/tests/functional/pbs_hook_exechost_periodic.py
@@ -125,8 +125,7 @@ class TestHookExechostPeriodic(TestFunctional):
         msg1 = "%s;Not allowed to update vnode '%s'," % (self.momA.hostname,
                                                          self.hostB)
         exp_msg1 = msg1 + common_msg
-        exp_msg2 = "%s;autocreated vnode %s" % (self.momA.hostname,
-                                                other_node)
+        exp_msg2 = "autocreated vnode %s" % other_node
         msg2 = "%s;Updated vnode %s's resource " % (self.momA.hostname,
                                                     other_node)
         exp_msg3 = msg2 + common_msg2


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature

- Test 'test_exechost_periodic_accept' of TestHookExechostPeriodic is failing intermittently while verifying server-logs


#### Describe Your Change

-  In the hook script we are updating resource of a invalid vnode. Periodic hook upon encountering an invalid node ’, proceeds to create one and the test is verifying this by verifying the following msg "autocreated vnode <vnode name>". In the current test, the test is verifying the existence of this log msg and along with that it is also verifying that the msg is received from first mom. The test is failing intermittently as the log msg in failed case has been sent from the other mom. So updating the test to check just for the log msg instead of checking from which mom the msg has been recieved.
-  In the test, hook is creating the second mom has vnode due to whichin the next test run whenever the mom is created it creates the vnode(Other mom) and when it tries to create other mom it throws error "Node already exist"


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
[Exec_periodic.txt](https://github.com/openpbs/openpbs/files/6782312/Exec_periodic.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
