### PR TITLE
Logging improvements for better diagnostics

### DIFF
--- a/src/lib/Libtpp/tpp_util.c
+++ b/src/lib/Libtpp/tpp_util.c
@@ -2243,21 +2243,6 @@ tpp_netaddr(tpp_addr_t *ap)
 	sprintf(port, ":%d", ntohs(ap->port));
 	strcat(ptr->tppstaticbuf, port);
 
-	/* if log mask is high, then reverse lookup the ip address
-	 * to print hostname along with ip
-	 */
-	if (tpp_log_event_mask >= (PBSEVENT_DEBUG4 - 1)) {
-		char host[256];
-
-		if (tpp_sock_resolve_ip(ap, host, sizeof(host)) == 0) {
-			char *tmp_buf;
-
-			pbs_asprintf(&tmp_buf, "(%s)%s", host, ptr->tppstaticbuf);
-			strcpy(ptr->tppstaticbuf, tmp_buf);
-			free(tmp_buf);
-		}
-	}
-
 	return ptr->tppstaticbuf;
 }
 

--- a/src/resmom/mom_server.c
+++ b/src/resmom/mom_server.c
@@ -688,6 +688,8 @@ is_request(int stream, int version)
 	command = disrsi(stream, &ret);
 	if (ret != DIS_SUCCESS)
 		goto err;
+	
+	log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_SERVER, LOG_DEBUG, msg_daemonname, "Received request: %d", command);
 
 	switch (command) {
 

--- a/src/resmom/mom_updates_bundle.c
+++ b/src/resmom/mom_updates_bundle.c
@@ -733,6 +733,7 @@ get_job_update(job *pjob)
 	}
 #endif
 	if ((at = get_jattr(pjob, JOB_ATR_session_id))->at_flags & ATR_VFLAG_MODIFY) {
+		log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_JOB, LOG_DEBUG, pjob->ji_qs.ji_jobid, "SID is: %ld", get_jattr_long(pjob, JOB_ATR_session_id));
 		job_attr_def[JOB_ATR_session_id].at_encode(at, &prused->ru_attr,
 							   job_attr_def[JOB_ATR_session_id].at_name,
 							   NULL, ATR_ENCODE_CLIENT, NULL);
@@ -890,7 +891,8 @@ send_resc_used(int cmd, int count, ruu *rud)
 
 	if (count == 0 || rud == NULL || server_stream < 0)
 		return;
-	DBPRT(("send_resc_used update to server on stream %d\n", server_stream))
+	log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_NODE, LOG_DEBUG, "",
+			"send_resc_used update to server on stream %d\n", server_stream);
 
 	ret = is_compose(server_stream, cmd);
 	if (ret != DIS_SUCCESS)

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -2130,6 +2130,8 @@ stat_update(int stream)
 				 * it may have already been changed to:
 				 * - EXITING if the OBIT arrived first.
 				 */
+				log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_JOB, LOG_DEBUG, pjob->ji_qs.ji_jobid,
+				        "Received session ID for job: %ld", get_jattr_long(pjob, JOB_ATR_session_id));
 				if ((check_job_substate(pjob, JOB_SUBSTATE_PRERUN)) ||
 					(check_job_substate(pjob, JOB_SUBSTATE_PROVISION))) {
 					/* log acct info and make RUNNING */
@@ -2155,8 +2157,10 @@ stat_update(int stream)
 				log_event(PBSEVENT_DEBUG3, PBS_EVENTCLASS_JOB,
 					LOG_DEBUG, pjob->ji_qs.ji_jobid,
 					"update from Mom without session id");
-			} else
+			} else {
+				log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_JOB, LOG_DEBUG, pjob->ji_qs.ji_jobid, "Received the same SID as before: %ld", get_jattr_long(pjob, JOB_ATR_session_id));
 				job_save_db(pjob);
+			}
 		}
 		(void)free(rused.ru_comment);
 		rused.ru_comment = NULL;
@@ -4310,6 +4314,7 @@ badcon:
 found:
 	psvrmom = (mom_svrinfo_t *)(pmom->mi_data);
 	pdmninfo = pmom->mi_dmn_info;
+	log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_SERVER, LOG_DEBUG, msg_daemonname, "Received request2: %d", command);
 
 	switch (command) {
 

--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -518,6 +518,9 @@ svr_setjobstate(job *pjob, char newstate, int newsubstate)
 		(check_job_state(pjob, newstate) && (check_job_substate(pjob, newsubstate))))
 		return (0);
 
+	log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_JOB, LOG_INFO, pjob->ji_qs.ji_jobid,
+				"Updated job state to %d and substate to %d", newstate, newsubstate);
+
 	/*
 	 * if its is a new job, then don't update counts, svr_enquejob() will
 	 * take care of that, also req_commit() will see that the job is saved.


### PR DESCRIPTION
#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Reverse resolution in logging at a higher level was slowing doing mom-server communication with power provisioning enabled

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* Removed reverse resolution for high level logging when no route to host
* Logging improvements to be able to do better diagnostics - log whenever state and substate of a job is changed

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Manual Test:
[Linux_log_improve.txt](https://github.com/openpbs/openpbs/files/6803442/Linux_log_improve.txt)

Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, WIN2K16, UBUNTU2004
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16,UBUNTU2004
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|8137|4177|4|1|0|1|4171|


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
