### PR TITLE
Deleted vnode using IP address

### DIFF
--- a/test/tests/functional/pbs_mom_local_nodename.py
+++ b/test/tests/functional/pbs_mom_local_nodename.py
@@ -101,5 +101,7 @@ pbs.logmsg(pbs.LOG_DEBUG,
         self.du.unset_pbs_config(hostname=self.mom.shortname,
                                  confs=['PBS_MOM_NODE_NAME'])
         self.server.restart()
+        self.server.manager(MGR_CMD_DELETE, VNODE, id="@default",
+                            runas=ROOT_USER)
         self.mom.restart()
         TestFunctional.tearDown(self)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
tests failed on cpuset machine, In test suite "TestMomLocalNodeName" test 'test_ip_nodename_not_truncated' creates node and vnode based on IP addresses via hook,  In tearDown  we didn't delete node and vnode created using IP. 
In next test setUp we  check  node_state for vnode=free, but vnodes are created by IP in previous test so PTL didn't get expected node state and next test 'test_url_nodename_not_truncated ' got failed in setUp().


#### Describe Your Change
In tearDown deleted all created node before restarting the MoM


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[mom_local_node_ptl_logs.txt](https://github.com/openpbs/openpbs/files/6752712/mom_local_node_ptl_logs.txt)

Description: Tests from given sources on platforms CENTOS8
Platforms: CENTOS8
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|8059|2|0|0|0|0|2|


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
