### PR TITLE
Added missed attribute in Fairshare class

### DIFF
--- a/test/fw/ptl/lib/ptl_fairshare.py
+++ b/test/fw/ptl/lib/ptl_fairshare.py
@@ -289,9 +289,9 @@ class Fairshare(object):
         self.user = user
         _m = ['fairshare']
         if self.sc_name is not None:
-            _m += ['-', self.sc_name]
+            _m += ['-', str(self.sc_name)]
         if self.user is not None:
-            _m += ['-', self.user]
+            _m += ['-', str(self.user)]
         _m += [':']
         self.logprefix = "".join(_m)
 

--- a/test/fw/ptl/lib/ptl_fairshare.py
+++ b/test/fw/ptl/lib/ptl_fairshare.py
@@ -281,13 +281,19 @@ class Fairshare(object):
     fs_tag = re.compile(fs_re)
 
     def __init__(self, has_snap=None, pbs_conf={}, sc_name=None,
-                 hostname=None, user=None, logprefix=None):
+                 hostname=None, user=None):
         self.has_snap = has_snap
         self.pbs_conf = pbs_conf
         self.sc_name = sc_name
         self.hostname = hostname
         self.user = user
-        self.logprefix = logprefix
+        _m = ['fairshare']
+        if self.sc_name is not None:
+            _m += ['-', self.sc_name]
+        if self.user is not None:
+            _m += ['-', self.user]
+        _m += [':']
+        self.logprefix = "".join(_m)
 
     def revert_fairshare(self):
         """

--- a/test/fw/ptl/lib/ptl_fairshare.py
+++ b/test/fw/ptl/lib/ptl_fairshare.py
@@ -281,12 +281,13 @@ class Fairshare(object):
     fs_tag = re.compile(fs_re)
 
     def __init__(self, has_snap=None, pbs_conf={}, sc_name=None,
-                 hostname=None, user=None):
+                 hostname=None, user=None, logprefix=None):
         self.has_snap = has_snap
         self.pbs_conf = pbs_conf
         self.sc_name = sc_name
         self.hostname = hostname
         self.user = user
+        self.logprefix = logprefix
 
     def revert_fairshare(self):
         """

--- a/test/fw/ptl/lib/ptl_sched.py
+++ b/test/fw/ptl/lib/ptl_sched.py
@@ -165,12 +165,6 @@ class Scheduler(PBSService):
                             "strict_fifo"
                             ]
 
-    fs_re = r'(?P<name>[\S]+)[\s]*:[\s]*Grp:[\s]*(?P<Grp>[-]*[0-9]*)' + \
-            r'[\s]*cgrp:[\s]*(?P<cgrp>[-]*[0-9]*)[\s]*' + \
-            r'Shares:[\s]*(?P<Shares>[-]*[0-9]*)[\s]*Usage:[\s]*' + \
-            r'(?P<Usage>[0-9]+)[\s]*Perc:[\s]*(?P<Perc>.*)%'
-    fs_tag = re.compile(fs_re)
-
     def __init__(self, server, hostname=None, pbsconf_file=None,
                  snapmap={}, snap=None, db_access=None, id='default',
                  sched_priv=None):
@@ -214,7 +208,7 @@ class Scheduler(PBSService):
 
         self.user = DAEMON_SERVICE_USER
         self.fairshare = Fairshare(self.has_snap, self.pbs_conf, self.sc_name,
-                                   self.hostname, self.user)
+                                   self.hostname, self.user, self.logprefix)
 
         self.dflt_sched_config_file = os.path.join(self.pbs_conf['PBS_EXEC'],
                                                    'etc', 'pbs_sched_config')

--- a/test/fw/ptl/lib/ptl_sched.py
+++ b/test/fw/ptl/lib/ptl_sched.py
@@ -208,7 +208,7 @@ class Scheduler(PBSService):
 
         self.user = DAEMON_SERVICE_USER
         self.fairshare = Fairshare(self.has_snap, self.pbs_conf, self.sc_name,
-                                   self.hostname, self.user, self.logprefix)
+                                   self.hostname, self.user)
 
         self.dflt_sched_config_file = os.path.join(self.pbs_conf['PBS_EXEC'],
                                                    'etc', 'pbs_sched_config')


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Attribute "self.logprefix " is not defined in class Fairshare. fs_re and fs_tag are not used in Scheduler class.


#### Describe Your Change
removed fs_re and fs_tag from Scheduler class and added missed attribute "self.logprefix"


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

mom_on_server

Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, WIN2K16, UBUNTU2004
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16,UBUNTU2004
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|8066|4177|2|0|0|1|4174|


no_mom_on_server

Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, WIN2K16, UBUNTU2004
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16,UBUNTU2004
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|8065|4177|18|6|0|13|4140|


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
