### PR TITLE
Fix deleting multi sched in TestMultipleSchedulers.test_list_multi_sched

### DIFF
--- a/test/tests/functional/pbs_multi_sched.py
+++ b/test/tests/functional/pbs_multi_sched.py
@@ -136,6 +136,17 @@ class TestMultipleSchedulers(TestFunctional):
                 self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': op},
                                     id=each)
 
+    def delete_sched(self, sched_name):
+        """
+        Helper function to delete sched"
+        """
+        self.scheds[sched_name].terminate()
+        sched_log = self.scheds[sched_name].attributes['sched_log']
+        sched_priv = self.scheds[sched_name].attributes['sched_priv']
+        self.du.rm(path=sched_log, sudo=True, recursive=True, force=True)
+        self.du.rm(path=sched_priv, sudo=True, recursive=True, force=True)
+        self.server.manager(MGR_CMD_DELETE, SCHED, id=sched_name)
+
     def test_job_sort_formula_multisched(self):
         """
         Test that job_sort_formula can be set for each sched
@@ -1192,7 +1203,7 @@ class TestMultipleSchedulers(TestFunctional):
                             "Error message is not expected")
 
         # delete sc3 sched
-        self.server.manager(MGR_CMD_DELETE, SCHED, id="sc3", sudo=True)
+        self.delete_sched("sc3")
 
         try:
             self.server.manager(MGR_CMD_LIST, SCHED, id="sc3")
@@ -1210,7 +1221,7 @@ class TestMultipleSchedulers(TestFunctional):
         self.server.manager(MGR_CMD_LIST, SCHED, id="sc2")
 
         # delete sc1 sched
-        self.server.manager(MGR_CMD_DELETE, SCHED, id="sc1")
+        self.delete_sched("sc1")
 
         try:
             self.server.manager(MGR_CMD_LIST, SCHED, id="sc1")


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Test test_multiple_queue_same_partition and test_pbsfs_revert_to_defaults of TestMultipleSchedulers are failing while verifying log match due to cleanup has not done properly in previous test which is test_list_multi_sched.

#### Describe Your Change
In test case test_list_multi_sched deleting scheduler sc1 and sc3 using qmgr command which leaves sched processed "pbs_sc1" and "pbs_sc3" running behind and also respective directories will be present under PBS Home directory.
In order to delete sched, we need to first kill the process, remove relative folders from PBS Home directory and then delete using qmgr.

#### Attach Test and Valgrind Logs/Output
Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, WIN2K16, UBUNTU2004
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16,UBUNTU2004
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|8113|570|0|0|0|10|560|



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
