### PR TITLE
Update test 'test_submit_large_env' of TestQsubPerformance accordingly

### DIFF
--- a/test/tests/performance/pbs_qsub_performance.py
+++ b/test/tests/performance/pbs_qsub_performance.py
@@ -73,7 +73,7 @@ class TestQsubPerformance(TestPerformance):
             subprocess.call(job_sub_arg, shell=True, env=env)
         end_time = time.time()
    
-        sub_time = int(end_time - start_time)
+        sub_time = round(end_time - start_time, 2)
         return sub_time
 
     def test_submit_large_env(self):

--- a/test/tests/performance/pbs_qsub_performance.py
+++ b/test/tests/performance/pbs_qsub_performance.py
@@ -51,7 +51,7 @@ class TestQsubPerformance(TestPerformance):
     def submit_jobs(self, qsub_exec_arg=None, env=None):
         """
         Submits n num of jobs according to the arguments provided
-        and returns starttime and endtime of job submission
+        and returns submission time
         :param qsub_exec_arg: Arguments to qsub.
         :type qsub_exec_arg: String. Defaults to None.
         :param env: Environment variable to be set before submittign job.
@@ -72,7 +72,9 @@ class TestQsubPerformance(TestPerformance):
             start_time = time.time()
             subprocess.call(job_sub_arg, shell=True, env=env)
             end_time = time.time()
-        return start_time, end_time
+   
+        sub_time = int(end_time - start_time)
+        return sub_time
 
     def test_submit_large_env(self):
         """
@@ -82,14 +84,11 @@ class TestQsubPerformance(TestPerformance):
         3. Submit 1000 jobs again with -V as argument to qsub
         4. Collect time taken for both submissions
         """
-        (start_time1, end_time1) = self.submit_jobs()
-        (start_time2, end_time2) = self.submit_jobs(qsub_exec_arg="-V")
-
-        sub_time1 = int(end_time1 - start_time1)
-        sub_time2 = int(end_time2 - start_time2)
+        sub_time_without_env = self.submit_jobs()
+        sub_time_with_env = self.submit_jobs(qsub_exec_arg="-V")
 
         self.logger.info(
             "Submission time without env is %d and with env is %d sec"
-            % (sub_time1, sub_time2))
-        self.perf_test_result(sub_time1, "submission_time_without_env", "sec")
-        self.perf_test_result(sub_time2, "submission_time_with_env", "sec")
+            % (sub_time_without_env, sub_time_with_env))
+        self.perf_test_result(sub_time_without_env, "submission_time_without_env", "sec")
+        self.perf_test_result(sub_time_with_env, "submission_time_with_env", "sec")

--- a/test/tests/performance/pbs_qsub_performance.py
+++ b/test/tests/performance/pbs_qsub_performance.py
@@ -51,6 +51,7 @@ class TestQsubPerformance(TestPerformance):
     def submit_jobs(self, qsub_exec_arg=None, env=None):
         """
         Submits n num of jobs according to the arguments provided
+        and returns starttime and endtime of job submission
         :param qsub_exec_arg: Arguments to qsub.
         :type qsub_exec_arg: String. Defaults to None.
         :param env: Environment variable to be set before submittign job.
@@ -68,7 +69,10 @@ class TestQsubPerformance(TestPerformance):
         job_sub_arg += ' -- /bin/sleep 100'
 
         for _ in range(1000):
+            start_time = time.time()
             subprocess.call(job_sub_arg, shell=True, env=env)
+            end_time = time.time()
+        return start_time, end_time
 
     def test_submit_large_env(self):
         """
@@ -78,13 +82,8 @@ class TestQsubPerformance(TestPerformance):
         3. Submit 1000 jobs again with -V as argument to qsub
         4. Collect time taken for both submissions
         """
-        start_time1 = time.time()
-        self.submit_jobs()
-        end_time1 = time.time()
-
-        start_time2 = time.time()
-        self.submit_jobs(qsub_exec_arg="-V")
-        end_time2 = time.time()
+        (start_time1, end_time1) = self.submit_jobs()
+        (start_time2, end_time2) = self.submit_jobs(qsub_exec_arg="-V")
 
         sub_time1 = int(end_time1 - start_time1)
         sub_time2 = int(end_time2 - start_time2)

--- a/test/tests/performance/pbs_qsub_performance.py
+++ b/test/tests/performance/pbs_qsub_performance.py
@@ -70,10 +70,10 @@ class TestQsubPerformance(TestPerformance):
         start_time = time.time()
         for _ in range(1000):
             qsub = self.du.run_cmd(self.server.hostname,
-                                    job_sub_arg,
-                                    env=env,
-                                    as_script=True,
-                                    logerr=False)
+                                   job_sub_arg,
+                                   env=env,
+                                   as_script=True,
+                                   logerr=False)
             if qsub['rc'] != 0:
                 return -1
         end_time = time.time()

--- a/test/tests/performance/pbs_qsub_performance.py
+++ b/test/tests/performance/pbs_qsub_performance.py
@@ -68,10 +68,10 @@ class TestQsubPerformance(TestPerformance):
 
         job_sub_arg += ' -- /bin/sleep 100'
 
+        start_time = time.time()
         for _ in range(1000):
-            start_time = time.time()
             subprocess.call(job_sub_arg, shell=True, env=env)
-            end_time = time.time()
+        end_time = time.time()
    
         sub_time = int(end_time - start_time)
         return sub_time


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature

- Update test 'test_submit_large_env' of TestQsubPerformance accordingly


#### Describe Your Change

- In the test we are submitting 1k jobs as pbsuser --> set env through os.environ --> submit another 1k jobs as pbsuser. After this the test is calculating the time diff between the first and last job submitted job (before and after setting env)

We currently run test as pbsroot and the env which is being set while be present in pbsroot's shell but not in pbsuser's shell

Also in the test we are setting env varibale in the shell which will not affect qsub performance..We need to modify test in such a way that it should consider submitting job through -V and -v in qsub.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output

- [Execution_logs_TestQsubPerformance.txt](https://github.com/openpbs/openpbs/files/6788515/Execution_logs_TestQsubPerformance.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
