### PR TITLE
Updated hook script of test_exechost_periodic_custom_resc

### DIFF
--- a/test/tests/functional/pbs_hook_exechost_periodic.py
+++ b/test/tests/functional/pbs_hook_exechost_periodic.py
@@ -190,7 +190,7 @@ class TestHookExechostPeriodic(TestFunctional):
         self.hostB = self.momB.shortname
         hook_name = "periodic"
         hook_attrs = {'event': 'exechost_periodic', 'enabled': 'True'}
-        hook_script = """vn[remote_node].resources_available["foo"] = True"""
+        hook_script = """vn[node].resources_available["foo"] = True"""
         hook_body = common_periodic_hook_script + hook_script
         self.server.create_import_hook(hook_name, hook_attrs, hook_body)
         node_attribs = {'resources_available.foo': True}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature

- Test "test_exechost_periodic_custom_resc" of TestHookExechostPeriodic is failing while verifying node attributes

#### Describe Your Change
-  In the hook script of Test "test_exechost_periodic_custom_resc" we are updating the value of "resources_available.foo" on remote node to be True but there is no such variable called remote_node. This varible has now been modifed as "node". so updated hook script accoridngly.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

- [Execution_logs_Periodiic_2022.txt](https://github.com/openpbs/openpbs/files/6799253/Execution_logs_Periodiic_2022.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
