### PR TITLE
Fixed post condition of *server_restart_immed tests

### DIFF
--- a/test/tests/functional/pbs_node_rampdown.py
+++ b/test/tests/functional/pbs_node_rampdown.py
@@ -332,7 +332,7 @@ class TestPbsNodeRampDown(TestFunctional):
         self.server.manager(MGR_CMD_SET, NODE, a, id=self.hostC)
 
         a = {'state': 'free', 'resources_available.ncpus': (GE, 1)}
-        self.server.expect(VNODE, {'state=free': 11}, op=EQ, count=True,
+        self.server.expect(VNODE, {'state=free': 11}, count=True,
                            interval=2)
 
         # Various node names

--- a/test/tests/functional/pbs_node_rampdown.py
+++ b/test/tests/functional/pbs_node_rampdown.py
@@ -544,6 +544,14 @@ return i\\n return fib(i-1) + fib(i-2)\\n\\nprint(fib(400))\\\")"'
             "%s:mem=1048576kb:ncpus=1+" % (self.n5,) + \
             "%s:ncpus=1)+" % (self.n6,) + \
             "(%s:ncpus=1:mem=1048576kb)" % (self.n7,)
+        self.job11x_exec_vnode_match = \
+            "\(.+:mem=1048576kb:ncpus=1\+" + \
+            ".+:mem=1048576kb:ncpus=1\+" + \
+            ".+:ncpus=1\)\+" + \
+            "\(.+:mem=1048576kb:ncpus=1\+" + \
+            ".+:mem=1048576kb:ncpus=1\+" + \
+            ".+:ncpus=1\)\+" + \
+            "\(.+:ncpus=1:mem=1048576kb\)"
         self.script['job11x'] = \
             "#PBS -S /bin/bash\n" \
             "#PBS -l select=" + self.job11x_select + "\n" + \
@@ -5587,7 +5595,7 @@ pbs.logjobmsg(pbs.event().job.id, "epilogue hook executed")
              server with qterm -t immediate which
              will requeue job completely, and when
              server is started, job gets assigned
-             the vnodes from the original request
+             resources to the original request
              before the pbs_release_nodes call.
 
              Given a job submitted with a select spec of
@@ -5612,8 +5620,8 @@ pbs.logjobmsg(pbs.event().job.id, "epilogue hook executed")
 
              Now start pbs_server.
 
-             The job goes back to getting assigned to the
-             original resources, before pbs_releaes_nodes
+             The job goes back to getting assigned resources for the
+             original request, before pbs_release_nodes
              was called.
         """
         jid = self.create_and_submit_job('job11x')
@@ -5732,6 +5740,8 @@ pbs.logjobmsg(pbs.event().job.id, "epilogue hook executed")
         self.server.set_op_mode(om)
         self.assertFalse(self.server.isUp())
 
+        check_time = time.time()
+
         # resume momC, but this is a stale request (nothing happens)
         # since server is down.
         self.momC.signal("-CONT")
@@ -5750,18 +5760,16 @@ pbs.logjobmsg(pbs.event().job.id, "epilogue hook executed")
                                  'Resource_List.select': self.job11x_select,
                                  'Resource_List.place': self.job11x_place,
                                  'schedselect': self.job11x_schedselect,
-                                 'exec_host': self.job11x_exec_host,
-                                 'exec_vnode': self.job11x_exec_vnode}, id=jid)
-        # Check various vnode status.
-        jobs_assn1 = "%s/0" % (jid,)
-        self.match_vnode_status([self.n1, self.n2, self.n4, self.n5,
-                                 self.n7], 'job-exclusive', jobs_assn1, 1,
-                                '1048576kb')
+                                 'exec_host': self.job11x_exec_host}, id=jid)
 
-        self.match_vnode_status([self.n3, self.n6],
-                                'job-exclusive', jobs_assn1, 1, '0kb')
+        self.server.log_match("Job;%s;Job Run.+on exec_vnode %s" % (
+                              jid, self.job11x_exec_vnode_match), regexp=True,
+                              starttime=check_time)
 
-        self.match_vnode_status([self.n0, self.n8, self.n9, self.n10], 'free')
+        self.server.expect(VNODE, {'state=job-exclusive': 7},
+                           count=True, max_attempts=20, interval=2)
+        self.server.expect(VNODE, {'state=free': 4},
+                           count=True, max_attempts=20, interval=2)
 
         self.server.expect(SERVER, {'resources_assigned.ncpus': 7,
                                     'resources_assigned.mem': '5242880kb'})
@@ -6081,6 +6089,8 @@ pbs.logjobmsg(pbs.event().job.id, "epilogue hook executed")
         self.server.set_op_mode(om)
         self.assertFalse(self.server.isUp())
 
+        check_time = time.time()
+
         # resume momC, but this is a stale request (nothing happens)
         # since server is down.
         self.momC.signal("-CONT")
@@ -6100,28 +6110,19 @@ pbs.logjobmsg(pbs.event().job.id, "epilogue hook executed")
                                  'Resource_List.select': self.job11_select,
                                  'Resource_List.place': self.job11_place,
                                  'schedselect': self.job11_schedselect,
-                                 'exec_host': self.job11_exec_host,
-                                 'exec_vnode': self.job11_exec_vnode}, id=jid)
+                                 'exec_host': self.job11_exec_host}, id=jid)
 
-        # Check various vnode status.
-        jobs_assn1 = "%s/0" % (jid,)
-        self.match_vnode_status([self.n1, self.n2, self.n4, self.n5],
-                                'job-busy', jobs_assn1, 1,
-                                '1048576kb')
+        self.server.log_match("Job;%s;Job Run.+on exec_vnode %s" % (
+                              jid, self.job11x_exec_vnode_match), regexp=True,
+                              starttime=check_time)
 
-        self.match_vnode_status([self.n3, self.n6],
-                                'job-busy', jobs_assn1, 1, '0kb')
-
-        # node <n7> still has resources (ncpus=1, mem=1gb) to share
-        self.server.expect(VNODE, {'state': 'free',
-                                   'jobs': jobs_assn1,
-                                   'resources_assigned.ncpus': 1,
-                                   'resources_assigned.mem': '1048576kb'},
-                           id=self.n7)
-        self.match_vnode_status([self.n7], 'free', jobs_assn1,
-                                1, '1048576kb')
-
-        self.match_vnode_status([self.n0, self.n8, self.n9, self.n10], 'free')
+        # 7 vnodes are assigned in a shared way: 6 of them has single cpu,
+        # while 1 has multiple cpus. So 6 will get "job-busy" state while
+        # the other will be in "free" state like the rest.
+        self.server.expect(VNODE, {'state=job-busy': 6},
+                           count=True, max_attempts=20, interval=2)
+        self.server.expect(VNODE, {'state=free': 5},
+                           count=True, max_attempts=20, interval=2)
 
         self.server.expect(SERVER, {'resources_assigned.ncpus': 7,
                                     'resources_assigned.mem': '5242880kb'})


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* Two tests in the TestPbsNodeRampDown testsuite, test_release_nodes_excl_server_restart_immed and test_release_nodes_shared_server_restart_immed need to be updated due to an  incorrect assumption on node assignment after job restart.
* The two tests incorrectly assume that the job will get assigned exactly the same set of vnodes upon job rerun, after a 'qterm -t immediate' is done and server is restarted. 
* There's no guarantee that the SAME set of vnodes would be re-assigned to the job. For instance, say job requests 3 vnodes and has been assigned vnode1+vnode2+vnode3. After a bunch of pbs_release_nodes calls and then a qterm -t immediate followed up by a server start, the job is requeued to go back to requesting 3 vnodes. Upon job rerun, it could be assigned to another set of nodes like vnode4+vnode2+vnode6.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* Upon job restart, instead of matching exactly the exec_vnode value of before, do a regular expression match instead and not include the exact vnode names.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

[logfile_PASS_test_release_nodes_excl_server_restart_immed.txt](https://github.com/openpbs/openpbs/files/6811053/logfile_PASS_test_release_nodes_excl_server_restart_immed.txt)
[logfile_PASS_test_release_nodes_shared_server_restart_immed.txt](https://github.com/openpbs/openpbs/files/6811054/logfile_PASS_test_release_nodes_shared_server_restart_immed.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
