### PR TITLE
Make sure no nodes are in down state after server restarts

### DIFF
--- a/test/fw/ptl/lib/ptl_server.py
+++ b/test/fw/ptl/lib/ptl_server.py
@@ -286,7 +286,7 @@ class Server(Wrappers):
         Terminate and start a PBS server.
         """
         cmd = os.path.join(self.client_conf['PBS_EXEC'], 'bin',
-                          'pbsnodes') + ' -av' + ' -Fjson'
+                           'pbsnodes') + ' -av' + ' -Fjson'
         cmd_out = self.du.run_cmd(self.hostname, cmd, sudo=True)
         pbsnodes_json = json.loads('\n'.join(cmd_out['out']))
         if self.isUp():

--- a/test/fw/ptl/lib/ptl_server.py
+++ b/test/fw/ptl/lib/ptl_server.py
@@ -285,17 +285,11 @@ class Server(Wrappers):
         """
         Terminate and start a PBS server.
         """
-        cmd = os.path.join(self.client_conf['PBS_EXEC'], 'bin',
-                           'pbsnodes') + ' -av' + ' -Fjson'
-        cmd_out = self.du.run_cmd(self.hostname, cmd, sudo=True)
-        pbsnodes_json = json.loads('\n'.join(cmd_out['out']))
         if self.isUp():
             if not self.stop():
                 return False
         start_rc = self.start()
-        for m in pbsnodes_json['nodes']:
-            a = {'state': pbsnodes_json['nodes'][m]['state']}
-            self.expect(NODE, a, id=m)
+        self.expect(NODE, {'state=state-unknown,down': 0})
         return start_rc
 
     def log_match(self, msg=None, id=None, n=50, tail=True, allmatch=False,

--- a/test/fw/ptl/lib/ptl_server.py
+++ b/test/fw/ptl/lib/ptl_server.py
@@ -285,10 +285,18 @@ class Server(Wrappers):
         """
         Terminate and start a PBS server.
         """
+        cmd = os.path.join(self.client_conf['PBS_EXEC'], 'bin',
+                          'pbsnodes') + ' -av' + ' -Fjson'
+        cmd_out = self.du.run_cmd(self.hostname, cmd, sudo=True)
+        pbsnodes_json = json.loads('\n'.join(cmd_out['out']))
         if self.isUp():
             if not self.stop():
                 return False
-        return self.start()
+        start_rc = self.start()
+        for m in pbsnodes_json['nodes']:
+            a = {'state': pbsnodes_json['nodes'][m]['state']}
+            self.expect(NODE, a, id=m)
+        return start_rc
 
     def log_match(self, msg=None, id=None, n=50, tail=True, allmatch=False,
                   regexp=False, max_attempts=None, interval=None,


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
After server restart, nodes may be down for a few seconds till they reconnect with server, which causes qdel failures where it cannot connect to Mom which are issues as soon as server restart.


#### Describe Your Change
Check nodes are in same state as before and after server restart


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

Description: Tests from given sources on platforms SUSE15, CENTOS8, CENTOS7, UBUNTU2004
Platforms: SUSE15,CENTOS8,CENTOS7,UBUNTU2004
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|8154|1243|3|1|0|0|1239|

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
