### PR TITLE
Switch to obtaining nvidia a100 MIG identifier/UUID from nvidia-smi -L directly, rather than constructing tuple format

### DIFF
--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -2056,6 +2056,8 @@ class NodeUtils(object):
 
         line_count = 0
         for out_line in out:
+            # Don't capture the first list element which has the GPU UUID and
+            # the last line, which has only a newline in it
             if(line_count == 0 or line_count == len(out)-1):
                 line_count += 1
                 continue
@@ -2120,7 +2122,6 @@ class NodeUtils(object):
 
             uuid = uuid_list[uuid_count]
             uuid_count += 1
-            # uuid = 'MIG-%s/%s/%s' % (gpus[gpuid]['uuid'], giid, ciid)
             ci = {'minor': minor, 'gi': giid, 'ci': ciid, 'uuid': uuid}
             pbs.logmsg(pbs.EVENT_DEBUG4, 'CI found %s' % str(ci))
             if 'cis' not in gpus[gpuid]['gis'][giid]:

--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -2023,13 +2023,14 @@ class NodeUtils(object):
                 gpus[gpuid]['gis'] = {}
             gpus[gpuid]['gis'][giid] = gi
 
-        #Find all MIG UUIDs using nvidia-smi -L and update it later while finding the CIs
+        # Find all MIG UUIDs using nvidia-smi -L
+        # and update it later while finding the CIs
         uuid_list = []
         cmd = [self.cfg['nvidia-smi'], '-L']
         pbs.logmsg(pbs.EVENT_DEBUG4, 'NVIDIA SMI command: %s' % cmd)
         time_start = time.time()
         out = []
- 
+
         try:
             # Try running the nvidia-smi command
             process = subprocess.Popen(cmd, shell=False,
@@ -2046,23 +2047,23 @@ class NodeUtils(object):
         if elapsed_time > 2.0:
             pbs.logmsg(pbs.EVENT_DEBUG,
                        '%s: nvidia-smi call took %f seconds' %
-                       (caller_name(), elapsed_time))   
+                       (caller_name(), elapsed_time))
 
-        #format is:
+        # format is:
         # GPU gpuID: gpu_name (UUID: GPU UUID)
-        #   MIG xg.ygb      Device  0: (UUID: MIG-UUID)
-        #   MIG xg.ygb      Device  1: (UUID: MIG-UUID)
+        # MIG xg.ygb      Device  0: (UUID: MIG-UUID)
+        # MIG xg.ygb      Device  1: (UUID: MIG-UUID)
 
         line_count = 0
-        for out_line in out : 
-            if(line_count==0 or line_count==len(out)-1):
-                line_count+=1
+        for out_line in out:
+            if(line_count == 0 or line_count == len(out)-1):
+                line_count += 1
                 continue
-            
+
             else:
                 mig_uuid = out_line.split()[-1].rstrip(")")
                 uuid_list.append(mig_uuid)
-                line_count+=1
+                line_count += 1
 
         pbs.logmsg(pbs.EVENT_DEBUG4, "uuid list : \n" + str(uuid_list))
 
@@ -2103,7 +2104,7 @@ class NodeUtils(object):
         # |   0      7       MIG 1g.5gb       0         0          0:1     |
         r = re.compile(
             r'^\|\s+(\d+)\s+(\d+)\s+MIG\s+\S+\s+\d+\s+(\d+)\s+(\S+\s+)?\|$')
- 
+
         uuid_count = 0
         for out_line in out:
             match = r.match(out_line)
@@ -2116,9 +2117,9 @@ class NodeUtils(object):
             minor = self._discover_mig_minor(gpu_num, giid, ciid)
             if minor == -1:
                 continue
-            
+
             uuid = uuid_list[uuid_count]
-            uuid_count+=1
+            uuid_count += 1
             # uuid = 'MIG-%s/%s/%s' % (gpus[gpuid]['uuid'], giid, ciid)
             ci = {'minor': minor, 'gi': giid, 'ci': ciid, 'uuid': uuid}
             pbs.logmsg(pbs.EVENT_DEBUG4, 'CI found %s' % str(ci))

--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -2023,6 +2023,49 @@ class NodeUtils(object):
                 gpus[gpuid]['gis'] = {}
             gpus[gpuid]['gis'][giid] = gi
 
+        #Find all MIG UUIDs using nvidia-smi -L and update it later while finding the CIs
+        uuid_list = []
+        cmd = [self.cfg['nvidia-smi'], '-L']
+        pbs.logmsg(pbs.EVENT_DEBUG4, 'NVIDIA SMI command: %s' % cmd)
+        time_start = time.time()
+        out = []
+ 
+        try:
+            # Try running the nvidia-smi command
+            process = subprocess.Popen(cmd, shell=False,
+                                       stdout=subprocess.PIPE,
+                                       stderr=subprocess.PIPE,
+                                       universal_newlines=True)
+            out = process.communicate()[0].split('\n')
+        except Exception:
+            pbs.logmsg(pbs.EVENT_DEBUG4, 'Failed to execute: %s' %
+                       " ".join(cmd))
+            pbs.logmsg(pbs.EVENT_DEBUG3, '%s: No MIGs found' % caller_name())
+            return
+        elapsed_time = time.time() - time_start
+        if elapsed_time > 2.0:
+            pbs.logmsg(pbs.EVENT_DEBUG,
+                       '%s: nvidia-smi call took %f seconds' %
+                       (caller_name(), elapsed_time))   
+
+        #format is:
+        # GPU gpuID: gpu_name (UUID: GPU UUID)
+        #   MIG xg.ygb      Device  0: (UUID: MIG-UUID)
+        #   MIG xg.ygb      Device  1: (UUID: MIG-UUID)
+
+        line_count = 0
+        for out_line in out : 
+            if(line_count==0 or line_count==len(out)-1):
+                line_count+=1
+                continue
+            
+            else:
+                mig_uuid = out_line.split()[-1].rstrip(")")
+                uuid_list.append(mig_uuid)
+                line_count+=1
+
+        pbs.logmsg(pbs.EVENT_DEBUG4, "uuid list : \n" + str(uuid_list))
+
         # now find all CIs
         cmd = [self.cfg['nvidia-smi'], 'mig', '-lci']
         pbs.logmsg(pbs.EVENT_DEBUG4, 'NVIDIA SMI command: %s' % cmd)
@@ -2060,6 +2103,8 @@ class NodeUtils(object):
         # |   0      7       MIG 1g.5gb       0         0          0:1     |
         r = re.compile(
             r'^\|\s+(\d+)\s+(\d+)\s+MIG\s+\S+\s+\d+\s+(\d+)\s+(\S+\s+)?\|$')
+ 
+        uuid_count = 0
         for out_line in out:
             match = r.match(out_line)
             if not match:
@@ -2071,7 +2116,10 @@ class NodeUtils(object):
             minor = self._discover_mig_minor(gpu_num, giid, ciid)
             if minor == -1:
                 continue
-            uuid = 'MIG-%s/%s/%s' % (gpus[gpuid]['uuid'], giid, ciid)
+            
+            uuid = uuid_list[uuid_count]
+            uuid_count+=1
+            # uuid = 'MIG-%s/%s/%s' % (gpus[gpuid]['uuid'], giid, ciid)
             ci = {'minor': minor, 'gi': giid, 'ci': ciid, 'uuid': uuid}
             pbs.logmsg(pbs.EVENT_DEBUG4, 'CI found %s' % str(ci))
             if 'cis' not in gpus[gpuid]['gis'][giid]:

--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -2025,7 +2025,6 @@ class NodeUtils(object):
 
         # Find all MIG UUIDs using nvidia-smi -L
         # and update it later while finding the CIs
-        uuid_list = []
         cmd = [self.cfg['nvidia-smi'], '-L']
         pbs.logmsg(pbs.EVENT_DEBUG4, 'NVIDIA SMI command: %s' % cmd)
         time_start = time.time()
@@ -2054,20 +2053,22 @@ class NodeUtils(object):
         # MIG xg.ygb      Device  0: (UUID: MIG-UUID)
         # MIG xg.ygb      Device  1: (UUID: MIG-UUID)
 
-        line_count = 0
+        # Map (gpu_id, instance_id) to a MIG UUID
+        uuid_map = dict()
+        r_gpu = re.compile(r'\s*GPU\s(\d+)')
+        r_mig = re.compile(r'\s*MIG.*Device\s*(\d+)')
+        current_gpu = 0
         for out_line in out:
-            # Don't capture the first list element which has the GPU UUID and
-            # the last line, which has only a newline in it
-            if(line_count == 0 or line_count == len(out)-1):
-                line_count += 1
-                continue
-
-            else:
+            gpu_match = r_gpu.match(out_line)
+            mig_match = r_mig.match(out_line)
+            if(gpu_match):
+                current_gpu = int(gpu_match.group(1))
+                uuid_map[current_gpu] = dict()
+            if(mig_match):
                 mig_uuid = out_line.split()[-1].rstrip(")")
-                uuid_list.append(mig_uuid)
-                line_count += 1
+                uuid_map[current_gpu][int(mig_match.group(1))] = mig_uuid
 
-        pbs.logmsg(pbs.EVENT_DEBUG4, "uuid list : \n" + str(uuid_list))
+        pbs.logmsg(pbs.EVENT_DEBUG4, "uuid map : \n" + str(uuid_map))
 
         # now find all CIs
         cmd = [self.cfg['nvidia-smi'], 'mig', '-lci']
@@ -2112,6 +2113,9 @@ class NodeUtils(object):
             match = r.match(out_line)
             if not match:
                 continue
+            # reset count if a new gpu is parsed
+            if(gpu_num != int(match.group(1))):
+                uuid_count = 0
             gpu_num = int(match.group(1))
             gpuid = 'nvidia%d' % gpu_num
             giid = int(match.group(2))
@@ -2119,8 +2123,7 @@ class NodeUtils(object):
             minor = self._discover_mig_minor(gpu_num, giid, ciid)
             if minor == -1:
                 continue
-
-            uuid = uuid_list[uuid_count]
+            uuid = uuid_map[gpu_num][uuid_count]
             uuid_count += 1
             ci = {'minor': minor, 'gi': giid, 'ci': ciid, 'uuid': uuid}
             pbs.logmsg(pbs.EVENT_DEBUG4, 'CI found %s' % str(ci))

--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -2061,14 +2061,14 @@ class NodeUtils(object):
         for out_line in out:
             gpu_match = r_gpu.match(out_line)
             mig_match = r_mig.match(out_line)
-            if(gpu_match):
+            if gpu_match:
                 current_gpu = int(gpu_match.group(1))
                 uuid_map[current_gpu] = dict()
-            if(mig_match):
+            if mig_match:
                 mig_uuid = out_line.split()[-1].rstrip(")")
                 uuid_map[current_gpu][int(mig_match.group(1))] = mig_uuid
 
-        pbs.logmsg(pbs.EVENT_DEBUG4, "uuid map : \n" + str(uuid_map))
+        pbs.logmsg(pbs.EVENT_DEBUG4, "uuid map: %s" % str(uuid_map))
 
         # now find all CIs
         cmd = [self.cfg['nvidia-smi'], 'mig', '-lci']
@@ -2115,7 +2115,7 @@ class NodeUtils(object):
             if not match:
                 continue
             # reset count if a new gpu is parsed
-            if(gpu_num != int(match.group(1))):
+            if gpu_num != int(match.group(1)):
                 uuid_count = 0
             gpu_num = int(match.group(1))
             gpuid = 'nvidia%d' % gpu_num

--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -2109,6 +2109,7 @@ class NodeUtils(object):
             r'^\|\s+(\d+)\s+(\d+)\s+MIG\s+\S+\s+\d+\s+(\d+)\s+(\S+\s+)?\|$')
 
         uuid_count = 0
+        gpu_num = 0
         for out_line in out:
             match = r.match(out_line)
             if not match:

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -3613,7 +3613,7 @@ if %s e.job.in_ms_mom():
             self.skipTest('Skipping test since nvidia-smi not found')
         last_gpu_was_physical = False
         gpus = 0
-        #store uuids of the MIG devices
+        # store uuids of the MIG devices
         uuid_list = []
         for l in rv['out']:
             if l.startswith('GPU'):
@@ -3651,8 +3651,9 @@ if %s e.job.in_ms_mom():
 
         mig_devices_in_use = tmp_out[-1]
         for mig_device in mig_devices_in_use.split(","):
-            self.assertIn(mig_device, uuid_list,"MIG identifiers do not match")
-            
+            self.assertIn(mig_device, uuid_list,
+                          "MIG identifiers do not match")
+
         self.logger.info(tmp_out)
         self.assertIn('There are 1 GPUs', tmp_out, 'No gpus were assigned')
         self.assertIn('c 195:255 rwm', tmp_out, 'Nvidia controller not found')


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Previously compute instances were identified via the format MIG-GPU-<GPU_UUID>/<GI_ID>/<CI_ID>, but now each compute instance in each GI would have it's own UUID of format MIG-<MIG_UUID> . Since the current 'tuple' format would be going out of support, the pbs_cgroups hook has to update it to the new one, the info of which can be gathered by the use of ```nvidia-smi -L``` command.


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* ```nvidia-smi -L``` is the recommended command to gather information about the MIG UUID details for an nvidia GPU. In the  discover_mig() function (NodeUtils class) , during the device discovery phase, this command is run and it gets the details of the new UUID. 
* The GPUs dictionary's (which is mutated by the function) format remains the same as before; the only change is in the UUID part while assigning it to the ci dict during the part where it finds CI information. The ci dict is then assigned to the gpus dict (as before).
* The CUDA_VISIBLE_DEVICES environment variable is thus also updated with the new MIG UUID format.



#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[test_log.txt](https://github.com/openpbs/openpbs/files/6814324/test_log.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
