### PR TITLE
In CI: make multiple parameter processing accurate; resolve configure option bugs

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -40,6 +40,9 @@ Following parameters can be set.
 # be taken as it is and given as an argument to the configure file in PBS. The same convention follows for other configuration options as well
 ./ci --params 'configure=CFLAGS=" -O2 -Wall -Werror" --prefix=/tmp/pbs --enable-ptl'
 
+# You can also pass multiple parameter with this option for example
+./ci -p 'configure=--enable-ptl --prefix=/opt/pbs' -p 'tests=-t SmokeTest.test_basic'
+
 
 # The following are examples how to define a custom test case for pbs_benchpress.
 # NOTE: The string is passed to pbs_benchpress command therefore one can use all available options of pbs_benchpress here.

--- a/ci/ci
+++ b/ci/ci
@@ -774,10 +774,10 @@ def run_ci(build_pkgs=False):
             ensure_ci_running()
     target_path = os.path.join(command_path, MACROS['CONFIGURE_OPT_FILE'])
     if conf_opts['configure'] != read_from_file(target_path):
+        write_to_file(target_path, conf_opts['configure'])
         cmd = ' export ONLY_CONFIGURE=1 && /src/etc/do.sh 2>&1 \
             | tee -a /logs/build-$(hostname -s) '
         run_docker_cmd(cmd)
-        write_to_file(target_path, conf_opts['configure'])
     cmd = ' export ONLY_REBUILD=1 && /src/etc/do.sh 2>&1 \
         | tee -a /logs/build-$(hostname -s) '
     run_docker_cmd(cmd)
@@ -819,7 +819,8 @@ if __name__ == "__main__":
                                  epilog=textwrap.dedent(_help),
                                  conflict_handler='resolve')
     _help = 'set configuration values for os | nodes | configure | tests'
-    ap.add_argument('-p', '--params', nargs='+', help=_help, metavar='param')
+    ap.add_argument('-p', '--params', nargs='+',
+                    action='append', help=_help, metavar='param')
     _help = 'destroy pbs container'
     ap.add_argument('-d', '--delete', action='store_true', help=_help)
     _help = 'build packages for the current platform.'
@@ -851,7 +852,8 @@ if __name__ == "__main__":
             sys.exit(1)
     try:
         if args.params is not None:
-            parse_params(args.params)
+            for p in args.params:
+                parse_params(p)
         if args.build_pkgs is not None:
             build_pkgs = True
         if args.delete is True:

--- a/ci/etc/do.sh
+++ b/ci/etc/do.sh
@@ -174,13 +174,29 @@ if [ "x${ONLY_REBUILD}" != "x1" -a "x${ONLY_INSTALL}" != "x1" -a "x${ONLY_TEST}"
   cd ${_targetdirname}
   if [ -f /src/ci ]; then
     if [ -f ${config_dir}/${CONFIGURE_OPT_FILE} ]; then
-      configure_opt="$(cat ${config_dir}/${CONFIGURE_OPT_FILE})"
-      _cflags="$(echo ${configure_opt} | awk -F'"' '{print $2}')"
-      configure_opt="$(echo ${configure_opt} | sed -e 's/CFLAGS=\".*\"//g')"
+      PYTHON_CODE=$(cat <<END
+with open('${config_dir}/${CONFIGURE_OPT_FILE}') as f:
+  x = f.read()
+import re
+if len(x.split("'")) > 1:
+  print(re.match(r"CFLAGS=(\"|\').*(\"|\')",x).group(0).split('\'')[1])
+else:
+  print(re.match(r"CFLAGS=(\"|\').*(\"|\')",x).group(0).split('"')[1])
+END
+)
+      _cflags="$(python3 -c "$PYTHON_CODE")"
+      PYTHON_CODE=$(cat <<END
+with open('${config_dir}/${CONFIGURE_OPT_FILE}') as f:
+  x = f.read()
+import re
+print(re.sub(r"CFLAGS=(\"|\').*(\"|\')","",x))
+END
+)
+    configure_opt="$(python3 -c "$PYTHON_CODE")"
     else
       configure_opt='--prefix=/opt/pbs --enable-ptl'
     fi
-    if [ -z ${_cflags} ]; then
+    if [ -z "${_cflags}" ]; then
       ../configure ${configure_opt} ${swig_opt}
     else
       ../configure CFLAGS="${_cflags}" ${configure_opt} ${swig_opt}
@@ -207,13 +223,29 @@ if [ "x${ONLY_INSTALL}" == "x1" -o "x${ONLY_TEST}" == "x1" ]; then
 else
   if [ ! -f ${PBS_DIR}/${_targetdirname}/Makefile ]; then
     if [ -f ${config_dir}/${CONFIGURE_OPT_FILE} ]; then
-      configure_opt="$(cat ${config_dir}/${CONFIGURE_OPT_FILE})"
-      _cflags="$(echo ${configure_opt} | awk -F'"' '{print $2}')"
-      configure_opt="$(echo ${configure_opt} | sed -e 's/CFLAGS=\".*\"//g')"
+      PYTHON_CODE=$(cat <<END
+with open('${config_dir}/${CONFIGURE_OPT_FILE}') as f:
+  x = f.read()
+import re
+if len(x.split("'")) > 1:
+  print(re.match(r"CFLAGS=(\"|\').*(\"|\')",x).group(0).split('\'')[1])
+else:
+  print(re.match(r"CFLAGS=(\"|\').*(\"|\')",x).group(0).split('"')[1])
+END
+)
+      _cflags="$(python3 -c "$PYTHON_CODE")"
+      PYTHON_CODE=$(cat <<END
+with open('${config_dir}/${CONFIGURE_OPT_FILE}') as f:
+  x = f.read()
+import re
+print(re.sub(r"CFLAGS=(\"|\').*(\"|\')","",x))
+END
+)
+      configure_opt="$(python3 -c "$PYTHON_CODE")"
     else
       configure_opt='--prefix=/opt/pbs --enable-ptl'
     fi
-    if [ -z ${_cflags} ]; then
+    if [ -z "${_cflags}" ]; then
       ../configure ${configure_opt}
     else
       ../configure CFLAGS="${_cflags}" ${configure_opt}
@@ -227,13 +259,29 @@ fi
 if [ "x${ONLY_TEST}" != "x1" ]; then
   if [ ! -f ${PBS_DIR}/${_targetdirname}/Makefile ]; then
     if [ -f ${config_dir}/${CONFIGURE_OPT_FILE} ]; then
-      configure_opt="$(cat ${config_dir}/${CONFIGURE_OPT_FILE})"
-      _cflags="$(echo ${configure_opt} | awk -F'"' '{print $2}')"
-      configure_opt="$(echo ${configure_opt} | sed -e 's/CFLAGS=\".*\"//g')"
+      PYTHON_CODE=$(cat <<END
+with open('${config_dir}/${CONFIGURE_OPT_FILE}') as f:
+  x = f.read()
+import re
+if len(x.split("'")) > 1:
+  print(re.match(r"CFLAGS=(\"|\').*(\"|\')",x).group(0).split('\'')[1])
+else:
+  print(re.match(r"CFLAGS=(\"|\').*(\"|\')",x).group(0).split('"')[1])
+END
+)
+      _cflags="$(python3 -c "$PYTHON_CODE")"
+      PYTHON_CODE=$(cat <<END
+with open('${config_dir}/${CONFIGURE_OPT_FILE}') as f:
+  x = f.read()
+import re
+print(re.sub(r"CFLAGS=(\"|\').*(\"|\')","",x))
+END
+)
+    configure_opt="$(python3 -c "$PYTHON_CODE")"
     else
       configure_opt='--prefix=/opt/pbs --enable-ptl'
     fi
-    if [ -z ${_cflags} ]; then
+    if [ -z "${_cflags}" ]; then
       ../configure ${configure_opt}
     else
       ../configure CFLAGS="${_cflags}" ${configure_opt}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* Fixed a bug where  in ci while parsing multiple '-p' options all parameters are parsed instead of the last one.
* Fixed a bug in pbs configure where changes were not showing up
* Fixed a bug where the script can parse all types of quotations input while passing CFLAGS to configure option:
   below are the formats that work the same now
` ./ci -p "configure=CFLAGS='-g -O2'"`
` ./ci -p 'configure=CFLAGS="-g -O2"'`
` ./ci -p "configure=CFLAGS=\"-g -O2\"`
` ./ci -p 'configure=CFLAGS='"'"'-g -O2'"'"'`


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* add multiple option parsing in argarse for "-p" option and parse all given arguments for the same in a loop
* configure updates were delayed because writing to the conf file was being done after running the configure script, moved the same to before running the script
* Used inline python to parse various quotations in ci

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

```
sanidhya@ubuntu:~/git_chng/pbspro/ci$ cat .config_dir/conf.json 
{
  "configure": "CFLAGS=\"-g -O2\" --enable-ptl",
  "tests": "-t SmokeTest.test_basic"
}sanidhya@ubuntu:~/git_chng/pbspro/ci$ ./ci -p 'configure=CFLAGS='"'"'-g -O2'"'"' --prefix=/opt/pbs --enable-ptl' -p 'tests='
11:35:58 ---> Running ci with the following options
{
  "OS": [
    "server=centos:8"
  ],
  "configure": "CFLAGS='-g -O2' --prefix=/opt/pbs --enable-ptl",
  "tests": ""
}
11:36:01 ---> No running service found
11:36:01 ---> Attempting to start container
Removing network ci.local
WARNING: Network ci.local not found.
Creating network "ci.local" with the default driver
Creating server-centos-8-1 ... done
11:36:05 ---> Waiting for container build to complete 
11:36:05 ---> Build logs can be found in /home/sanidhya/git_chng/pbspro/ci/logs
...
KeyboardInterrupt

sanidhya@ubuntu:~/git_chng/pbspro/ci$ ./ci -p "configure=CFLAGS=\"-g -O2\" --enable-ptl"
11:36:44 ---> Running ci with the following options
{
  "OS": [
    "server=centos:8"
  ],
  "configure": "CFLAGS=\"-g -O2\" --enable-ptl",
  "tests": ""
}
11:36:46 ---> Configured nodes for ci
...
KeyboardInterrupt
sanidhya@ubuntu:~/git_chng/pbspro/ci$ 
```
<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
