### PR TITLE
Check nodes are free after create_moms creates them

### DIFF
--- a/test/fw/ptl/lib/ptl_server.py
+++ b/test/fw/ptl/lib/ptl_server.py
@@ -1920,6 +1920,8 @@ class Server(Wrappers):
                     if rc != 0:
                         self.logger.error("error creating node " + _n)
                         error = True
+        num_nodes = num * len(momhosts)
+        self.expect(NODE, {'state=free': num_nodes})
         if error:
             return False
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
After moms are created by create_moms, nodes take some time to connect server.


#### Describe Your Change
After moms are created wait for the nodes to be in free state.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
