### PR TITLE
fix few tests from TestJobArray failed due to race condition

### DIFF
--- a/test/tests/functional/pbs_job_array.py
+++ b/test/tests/functional/pbs_job_array.py
@@ -461,6 +461,8 @@ e.accept()
         self.server.expect(JOB, a, subjid_1, attrop=PTL_AND)
         self.server.delete(subjid_1, extend='force')
         self.kill_and_restart_svr()
+        subjid_2 = j.create_subjob_id(j_id, 2)
+        self.server.expect(JOB, {'job_state': 'R'}, subjid_2)
         self.server.delete(j_id, wait=True)
         self.server.manager(MGR_CMD_DELETE, QUEUE, id='workq')
 
@@ -715,14 +717,20 @@ e.accept()
         # while the server is sending the jobs to the MoM, restart the server
         self.server.restart()
         # make sure the mom is free so the scheduler can run jobs on it
-        self.server.expect(NODE, {'state': 'free'}, id=self.mom.shortname)
-        self.logger.info('Sleeping to ensure licenses are received')
-        time.sleep(5)
-        self.server.manager(MGR_CMD_SET, MGR_OBJ_SERVER,
-                            {'scheduling': 'True'})
-        # ensure the sched cycle is finished
-        self.server.manager(MGR_CMD_SET, MGR_OBJ_SERVER,
-                            {'scheduling': 'False'})
+        # if mom is in job-busy state all jobs are already scheduled.
+        attr = {'state': (MATCH_RE, 'free|job-busy')}
+        self.server.expect(NODE, attr, self.mom.shortname)
+        n_state = self.server.status(NODE, 'state',
+                                     id=self.mom.shortname)[0]['state']
+        # triggering scheduling cycle all jobs are in R state.
+        if n_state == 'free':
+            self.logger.info('Sleeping to ensure licenses are received')
+            time.sleep(5)
+            self.server.manager(MGR_CMD_SET, MGR_OBJ_SERVER,
+                                {'scheduling': 'True'})
+            # ensure the sched cycle is finished
+            self.server.manager(MGR_CMD_SET, MGR_OBJ_SERVER,
+                                {'scheduling': 'False'})
         # ensure all the subjobs are running
         self.server.expect(JOB, {'job_state=R': 200}, extend='t')
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
following tests are failing from TestJobArray due to race condition.

- **test_subjob_wrong_state**:-
in the test after restarting PBS Server test is checking for MoM state = free, but sometime all sub-jobs from array are in R state due to MoM state is job-busy. when one of the sub-job got completed Mom state is comes as free.
Then in test PTL is checking for no. of running jobs=200, but while checking MoM state = free few sub jobs completed and test got failed.

- **test_queue_deletion_after_terminated_subjob**:-
On cpuset machine when we restart PBS Server, running jobs on MoM get requeued and while requeue execjob_end and execjob epiogue hooks get executed. to execute it take some time and job remains in E state due to while we deleting the job it returns error 'qdel: Request invalid for state of job <job-id>'. 


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

- **test_subjob_wrong_state**:- 
Need to check MoM state is free or job-busy, if MoM state is free then only trigger scheduling cycle otherwise no need to trigger scheduling cycle as all jobs are already scheduled.

- **test_queue_deletion_after_terminated_subjob**:- 
Need to first check second sub-job is in R state and then delete array job.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Before Fix:
[res_test_queue_deletion_after_terminated_subjob_before_fix.txt](https://github.com/openpbs/openpbs/files/6842059/res_test_queue_deletion_after_terminated_subjob_before_fix.txt)
[res_test_subjob_wrong_state_before_fix.txt](https://github.com/openpbs/openpbs/files/6842062/res_test_subjob_wrong_state_before_fix.txt)

After Fix:
[res_test_subjob_wrong_state_after_change_1.txt](https://github.com/openpbs/openpbs/files/6842064/res_test_subjob_wrong_state_after_change_1.txt)
[res_test_subjob_wrong_state_after_change_2.txt](https://github.com/openpbs/openpbs/files/6842065/res_test_subjob_wrong_state_after_change_2.txt)
[res_test_subjob_wrong_state_after_change_3.txt](https://github.com/openpbs/openpbs/files/6842066/res_test_subjob_wrong_state_after_change_3.txt)
[res_test_subjob_wrong_state_after_change_4.txt](https://github.com/openpbs/openpbs/files/6842067/res_test_subjob_wrong_state_after_change_4.txt)
[res_test_subjob_wrong_state_after_change_5.txt](https://github.com/openpbs/openpbs/files/6842068/res_test_subjob_wrong_state_after_change_5.txt)

[res_test_queue_deletion_after_terminated_subjob_after_change_cpuset_1.txt](https://github.com/openpbs/openpbs/files/6842069/res_test_queue_deletion_after_terminated_subjob_after_change_cpuset_1.txt)
[res_test_queue_deletion_after_terminated_subjob_after_change_cpuset_2.txt](https://github.com/openpbs/openpbs/files/6842072/res_test_queue_deletion_after_terminated_subjob_after_change_cpuset_2.txt)
[res_test_queue_deletion_after_terminated_subjob_after_change_cpuset_3.txt](https://github.com/openpbs/openpbs/files/6842073/res_test_queue_deletion_after_terminated_subjob_after_change_cpuset_3.txt)
[res_test_queue_deletion_after_terminated_subjob_after_change_cpuset_4.txt](https://github.com/openpbs/openpbs/files/6842074/res_test_queue_deletion_after_terminated_subjob_after_change_cpuset_4.txt)
[res_test_queue_deletion_after_terminated_subjob_after_change_cpuset_5.txt](https://github.com/openpbs/openpbs/files/6842075/res_test_queue_deletion_after_terminated_subjob_after_change_cpuset_5.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
