### PR TITLE
Fixed invalid read with in-conflict reservations

### DIFF
--- a/src/scheduler/resv_info.cpp
+++ b/src/scheduler/resv_info.cpp
@@ -738,7 +738,9 @@ query_resv(struct batch_status *resv, server_info *sinfo)
 	}
 	advresv->resv->resv_queue =
 		find_queue_info(sinfo->queues, advresv->resv->queuename);
-	if (is_resresv_running(advresv)) {
+		
+	/* It's possible for an in-conflict reservation to be running with no nodes */
+	if (is_resresv_running(advresv) && advresv->ninfo_arr != NULL) {
 		for (int j = 0; advresv->ninfo_arr[j] != NULL; j++)
 			advresv->ninfo_arr[j]->num_run_resv++;
 	}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Maintenance reservations can steal nodes from other reservations.  The other reservations go to the in-conflict state.  It is possible for a maintenance reservation to steal all the nodes from another reservation.  This means the in-conflict reservation can start running with no nodes.

Some of the code in query_resv() assumed that if a reservation was running it had nodes.  This would cause an invalid read and crash the scheduler

#### Describe Your Change
When checking if the reservation is running, check if there are nodes as well.

#### Attach Test and Valgrind Logs/Output
This was found by the maintenance reservation test suite.
Before:
```
==385184== Invalid read of size 8
==385184==    at 0x4AE897: query_resv(batch_status*, server_info*) (resv_info.cpp:742)
==385184==    by 0x4ACAA6: query_reservations(int, server_info*, batch_status*) (resv_info.cpp:199)
==385184==    by 0x4B2CDE: query_server(status*, int) (server_info.cpp:305)
==385184==    by 0x460B76: scheduling_cycle(int, sched_cmd const*) (fifo.cpp:609)
==385184==    by 0x460A8C: intermediate_schedule(int, sched_cmd const*) (fifo.cpp:542)
==385184==    by 0x4609D2: schedule (fifo.cpp:498)
==385184==    by 0x4D17B1: schedule_wrapper(sched_cmd*, int) (pbs_sched_utils.cpp:1330)
==385184==    by 0x4D16A1: sched_main(int, char**, int (*)(int, sched_cmd const*)) (pbs_sched_utils.cpp:1277)
==385184==    by 0x45F8A2: main (pbs_sched.cpp:61)
==385184==  Address 0x0 is not stack'd, malloc'd or (recently) free'd
==385184== 
==385184== 
==385184== Process terminating with default action of signal 6 (SIGABRT): dumping core
==385184==    at 0x67B17FF: raise (in /usr/lib64/libc-2.28.so)
==385184==    by 0x679BC34: abort (in /usr/lib64/libc-2.28.so)
==385184==    by 0x4CF18A: on_segv(int) (pbs_sched_utils.cpp:162)
==385184==    by 0x5392B1F: ??? (in /usr/lib64/libpthread-2.28.so)
==385184==    by 0x4AE896: query_resv(batch_status*, server_info*) (resv_info.cpp:742)
==385184==    by 0x4ACAA6: query_reservations(int, server_info*, batch_status*) (resv_info.cpp:199)
==385184==    by 0x4B2CDE: query_server(status*, int) (server_info.cpp:305)
==385184==    by 0x460B76: scheduling_cycle(int, sched_cmd const*) (fifo.cpp:609)
==385184==    by 0x460A8C: intermediate_schedule(int, sched_cmd const*) (fifo.cpp:542)
==385184==    by 0x4609D2: schedule (fifo.cpp:498)
==385184==    by 0x4D17B1: schedule_wrapper(sched_cmd*, int) (pbs_sched_utils.cpp:1330)
==385184==    by 0x4D16A1: sched_main(int, char**, int (*)(int, sched_cmd const*)) (pbs_sched_utils.cpp:1277)
==385184== 
```
After it passed without a problem.