### PR TITLE
Increase buffer size to parse /proc/cpuinfo of modern chips

### DIFF
--- a/src/resmom/linux/mom_mach.c
+++ b/src/resmom/linux/mom_mach.c
@@ -2474,7 +2474,7 @@ getnum(char *str)
 	return (int)val;
 }
 
-#define	LABLELEN	1024
+#define	LABLELEN	2048
 
 struct {
 	int	physid;


### PR DESCRIPTION
#### Describe Bug or Feature
pbs_mom fails to parse /proc/cpuinfo of modern processors. In particular, the "flags" entry can exceed 1024 chars. For example,  in my system (Intel Xeon Gold 6354) it looks like this:

`flags           : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf eagerfpu pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch epb cat_l3 invpcid_single intel_pt ssbd mba ibrs ibpb stibp ibrs_enhanced tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid rtm cqm rdt_a avx512f avx512dq rdseed adx smap avx512ifma clflushopt clwb avx512cd sha_ni avx512bw avx512vl xsaveopt xsavec xgetbv1 cqm_llc cqm_occup_llc cqm_mbm_total cqm_mbm_local dtherm ida arat pln pts hwp hwp_act_window hwp_epp hwp_pkg_req avx512vbmi umip pku ospke avx512_vbmi2 gfni vaes vpclmulqdq avx512_vnni avx512_bitalg avx512_vpopcntdq md_clear pconfig spec_ctrl intel_stibp flush_l1d arch_capabilities`

That's 1032 chars, which is above 1024. The result is a log with warnings like
```
07/21/2021 10:43:58;0002;pbs_mom;n/a;ncpus;warning: /proc/cpuinfo format not recognized
07/21/2021 10:43:58;0002;pbs_mom;n/a;ncpus;line 20 too long
07/21/2021 10:43:58;0002;pbs_mom;n/a;ncpus;line 47 too long
```
etc. Hopefully, 2048 will be enough for years to come :).
