### PR TITLE
qdel is getting hanged while deleting array jobs

### DIFF
--- a/src/include/batch_request.h
+++ b/src/include/batch_request.h
@@ -107,7 +107,7 @@ struct rq_manage {
 struct rq_deletejoblist {
 	int rq_count;
 	char **rq_jobslist;
-	int rq_resume;
+	bool rq_resume;
 	int jobid_to_resume;
 	int subjobid_to_resume;
 };

--- a/src/include/job.h
+++ b/src/include/job.h
@@ -1008,7 +1008,7 @@ extern int   modify_job_attr(job *, svrattrl *, int, int *);
 extern char *prefix_std_file(job *, int);
 extern void  cat_default_std(job *, int, char *, char **);
 extern int   set_objexid(void *, int, attribute *);
-extern bool update_deljob_rply(struct batch_request *, int, char *, int);
+extern bool update_deljob_rply(struct batch_request *, char *, int);
 #if 0
 extern int   site_check_user_map(job *, char *);
 #endif

--- a/src/include/job.h
+++ b/src/include/job.h
@@ -1008,6 +1008,7 @@ extern int   modify_job_attr(job *, svrattrl *, int, int *);
 extern char *prefix_std_file(job *, int);
 extern void  cat_default_std(job *, int, char *, char **);
 extern int   set_objexid(void *, int, attribute *);
+extern bool update_deljob_rply(struct batch_request *, int, char *, int);
 #if 0
 extern int   site_check_user_map(job *, char *);
 #endif

--- a/src/include/libpbs.h
+++ b/src/include/libpbs.h
@@ -219,9 +219,8 @@ struct batch_reply
 		pbs_list_head brp_status; /* status (svr) replies */
 		struct batch_status *brp_statc; /* status (cmd) replies) */
 		struct {
-			int pend_jobs;
-			int pend_arrjobs;
-			struct batch_deljob_status *brp_delstatc;
+			void *undeleted_job_idx; /* tracking undeleted jobs */
+			struct batch_deljob_status *brp_delstatc; /* list of failed jobs with errcode */
 		} brp_deletejoblist;
 		struct {
 			int brp_txtlen;

--- a/src/include/libpbs.h
+++ b/src/include/libpbs.h
@@ -219,9 +219,8 @@ struct batch_reply
 		pbs_list_head brp_status; /* status (svr) replies */
 		struct batch_status *brp_statc; /* status (cmd) replies) */
 		struct {
-			int tot_jobs;
-			int tot_rpys;
-			int tot_arr_jobs;
+			int pend_jobs;
+			int pend_arrjobs;
 			struct batch_deljob_status *brp_delstatc;
 		} brp_deletejoblist;
 		struct {

--- a/src/include/pbs_idx.h
+++ b/src/include/pbs_idx.h
@@ -153,6 +153,13 @@ extern int pbs_idx_find(void *idx, void **key, void **data, void **ctx);
  */
 extern void pbs_idx_free_ctx(void *ctx);
 
+/**
+ * @brief check whether idx is empty and has no key associated with it
+ * 
+ * @param idx[in] - avl index
+ */
+extern int pbs_idx_is_empty(void *idx);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/include/svrfunc.h
+++ b/src/include/svrfunc.h
@@ -138,6 +138,7 @@ extern int compare_obj_hash(void *, int , void *);
 extern void panic_stop_db();
 extern void free_db_attr_list(pbs_db_attr_list_t *);
 extern void req_stat_svr_ready(struct work_task *);
+extern void delete_pending_arrayjobs(struct batch_request *);
 
 #ifdef _PROVISION_H
 extern int find_prov_vnode_list(job *, exec_vnode_listtype *, char **);

--- a/src/lib/Libifl/dec_DelJobList.c
+++ b/src/lib/Libifl/dec_DelJobList.c
@@ -118,6 +118,6 @@ decode_DIS_DelJobList(int sock, struct batch_request *preq)
 	}
 	tmp_jobslist[i] = NULL;
 	preq->rq_ind.rq_deletejoblist.rq_jobslist = tmp_jobslist;
-	preq->rq_ind.rq_deletejoblist.rq_resume = 0;
+	preq->rq_ind.rq_deletejoblist.rq_resume = FALSE;
 	return rc;
 }

--- a/src/lib/Libutil/pbs_idx.c
+++ b/src/lib/Libutil/pbs_idx.c
@@ -291,3 +291,24 @@ pbs_idx_free_ctx(void *ctx)
 		ctx = NULL;
 	}
 }
+
+/**
+ * @brief check whether idx is empty and has no key associated with it
+ * 
+ * @param idx[in] - avl index
+ * 
+ * @return int
+ * @retval 1 : idx is empty
+ * @retval 0: idx is not empty
+ */
+int
+pbs_idx_is_empty(void *idx)
+{
+	void *idx_ctx = NULL;
+	char **data = NULL;
+
+	if (pbs_idx_find(idx, NULL, (void **) &data, &idx_ctx) == PBS_IDX_RET_OK)
+		return 0;
+
+	return 1;
+}

--- a/src/server/array_func.c
+++ b/src/server/array_func.c
@@ -147,10 +147,10 @@ static enum job_atr attrs_to_copy[] = {
  * @param[in]	id - Job Id.
  *
  * @return      Job Type
- * @retval	 0  - A regular job
- * @retval	-1  - A ArrayJob
- * @retval	 2  - A single subjob
- * @retval	-3  - A range of subjobs
+ * @retval	IS_ARRAY_NO  - A regular job
+ * @retval	IS_ARRAY_ArrayJob  - A ArrayJob
+ * @retval	IS_ARRAY_Single  - A single subjob
+ * @retval	IS_ARRAY_Range  - A range of subjobs
  */
 int
 is_job_array(char *id)
@@ -836,6 +836,7 @@ dup_br_for_subjob(struct batch_request *opreq, job *pjob, int (*func)(struct bat
 			npreq->rq_ind.rq_deletejoblist = opreq->rq_ind.rq_deletejoblist;
 			npreq->rq_ind.rq_deletejoblist.rq_count = 1;
 			npreq->rq_ind.rq_deletejoblist.rq_jobslist = break_comma_list(pjob->ji_qs.ji_jobid);
+			npreq->rq_ind.rq_deletejoblist.jobid_to_resume = 0;
 			break;
 		case PBS_BATCH_DeleteJob:
 			npreq->rq_ind.rq_delete = opreq->rq_ind.rq_delete;

--- a/src/server/process_request.c
+++ b/src/server/process_request.c
@@ -1565,14 +1565,15 @@ free_br(struct batch_request *preq)
 		 * decrement the reference count in the parent and when it
 		 * goes to zero,  reply_send() it
 		 */
-		struct batch_reply *preply = &preq->rq_parentbr->rq_reply;
 		if (preq->rq_parentbr->rq_refct > 0) {
 			if (--preq->rq_parentbr->rq_refct == 0) {
+#ifndef PBS_MOM		/* Server Only */
+				struct batch_reply *preply = &preq->rq_parentbr->rq_reply;
 				if (preq->rq_parentbr->rq_type == PBS_BATCH_DeleteJobList) {
-					preply->brp_un.brp_deletejoblist.tot_rpys += preply->brp_un.brp_deletejoblist.tot_arr_jobs ;
-					if (preply->brp_un.brp_deletejoblist.tot_rpys == preply->brp_un.brp_deletejoblist.tot_jobs)
+					if (update_deljob_rply(preq->rq_parentbr, preply->brp_un.brp_deletejoblist.pend_arrjobs, NULL, PBSE_NONE))
 						reply_send(preq->rq_parentbr);
-				} else 
+				} else
+#endif	/* End of server */
 					reply_send(preq->rq_parentbr);
 			}
 		}

--- a/src/server/process_request.c
+++ b/src/server/process_request.c
@@ -1543,7 +1543,6 @@ decode_DIS_RelnodesJob(int sock, struct batch_request *preq)
 	return rc;
 }
 
-
 /**
  * @brief
  * 		Free space allocated to a batch_request structure
@@ -1551,7 +1550,6 @@ decode_DIS_RelnodesJob(int sock, struct batch_request *preq)
  *
  * @param[in]	preq - the batch_request structure to free up.
  */
-
 void
 free_br(struct batch_request *preq)
 {
@@ -1568,9 +1566,9 @@ free_br(struct batch_request *preq)
 		if (preq->rq_parentbr->rq_refct > 0) {
 			if (--preq->rq_parentbr->rq_refct == 0) {
 #ifndef PBS_MOM		/* Server Only */
-				struct batch_reply *preply = &preq->rq_parentbr->rq_reply;
 				if (preq->rq_parentbr->rq_type == PBS_BATCH_DeleteJobList) {
-					if (update_deljob_rply(preq->rq_parentbr, preply->brp_un.brp_deletejoblist.pend_arrjobs, NULL, PBSE_NONE))
+					delete_pending_arrayjobs(preq->rq_parentbr);
+					if (update_deljob_rply(preq->rq_parentbr, NULL, PBSE_NONE))
 						reply_send(preq->rq_parentbr);
 				} else
 #endif	/* End of server */

--- a/test/fw/ptl/lib/ptl_wrappers.py
+++ b/test/fw/ptl/lib/ptl_wrappers.py
@@ -2069,23 +2069,31 @@ class Wrappers(PBSService):
             return 0
 
         obj_type = {}
+        job_list = []
+        resv_list = []
         for j in id:
             if j[0] in ('R', 'S', 'M'):
-                obj_type[j] = RESV
-                try:
-                    rc = self.delresv(j, extend, runas, logerr=logerr)
-                except PbsDelresvError as e:
-                    rc = e.rc
-                    msg = e.msg
-                    rv = e.rv
+                 obj_type[j] = RESV
+                 resv_list.append(j)
             else:
                 obj_type[j] = JOB
-                try:
-                    rc = self.deljob(j, extend, runas, logerr=logerr)
-                except PbsDeljobError as e:
-                    rc = e.rc
-                    msg = e.msg
-                    rv = e.rv
+                job_list.append(j)
+
+        if resv_list:
+            try:
+                rc = self.delresv(resv_list, extend, runas, logerr=logerr)
+            except PbsDelresvError as e:
+                rc = e.rc
+                msg = e.msg
+                rv = e.rv
+        elif job_list:
+            obj_type[j] = JOB
+            try:
+                rc = self.deljob(job_list, extend, runas, logerr=logerr)
+            except PbsDeljobError as e:
+                rc = e.rc
+                msg = e.msg
+                rv = e.rv
 
         if rc != 0:
             raise PbsDeleteError(rc=rc, rv=rv, msg=msg)

--- a/test/scripts/qsub_multi.sh
+++ b/test/scripts/qsub_multi.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Used to achieve faster job submission of large number of jobs for performance testing
+
+if [ $# -lt 2 ]; then
+	echo "syntax: $0 <num-threads> <jobs-per-thread>"
+	exit 1
+fi
+
+function submit_jobs {
+	njobs=$1
+
+	echo "New thread submitting jobs=$njobs"
+
+	for i in $(seq 1 $njobs)
+	do
+		qsub -- /bin/date > /dev/null
+	done
+}
+
+if [ "$1" = "submit" ]; then
+	njobs=$2
+	submit_jobs $njobs
+	exit 0
+fi
+
+nthreads=$1
+njobs=$2
+
+echo "parameters supplied: nthreads=$nthreads, njobs=$njobs"
+
+start_time=`date +%s%3N`
+
+for i in $(seq 1 $nthreads)
+do
+	setsid $0 submit $njobs &
+done
+
+wait
+
+end_time=`date +%s%3N`
+
+diff=`bc -l <<< "scale=3; ($end_time - $start_time) / 1000"`
+total_jobs=`bc -l <<< "$njobs * $nthreads"`
+perf=`bc -l <<< "scale=3; $total_jobs / $diff"`
+
+echo "Time(ms) started=$start_time, ended=$end_time"
+echo "Total jobs submitted=$total_jobs, time taken(secs.ms)=$diff, jobs/sec=$perf"

--- a/test/tests/functional/pbs_qdel.py
+++ b/test/tests/functional/pbs_qdel.py
@@ -118,8 +118,8 @@ class TestQdel(TestFunctional):
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'true'})
         self.server.delete(job_set)
         # Make sure that the counters are not going negative
-        msg = "pend_jobs count went negative for delete request"
-        self.scheduler.log_match(msg, existence=False, max_attempts=3)
+        msg = "job*has already been deleted from delete job list"
+        self.scheduler.log_match(msg, existence=False, max_attempts=3, regexp=True)
         # Make sure the last two jobs doesn't started running while the deletion is in process
         for job in job_set[2:]:
             jobid, server = job.split('.')

--- a/test/tests/functional/pbs_qdel.py
+++ b/test/tests/functional/pbs_qdel.py
@@ -102,3 +102,27 @@ class TestQdel(TestFunctional):
         m = "Resource busy on job"
         self.assertIn(m, e.exception.msg[0])
         self.server.delete(jid, extend='deletehist')
+
+    def test_qdel_arrayjob_in_tranit(self):
+        """
+        Test the array job deletion soon after they have been signalled for running.
+        """
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'false'})
+        a = {'resources_available.ncpus': 6}
+        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
+        j = Job(TEST_USER, attrs={
+            ATTR_J: '1-3', 'Resource_List.select': 'ncpus=1'})
+        job_set = []
+        for i in range(4):
+            job_set.append(self.server.submit(j))
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'true'})
+        self.server.delete(job_set)
+        # Make sure that the counters are not going negative
+        msg = "pend_jobs count went negative for delete request"
+        self.scheduler.log_match(msg, existence=False, max_attempts=3)
+        # Make sure the last two jobs doesn't started running while the deletion is in process
+        for job in job_set[2:]:
+            jobid, server = job.split('.')
+            arrjob = jobid + '[1]' + server
+            msg = arrjob + ";Job Run at request of Scheduler"
+            self.scheduler.log_match(msg, existence=False, max_attempts=3)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
* qdel is getting hanged while deleting array jobs
The hang is because of two reasons:
1. Server doesn't create a worktask to track the deljob list when a subjob deletion fails
2. Total array job reply count was not getting updated


#### Describe Your Change
* Create work tasks to handle the deljoblist even when subjob deletion fails
* Update total array job count whenever the reply count is getting updated for an array job.
* Reorder the deljoblist to avoid any deletion triggered runs from the same list
* Modified PTL framework to delete list of id's together instead of deleting one by one.


#### Attach Test and Valgrind Logs/Output
```
[root@head1 tmp]# qstat
[root@head1 tmp]# for i in {1..4}; do qsub -J1-6 -- /bin/sleep 100; done; qstat; qdel `qselect`
586[].head1
587[].head1
588[].head1
589[].head1
Job id            Name             User              Time Use S Queue
----------------  ---------------- ----------------  -------- - -----
586[].head1       STDIN            root                     0 B workq           
587[].head1       STDIN            root                     0 Q workq           
588[].head1       STDIN            root                     0 Q workq           
589[].head1       STDIN            root                     0 Q workq
```



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
