### PR TITLE
Add generic interface to allow external libraries to handle web requests 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,6 +137,7 @@ buildutils/py-compile
 buildutils/exclude_script
 buildutils/makedepend-sh
 buildutils/ylwrap
+*.dirstamp
 
 # Generated binaries
 

--- a/configure.ac
+++ b/configure.ac
@@ -387,6 +387,7 @@ AC_CONFIG_FILES([
 	src/lib/Libauth/gss/Makefile
 	src/lib/Libauth/munge/Makefile
 	src/lib/Liblicensing/Makefile
+	src/lib/Libapi/Makefile
 	src/lib/Makefile
 	src/modules/Makefile
 	src/modules/python/Makefile

--- a/src/include/Makefile.am
+++ b/src/include/Makefile.am
@@ -77,6 +77,7 @@ noinst_HEADERS = \
 	mom_server.h \
 	mom_vnode.h \
 	net_connect.h \
+	pbs_api_wrapper.h \
 	pbs_array_list.h \
 	pbs_assert.h \
 	pbs_client_thread.h \

--- a/src/include/attribute.h
+++ b/src/include/attribute.h
@@ -319,7 +319,7 @@ extern int  recov_attr_fs(int fd, void *parent, void *padef_idx, attribute_def *
 extern void free_null  (attribute *attr);
 extern void free_none  (attribute *attr);
 extern svrattrl *attrlist_alloc(int szname, int szresc, int szval);
-extern svrattrl *attrlist_create(char *aname, char *rname, int szval);
+extern svrattrl *attrlist_create(const char *aname, const char *rname, int szval);
 extern void free_svrattrl(svrattrl *pal);
 extern void free_attrlist(pbs_list_head *attrhead);
 extern void free_svrcache(attribute *attr);

--- a/src/include/libutil.h
+++ b/src/include/libutil.h
@@ -222,6 +222,9 @@ char *pbs_fgets_extend(char **pbuf, int *pbuf_size, FILE *fp);
 extern int pbs_asprintf(char **dest, const char *fmt, ...);
 extern char *pbs_asprintf_format(int len, const char *fmt, va_list args);
 
+int pbs_asprintcatf(char **dest, size_t *size, size_t *idx, const char *fmt, ...);
+
+
 /*
  * calculate the number of digits to the right of the decimal point in
  *        a floating point number.  This can be used in conjunction with
@@ -269,7 +272,7 @@ char **break_comma_list(char *list);
  *      break_delimited_str - break apart a delimited string into an array
  *                         of strings
  */
-char **break_delimited_str(char *list, char delim);
+char **break_delimited_str(const char *list, char delim);
 
 /*
  * find index of str in strarr

--- a/src/include/pbs_api_wrapper.h
+++ b/src/include/pbs_api_wrapper.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 1994-2021 Altair Engineering, Inc.
+ * For more information, contact Altair at www.altair.com.
+ *
+ * This file is part of both the OpenPBS software ("OpenPBS")
+ * and the PBS Professional ("PBS Pro") software.
+ *
+ * Open Source License Information:
+ *
+ * OpenPBS is free software. You can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * OpenPBS is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Commercial License Information:
+ *
+ * PBS Pro is commercially licensed software that shares a common core with
+ * the OpenPBS software.  For a copy of the commercial license terms and
+ * conditions, go to: (http://www.pbspro.com/agreement.html) or contact the
+ * Altair Legal Department.
+ *
+ * Altair's dual-license business model allows companies, individuals, and
+ * organizations to create proprietary derivative works of OpenPBS and
+ * distribute them - whether embedded or bundled with other software -
+ * under a commercial license agreement.
+ *
+ * Use of Altair's trademarks, including but not limited to "PBS™",
+ * "OpenPBS®", "PBS Professional®", and "PBS Pro™" and Altair's logos is
+ * subject to Altair's trademark licensing policies.
+ */
+
+#ifndef PBS_API_WRAPPER
+#define PBS_API_WRAPPER
+
+int apiStart();
+int apiStop();
+
+#endif

--- a/src/lib/Libapi/Makefile.am
+++ b/src/lib/Libapi/Makefile.am
@@ -39,18 +39,11 @@
 
 #
 
-SUBDIRS = \
-	Libattr \
-	Libdb \
-	Liblog \
-	Libnet \
-	Libifl \
-	Libpbs \
-	Libpython \
-	Libsite \
-	Libsec \
-	Libtpp \
-	Libutil \
-	Libauth \
-	Liblicensing \
-	Libapi
+lib_LTLIBRARIES = libapi.la
+
+libapi_la_CPPFLAGS = \
+    -I$(top_srcdir)/src/include \
+    @KRB5_CFLAGS@
+
+libapi_la_SOURCES = \
+    pbs_api_wrapper.c

--- a/src/lib/Libapi/pbs_api_wrapper.c
+++ b/src/lib/Libapi/pbs_api_wrapper.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 1994-2021 Altair Engineering, Inc.
+ * For more information, contact Altair at www.altair.com.
+ *
+ * This file is part of both the OpenPBS software ("OpenPBS")
+ * and the PBS Professional ("PBS Pro") software.
+ *
+ * Open Source License Information:
+ *
+ * OpenPBS is free software. You can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * OpenPBS is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Commercial License Information:
+ *
+ * PBS Pro is commercially licensed software that shares a common core with
+ * the OpenPBS software.  For a copy of the commercial license terms and
+ * conditions, go to: (http://www.pbspro.com/agreement.html) or contact the
+ * Altair Legal Department.
+ *
+ * Altair's dual-license business model allows companies, individuals, and
+ * organizations to create proprietary derivative works of OpenPBS and
+ * distribute them - whether embedded or bundled with other software -
+ * under a commercial license agreement.
+ *
+ * Use of Altair's trademarks, including but not limited to "PBS™",
+ * "OpenPBS®", "PBS Professional®", and "PBS Pro™" and Altair's logos is
+ * subject to Altair's trademark licensing policies.
+ */
+
+#include "pbs_api_wrapper.h"
+
+int apiStart() {
+    return 0;
+}
+
+int apiStop() {
+    return 0;
+}

--- a/src/lib/Libattr/attr_fn_size.c
+++ b/src/lib/Libattr/attr_fn_size.c
@@ -98,7 +98,7 @@
 int
 decode_size(attribute *patr, char *name, char *rescn, char *val)
 {
-	int to_size(char *, struct size_value *);
+	int to_size(const char *, struct size_value *);
 
 	patr->at_val.at_size.atsv_num   = 0;
 	patr->at_val.at_size.atsv_shift = 0;
@@ -360,7 +360,7 @@ normalize_size(struct size_value *a, struct size_value *b, struct size_value *ta
  */
 
 int
-to_size(char *val, struct size_value *psize)
+to_size(const char *val, struct size_value *psize)
 {
 	int   havebw = 0;
 	char *pc;

--- a/src/lib/Libattr/attr_func.c
+++ b/src/lib/Libattr/attr_func.c
@@ -343,7 +343,7 @@ attrlist_alloc(int szname, int szresc, int szval)
  */
 
 svrattrl *
-attrlist_create(char  *aname, char  *rname, int vsize)
+attrlist_create(const char  *aname, const char  *rname, int vsize)
 {
 	svrattrl *pal;
 	size_t	     asz;
@@ -1891,7 +1891,7 @@ free_attr(attribute_def *attr_def, attribute *pattr, int attr_idx)
 
 /**
  * @brief	Generic getter for attribute's list value
- * 
+ *
  *
  * @param[in]	pattr - pointer to the object
  *

--- a/src/lib/Libifl/pbs_loadconf.c
+++ b/src/lib/Libifl/pbs_loadconf.c
@@ -70,6 +70,7 @@ char *pbs_conf_env = "PBS_CONF_FILE";
 static char *pbs_loadconf_buf = NULL;
 static int   pbs_loadconf_len = 0;
 
+
 /*
  * Initialize the pbs_conf structure.
  *
@@ -259,10 +260,10 @@ parse_config_line(FILE *fp, char **key, char **val)
 
 /**
  * @brief frame the psi_t struct from svr instance id passed
- * 
+ *
  * @param[in,out] psi - server instance id
  * @param[in] svr_id - server instance id
- * @return int 
+ * @return int
  * @retval 0 - success
  * @retval !0 - failure
  */
@@ -294,9 +295,9 @@ frame_psi(psi_t *psi, char *svr_id)
 /**
  * @brief
  * parse_psi - parses the PBS_SERVER_INSTANCES
- *    
+ *
  * @param[in] conf_value  configuration value set in pbs.conf
- * 
+ *
  * @return int
  * @retval -1, For error
  * @retval 0, For success
@@ -1210,7 +1211,7 @@ err:
 		free_string_array(pbs_conf.supported_auth_methods);
 		pbs_conf.supported_auth_methods = NULL;
 	}
-	
+
 	if (psi_value != NULL)
 		free(psi_value);
 
@@ -1292,7 +1293,7 @@ pbs_get_conf_var(char *conf_var_name)
 		fclose(fp);
 	}
 	free(conf_file);
-	
+
 	if (conf_val_out)
 		return conf_val_out;
 

--- a/src/lib/Liblog/pbs_log.c
+++ b/src/lib/Liblog/pbs_log.c
@@ -38,7 +38,7 @@
  */
 
 /**
- * 
+ *
  * @brief
  *  contains functions to log error and event messages to
  *	the log file.
@@ -94,6 +94,7 @@ typedef struct {
 	struct tm ptm;
 	char microsec_buf[8];
 } ms_time; /* microsecond time stamp */
+
 
 char *msg_daemonname;
 
@@ -379,20 +380,20 @@ log_init(void)
 		return;
 	}
 
-	/* 
+	/*
 	 * atfork handlers are required for the logging layer
-	 * since child processes might still want to log in the 
+	 * since child processes might still want to log in the
 	 * child after fork, from the APP thread, then the APP thread
-	 * needs access to the log mutex - else if the fork happened 
+	 * needs access to the log mutex - else if the fork happened
 	 * when the TPP thread acquired the lock, then the APP thread
 	 * after fork can never acquire it (since the TPP thread would
 	 * be dead after fork - only the thread calling fork is duplicated
 	 * in the child process).
-	 * 
+	 *
 	 * Hence in the prefork handler, we acquire the lock - thus ensuring
-	 * that the TPP thread does not own it, and then post fork we unlock 
+	 * that the TPP thread does not own it, and then post fork we unlock
 	 * it both for the parent and child.
-	 *  
+	 *
 	 */
 #ifndef WIN32
 	/* for unix, set a pthread_atfork handler */
@@ -776,7 +777,7 @@ log_err(int errnum, const char *routine, const char *text)
  * @param[in] errnum - error number
  * @param[in] routine - error in which routine
  * @param[in] fmt - format string
- * @param[in] ... - arguments to format string * 
+ * @param[in] ... - arguments to format string *
  *
  */
 
@@ -956,9 +957,9 @@ get_timestamp(ms_time *mst)
  * 	log_record - log a critical error to the console
  *
  * @param[in] msg - log msg to be logged
- * 
+ *
  */
-void 
+void
 log_console_error(char *msg)
 {
 	FILE *errf;
@@ -988,7 +989,7 @@ log_console_error(char *msg)
  * See syslog(3) for details.
  *
  * Note: Do NOT call this function from log_open() or log_close() since log_record
- * acquires a mutex and calls log_open(), log_close(), making it a recursive call, 
+ * acquires a mutex and calls log_open(), log_close(), making it a recursive call,
  * and confusing the mutex. Rather call, log_record_inner() from log_open, log_close
  * etc
  */
@@ -1022,7 +1023,7 @@ log_record(int eventtype, int objclass, int sev, const char *objname, const char
 	/* lock the file mutex */
 	if (log_mutex_lock() == 0) {
 		get_timestamp(&mst);
-		
+
 		/* Do we need to switch the log? */
 		if (log_auto_switch && (mst.ptm.tm_yday != log_open_day)) {
 			log_close(1);

--- a/src/lib/Libnet/net_server.c
+++ b/src/lib/Libnet/net_server.c
@@ -577,22 +577,22 @@ wait_request(float waittime, void *priority_context)
 			em_event_t *pevents;
 			timeout = 0;
 #ifndef WIN32
-        		/* wait after unblocking signals in an atomic call */
-        		sigemptyset(&emptyset);
-        		pnfds = tpp_em_pwait(priority_context, &pevents, timeout, &emptyset);
-        		err = errno;
+			/* wait after unblocking signals in an atomic call */
+			sigemptyset(&emptyset);
+			pnfds = tpp_em_pwait(priority_context, &pevents, timeout, &emptyset);
+			err = errno;
 #else
-        		pnfds = tpp_em_wait(priority_context, &pevents, timeout);
-        		err = errno;
+			pnfds = tpp_em_wait(priority_context, &pevents, timeout);
+			err = errno;
 #endif /* WIN32 */
-                	for (i = 0; i < pnfds; i++) {
-                        	em_pfd = EM_GET_FD(pevents, i);
+			for (i = 0; i < pnfds; i++) {
+				em_pfd = EM_GET_FD(pevents, i);
 				log_event(PBSEVENT_DEBUG3, PBS_EVENTCLASS_SERVER,
-                                        LOG_DEBUG, __func__, "processing priority socket");
+					LOG_DEBUG, __func__, "processing priority socket");
 				if (process_socket(em_pfd) == -1) {
-                                	log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_SERVER,
-                                        	LOG_DEBUG, __func__, "process priority socket failed");
-                        	} else {
+					log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_SERVER,
+						LOG_DEBUG, __func__, "process priority socket failed");
+				} else {
 					prio_sock_processed = 1;
 				}
 			}

--- a/src/lib/Libpython/pbs_python_svr_size_type.c
+++ b/src/lib/Libpython/pbs_python_svr_size_type.c
@@ -81,7 +81,7 @@
 extern int  comp_size(attribute *, attribute *);
 extern void from_size(const struct size_value *, char *);
 extern int set_size(attribute *, attribute *, enum batch_op op);
-extern int to_size(char *, struct size_value *);
+extern int to_size(const char *, struct size_value *);
 extern int normalize_size(struct size_value *, struct size_value *,
 	struct size_value *, struct size_value *);
 

--- a/src/lib/Libutil/misc_utils.c
+++ b/src/lib/Libutil/misc_utils.c
@@ -618,7 +618,7 @@ pbs_asprintf_exit:
  * @param[in] ... - arguments to format string
  *
  * @return int
- * @retval -1 - Error
+ * @retval -1 - Error - No new allocation or freeing done.
  * @retval >=0 - Length of new string, not including terminator
  */
 int
@@ -629,6 +629,10 @@ pbs_asprintcatf(char **dest, size_t *size, size_t *idx, const char *fmt, ...)
 	size_t new_size = *size;
 	char * newbuf = NULL;
 
+	if (!size)
+		return -1;
+	if (!idx)
+		return -1;
 	if (!dest)
 		return -1;
 	if (!fmt)

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -614,7 +614,7 @@ extern	void	catch_child(int);
 extern	void	init_abort_jobs(int, pbs_list_head *);
 extern	void	scan_for_exiting(void);
 #ifdef NAS /* localmod 015 */
-extern	int	to_size(char *, struct size_value *);
+extern	int	to_size(const char *, struct size_value *);
 #endif /* localmod 015 */
 
 extern	void	cleanup_hooks_workdir(struct work_task *);

--- a/src/scheduler/constant.h
+++ b/src/scheduler/constant.h
@@ -37,8 +37,8 @@
  * subject to Altair's trademark licensing policies.
  */
 
-#ifndef	_CONSTANT_H
-#define	_CONSTANT_H
+#ifndef	_PBS_CONSTANT_H
+#define	_PBS_CONSTANT_H
 
 #include <math.h>
 
@@ -637,4 +637,4 @@ enum nscr_vals {
 	NSCR_CYCLE_INELIGIBLE = 8
 };
 
-#endif	/* _CONSTANT_H */
+#endif	/* _PBS_CONSTANT_H */

--- a/src/scheduler/server_info.cpp
+++ b/src/scheduler/server_info.cpp
@@ -324,7 +324,7 @@ query_server(status *pol, int pbs_sd)
 	for (const auto& rd : policy->resdef_to_check) {
 		if (!(rd == allres["host"] || rd == allres["vnode"]))
 			policy->resdef_to_check_no_hostvnode.insert(rd);
-		
+
 		if (rd->flags & ATR_DFLAG_RASSN)
 			policy->resdef_to_check_rassn.insert(rd);
 

--- a/src/server/Makefile.am
+++ b/src/server/Makefile.am
@@ -60,6 +60,7 @@ pbs_server_bin_LDADD = \
 	$(top_builddir)/src/lib/Libsite/libsite.a \
 	$(top_builddir)/src/lib/Libpython/libpbspython_svr.a \
 	$(top_builddir)/src/lib/Libdb/libpbsdb.la \
+	$(top_builddir)/src/lib/Libapi/libapi.la \
 	$(top_builddir)/src/lib/Libpbs/.libs/libpbs.a \
 	$(top_builddir)/src/lib/Liblicensing/liblicensing.la \
 	@expat_lib@ \

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -106,6 +106,7 @@
 #include <pbs_python.h>  /* for python interpreter */
 #include "pbs_undolr.h"
 #include "auth.h"
+#include "pbs_api_wrapper.h"
 
 #include "pbs_v1_module_common.i"
 
@@ -1318,6 +1319,8 @@ main(int argc, char **argv)
 	}
 	process_hooks(periodic_req, hook_msg, sizeof(hook_msg), pbs_python_set_interrupt);
 
+	apiStart();
+
 	/*
 	 * main loop of server
 	 * stays in this loop until server's state is either
@@ -1450,6 +1453,8 @@ main(int argc, char **argv)
 		}
 	}
 	DBPRT(("Server out of main loop, state is %ld\n", state))
+
+	apiStop();
 
 	/* set the current seq id to the last id before final save */
 	server.sv_qs.sv_lastid = server.sv_qs.sv_jobidnumber;

--- a/src/server/reply_send.c
+++ b/src/server/reply_send.c
@@ -415,7 +415,7 @@ reply_ack(struct batch_request *preq)
 			reply_free(&preq->rq_reply);
 		preq->rq_reply.brp_choice  = BATCH_REPLY_CHOICE_NULL;
 	}
-		
+
 	preq->rq_reply.brp_code    = PBSE_NONE;
 	preq->rq_reply.brp_auxcode = 0;
 
@@ -462,7 +462,7 @@ reply_free(struct batch_reply *prep)
 			(void)free(pstat);
 			pstat = pstatx;
 		}
-		
+
 	} else if (prep->brp_choice == BATCH_REPLY_CHOICE_Delete) {
 		pdelstat = prep->brp_un.brp_deletejoblist.brp_delstatc;
 		while (pdelstat) {
@@ -472,7 +472,7 @@ reply_free(struct batch_reply *prep)
 			free(pdelstat);
 			pdelstat = pdelstatx;
 	}
-		
+
 	} else if (prep->brp_choice == BATCH_REPLY_CHOICE_RescQuery) {
 		(void)free(prep->brp_un.brp_rescq.brq_avail);
 		(void)free(prep->brp_un.brp_rescq.brq_alloc);
@@ -526,7 +526,7 @@ req_reject(int code, int aux, struct batch_request *preq)
 			"req_reject", log_buffer);
 	}
 	set_err_msg(code, msgbuf, ERR_MSG_SIZE);
-	
+
 	if (preq->rq_type != PBS_BATCH_DeleteJobList) {
 		if (preq->rq_reply.brp_choice != BATCH_REPLY_CHOICE_NULL) {
 			/* in case another reply was being built up, clean it out */
@@ -544,10 +544,10 @@ req_reject(int code, int aux, struct batch_request *preq)
 			preq->rq_reply.brp_choice  = BATCH_REPLY_CHOICE_NULL;
 		}
 	}
-		
+
 	preq->rq_reply.brp_code    = code;
 	preq->rq_reply.brp_auxcode = aux;
-	
+
 	(void)reply_send(preq);
 }
 

--- a/src/server/req_stat.c
+++ b/src/server/req_stat.c
@@ -397,7 +397,7 @@ req_stat_job(struct batch_request *preq)
 				return;
 			}
 			pjob = (job *) GET_NEXT(type == 2 ? pjob->ji_jobque : pjob->ji_alljobs);
-			if (preply->brp_count >= MAX_JOBS_PER_REPLY && pjob) {
+			if (preply->brp_count >= MAX_JOBS_PER_REPLY && pjob && preq->rq_conn != PBS_LOCAL_CONNECTION) {
 				rc = reply_send_status_part(preq);
 				if (rc != PBSE_NONE)
 					return;
@@ -599,7 +599,7 @@ req_stat_node(struct batch_request *preq)
 		rc = status_node(pnode, preq, &preply->brp_un.brp_status);
 
 	} else {			/* get status of all nodes */
-	
+
 		for (i = 0; i < svr_totnodes; i++) {
 			pnode = pbsndlist[i];
 
@@ -800,12 +800,12 @@ req_stat_svr(struct batch_request *preq)
  * Replies back only if the server is in a consistent state.
  * Otherwise, it will leave a work task with the request in it
  * which will be converted to immediate when all acks are received.
- * 
+ *
  * Scheduler can proceed only when all the servers answers to this which
  * means the multi-svr cluster is in a consistent state.
  *
  * @param[in]	ptask	-	work task which contains the request
- * 
+ *
  * @return void
  */
 void


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Add generic interface to allow external libraries to handle web requests.
Also, some *totally* unrelated bug fixes are introduced in this as well.
Introduced pbs_asprintcatf, a performant way to concatenate a formatted string to a buffer, with automatic reallocation if the buffer must be increased.

#### Describe Your Change
Add interface to handle webapi calls.


#### Link to Design Doc
N/A - There is no external functional changes in openpbs, so therefore no design documents are required.


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Description: Tests from given sources on platforms UBUNTU1804, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, UBUNTU2004
Platforms: UBUNTU1804,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,UBUNTU2004
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|8238|3282|1|0|0|0|3281|

The failure is unrelated, TestMultipleSchedulers.test_prime_time_backfill


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
