### PR TITLE
Update mom state to free from sleep on restart of node

### DIFF
--- a/test/tests/functional/pbs_node_sleep_state.py
+++ b/test/tests/functional/pbs_node_sleep_state.py
@@ -1,0 +1,99 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2021 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of both the OpenPBS software ("OpenPBS")
+# and the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# OpenPBS is free software. You can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# OpenPBS is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# PBS Pro is commercially licensed software that shares a common core with
+# the OpenPBS software.  For a copy of the commercial license terms and
+# conditions, go to: (http://www.pbspro.com/agreement.html) or contact the
+# Altair Legal Department.
+#
+# Altair's dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of OpenPBS and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair's trademarks, including but not limited to "PBS™",
+# "OpenPBS®", "PBS Professional®", and "PBS Pro™" and Altair's logos is
+# subject to Altair's trademark licensing policies.
+
+
+from tests.functional import *
+
+
+class TestNodeSleepState(TestFunctional):
+
+    """
+    This test suite contains regression tests for node sleep state
+    """
+    def setUp(self):
+        super(TestNodeSleepState, self).setUp()
+        self.server.manager(MGR_CMD_DELETE, NODE, id="", sudo=True)
+        self.server.manager(MGR_CMD_CREATE, NODE, id=self.mom.shortname)
+        self.server.expect(NODE, {'state': 'free'})
+
+    def test_node_set_sleep_state(self):
+        """
+        Tests node setting state to sleep
+        """
+        self.server.manager(MGR_CMD_SET, NODE, {'state': 'sleep'},
+                            id=self.mom.shortname)
+        self.server.expect(NODE, {'state': 'sleep'})
+        # submit a job and it should remain in Q state
+        j = Job(self.du.get_current_user())
+        self.jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=self.jid)
+
+    def test_node_state_sleep_to_free_manual(self):
+        """
+        Tests setting node state to free from sleep manually
+        """
+        self.test_node_set_sleep_state()
+        self.server.manager(MGR_CMD_SET, NODE, {'state': 'free'},
+                            id=self.mom.shortname)
+        self.server.expect(NODE, {'state': 'free'})
+        self.server.expect(JOB, {'job_state': 'R'}, id=self.jid)
+
+    def test_node_state_sleep_to_free_on_node_restart(self):
+        """
+        Tests setting node state to free from sleep on node restart
+        """
+        self.test_node_set_sleep_state()
+        self.mom.stop()
+        self.server.expect(NODE, {'state': 'down,sleep'})
+        self.mom.start()
+        self.server.expect(NODE, {'state': 'free'})
+        self.server.expect(JOB, {'job_state': 'R'}, id=self.jid)
+
+    def test_node_state_offline_and_sleep_restart(self):
+        """
+        Tests setting node state to offline and sleep on restart node
+        will still remain in offline
+        """
+        self.test_node_set_sleep_state()
+        self.server.manager(MGR_CMD_SET, NODE, {'state': (INCR, 'offline')},
+                            id=self.mom.shortname)
+        self.mom.stop()
+        self.server.expect(NODE, {'state': 'down,offline,sleep'})
+        self.mom.start()
+        self.server.expect(NODE, {'state': 'offline'})

--- a/test/tests/functional/pbs_node_sleep_state.py
+++ b/test/tests/functional/pbs_node_sleep_state.py
@@ -46,11 +46,6 @@ class TestNodeSleepState(TestFunctional):
     """
     This test suite contains regression tests for node sleep state
     """
-    def setUp(self):
-        super(TestNodeSleepState, self).setUp()
-        self.server.manager(MGR_CMD_DELETE, NODE, id="", sudo=True)
-        self.server.manager(MGR_CMD_CREATE, NODE, id=self.mom.shortname)
-        self.server.expect(NODE, {'state': 'free'})
 
     def test_node_set_sleep_state(self):
         """


### PR DESCRIPTION

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Sleep state nodes are remaining in sleep state even after node restart.


#### Describe Your Change
On restart of mom, mom send IS_REGISTERMOM signal to server, in that server will clear **sleep** state if it is set on node.
In case of crary_compute node, no need to update it as free on restart(cray library will take care of it).




#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Description: Tests from given sources on platforms UBUNTU1804, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, UBUNTU2004
Platforms: UBUNTU1804,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,UBUNTU2004
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|8249|4132|1|18|0|1|4112|

Note: failures are known issues.


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
