### PR TITLE
Job Submission of test test_chunk_level_host_resource_contention of TestPreemption needs to be updated

### DIFF
--- a/test/tests/functional/pbs_preemption.py
+++ b/test/tests/functional/pbs_preemption.py
@@ -768,7 +768,7 @@ exit 3
 
         a = {'resources_available.ncpus': 2}
         self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom1)
-        a = {'resources_available.ncpus': 3}
+        a = {'resources_available.ncpus': 2}
         self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom2)
 
         a = {'Resource_List.select': '1:ncpus=2'}
@@ -791,7 +791,7 @@ exit 3
 
         # Submit another express queue job requesting the host,
         # this job will stay queued
-        a = {ATTR_q: 'expressq', 'Resource_List.host': self.mom1,
+        a = {ATTR_q: 'expressq', 'Resource_List.host': ehost,
              'Resource_List.ncpus': 2}
         hj2 = Job(TEST_USER, attrs=a)
         hjid2 = self.server.submit(hj2)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature

- Test "test_chunk_level_host_resource_contention" of TestPreemption is failing while verifying job attributes


#### Describe Your Change
- The intent of the test is to submit expressq jobs on the host the where job is running and verify that first expressq job is in R state by suspending the normal running job and the second expressq job remains in Q state but in failed scenario

1. First job was submitted on second host
2. First Expressq job was submitted on second host
3. second Expressq job was submitted on first host --> due to which job started running

Test needs to be updated such that Second Expressq job had to be submitted on the same host.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

- [Execution_logs_TestPreemption_bfr_fix.txt](https://github.com/openpbs/openpbs/files/6883635/Execution_logs_TestPreemption_bfr_fix.txt)


- [Execution_logs_TestPreemption_aftr_fix.txt](https://github.com/openpbs/openpbs/files/6883626/Execution_logs_TestPreemption_aftr_fix.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
