### PR TITLE
Replacing MSG_OOB for MSG_PEEK in qsub

### DIFF
--- a/src/cmds/qsub_sup.c
+++ b/src/cmds/qsub_sup.c
@@ -1592,6 +1592,14 @@ daemon_stuff(void)
 			cred_timeout = 1;
 		}
 
+		/* Shut the qsub daemon if the server had closed the connection */
+		for (i = 0; svr_conns[i]; i++) {
+			if (FD_ISSET(svr_conns[i]->sd, &workset)) {
+				if (recv(svr_conns[i]->sd, &rc, 1, MSG_PEEK) < 1)
+					goto out;
+			}
+		}
+
 		/* accept the connection */
 		fromlen = sizeof(from);
 		if ((sock = accept(bindfd, &from, &fromlen)) == -1) {

--- a/src/cmds/qsub_sup.c
+++ b/src/cmds/qsub_sup.c
@@ -1592,13 +1592,6 @@ daemon_stuff(void)
 			cred_timeout = 1;
 		}
 
-		for (i = 0; svr_conns[i]; i++) {
-			if (FD_ISSET(svr_conns[i]->sd, &workset)) {
-				if (recv(svr_conns[i]->sd, &rc, 1, MSG_OOB) < 1)
-					goto out;
-			}
-		}
-
 		/* accept the connection */
 		fromlen = sizeof(from);
 		if ((sock = accept(bindfd, &from, &fromlen)) == -1) {


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
* Replacing MSG_OOB for MSG_PEEK from qsub
* Why the code exists is puzzling when the server does not send any MSG_OOB


#### Describe Your Change
* MSG_OOB exists today to find out whether the server had closed the connection. Replacing it with MSG_PEEK and adding a comment to explain why it is there.


#### Attach Test and Valgrind Logs/Output
```
[root@head1 pbspro]# qsub -- /bin/sleep 100
25032.head1
```

Regression
--------------
Description: Tests from given sources on platforms UBUNTU1804, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, UBUNTU2004
Platforms: UBUNTU1804,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,UBUNTU2004
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|8340|4117|3|0|0|0|4114|


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
