### PR TITLE
Stagein vnode

### DIFF
--- a/src/include/svrfunc.h
+++ b/src/include/svrfunc.h
@@ -173,7 +173,7 @@ extern void check_block(job *, char *);
 extern void free_nodes(job *);
 extern int job_route(job *);
 extern void rel_resc(job *);
-extern void remove_stagein(job *);
+extern int remove_stagein(job *);
 extern size_t check_for_cred(job *, char **);
 extern void svr_mailowner(job *, int, int, char *);
 extern void svr_mailowner_id(char *, job *, int, int, char *);

--- a/src/server/req_delete.c
+++ b/src/server/req_delete.c
@@ -180,7 +180,7 @@ job *pjob;
 			free_br(preq);
 		}
 	}
-	return (rc);
+	return rc;
 }
 
 /**

--- a/src/server/req_delete.c
+++ b/src/server/req_delete.c
@@ -148,13 +148,18 @@ resume_deletion(struct work_task *ptask)
  *		used when the job is to be purged after files have been staged in
  *
  * @param[in,out]	pjob	- job
+ * 
+ * @return	int
+ * @retval	0	- success
+ * @retval	non-zero	- error code
  */
 
-void
+int
 remove_stagein(pjob)
 job *pjob;
 {
 	struct batch_request *preq = 0;
+	int rc = 0;
 
 	preq = cpy_stage(preq, pjob, JOB_ATR_stagein, 0);
 
@@ -164,7 +169,8 @@ job *pjob;
 
 		preq->rq_type = PBS_BATCH_DelFiles;
 		preq->rq_extra = NULL;
-		if (relay_to_mom(pjob, preq, release_req) == 0) {
+		rc = relay_to_mom(pjob, preq, release_req);
+		if (rc == 0) {
 			pjob->ji_qs.ji_svrflags &= ~JOB_SVFLG_StagedIn;
 		} else {
 			/* log that we were unable to remove the files */
@@ -174,6 +180,7 @@ job *pjob;
 			free_br(preq);
 		}
 	}
+	return (rc);
 }
 
 /**

--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -1611,9 +1611,13 @@ post_sendmom(struct work_task *pwt)
 			else
 				free_nodes(jobp);
 
-			/* turn off the staged in flag */
+			/* delete stagein files if flag is set */
 			if (jobp->ji_qs.ji_svrflags & JOB_SVFLG_StagedIn)
-				remove_stagein(jobp);
+				if (remove_stagein(jobp) != 0) {
+					/* if remove stagein is failed then */
+					/* we will remove stagedin flag from job */
+					jobp->ji_qs.ji_svrflags &= ~JOB_SVFLG_StagedIn;
+				}
 			snprintf(dest_host, sizeof(dest_host), "%s", jobp->ji_qs.ji_destin);
 			clear_exec_on_run_fail(jobp);
 			

--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -790,8 +790,7 @@ req_runjob2(struct batch_request *preq, job *pjob)
  *		clear exec strings so job can be resecheduled anywhere.
  *
  * @par Functionality:
- *		If the job has been checkpointed then
- *		the job must run where it ran before.
+ *		If the job has been checkpointed then the job must run where it ran before.
  *		Otherwise it is free to run anywhere when re-scheduled.  In this case,
  *		clear the exec_hosts, exec_vnodes, etc.
  *
@@ -804,7 +803,7 @@ req_runjob2(struct batch_request *preq, job *pjob)
 void
 clear_exec_on_run_fail(job *jobp)
 {
-	if ((jobp->ji_qs.ji_svrflags & JOB_SVFLG_CHKPT ) == 0) {
+	if ((jobp->ji_qs.ji_svrflags & JOB_SVFLG_CHKPT) == 0) {
 
 		free_jattr(jobp, JOB_ATR_exec_host);
 		free_jattr(jobp, JOB_ATR_exec_host2);

--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -790,8 +790,8 @@ req_runjob2(struct batch_request *preq, job *pjob)
  *		clear exec strings so job can be resecheduled anywhere.
  *
  * @par Functionality:
- *		If the job has been checkpointed or has files staged in, then
- *		the job must run where it ran before or where the files where staged.
+ *		If the job has been checkpointed then
+ *		the job must run where it ran before.
  *		Otherwise it is free to run anywhere when re-scheduled.  In this case,
  *		clear the exec_hosts, exec_vnodes, etc.
  *
@@ -804,8 +804,7 @@ req_runjob2(struct batch_request *preq, job *pjob)
 void
 clear_exec_on_run_fail(job *jobp)
 {
-	if ((jobp->ji_qs.ji_svrflags &
-		(JOB_SVFLG_CHKPT | JOB_SVFLG_StagedIn)) == 0) {
+	if ((jobp->ji_qs.ji_svrflags & JOB_SVFLG_CHKPT ) == 0) {
 
 		free_jattr(jobp, JOB_ATR_exec_host);
 		free_jattr(jobp, JOB_ATR_exec_host2);
@@ -1612,17 +1611,12 @@ post_sendmom(struct work_task *pwt)
 			else
 				free_nodes(jobp);
 
-			/*
-			 * If there is a checkpoint, we leave exec_vnode
-			 *    to force that it will run there again;
-			 * Or if stagein was already successful, we leave
-			 *    exec_vnode set as the files are there and
-			 *    we dont want to copy them again;
-			 * ELSE clear exec_vnode, exec_host, etc.
-			 */
+			/* turn off the staged in flag */
+			if (jobp->ji_qs.ji_svrflags & JOB_SVFLG_StagedIn)
+				remove_stagein(jobp);
 			snprintf(dest_host, sizeof(dest_host), "%s", jobp->ji_qs.ji_destin);
 			clear_exec_on_run_fail(jobp);
-
+			
 			if (!check_job_substate(jobp, JOB_SUBSTATE_ABORT)) {
 				if (preq) {
 					if ((r == SEND_JOB_HOOKERR) ||

--- a/test/tests/functional/pbs_check_job_attrib.py
+++ b/test/tests/functional/pbs_check_job_attrib.py
@@ -67,7 +67,7 @@ class TestCheckJobAttrib(TestFunctional):
         j = Job(TEST_USER, a)
         jid = self.server.submit(j)
         self.server.expect(JOB, 'exec_vnode', id=jid, op=UNSET)
-        self.server.expect(JOB, {'run_count': 1}, id=jid)
+        self.server.expect(JOB, {'run_count': (GT, 0)}, id=jid)
         self.server.log_match('my custom message', starttime=starttime)
         path = stagein_path.split("@")
         msg = "Staged in file not cleaned"

--- a/test/tests/functional/pbs_check_job_attrib.py
+++ b/test/tests/functional/pbs_check_job_attrib.py
@@ -1,0 +1,68 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2021 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of both the OpenPBS software ("OpenPBS")
+# and the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# OpenPBS is free software. You can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# OpenPBS is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# PBS Pro is commercially licensed software that shares a common core with
+# the OpenPBS software.  For a copy of the commercial license terms and
+# conditions, go to: (http://www.pbspro.com/agreement.html) or contact the
+# Altair Legal Department.
+#
+# Altair's dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of OpenPBS and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair's trademarks, including but not limited to "PBS™",
+# "OpenPBS®", "PBS Professional®", and "PBS Pro™" and Altair's logos is
+# subject to Altair's trademark licensing policies.
+
+
+from tests.functional import *
+
+
+class TestCheckJobAttrib(TestFunctional):
+    """
+    """
+
+    def test_exec_vnode_after_job_rerun(self):
+        """
+        """
+        hook_name = "momhook"
+        hook_body = "import pbs\npbs.event().reject('my custom message')\n"
+        a = {'event': 'execjob_begin', 'enabled': 'True'}
+        self.server.create_import_hook(hook_name, a, hook_body)
+
+        self.server.log_match(".*successfully sent hook file.*" +
+                              hook_name + ".PY" + ".*", regexp=True,
+                              max_attempts=100, interval=5)
+        storage_info = {}
+        stagein_path = self.mom.create_and_format_stagein_path(
+            storage_info, asuser=str(TEST_USER))
+        a = {ATTR_stagein: stagein_path}
+        j = Job(TEST_USER, a)
+        jid = self.server.submit(j)
+        self.server.expect(JOB, 'exec_vnode', id=jid, op=UNSET)
+        path = stagein_path.split("@")
+        msg = "Staged in file not cleaned"
+        self.assertFalse(self.mom.isfile(path[0]), msg)

--- a/test/tests/functional/pbs_check_job_attrib.py
+++ b/test/tests/functional/pbs_check_job_attrib.py
@@ -67,6 +67,9 @@ class TestCheckJobAttrib(TestFunctional):
         j = Job(TEST_USER, a)
         jid = self.server.submit(j)
         self.server.expect(JOB, 'exec_vnode', id=jid, op=UNSET)
+        # make scheduling off to avoid any race conditions
+        # otherwise scheduler tries to run job till it reached H state
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
         self.server.expect(JOB, {'run_count': (GT, 0)}, id=jid)
         self.server.log_match('my custom message', starttime=starttime)
         path = stagein_path.split("@")


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
If a job with stage-in option got requeued after stage-in of files then that job will scheduled on the same node all the time. This can make that job can never run if the node(s) assigned to the job goes down.


#### Describe Your Change
Currently PBS stores the vnodes of the requeued job(s) where stage-in is successful and tries to run again on the same vnodes.
Since there is a chance of that job(s) being orphan, updated the code to unset vnodes assigned to a requeued job event after stage-in and also delete the staged files from the mom before unsetting.


#### Attach Test and Valgrind Logs/Output
Description: Rerun All Tests From #8293
Platforms: UBUNTU1804,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,UBUNTU2004
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|8294|4119|2|1|0|0|4116|

Description: run TestCheckJobAttrib (#8297)
Platforms: UBUNTU1804,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,UBUNTU2004
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|8297|1|0|0|0|0|1|


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
