### PR TITLE
fix attribute unset code to not munge original attribute list

### DIFF
--- a/src/include/attribute.h
+++ b/src/include/attribute.h
@@ -320,6 +320,7 @@ extern void free_null  (attribute *attr);
 extern void free_none  (attribute *attr);
 extern svrattrl *attrlist_alloc(int szname, int szresc, int szval);
 extern svrattrl *attrlist_create(char *aname, char *rname, int szval);
+svrattrl *dup_svrattrl(svrattrl *osvrat);
 extern void free_svrattrl(svrattrl *pal);
 extern void free_attrlist(pbs_list_head *attrhead);
 extern void free_svrcache(attribute *attr);

--- a/src/lib/Libattr/attr_func.c
+++ b/src/lib/Libattr/attr_func.c
@@ -582,6 +582,59 @@ free_none(attribute *attr)
 }
 
 /**
+ *  @brief duplicate svrattrl structure
+ *
+ *  @param[in] osvrat - svrattrl to dup
+ *
+ *  @return dup'd svrattrl or NULL (failure)
+ */
+
+svrattrl *
+dup_svrattrl(svrattrl *osvrat)
+{
+	svrattrl *psvrat;
+	size_t tsize;
+
+	if (osvrat == NULL)
+		return NULL;
+
+	tsize = sizeof(svrattrl) + osvrat->al_nameln + osvrat->al_valln + 2;
+	if (osvrat->al_rescln > 0)
+		tsize += osvrat->al_rescln + 1;
+
+	if ((psvrat = (svrattrl *)malloc(tsize)) == 0)
+		return NULL;
+
+	CLEAR_LINK(psvrat->al_link);
+	psvrat->al_sister = NULL;
+	psvrat->al_atopl.next = 0;
+	psvrat->al_tsize = tsize;
+	
+	psvrat->al_name  = (char *)psvrat + sizeof(svrattrl);
+	strcpy(psvrat->al_name, osvrat->al_name);
+	psvrat->al_nameln = osvrat->al_nameln + 1;
+
+	if (osvrat->al_rescln > 0) {
+		psvrat->al_resc = psvrat->al_name + psvrat->al_nameln;
+		strcpy(psvrat->al_resc, osvrat->al_resc);
+		psvrat->al_rescln = osvrat->al_rescln + 1;
+	} else {
+		psvrat->al_resc = NULL;
+		psvrat->al_rescln = 0;
+	}
+
+	psvrat->al_value = psvrat->al_resc + psvrat->al_rescln;
+	strcpy(psvrat->al_value, osvrat->al_value);
+	psvrat->al_valln  = osvrat->al_valln + 1;
+
+	psvrat->al_flags  = osvrat->al_flags;
+	psvrat->al_refct  = 1;
+	psvrat->al_op = osvrat->al_op;
+
+	return psvrat;
+}
+
+/**
  * @brief
  * 	Adds a new entry (name_str, resc_str, val_str, flag) to the 'phead'
  *	svrattrl list.


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Functions like mgr_set_node, mgr_set_queue, mgr_set_server munges the original attribute list while bifurcating it into list of attributes to set and list of attributes to unset

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
While adding to the setlist and unsetlist, "copy" the original attribute instead of moving from the original request list 
Other formatting changes are also done

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
