### PR TITLE
Fix test_server_restart2 delay in exiting test job

### DIFF
--- a/test/tests/functional/pbs_accumulate_resc_used.py
+++ b/test/tests/functional/pbs_accumulate_resc_used.py
@@ -1261,7 +1261,8 @@ time.sleep(15)
         # Submit a job
         a = {'Resource_List.select': '3:ncpus=1',
              'Resource_List.walltime': 10,
-             'Resource_List.place': "scatter"}
+             'Resource_List.place': "scatter",
+             'Keep_Files': 'oe'}
         j = Job(TEST_USER)
         j.set_attributes(a)
         j.set_sleep_time("5")


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* TestPbsAccumulateRescUsed.test_server_restart2 is failing under "no mom on server host" setup.
* The test instantiates an epilogue hook that updates special resources_used values, then submits a job, restart the server, and then checks if epilogue hook was executed and new resources_used values reflected.
* The test is failing with message:
```
    raise PtlExpectError(rc=1, rv=False, msg=_msg)
ptl.lib.ptl_error.PtlExpectError: rc=1, rv=False, msg=expected on server djoko:  no data for resources_used.foo_i = 29 && resources_used.foo_f = 0.29 job 2.djoko attempt: 180
```


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* The problem turned out to be that the job, after server restart, took awhile requeuieng/rerunning due to scp failure from MS host 'laver' (for example) to server/client host 'djoko' (a server host with no mom):
```
8/04/2021 13:02:36.496752;0080;pbs_mom;Job;2.djoko;copy file request received
08/04/2021 13:02:36.547571;0080;pbs_mom;Fil;sys_copy;command: /bin/scp -Brvp /var/spool/pbs/spool/2.djoko.OU pbsuser@djoko.pbspro.com:/home/pbsuser/STDIN.o2 status=1, try=1
08/04/2021 13:02:38.676912;0002;pbs_mom;Svr;pbs_mom;ReplyHello from server at 192.168.80.153:15001
08/04/2021 13:02:52.679827;0080;pbs_mom;Fil;sys_copy;command: /opt/pbs/sbin/pbs_rcp -rp /var/spool/pbs/spool/2.djoko.OU pbsuser@djoko.pbspro.com:/home/pbsuser/STDIN.o2 status=1, try=2
08/04/2021 13:03:03.706339;0080;pbs_mom;Fil;sys_copy;command: /bin/scp -Brvp /var/spool/pbs/spool/2.djoko.OU pbsuser@djoko.pbspro.com:/home/pbsuser/STDIN.o2 status=1, try=3
08/04/2021 13:03:07.557948;0080;pbs_mom;Fil;sys_copy;command: /opt/pbs/sbin/pbs_rcp -rp /var/spool/pbs/spool/2.djoko.OU pbsuser@djoko.pbspro.com:/home/pbsuser/STDIN.o2 status=1, try=2
08/04/2021 13:03:18.588020;0080;pbs_mom;Fil;sys_copy;command: /bin/scp -Brvp /var/spool/pbs/spool/2.djoko.OU pbsuser@djoko.pbspro.com:/home/pbsuser/STDIN.o2 status=1, try=3
08/04/2021 13:03:34.714008;0080;pbs_mom;Fil;sys_copy;command: /opt/pbs/sbin/pbs_rcp -rp /var/spool/pbs/spool/2.djoko.OU pbsuser@djoko.pbspro.com:/home/pbsuser/STDIN.o2 status=1, try=4
08/04/2021 13:03:49.596011;0080;pbs_mom;Fil;sys_copy;command: /opt/pbs/sbin/pbs_rcp -rp /var/spool/pbs/spool/2.djoko.OU pbsuser@djoko.pbspro.com:/home/pbsuser/STDIN.o2 status=1, try=4
08/04/2021 13:03:55.714328;0001;pbs_mom;Fil;copy_file;Job 2.djoko: sys_copy failed, return value=
```
* Fix is to submit job with option to keep files on execution host so as to not deal with scp setup issues, which is not the target of this test.
#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

* [ptl.FAIL.txt](https://github.com/openpbs/openpbs/files/6934516/ptl.FAIL.txt)
* [ptl.PASS.txt](https://github.com/openpbs/openpbs/files/6934517/ptl.PASS.txt)
* [8344-regression_report.FAIL.txt](https://github.com/openpbs/openpbs/files/6934766/8344-regression_report.FAIL.txt)
* [8360-regression_report.PASS.txt](https://github.com/openpbs/openpbs/files/6934768/8360-regression_report.PASS.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
