### PR TITLE
ptl  resources list should be updated after resources deletion

### DIFF
--- a/test/fw/ptl/lib/ptl_wrappers.py
+++ b/test/fw/ptl/lib/ptl_wrappers.py
@@ -2764,37 +2764,37 @@ class Wrappers(PBSService):
         if id is None and obj_type == SERVER:
             id = self.pbs_conf['PBS_SERVER']
         bs_list = []
-        deleted = False
         if cmd == MGR_CMD_DELETE and oid is not None:
-            deleted = True
-        if deleted and obj_type == MGR_OBJ_RSC:
-            res_ret = self.du.run_cmd(cmd=[
-                os.path.join(
-                    self.pbs_conf['PBS_EXEC'],
-                    'bin',
-                    'qmgr'),
-                '-c',
-                "list resource"],
-                logerr=True)
-            ress = []
-            for x in res_ret['out']:
-                if 'Resource' in x:
-                    ress.append(x.split()[1].strip())
-            tmp_res = copy.deepcopy(self.resources)
-            for i in tmp_res:
-                if i not in ress:
-                    del self.resources[i]
-
-        elif cmd == MGR_CMD_DELETE and oid is not None and rc == 0:
-            for i in oid:
-                if obj_type == MGR_OBJ_HOOK and i in self.hooks:
-                    del self.hooks[i]
-                if obj_type in (NODE, VNODE) and i in self.nodes:
-                    del self.nodes[i]
-                if obj_type == MGR_OBJ_QUEUE and i in self.queues:
-                    del self.queues[i]
-                if obj_type == SCHED and i in self.schedulers:
-                    del self.schedulers[i]
+            if rc == 0:
+                for i in oid:
+                    if obj_type == MGR_OBJ_HOOK and i in self.hooks:
+                        del self.hooks[i]
+                    if obj_type in (NODE, VNODE) and i in self.nodes:
+                        del self.nodes[i]
+                    if obj_type == MGR_OBJ_QUEUE and i in self.queues:
+                        del self.queues[i]
+                    if obj_type == MGR_OBJ_RSC and i in self.resources:
+                        del self.resources[i]
+                    if obj_type == SCHED and i in self.schedulers:
+                        del self.schedulers[i]
+            else:
+                if obj_type == MGR_OBJ_RSC:
+                    res_ret = self.du.run_cmd(cmd=[
+                        os.path.join(
+                            self.pbs_conf['PBS_EXEC'],
+                            'bin',
+                            'qmgr'),
+                        '-c',
+                        "list resource"],
+                        logerr=True)
+                    ress = []
+                    for x in res_ret['out']:
+                        if 'Resource' in x:
+                            ress.append(x.split()[1].strip())
+                    tmp_res = copy.deepcopy(self.resources)
+                    for i in tmp_res:
+                        if i not in ress:
+                            del self.resources[i]
 
         elif cmd == MGR_CMD_SET and rc == 0 and id is not None:
             if isinstance(id, list):

--- a/test/fw/ptl/lib/ptl_wrappers.py
+++ b/test/fw/ptl/lib/ptl_wrappers.py
@@ -2788,9 +2788,8 @@ class Wrappers(PBSService):
                         "list resource"],
                         logerr=True)
                     ress = []
-                    for x in res_ret['out']:
-                        if 'Resource' in x:
-                            ress.append(x.split()[1].strip())
+                    ress = [x.split()[1].strip()
+                            for x in res_ret['out'] if 'Resource' in x]
                     tmp_res = copy.deepcopy(self.resources)
                     for i in tmp_res:
                         if i not in ress:

--- a/test/fw/ptl/lib/ptl_wrappers.py
+++ b/test/fw/ptl/lib/ptl_wrappers.py
@@ -2787,7 +2787,6 @@ class Wrappers(PBSService):
                         '-c',
                         "list resource"],
                         logerr=True)
-                    ress = []
                     ress = [x.split()[1].strip()
                             for x in res_ret['out'] if 'Resource' in x]
                     tmp_res = copy.deepcopy(self.resources)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
If PTL gets a resource deletion request for multiple resource then PTL updates resource list if it gets rc=0 means all requested delete resources are deleted. If any one of them is not getting deleted then ptl doesn't update resources list.
Because of that few those are actually deleted are still exist in resources list.

#### Describe Your Change
PTL should update resources list even a single resources is deleted out of requested multiple resouress. 


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

Before changes

Description: Tests from given sources on platforms UBUNTU1804, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, UBUNTU2004
Platforms: UBUNTU1804,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,UBUNTU2004
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|8357|3317|3|0|0|0|3314|

After changes

Description: Tests from given sources on platforms UBUNTU1804, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, UBUNTU2004
Platforms: UBUNTU1804,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,UBUNTU2004
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|8356|3317|0|0|0|0|3317|

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
