### PR TITLE
fix attribute unset code to not munge original attribute list

### DIFF
--- a/src/include/attribute.h
+++ b/src/include/attribute.h
@@ -320,6 +320,7 @@ extern void free_null  (attribute *attr);
 extern void free_none  (attribute *attr);
 extern svrattrl *attrlist_alloc(int szname, int szresc, int szval);
 extern svrattrl *attrlist_create(char *aname, char *rname, int szval);
+svrattrl *dup_svrattrl(svrattrl *osvrat);
 extern void free_svrattrl(svrattrl *pal);
 extern void free_attrlist(pbs_list_head *attrhead);
 extern void free_svrcache(attribute *attr);

--- a/src/lib/Libattr/attr_func.c
+++ b/src/lib/Libattr/attr_func.c
@@ -582,6 +582,59 @@ free_none(attribute *attr)
 }
 
 /**
+ *  @brief duplicate svrattrl structure
+ *
+ *  @param[in] osvrat - svrattrl to dup
+ *
+ *  @return dup'd svrattrl or NULL (failure)
+ */
+
+svrattrl *
+dup_svrattrl(svrattrl *osvrat)
+{
+	svrattrl *psvrat;
+	size_t tsize;
+
+	if (osvrat == NULL)
+		return NULL;
+
+	tsize = sizeof(svrattrl) + osvrat->al_nameln + osvrat->al_valln + 2;
+	if (osvrat->al_rescln > 0)
+		tsize += osvrat->al_rescln + 1;
+
+	if ((psvrat = (svrattrl *)malloc(tsize)) == 0)
+		return NULL;
+
+	CLEAR_LINK(psvrat->al_link);
+	psvrat->al_sister = NULL;
+	psvrat->al_atopl.next = 0;
+	psvrat->al_tsize = tsize;
+	
+	psvrat->al_name  = (char *)psvrat + sizeof(svrattrl);
+	strcpy(psvrat->al_name, osvrat->al_name);
+	psvrat->al_nameln = osvrat->al_nameln + 1;
+
+	if (osvrat->al_rescln > 0) {
+		psvrat->al_resc = psvrat->al_name + psvrat->al_nameln;
+		strcpy(psvrat->al_resc, osvrat->al_resc);
+		psvrat->al_rescln = osvrat->al_rescln + 1;
+	} else {
+		psvrat->al_resc = NULL;
+		psvrat->al_rescln = 0;
+	}
+
+	psvrat->al_value = psvrat->al_resc + psvrat->al_rescln;
+	strcpy(psvrat->al_value, osvrat->al_value);
+	psvrat->al_valln  = osvrat->al_valln + 1;
+
+	psvrat->al_flags  = osvrat->al_flags;
+	psvrat->al_refct  = 1;
+	psvrat->al_op = osvrat->al_op;
+
+	return psvrat;
+}
+
+/**
  * @brief
  * 	Adds a new entry (name_str, resc_str, val_str, flag) to the 'phead'
  *	svrattrl list.

--- a/src/lib/Libattr/attr_func.c
+++ b/src/lib/Libattr/attr_func.c
@@ -612,20 +612,21 @@ dup_svrattrl(svrattrl *osvrat)
 	
 	psvrat->al_name  = (char *)psvrat + sizeof(svrattrl);
 	strcpy(psvrat->al_name, osvrat->al_name);
-	psvrat->al_nameln = osvrat->al_nameln + 1;
+	psvrat->al_nameln = osvrat->al_nameln;
 
 	if (osvrat->al_rescln > 0) {
-		psvrat->al_resc = psvrat->al_name + psvrat->al_nameln;
+		psvrat->al_resc = psvrat->al_name + psvrat->al_nameln + 1;
 		strcpy(psvrat->al_resc, osvrat->al_resc);
-		psvrat->al_rescln = osvrat->al_rescln + 1;
+		psvrat->al_rescln = osvrat->al_rescln;
+		psvrat->al_value = psvrat->al_resc + psvrat->al_rescln + 1;
 	} else {
 		psvrat->al_resc = NULL;
 		psvrat->al_rescln = 0;
+		psvrat->al_value = psvrat->al_name + psvrat->al_nameln + 1;
 	}
 
-	psvrat->al_value = psvrat->al_resc + psvrat->al_rescln;
 	strcpy(psvrat->al_value, osvrat->al_value);
-	psvrat->al_valln  = osvrat->al_valln + 1;
+	psvrat->al_valln  = osvrat->al_valln;
 
 	psvrat->al_flags  = osvrat->al_flags;
 	psvrat->al_refct  = 1;

--- a/test/fw/ptl/lib/ptl_service.py
+++ b/test/fw/ptl/lib/ptl_service.py
@@ -930,7 +930,9 @@ class PBSService(PBSObject):
                     to current day
         :type day: int
         :param starttime: date timestamp to start matching
+        :type starttime: float
         :param endtime: date timestamp to end matching
+        :type endtime: float
         :param host: Hostname
         :type host: str
         :returns: Last ``<n>`` lines of logfile for ``Server``,

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -40,6 +40,7 @@
 
 import calendar
 import grp
+import inspect
 import logging
 import os
 import platform
@@ -48,6 +49,7 @@ import socket
 import subprocess
 import sys
 import time
+import textwrap
 import unittest
 from distutils.util import strtobool
 
@@ -224,6 +226,13 @@ def testparams(**kwargs):
         wrapper.__name__ = function.__name__
         return wrapper
     return decorated
+
+
+def generate_hook_body_from_func(hook_func, *args):
+    return inspect.getsource(hook_func) + textwrap.dedent(
+        """
+        %s%s
+        """ % (hook_func.__name__, str(args)))
 
 
 class PBSServiceInstanceWrapper(dict):
@@ -493,7 +502,7 @@ class PBSTestSuite(unittest.TestCase):
             for mom in self.moms.values():
                 ret = mom.save_configuration()
                 if not ret:
-                    cls.logger.error("Failed to save mom's test setup")
+                    self.logger.error("Failed to save mom's test setup")
                     raise Exception("Failed to save mom's test setup")
             ret = self.scheduler.save_configuration(path, 'w')
             if ret:

--- a/test/tests/functional/pbs_hook_management.py
+++ b/test/tests/functional/pbs_hook_management.py
@@ -39,6 +39,7 @@
 
 import datetime
 import os
+import sys
 import socket
 import textwrap
 import time
@@ -132,6 +133,7 @@ def hook_attrs_func(hook_msg):
                   "reply_code", "reply_auxcode", "reply_choice",
                   "reply_text", 'attribs']
     import pbs
+    import sys
     import pbs_ifl
     from pprint import pformat
     missing = []
@@ -204,6 +206,9 @@ def hook_attrs_func(hook_msg):
             e.accept()
     except Exception as err:
         pbs.logmsg(pbs.LOG_DEBUG, "Error in hook:%s" % str(err))
+        errstr = str(sys.exc_info()[:2])
+        errstr = errstr.replace('\n', '||')
+        pbs.logmsg(pbs.LOG_DEBUG, "Error in hook:%s" % errstr)
         e.reject("a hook error has occurred")
 
 
@@ -890,10 +895,16 @@ class TestHookManagement(TestFunctional):
             match = self.server.log_match("Hook, processed normally.",
                                           starttime=start_time_mom)
             self.logger.info(pformat(match))
-            match = self.server.log_match("Error in hook",
-                                          starttime=start_time_mom,
-                                          existence=False)
-            self.logger.info(pformat(match))
+            try:
+                match = self.server.log_match("Error in hook",
+                                              starttime=start_time_mom,
+                                              existence=False)
+            except Exception:
+                match = self.server.log_match("Error in hook",
+                                              starttime=start_time_mom,
+                                              existence=True)
+                self.logger.info(pformat(match))
+                raise
             self.server.log_match("attribs[0]=>flags:0,flags_lst:[],name:reso"
                                   "urces_available,op:0,op_str:BATCH_OP_SET,r"
                                   "esource:ncpus,sisters:[],value:700000 (str"

--- a/test/tests/functional/pbs_hook_management.py
+++ b/test/tests/functional/pbs_hook_management.py
@@ -129,8 +129,8 @@ def get_hook_body_sleep(hook_msg, sleeptime=0.0):
 
 def hook_attrs_func(hook_msg):
     attributes = ["cmd", "objtype", "objname", "request_time",
-                "reply_code", "reply_auxcode", "reply_choice",
-                "reply_text", 'attribs']
+                  "reply_code", "reply_auxcode", "reply_choice",
+                  "reply_text", 'attribs']
     import pbs
     import pbs_ifl
     from pprint import pformat
@@ -166,13 +166,16 @@ def hook_attrs_func(hook_msg):
                             value_lst.append(value_dct)
                 elif attr == 'objtype':
                     value_str = pbs.REVERSE_MGR_OBJS[value]
-                    pbs.logmsg(pbs.LOG_DEBUG, f"{attr}=>{value_str} (reversed)")
+                    pbs.logmsg(pbs.LOG_DEBUG, f"{attr}=>{value_str} "
+                                              f"(reversed)")
                 elif attr == 'reply_choice':
                     value_str = pbs.REVERSE_BRP_CHOICES[value]
-                    pbs.logmsg(pbs.LOG_DEBUG, f"{attr}=>{value_str} (reversed)")
+                    pbs.logmsg(pbs.LOG_DEBUG, f"{attr}=>{value_str} "
+                                              f"(reversed)")
                 elif attr == 'cmd':
                     value_str = pbs.REVERSE_MGR_CMDS[value]
-                    pbs.logmsg(pbs.LOG_DEBUG, f"{attr}=>{value_str} (reversed)")
+                    pbs.logmsg(pbs.LOG_DEBUG, f"{attr}=>{value_str} "
+                                              f"(reversed)")
                 if attr == 'attribs':
                     lst = []
                     for idx, dct in enumerate(value_lst):
@@ -183,7 +186,8 @@ def hook_attrs_func(hook_msg):
                         # find the string correctly.
                         dct_lst = sorted(dct_lst)
                         dct_lst_str = f"{attr}[{idx}]=>{','.join(dct_lst)}"
-                        pbs.logmsg(pbs.LOG_DEBUG, f"{dct_lst_str} (stringified)")
+                        pbs.logmsg(pbs.LOG_DEBUG, f"{dct_lst_str} "
+                                                  f"(stringified)")
                 else:
                     pbs.logmsg(pbs.LOG_DEBUG, f"{attr}=>{value}")
         if len(missing) > 0:
@@ -873,11 +877,11 @@ class TestHookManagement(TestFunctional):
                                           )
             self.logger.info(pformat(match))
             match = self.server.log_match("Hook, processed normally.",
-                                  starttime=start_time_mom)
+                                          starttime=start_time_mom)
             self.logger.info(pformat(match))
             match = self.server.log_match("Error in hook",
-                                  starttime=start_time_mom,
-                                  existence=False)
+                                          starttime=start_time_mom,
+                                          existence=False)
             self.logger.info(pformat(match))
             self.server.log_match("attribs[0]=>flags:0,flags_lst:[],name:reso"
                                   "urces_available,op:0,op_str:BATCH_OP_SET,r"

--- a/test/tests/functional/pbs_hook_management.py
+++ b/test/tests/functional/pbs_hook_management.py
@@ -162,7 +162,7 @@ def hook_attrs_func(hook_msg):
                         value_dct['resource'] = obj.resource
                         value_dct['sisters'] = obj.sisters
                         value_lst.append(value_dct)
-                    pbs.logmsg(pbs.LOG_DEBUG, f"attribs=>{pformat(value_lst)}")
+                    # pbs.logmsg(pbs.LOG_DEBUG, f"attribs=>{pformat(value_lst)}")
             elif attr == 'objtype':
                 value_str = pbs.REVERSE_MGR_OBJS[value]
                 pbs.logmsg(pbs.LOG_DEBUG, f"{attr}=>{value_str} (reversed)")
@@ -861,13 +861,13 @@ class TestHookManagement(TestFunctional):
             self.server.log_match("objname=>%s" % mom.shortname,
                                   starttime=start_time_mom)
 
-            self.server.log_match("attribs=>flags:0,flags_lst:[],name:resource"
+            self.server.log_match("attribs[0]=>flags:0,flags_lst:[],name:resource"
                                   "s_available,op:0,op_str:BATCH_OP_SET,resour"
                                   "ce:ncpus,sisters:[],value:700000 (stringifi"
                                   "ed)",
                                   starttime=start_time_mom,
                                   n='ALL', max_attempts=16)
-            self.server.log_match("attribs=>flags:0,flags_lst:[],name:resource"
+            self.server.log_match("attribs[0]=>flags:0,flags_lst:[],name:resource"
                                   "s_available,op:0,op_str:BATCH_OP_SET,resour"
                                   "ce:ncpus,sisters:[],value: (stringified)",
                                   starttime=start_time_mom,

--- a/test/tests/functional/pbs_hook_management.py
+++ b/test/tests/functional/pbs_hook_management.py
@@ -219,10 +219,10 @@ def hook_attrs_func(hook_msg):
             pbs.logmsg(pbs.LOG_DEBUG, "Hook, processed normally.")
             e.accept()
     except Exception as err:
-        pbs.logmsg(pbs.LOG_DEBUG, "Error in hook:%s" % str(err))
         now_str = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S.%f")
         pbs.logmsg(pbs.LOG_DEBUG, "%s|Error in hook:%s" %
                    (now_str, '||'.join(get_traceback())))
+        pbs.logmsg(pbs.LOG_DEBUG, "Error in hook:%s" % str(err))
         # errstr = str(sys.exc_info()[:2])
         # errstr = errstr.replace('\n', '||')
         # pbs.logmsg(pbs.LOG_DEBUG, "Error in hook:%s" % errstr)

--- a/test/tests/functional/pbs_hook_management.py
+++ b/test/tests/functional/pbs_hook_management.py
@@ -128,8 +128,8 @@ def get_hook_body_sleep(hook_msg, sleeptime=0.0):
 
 def hook_attrs_func(hook_msg):
     attributes = ["cmd", "objtype", "objname", "request_time",
-                    "reply_code", "reply_auxcode", "reply_choice",
-                    "reply_text", 'attribs']
+                  "reply_code", "reply_auxcode", "reply_choice",
+                  "reply_text", 'attribs']
     import pbs
     import pbs_ifl
     from pprint import pformat
@@ -162,7 +162,6 @@ def hook_attrs_func(hook_msg):
                         value_dct['resource'] = obj.resource
                         value_dct['sisters'] = obj.sisters
                         value_lst.append(value_dct)
-                    # pbs.logmsg(pbs.LOG_DEBUG, f"attribs=>{pformat(value_lst)}")
             elif attr == 'objtype':
                 value_str = pbs.REVERSE_MGR_OBJS[value]
                 pbs.logmsg(pbs.LOG_DEBUG, f"{attr}=>{value_str} (reversed)")
@@ -681,7 +680,6 @@ class TestHookManagement(TestFunctional):
 
         self.logger.info("**************** HOOK END ****************")
 
-
     def test_hook_attrs_00(self):
         """
         Test for a set of the management hook attributes.
@@ -852,7 +850,8 @@ class TestHookManagement(TestFunctional):
 
             a = {'max_run_res_soft.ncpus': "[u:" + str(TEST_USER1) + "=2]"}
             self.server.manager(MGR_CMD_SET, QUEUE, a, 'workq')
-            self.server.manager(MGR_CMD_UNSET, QUEUE, 'max_run_res_soft.ncpus', 'workq')
+            self.server.manager(MGR_CMD_UNSET, QUEUE,
+                                'max_run_res_soft.ncpus', 'workq')
 
             self.server.log_match("cmd=>MGR_CMD_SET",
                                   starttime=start_time_mom)
@@ -861,67 +860,18 @@ class TestHookManagement(TestFunctional):
             self.server.log_match("objname=>%s" % mom.shortname,
                                   starttime=start_time_mom)
 
-            self.server.log_match("attribs[0]=>flags:0,flags_lst:[],name:resource"
-                                  "s_available,op:0,op_str:BATCH_OP_SET,resour"
-                                  "ce:ncpus,sisters:[],value:700000 (stringifi"
+            self.server.log_match("attribs[0]=>flags:0,flags_lst:[],name:reso"
+                                  "urces_available,op:0,op_str:BATCH_OP_SET,r"
+                                  "esource:ncpus,sisters:[],value:700000 (str"
+                                  "ingified)",
+                                  starttime=start_time_mom,
+                                  n='ALL')
+            self.server.log_match("attribs[0]=>flags:0,flags_lst:[],name:reso"
+                                  "urces_available,op:0,op_str:BATCH_OP_SET,r"
+                                  "esource:ncpus,sisters:[],value: (stringifi"
                                   "ed)",
                                   starttime=start_time_mom,
-                                  n='ALL', max_attempts=16)
-            self.server.log_match("attribs[0]=>flags:0,flags_lst:[],name:resource"
-                                  "s_available,op:0,op_str:BATCH_OP_SET,resour"
-                                  "ce:ncpus,sisters:[],value: (stringified)",
-                                  starttime=start_time_mom,
-                                  n='ALL', max_attempts=16)
-
-            # figure out where this went wrong:
-            # https://github.com/openpbs/openpbs/pull/1902/files
-
-            """07/08/2021 13:57:09.301273;0006;Server@pdw-s1;Hook;Server@pdw-s1;cmd=>MGR_CMD_SET (reversed)
-            07/08/2021 13:57:09.301282;0006;Server@pdw-s1;Hook;Server@pdw-s1;cmd=>2
-            07/08/2021 13:57:09.301288;0006;Server@pdw-s1;Hook;Server@pdw-s1;objtype=>MGR_OBJ_NODE (reversed)
-            07/08/2021 13:57:09.301292;0006;Server@pdw-s1;Hook;Server@pdw-s1;objtype=>3
-            07/08/2021 13:57:09.301297;0006;Server@pdw-s1;Hook;Server@pdw-s1;objname=>pdw-c4
-            07/08/2021 13:57:09.301301;0006;Server@pdw-s1;Hook;Server@pdw-s1;request_time=>1625752629
-            07/08/2021 13:57:09.301306;0006;Server@pdw-s1;Hook;Server@pdw-s1;reply_code=>0
-            07/08/2021 13:57:09.301310;0006;Server@pdw-s1;Hook;Server@pdw-s1;reply_auxcode=>0
-            07/08/2021 13:57:09.301314;0006;Server@pdw-s1;Hook;Server@pdw-s1;reply_choice=>BRP_CHOICE_NULL (reversed)
-            07/08/2021 13:57:09.301318;0006;Server@pdw-s1;Hook;Server@pdw-s1;reply_choice=>1
-            07/08/2021 13:57:09.301324;0006;Server@pdw-s1;Hook;Server@pdw-s1;reply_text=>None
-            07/08/2021 13:57:09.301472;0006;Server@pdw-s1;Hook;Server@pdw-s1;attribs=>[{'flags': 0,
-            'flags_lst': [],
-            'name': 'resources_available',
-            'op': 0,
-            'op_str': 'BATCH_OP_SET',
-            'resource': 'ncpus',
-            'sisters': [],
-            'value': '700000'}]"""
-
-            """07/08/2021 13:57:09.324183;0006;Server@pdw-s1;Hook;Server@pdw-s1;cmd=>MGR_CMD_UNSET (reversed)
-            07/08/2021 13:57:09.324194;0006;Server@pdw-s1;Hook;Server@pdw-s1;cmd=>3
-            07/08/2021 13:57:09.324200;0006;Server@pdw-s1;Hook;Server@pdw-s1;objtype=>MGR_OBJ_NODE (reversed)
-            07/08/2021 13:57:09.324205;0006;Server@pdw-s1;Hook;Server@pdw-s1;objtype=>3
-            07/08/2021 13:57:09.324223;0006;Server@pdw-s1;Hook;Server@pdw-s1;objname=>pdw-c4
-            07/08/2021 13:57:09.324228;0006;Server@pdw-s1;Hook;Server@pdw-s1;request_time=>1625752629
-            07/08/2021 13:57:09.324232;0006;Server@pdw-s1;Hook;Server@pdw-s1;reply_code=>0
-            07/08/2021 13:57:09.324237;0006;Server@pdw-s1;Hook;Server@pdw-s1;reply_auxcode=>0
-            07/08/2021 13:57:09.324241;0006;Server@pdw-s1;Hook;Server@pdw-s1;reply_choice=>BRP_CHOICE_NULL (reversed)
-            07/08/2021 13:57:09.324245;0006;Server@pdw-s1;Hook;Server@pdw-s1;reply_choice=>1
-            07/08/2021 13:57:09.324251;0006;Server@pdw-s1;Hook;Server@pdw-s1;reply_text=>None
-            07/08/2021 13:57:09.324482;0006;Server@pdw-s1;Hook;Server@pdw-s1;attribs=>[{'flags': 0,
-            'flags_lst': [],
-            'name': 'resources_available',
-            'op': 0,
-            'op_str': 'BATCH_OP_SET',
-            'resource': 'ncpus',
-            'sisters': [],
-            'value': ''}]
-            """
-
-
-            # self.server.log_match("Node;%s;node up" % mom.fqdn,
-            #                       starttime=start_time)
-            # self.server.log_match("Node;%s;node down" % mom.fqdn,
-            #                       starttime=start_time)
+                                  n='ALL')
 
         ret = self.server.delete_hook(hook_name_00)
         self.assertEqual(ret, True, "Could not delete hook %s" % hook_name_00)
@@ -934,5 +884,3 @@ class TestHookManagement(TestFunctional):
                               starttime=start_time, existence=True)
 
         self.logger.info("**************** HOOK END ****************")
-
-

--- a/test/tests/functional/pbs_hook_management.py
+++ b/test/tests/functional/pbs_hook_management.py
@@ -42,6 +42,7 @@ import os
 import socket
 import textwrap
 import time
+from pprint import pformat
 from ptl.utils.pbs_testsuite import generate_hook_body_from_func
 
 from tests.functional import *
@@ -859,19 +860,22 @@ class TestHookManagement(TestFunctional):
                                   starttime=start_time_mom)
             self.server.log_match("objname=>%s" % mom.shortname,
                                   starttime=start_time_mom)
-
+            match = self.server.log_match("(stringified)",
+                                          starttime=start_time_mom,
+                                          allmatch=True,
+                                          n="ALL"
+                                          )
+            self.logger.info(pformat(match))
             self.server.log_match("attribs[0]=>flags:0,flags_lst:[],name:reso"
                                   "urces_available,op:0,op_str:BATCH_OP_SET,r"
                                   "esource:ncpus,sisters:[],value:700000 (str"
                                   "ingified)",
-                                  starttime=start_time_mom,
-                                  n='ALL')
+                                  starttime=start_time_mom)
             self.server.log_match("attribs[0]=>flags:0,flags_lst:[],name:reso"
                                   "urces_available,op:0,op_str:BATCH_OP_SET,r"
                                   "esource:ncpus,sisters:[],value: (stringifi"
                                   "ed)",
-                                  starttime=start_time_mom,
-                                  n='ALL')
+                                  starttime=start_time_mom)
 
         ret = self.server.delete_hook(hook_name_00)
         self.assertEqual(ret, True, "Could not delete hook %s" % hook_name_00)

--- a/test/tests/functional/pbs_hook_management.py
+++ b/test/tests/functional/pbs_hook_management.py
@@ -160,7 +160,8 @@ def hook_attrs_func(hook_msg):
                                     subvalue_lst.append(str(v))
                             value_dct[f"flags_lst"] = subvalue_lst
                             value_dct['op'] = obj.op
-                            value_dct[f"op_str"] = pbs.REVERSE_BATCH_OPS[obj.op]
+                            value_dct[f"op_str"] = \
+                                pbs.REVERSE_BATCH_OPS[obj.op]
                             value_dct['resource'] = obj.resource
                             value_dct['sisters'] = obj.sisters
                             value_lst.append(value_dct)

--- a/test/tests/functional/pbs_hook_management.py
+++ b/test/tests/functional/pbs_hook_management.py
@@ -42,6 +42,7 @@ import os
 import socket
 import textwrap
 import time
+from ptl.utils.pbs_testsuite import generate_hook_body_from_func
 
 from tests.functional import *
 from tests.functional import JOB, MGR_CMD_SET, SERVER, TEST_USER, ATTR_h, Job
@@ -71,28 +72,20 @@ def get_hook_body_str(hook_msg):
     return hook_body
 
 
-def get_hook_body_accept(hook_msg):
-    hook_body = """
+def hook_accept(hook_msg):
     import pbs
     e = pbs.event()
     m = e.management
-    pbs.logmsg(pbs.LOG_DEBUG, '%s')
+    pbs.logmsg(pbs.LOG_DEBUG, hook_msg)
     e.accept()
-    """ % hook_msg
-    hook_body = textwrap.dedent(hook_body)
-    return hook_body
 
 
-def get_hook_body_reject(hook_msg):
-    hook_body = """
+def hook_reject(hook_msg):
     import pbs
     e = pbs.event()
     m = e.management
-    pbs.logmsg(pbs.LOG_DEBUG, '%s')
+    pbs.logmsg(pbs.LOG_DEBUG, hook_msg)
     e.reject()
-    """ % hook_msg
-    hook_body = textwrap.dedent(hook_body)
-    return hook_body
 
 
 def get_hook_body_reject_with_text(hook_msg, bad_message="badmsg"):
@@ -131,6 +124,78 @@ def get_hook_body_sleep(hook_msg, sleeptime=0.0):
     """ % (hook_msg, sleeptime)
     hook_body = textwrap.dedent(hook_body)
     return hook_body
+
+
+def hook_attrs_func(hook_msg):
+    attributes = ["cmd", "objtype", "objname", "request_time",
+                    "reply_code", "reply_auxcode", "reply_choice",
+                    "reply_text", 'attribs']
+    import pbs
+    import pbs_ifl
+    from pprint import pformat
+    missing = []
+    e = pbs.event()
+    m = e.management
+    # pbs.logmsg(pbs.LOG_DEBUG, str(dir(pbs)))
+    # pbs.logmsg(pbs.LOG_DEBUG, str(dir(e)))
+    # pbs.logmsg(pbs.LOG_DEBUG, str(dir(m)))
+    for attr in attributes:
+        if not hasattr(m, attr):
+            missing.append(attr)
+        else:
+            value = getattr(m, attr)
+            value_lst = []
+            if attr == 'attribs':
+                if type(value) == list:
+                    for obj in value:
+                        value_dct = {}
+                        value_dct['name'] = obj.name
+                        value_dct['value'] = obj.value
+                        value_dct['flags'] = obj.flags
+                        subvalue_lst = []
+                        for k, v in pbs.REVERSE_ATR_VFLAGS.items():
+                            if int(k) & int(obj.flags):
+                                subvalue_lst.append(str(v))
+                        value_dct[f"flags_lst"] = subvalue_lst
+                        value_dct['op'] = obj.op
+                        value_dct[f"op_str"] = pbs.REVERSE_BATCH_OPS[obj.op]
+                        value_dct['resource'] = obj.resource
+                        value_dct['sisters'] = obj.sisters
+                        value_lst.append(value_dct)
+                    pbs.logmsg(pbs.LOG_DEBUG, f"attribs=>{pformat(value_lst)}")
+            elif attr == 'objtype':
+                value_str = pbs.REVERSE_MGR_OBJS[value]
+                pbs.logmsg(pbs.LOG_DEBUG, f"{attr}=>{value_str} (reversed)")
+            elif attr == 'reply_choice':
+                value_str = pbs.REVERSE_BRP_CHOICES[value]
+                pbs.logmsg(pbs.LOG_DEBUG, f"{attr}=>{value_str} (reversed)")
+            elif attr == 'cmd':
+                value_str = pbs.REVERSE_MGR_CMDS[value]
+                pbs.logmsg(pbs.LOG_DEBUG, f"{attr}=>{value_str} (reversed)")
+            if attr == 'attribs':
+                lst = []
+                for idx, dct in enumerate(value_lst):
+                    dct_lst = []
+                    for key, value in dct.items():
+                        dct_lst.append(f"{key}:{value}")
+                    # need to sort the list to allow for the test to
+                    # find the string correctly.
+                    dct_lst = sorted(dct_lst)
+                    dct_lst_str = f"{attr}[{idx}]=>{','.join(dct_lst)}"
+                    pbs.logmsg(pbs.LOG_DEBUG, f"{dct_lst_str} (stringified)")
+            else:
+                pbs.logmsg(pbs.LOG_DEBUG, f"{attr}=>{value}")
+    if len(missing) > 0:
+        e.reject("missing attributes in pbs:" + ",".join(missing))
+    else:
+        pbs.logmsg(pbs.LOG_DEBUG, 'all attributes found in pbs')
+        # pbs.logmsg(pbs.LOG_DEBUG, 'dir(pbs_ifl):')
+        # pbs.logmsg(pbs.LOG_DEBUG, str(dir(pbs_ifl)))
+        # pbs.logmsg(pbs.LOG_DEBUG, 'dir(pbs):')
+        # pbs.logmsg(pbs.LOG_DEBUG, str(dir(pbs)))
+        m = e.management
+        pbs.logmsg(pbs.LOG_DEBUG, hook_msg)
+        e.accept()
 
 
 @tags('hooks', 'smoke')
@@ -309,7 +374,7 @@ class TestHookManagement(TestFunctional):
         hook_body_00 = get_hook_body(hook_msg_00)
         hook_msg_01 = 'running management hook_reject_00 name:%s' % \
                       hook_name_01
-        hook_body_01 = get_hook_body_reject(hook_msg_01)
+        hook_body_01 = generate_hook_body_from_func(hook_reject, hook_msg_01)
         hook_msg_02 = 'running management hook_reject_00 name:%s' % \
                       hook_name_02
         hook_body_02 = get_hook_body(hook_msg_02)
@@ -338,7 +403,7 @@ class TestHookManagement(TestFunctional):
 
         self.server.log_match(hook_msg_00, starttime=start_time)
         self.server.log_match(hook_msg_01, starttime=start_time)
-        # we should not see it fire because ^^^ b1234 ^^^ rejects
+        # we should not see vvv it vvv fire because ^^^ b1234 ^^^ rejects
         self.server.log_match(hook_msg_02, starttime=start_time,
                               existence=False)
 
@@ -374,7 +439,7 @@ class TestHookManagement(TestFunctional):
         hook_body_00 = get_hook_body(hook_msg_00)
         hook_msg_01 = 'running management hook_reject_00 name:%s' % \
                       hook_name_01
-        hook_body_01 = get_hook_body_reject(hook_msg_01)
+        hook_body_01 = generate_hook_body_from_func(hook_reject, hook_msg_01)
         hook_msg_02 = 'running management hook_reject_00 name:%s' % \
                       hook_name_02
         hook_body_02 = get_hook_body(hook_msg_02)
@@ -614,5 +679,250 @@ class TestHookManagement(TestFunctional):
         self.server.log_match("all attributes found in pbs",
                               starttime=start_time, existence=True)
 
-        self.logger.info(str(dir()))
         self.logger.info("**************** HOOK END ****************")
+
+
+    def test_hook_attrs_00(self):
+        """
+        Test for a set of the management hook attributes.
+        """
+        self.logger.info("**************** HOOK START ****************")
+        attrs = {'event': 'management', 'enabled': 'True'}
+
+        hook_name_00 = 'h1234'
+        hook_msg_00 = 'running management hook_import_00 name:%s' % \
+                      hook_name_00
+        hook_body_00 = generate_hook_body_from_func(hook_attrs_func,
+                                                    hook_msg_00)
+        self.server.manager(MGR_CMD_SET, SERVER, {'log_events': 2047})
+
+        start_time = time.time()
+        ret = self.server.create_hook(hook_name_00, attrs)
+        self.assertEqual(ret, True, "Could not create hook %s" % hook_name_00)
+
+        self.server.log_match("%s;created at request" % hook_name_00,
+                              starttime=start_time)
+
+        ret = self.server.import_hook(hook_name_00, hook_body_00)
+        self.assertEqual(ret, True, "Could not import hook %s" % hook_name_00)
+
+        self.server.log_match(hook_msg_00, starttime=start_time)
+        self.server.log_match("cmd=>7", starttime=start_time)
+        self.server.log_match("objtype=>8", starttime=start_time)
+        self.server.log_match("objname=>%s" % hook_name_00,
+                              starttime=start_time)
+        self.server.log_match("reply_code=>0", starttime=start_time)
+        self.server.log_match("reply_auxcode=>0", starttime=start_time)
+        self.server.log_match("reply_choice=>1", starttime=start_time)
+        self.server.log_match("reply_text=>None", starttime=start_time)
+
+        ret = self.server.delete_hook(hook_name_00)
+        self.assertEqual(ret, True, "Could not delete hook %s" % hook_name_00)
+
+        self.server.log_match("%s;deleted at request of" % hook_name_00,
+                              starttime=start_time)
+
+        self.server.log_match("missing attributes in pbs",
+                              starttime=start_time, existence=False)
+        self.server.log_match("all attributes found in pbs",
+                              starttime=start_time, existence=True)
+
+        self.logger.info("**************** HOOK END ****************")
+
+    def test_hook_attrs_01(self):
+        """
+        Test for a set of the management hook attributes.
+        """
+        self.logger.info("**************** HOOK START ****************")
+        attrs = {'event': 'management', 'enabled': 'True'}
+
+        hook_name_00 = 'i1234'
+        hook_msg_00 = 'running management hook_import_00 name:%s' % \
+                      hook_name_00
+        hook_body_00 = generate_hook_body_from_func(hook_attrs_func,
+                                                    hook_msg_00)
+        self.server.manager(MGR_CMD_SET, SERVER, {'log_events': 2047})
+
+        start_time = time.time()
+        ret = self.server.create_hook(hook_name_00, attrs)
+        self.assertEqual(ret, True, "Could not create hook %s" % hook_name_00)
+
+        self.server.log_match("%s;created at request" % hook_name_00,
+                              starttime=start_time)
+
+        ret = self.server.import_hook(hook_name_00, hook_body_00)
+        self.assertEqual(ret, True, "Could not import hook %s" % hook_name_00)
+
+        self.server.log_match(hook_msg_00, starttime=start_time)
+        self.server.log_match("cmd=>7", starttime=start_time)
+        self.server.log_match("objtype=>8", starttime=start_time)
+        self.server.log_match("objname=>%s" % hook_name_00,
+                              starttime=start_time)
+        self.server.log_match("reply_code=>0", starttime=start_time)
+        self.server.log_match("reply_auxcode=>0", starttime=start_time)
+        self.server.log_match("reply_choice=>1", starttime=start_time)
+        self.server.log_match("reply_text=>None", starttime=start_time)
+
+        # run a qmgr command and import the script.
+        hook_name_01 = 'i1234accept'
+        hook_msg_01 = "%s accept hook" % hook_name_01
+        hook_body_01 = generate_hook_body_from_func(hook_accept, hook_msg_01)
+        attrs = {'event': 'queuejob', 'enabled': 'True'}
+        ret = self.server.create_hook(hook_name_01, attrs)
+        ret = self.server.import_hook(hook_name_01, hook_body_01)
+
+        # we don't need to run a job, we just want to check the attributes.
+        self.server.log_match(hook_msg_00, starttime=start_time)
+        self.server.log_match("cmd=>0", starttime=start_time)
+        self.server.log_match("objtype=>8", starttime=start_time)
+        self.server.log_match("objname=>%s" % hook_name_01,
+                              starttime=start_time)
+        self.server.log_match("reply_code=>0", starttime=start_time)
+        self.server.log_match("reply_auxcode=>0", starttime=start_time)
+        self.server.log_match("reply_choice=>1", starttime=start_time)
+        self.server.log_match("reply_text=>None", starttime=start_time)
+        self.server.log_match("server_priv/hooks/%s.PY" % hook_name_01,
+                              starttime=start_time)
+
+        ret = self.server.delete_hook(hook_name_00)
+        self.assertEqual(ret, True, "Could not delete hook %s" % hook_name_00)
+        self.server.log_match("%s;deleted at request of" % hook_name_00,
+                              starttime=start_time)
+        ret = self.server.delete_hook(hook_name_01)
+        self.assertEqual(ret, True, "Could not delete hook %s" % hook_name_01)
+        self.server.log_match("%s;deleted at request of" % hook_name_01,
+                              starttime=start_time)
+        self.server.log_match("missing attributes in pbs",
+                              starttime=start_time, existence=False)
+        self.server.log_match("all attributes found in pbs",
+                              starttime=start_time, existence=True)
+
+        self.logger.info("**************** HOOK END ****************")
+
+    def test_hook_attrs_02(self):
+        """
+        Test for a set of the management hook attributes.
+        """
+        self.logger.info("**************** HOOK START ****************")
+        attrs = {'event': 'management', 'enabled': 'True'}
+
+        hook_name_00 = 'j1234'
+        hook_msg_00 = 'running management hook_import_00 name:%s' % \
+                      hook_name_00
+        hook_body_00 = generate_hook_body_from_func(hook_attrs_func,
+                                                    hook_msg_00)
+        self.server.manager(MGR_CMD_SET, SERVER, {'log_events': 2047})
+
+        start_time = time.time()
+        ret = self.server.create_hook(hook_name_00, attrs)
+        self.assertEqual(ret, True, "Could not create hook %s" % hook_name_00)
+
+        self.server.log_match("%s;created at request" % hook_name_00,
+                              starttime=start_time)
+
+        ret = self.server.import_hook(hook_name_00, hook_body_00)
+        self.assertEqual(ret, True, "Could not import hook %s" % hook_name_00)
+
+        self.server.log_match(hook_msg_00, starttime=start_time)
+        self.server.log_match("cmd=>7", starttime=start_time)
+        self.server.log_match("objtype=>8", starttime=start_time)
+        self.server.log_match("objname=>%s" % hook_name_00,
+                              starttime=start_time)
+        self.server.log_match("reply_code=>0", starttime=start_time)
+        self.server.log_match("reply_auxcode=>0", starttime=start_time)
+        self.server.log_match("reply_choice=>1", starttime=start_time)
+        self.server.log_match("reply_text=>None", starttime=start_time)
+
+        for mom in self.server.moms.values():
+            start_time_mom = time.time()
+            self.logger.error(f"deleting and creating\n"
+                              f"mom.hostname:{mom.hostname}\n"
+                              f"mom.fqdn:{mom.fqdn}\n"
+                              f"mom.name:{mom.name}\n"
+                              f"mom.__dict__:{mom.__dict__}\n"
+                              )
+            # self.server.delete_node(mom.shortname)
+            # self.server.create_node(mom.shortname)
+            self.server.manager(MGR_CMD_SET, NODE,
+                                {'resources_available.ncpus': '700000'},
+                                id=mom.shortname)
+            self.server.manager(MGR_CMD_UNSET, NODE,
+                                'resources_available.ncpus',
+                                id=mom.shortname)
+            self.server.log_match("cmd=>MGR_CMD_SET",
+                                  starttime=start_time_mom)
+            self.server.log_match("objtype=>MGR_OBJ_NODE",
+                                  starttime=start_time_mom)
+            self.server.log_match("objname=>%s" % mom.shortname,
+                                  starttime=start_time_mom)
+
+            self.server.log_match("attribs=>flags:0,flags_lst:[],name:resource"
+                                  "s_available,op:0,op_str:BATCH_OP_SET,resour"
+                                  "ce:ncpus,sisters:[],value:700000 (stringifi"
+                                  "ed)",
+                                  starttime=start_time_mom)
+            self.server.log_match("attribs=>flags:0,flags_lst:[],name:resource"
+                                  "s_available,op:0,op_str:BATCH_OP_SET,resour"
+                                  "ce:ncpus,sisters:[],value: (stringified)",
+                                  starttime=start_time_mom)
+
+            """07/08/2021 13:57:09.301273;0006;Server@pdw-s1;Hook;Server@pdw-s1;cmd=>MGR_CMD_SET (reversed)
+            07/08/2021 13:57:09.301282;0006;Server@pdw-s1;Hook;Server@pdw-s1;cmd=>2
+            07/08/2021 13:57:09.301288;0006;Server@pdw-s1;Hook;Server@pdw-s1;objtype=>MGR_OBJ_NODE (reversed)
+            07/08/2021 13:57:09.301292;0006;Server@pdw-s1;Hook;Server@pdw-s1;objtype=>3
+            07/08/2021 13:57:09.301297;0006;Server@pdw-s1;Hook;Server@pdw-s1;objname=>pdw-c4
+            07/08/2021 13:57:09.301301;0006;Server@pdw-s1;Hook;Server@pdw-s1;request_time=>1625752629
+            07/08/2021 13:57:09.301306;0006;Server@pdw-s1;Hook;Server@pdw-s1;reply_code=>0
+            07/08/2021 13:57:09.301310;0006;Server@pdw-s1;Hook;Server@pdw-s1;reply_auxcode=>0
+            07/08/2021 13:57:09.301314;0006;Server@pdw-s1;Hook;Server@pdw-s1;reply_choice=>BRP_CHOICE_NULL (reversed)
+            07/08/2021 13:57:09.301318;0006;Server@pdw-s1;Hook;Server@pdw-s1;reply_choice=>1
+            07/08/2021 13:57:09.301324;0006;Server@pdw-s1;Hook;Server@pdw-s1;reply_text=>None
+            07/08/2021 13:57:09.301472;0006;Server@pdw-s1;Hook;Server@pdw-s1;attribs=>[{'flags': 0,
+            'flags_lst': [],
+            'name': 'resources_available',
+            'op': 0,
+            'op_str': 'BATCH_OP_SET',
+            'resource': 'ncpus',
+            'sisters': [],
+            'value': '700000'}]"""
+
+            """07/08/2021 13:57:09.324183;0006;Server@pdw-s1;Hook;Server@pdw-s1;cmd=>MGR_CMD_UNSET (reversed)
+            07/08/2021 13:57:09.324194;0006;Server@pdw-s1;Hook;Server@pdw-s1;cmd=>3
+            07/08/2021 13:57:09.324200;0006;Server@pdw-s1;Hook;Server@pdw-s1;objtype=>MGR_OBJ_NODE (reversed)
+            07/08/2021 13:57:09.324205;0006;Server@pdw-s1;Hook;Server@pdw-s1;objtype=>3
+            07/08/2021 13:57:09.324223;0006;Server@pdw-s1;Hook;Server@pdw-s1;objname=>pdw-c4
+            07/08/2021 13:57:09.324228;0006;Server@pdw-s1;Hook;Server@pdw-s1;request_time=>1625752629
+            07/08/2021 13:57:09.324232;0006;Server@pdw-s1;Hook;Server@pdw-s1;reply_code=>0
+            07/08/2021 13:57:09.324237;0006;Server@pdw-s1;Hook;Server@pdw-s1;reply_auxcode=>0
+            07/08/2021 13:57:09.324241;0006;Server@pdw-s1;Hook;Server@pdw-s1;reply_choice=>BRP_CHOICE_NULL (reversed)
+            07/08/2021 13:57:09.324245;0006;Server@pdw-s1;Hook;Server@pdw-s1;reply_choice=>1
+            07/08/2021 13:57:09.324251;0006;Server@pdw-s1;Hook;Server@pdw-s1;reply_text=>None
+            07/08/2021 13:57:09.324482;0006;Server@pdw-s1;Hook;Server@pdw-s1;attribs=>[{'flags': 0,
+            'flags_lst': [],
+            'name': 'resources_available',
+            'op': 0,
+            'op_str': 'BATCH_OP_SET',
+            'resource': 'ncpus',
+            'sisters': [],
+            'value': ''}]
+            """
+
+
+            # self.server.log_match("Node;%s;node up" % mom.fqdn,
+            #                       starttime=start_time)
+            # self.server.log_match("Node;%s;node down" % mom.fqdn,
+            #                       starttime=start_time)
+
+        ret = self.server.delete_hook(hook_name_00)
+        self.assertEqual(ret, True, "Could not delete hook %s" % hook_name_00)
+        self.server.log_match("%s;deleted at request of" % hook_name_00,
+                              starttime=start_time)
+
+        self.server.log_match("missing attributes in pbs",
+                              starttime=start_time, existence=False)
+        self.server.log_match("all attributes found in pbs",
+                              starttime=start_time, existence=True)
+
+        self.logger.info("**************** HOOK END ****************")
+
+

--- a/test/tests/functional/pbs_hook_management.py
+++ b/test/tests/functional/pbs_hook_management.py
@@ -146,6 +146,7 @@ def hook_attrs_func(hook_msg):
                   "reply_code", "reply_auxcode", "reply_choice",
                   "reply_text", 'attribs']
     import pbs
+    from datetime import datetime
     missing = []
     e = pbs.event()
     try:

--- a/test/tests/functional/pbs_hook_management.py
+++ b/test/tests/functional/pbs_hook_management.py
@@ -129,73 +129,79 @@ def get_hook_body_sleep(hook_msg, sleeptime=0.0):
 
 def hook_attrs_func(hook_msg):
     attributes = ["cmd", "objtype", "objname", "request_time",
-                  "reply_code", "reply_auxcode", "reply_choice",
-                  "reply_text", 'attribs']
+                "reply_code", "reply_auxcode", "reply_choice",
+                "reply_text", 'attribs']
     import pbs
     import pbs_ifl
     from pprint import pformat
     missing = []
     e = pbs.event()
-    m = e.management
-    # pbs.logmsg(pbs.LOG_DEBUG, str(dir(pbs)))
-    # pbs.logmsg(pbs.LOG_DEBUG, str(dir(e)))
-    # pbs.logmsg(pbs.LOG_DEBUG, str(dir(m)))
-    for attr in attributes:
-        if not hasattr(m, attr):
-            missing.append(attr)
-        else:
-            value = getattr(m, attr)
-            value_lst = []
-            if attr == 'attribs':
-                if type(value) == list:
-                    for obj in value:
-                        value_dct = {}
-                        value_dct['name'] = obj.name
-                        value_dct['value'] = obj.value
-                        value_dct['flags'] = obj.flags
-                        subvalue_lst = []
-                        for k, v in pbs.REVERSE_ATR_VFLAGS.items():
-                            if int(k) & int(obj.flags):
-                                subvalue_lst.append(str(v))
-                        value_dct[f"flags_lst"] = subvalue_lst
-                        value_dct['op'] = obj.op
-                        value_dct[f"op_str"] = pbs.REVERSE_BATCH_OPS[obj.op]
-                        value_dct['resource'] = obj.resource
-                        value_dct['sisters'] = obj.sisters
-                        value_lst.append(value_dct)
-            elif attr == 'objtype':
-                value_str = pbs.REVERSE_MGR_OBJS[value]
-                pbs.logmsg(pbs.LOG_DEBUG, f"{attr}=>{value_str} (reversed)")
-            elif attr == 'reply_choice':
-                value_str = pbs.REVERSE_BRP_CHOICES[value]
-                pbs.logmsg(pbs.LOG_DEBUG, f"{attr}=>{value_str} (reversed)")
-            elif attr == 'cmd':
-                value_str = pbs.REVERSE_MGR_CMDS[value]
-                pbs.logmsg(pbs.LOG_DEBUG, f"{attr}=>{value_str} (reversed)")
-            if attr == 'attribs':
-                lst = []
-                for idx, dct in enumerate(value_lst):
-                    dct_lst = []
-                    for key, value in dct.items():
-                        dct_lst.append(f"{key}:{value}")
-                    # need to sort the list to allow for the test to
-                    # find the string correctly.
-                    dct_lst = sorted(dct_lst)
-                    dct_lst_str = f"{attr}[{idx}]=>{','.join(dct_lst)}"
-                    pbs.logmsg(pbs.LOG_DEBUG, f"{dct_lst_str} (stringified)")
-            else:
-                pbs.logmsg(pbs.LOG_DEBUG, f"{attr}=>{value}")
-    if len(missing) > 0:
-        e.reject("missing attributes in pbs:" + ",".join(missing))
-    else:
-        pbs.logmsg(pbs.LOG_DEBUG, 'all attributes found in pbs')
-        # pbs.logmsg(pbs.LOG_DEBUG, 'dir(pbs_ifl):')
-        # pbs.logmsg(pbs.LOG_DEBUG, str(dir(pbs_ifl)))
-        # pbs.logmsg(pbs.LOG_DEBUG, 'dir(pbs):')
-        # pbs.logmsg(pbs.LOG_DEBUG, str(dir(pbs)))
+    try:
         m = e.management
-        pbs.logmsg(pbs.LOG_DEBUG, hook_msg)
-        e.accept()
+        # pbs.logmsg(pbs.LOG_DEBUG, str(dir(pbs)))
+        # pbs.logmsg(pbs.LOG_DEBUG, str(dir(e)))
+        # pbs.logmsg(pbs.LOG_DEBUG, str(dir(m)))
+        for attr in attributes:
+            if not hasattr(m, attr):
+                missing.append(attr)
+            else:
+                value = getattr(m, attr)
+                value_lst = []
+                if attr == 'attribs':
+                    if type(value) == list:
+                        for obj in value:
+                            value_dct = {}
+                            value_dct['name'] = obj.name
+                            value_dct['value'] = obj.value
+                            value_dct['flags'] = obj.flags
+                            subvalue_lst = []
+                            for k, v in pbs.REVERSE_ATR_VFLAGS.items():
+                                if int(k) & int(obj.flags):
+                                    subvalue_lst.append(str(v))
+                            value_dct[f"flags_lst"] = subvalue_lst
+                            value_dct['op'] = obj.op
+                            value_dct[f"op_str"] = pbs.REVERSE_BATCH_OPS[obj.op]
+                            value_dct['resource'] = obj.resource
+                            value_dct['sisters'] = obj.sisters
+                            value_lst.append(value_dct)
+                elif attr == 'objtype':
+                    value_str = pbs.REVERSE_MGR_OBJS[value]
+                    pbs.logmsg(pbs.LOG_DEBUG, f"{attr}=>{value_str} (reversed)")
+                elif attr == 'reply_choice':
+                    value_str = pbs.REVERSE_BRP_CHOICES[value]
+                    pbs.logmsg(pbs.LOG_DEBUG, f"{attr}=>{value_str} (reversed)")
+                elif attr == 'cmd':
+                    value_str = pbs.REVERSE_MGR_CMDS[value]
+                    pbs.logmsg(pbs.LOG_DEBUG, f"{attr}=>{value_str} (reversed)")
+                if attr == 'attribs':
+                    lst = []
+                    for idx, dct in enumerate(value_lst):
+                        dct_lst = []
+                        for key, value in dct.items():
+                            dct_lst.append(f"{key}:{value}")
+                        # need to sort the list to allow for the test to
+                        # find the string correctly.
+                        dct_lst = sorted(dct_lst)
+                        dct_lst_str = f"{attr}[{idx}]=>{','.join(dct_lst)}"
+                        pbs.logmsg(pbs.LOG_DEBUG, f"{dct_lst_str} (stringified)")
+                else:
+                    pbs.logmsg(pbs.LOG_DEBUG, f"{attr}=>{value}")
+        if len(missing) > 0:
+            pbs.logmsg(pbs.LOG_DEBUG, "Hook, processed normally.")
+            e.reject("missing attributes in pbs:" + ",".join(missing))
+        else:
+            pbs.logmsg(pbs.LOG_DEBUG, 'all attributes found in pbs')
+            # pbs.logmsg(pbs.LOG_DEBUG, 'dir(pbs_ifl):')
+            # pbs.logmsg(pbs.LOG_DEBUG, str(dir(pbs_ifl)))
+            # pbs.logmsg(pbs.LOG_DEBUG, 'dir(pbs):')
+            # pbs.logmsg(pbs.LOG_DEBUG, str(dir(pbs)))
+            m = e.management
+            pbs.logmsg(pbs.LOG_DEBUG, hook_msg)
+            pbs.logmsg(pbs.LOG_DEBUG, "Hook, processed normally.")
+            e.accept()
+    except Exception as err:
+        pbs.logmsg(pbs.LOG_DEBUG, "Error in hook:%s" % str(err))
+        e.reject("a hook error has occurred")
 
 
 @tags('hooks', 'smoke')
@@ -866,6 +872,13 @@ class TestHookManagement(TestFunctional):
                                           n="ALL"
                                           )
             self.logger.info(pformat(match))
+            match = self.server.log_match("Hook, processed normally.",
+                                  starttime=start_time_mom)
+            self.logger.info(pformat(match))
+            match = self.server.log_match("Error in hook",
+                                  starttime=start_time_mom,
+                                  existence=False)
+            self.logger.info(pformat(match))
             self.server.log_match("attribs[0]=>flags:0,flags_lst:[],name:reso"
                                   "urces_available,op:0,op_str:BATCH_OP_SET,r"
                                   "esource:ncpus,sisters:[],value:700000 (str"
@@ -876,7 +889,6 @@ class TestHookManagement(TestFunctional):
                                   "esource:ncpus,sisters:[],value: (stringifi"
                                   "ed)",
                                   starttime=start_time_mom)
-
         ret = self.server.delete_hook(hook_name_00)
         self.assertEqual(ret, True, "Could not delete hook %s" % hook_name_00)
         self.server.log_match("%s;deleted at request of" % hook_name_00,

--- a/test/tests/functional/pbs_hook_management.py
+++ b/test/tests/functional/pbs_hook_management.py
@@ -178,7 +178,6 @@ def hook_attrs_func(hook_msg):
                     pbs.logmsg(pbs.LOG_DEBUG, f"{attr}=>{value_str} "
                                               f"(reversed)")
                 if attr == 'attribs':
-                    lst = []
                     for idx, dct in enumerate(value_lst):
                         dct_lst = []
                         for key, value in dct.items():
@@ -189,8 +188,7 @@ def hook_attrs_func(hook_msg):
                         dct_lst_str = f"{attr}[{idx}]=>{','.join(dct_lst)}"
                         pbs.logmsg(pbs.LOG_DEBUG, f"{dct_lst_str} "
                                                   f"(stringified)")
-                else:
-                    pbs.logmsg(pbs.LOG_DEBUG, f"{attr}=>{value}")
+                pbs.logmsg(pbs.LOG_DEBUG, f"{attr}=>{value}")
         if len(missing) > 0:
             pbs.logmsg(pbs.LOG_DEBUG, "Hook, processed normally.")
             e.reject("missing attributes in pbs:" + ",".join(missing))
@@ -872,6 +870,18 @@ class TestHookManagement(TestFunctional):
             self.server.log_match("objname=>%s" % mom.shortname,
                                   starttime=start_time_mom)
             match = self.server.log_match("(stringified)",
+                                          starttime=start_time_mom,
+                                          allmatch=True,
+                                          n="ALL"
+                                          )
+            self.logger.info(pformat(match))
+            match = self.server.log_match("resources_available.ncpus",
+                                          starttime=start_time_mom,
+                                          allmatch=True,
+                                          n="ALL"
+                                          )
+            self.logger.info(pformat(match))
+            match = self.server.log_match("max_run_res_soft.ncpus",
                                           starttime=start_time_mom,
                                           allmatch=True,
                                           n="ALL"

--- a/test/tests/functional/pbs_hook_management.py
+++ b/test/tests/functional/pbs_hook_management.py
@@ -849,6 +849,11 @@ class TestHookManagement(TestFunctional):
             self.server.manager(MGR_CMD_UNSET, NODE,
                                 'resources_available.ncpus',
                                 id=mom.shortname)
+
+            a = {'max_run_res_soft.ncpus': "[u:" + str(TEST_USER1) + "=2]"}
+            self.server.manager(MGR_CMD_SET, QUEUE, a, 'workq')
+            self.server.manager(MGR_CMD_UNSET, QUEUE, 'max_run_res_soft.ncpus', 'workq')
+
             self.server.log_match("cmd=>MGR_CMD_SET",
                                   starttime=start_time_mom)
             self.server.log_match("objtype=>MGR_OBJ_NODE",
@@ -860,11 +865,16 @@ class TestHookManagement(TestFunctional):
                                   "s_available,op:0,op_str:BATCH_OP_SET,resour"
                                   "ce:ncpus,sisters:[],value:700000 (stringifi"
                                   "ed)",
-                                  starttime=start_time_mom)
+                                  starttime=start_time_mom,
+                                  n='ALL', max_attempts=16)
             self.server.log_match("attribs=>flags:0,flags_lst:[],name:resource"
                                   "s_available,op:0,op_str:BATCH_OP_SET,resour"
                                   "ce:ncpus,sisters:[],value: (stringified)",
-                                  starttime=start_time_mom)
+                                  starttime=start_time_mom,
+                                  n='ALL', max_attempts=16)
+
+            # figure out where this went wrong:
+            # https://github.com/openpbs/openpbs/pull/1902/files
 
             """07/08/2021 13:57:09.301273;0006;Server@pdw-s1;Hook;Server@pdw-s1;cmd=>MGR_CMD_SET (reversed)
             07/08/2021 13:57:09.301282;0006;Server@pdw-s1;Hook;Server@pdw-s1;cmd=>2

--- a/test/tests/functional/pbs_hook_management.py
+++ b/test/tests/functional/pbs_hook_management.py
@@ -179,7 +179,7 @@ def hook_attrs_func(hook_msg):
                             try:
                                 value_dct[f"op_str"] = \
                                     pbs.REVERSE_BATCH_OPS[obj.op]
-                            except:
+                            except Exception as err:
                                 pass
                             value_dct['resource'] = obj.resource
                             value_dct['sisters'] = obj.sisters

--- a/test/tests/functional/pbs_hook_management.py
+++ b/test/tests/functional/pbs_hook_management.py
@@ -180,7 +180,7 @@ def hook_attrs_func(hook_msg):
                                 value_dct[f"op_str"] = \
                                     pbs.REVERSE_BATCH_OPS[obj.op]
                             except Exception as err:
-                                pass
+                                value_dct[f"op_str"] = "?"
                             value_dct['resource'] = obj.resource
                             value_dct['sisters'] = obj.sisters
                             value_lst.append(value_dct)
@@ -889,6 +889,12 @@ class TestHookManagement(TestFunctional):
                                   starttime=start_time_mom)
             self.server.log_match("objname=>%s" % mom.shortname,
                                   starttime=start_time_mom)
+            match = self.server.log_match("attribs[0]=>flags:0,flags_lst:[]",
+                                          starttime=start_time_mom,
+                                          existence=True,
+                                          allmatch=True,
+                                          n="ALL")
+            self.logger.info(pformat(match))
             match = self.server.log_match("(stringified)",
                                           starttime=start_time_mom,
                                           allmatch=True,
@@ -922,15 +928,16 @@ class TestHookManagement(TestFunctional):
                                               n="ALL")
                 self.logger.info(pformat(match))
                 raise
+
             self.server.log_match("attribs[0]=>flags:0,flags_lst:[],name:reso"
                                   "urces_available,op:0,op_str:BATCH_OP_SET,r"
                                   "esource:ncpus,sisters:[],value:700000 (str"
                                   "ingified)",
                                   starttime=start_time_mom)
             self.server.log_match("attribs[0]=>flags:0,flags_lst:[],name:reso"
-                                  "urces_available,op:0,op_str:BATCH_OP_SET,r"
-                                  "esource:ncpus,sisters:[],value: (stringifi"
-                                  "ed)",
+                                  "urces_available,op:1,op_str:BATCH_OP_UNSET"
+                                  ",resource:ncpus,sisters:[],value: (stringi"
+                                  "fied)",
                                   starttime=start_time_mom)
         ret = self.server.delete_hook(hook_name_00)
         self.assertEqual(ret, True, "Could not delete hook %s" % hook_name_00)

--- a/test/tests/functional/pbs_hook_management.py
+++ b/test/tests/functional/pbs_hook_management.py
@@ -129,16 +129,29 @@ def get_hook_body_sleep(hook_msg, sleeptime=0.0):
 
 
 def hook_attrs_func(hook_msg):
+    def get_traceback():
+        import os
+        import traceback
+        (exc_cls, exc, tracbk) = sys.exc_info()
+        stack = traceback.format_tb(tracbk)
+        tracebacklst = []
+        for stackpiece in stack:
+            stackpiece = stackpiece.strip()
+            stackpiece_lst = stackpiece.split(os.linesep)
+            for stack_item in stackpiece_lst:
+                tracebacklst.append("%s" % stack_item)
+        return tracebacklst
+
     attributes = ["cmd", "objtype", "objname", "request_time",
                   "reply_code", "reply_auxcode", "reply_choice",
                   "reply_text", 'attribs']
     import pbs
-    import sys
-    import pbs_ifl
-    from pprint import pformat
     missing = []
     e = pbs.event()
     try:
+        import sys
+        import pbs_ifl
+        from pprint import pformat
         m = e.management
         # pbs.logmsg(pbs.LOG_DEBUG, str(dir(pbs)))
         # pbs.logmsg(pbs.LOG_DEBUG, str(dir(e)))
@@ -206,9 +219,12 @@ def hook_attrs_func(hook_msg):
             e.accept()
     except Exception as err:
         pbs.logmsg(pbs.LOG_DEBUG, "Error in hook:%s" % str(err))
-        errstr = str(sys.exc_info()[:2])
-        errstr = errstr.replace('\n', '||')
-        pbs.logmsg(pbs.LOG_DEBUG, "Error in hook:%s" % errstr)
+        now_str = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S.%f")
+        pbs.logmsg(pbs.LOG_DEBUG, "%s|Error in hook:%s" %
+                   (now_str, '||'.join(get_traceback())))
+        # errstr = str(sys.exc_info()[:2])
+        # errstr = errstr.replace('\n', '||')
+        # pbs.logmsg(pbs.LOG_DEBUG, "Error in hook:%s" % errstr)
         e.reject("a hook error has occurred")
 
 


### PR DESCRIPTION
Copy and modification of pull request: https://github.com/openpbs/openpbs/pull/2469

Describe Bug or Feature
Functions like mgr_set_node, mgr_set_queue, mgr_set_server munges the original attribute list while bifurcating it into list of attributes to set and list of attributes to unset

Describe Your Change
While adding to the setlist and unsetlist, "copy" the original attribute instead of moving from the original request list
Other formatting changes are also done

Link to Design Doc
Attach Test and Valgrind Logs/Output
