### PR TITLE
Fixed leak in query_resv()

### DIFF
--- a/src/scheduler/resv_info.cpp
+++ b/src/scheduler/resv_info.cpp
@@ -503,9 +503,9 @@ query_resv(struct batch_status *resv, server_info *sinfo)
 
 	while (attrp != NULL) {
 		if (!strcmp(attrp->name, ATTR_resv_owner))
-			advresv->user = string_dup(attrp->value);
+			advresv->user = attrp->value;
 		else if (!strcmp(attrp->name, ATTR_egroup))
-			advresv->group = string_dup(attrp->value);
+			advresv->group = attrp->value;
 		else if (!strcmp(attrp->name, ATTR_queue))
 			advresv->resv->queuename = string_dup(attrp->value);
 		else if (!strcmp(attrp->name, ATTR_SchedSelect)) {


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
A recent PR converted the resource_resv user/group members into strings from char *'s.  Before with the char *, when you query from a batch_status, you call string_dup().  Now with a string that is not needed.  The string does the memory allocation internally.  What happens is string_dup() allocates memory.  It is assigned into the string.  After that, the dup'd char * is leaked.

#### Describe Your Change
Don't call string_dup().

#### Attach Test and Valgrind Logs/Output
Before:
$ grep query_resv /tmp/valgrind.log 
==1372205==    by 0x4C9082: query_resv(batch_status*, server_info*) (resv_info.cpp:508)
==1372205==    by 0x4C903E: query_resv(batch_status*, server_info*) (resv_info.cpp:506)
After:
$ qmgr -c 's s scheduling=1'
$ grep query_resv /tmp/valgrind.log 
$ 
