### PR TITLE
PTL cleanup_jobs() method should use actual mom host name

### DIFF
--- a/test/fw/ptl/lib/ptl_server.py
+++ b/test/fw/ptl/lib/ptl_server.py
@@ -1304,7 +1304,8 @@ class Server(Wrappers):
                 ret = self.du.run_cmd(
                     self.hostname, [pbsnodes, '-v', host, '-F', 'json'],
                     logerr=False, level=logging.DEBUG, sudo=True)
-                host = ((ret['out'][6]).split(':'))[1].split('"')[1]
+                pbsnodes_json = json.loads('\n'.join(ret['out']))
+                host = pbsnodes_json['nodes'][host]['Mom']
                 for chunk in chunks:
                     self.du.run_cmd(host, ['kill', '-9'] + chunk,
                                     runas=ROOT_USER, logerr=False)

--- a/test/fw/ptl/lib/ptl_server.py
+++ b/test/fw/ptl/lib/ptl_server.py
@@ -1302,12 +1302,9 @@ class Server(Wrappers):
                 pbsnodes = os.path.join(
                     self.client_conf['PBS_EXEC'], 'bin', 'pbsnodes')
                 ret = self.du.run_cmd(
-                    self.hostname, [pbsnodes, '-v', host],
+                    self.hostname, [pbsnodes, '-v', host, '-F', 'json'],
                     logerr=False, level=logging.DEBUG, sudo=True)
-                for i in ret['out']:
-                    if "Mom" in i:
-                        host = (i.split('='))[1]
-                        break
+                host = ((ret['out'][6]).split(':'))[1].split('"')[1]
                 for chunk in chunks:
                     self.du.run_cmd(host, ['kill', '-9'] + chunk,
                                     runas=ROOT_USER, logerr=False)

--- a/test/fw/ptl/lib/ptl_server.py
+++ b/test/fw/ptl/lib/ptl_server.py
@@ -1299,6 +1299,15 @@ class Server(Wrappers):
         if len(job_ids) > 100:
             for host, pids in host_pid_map.items():
                 chunks = [pids[i:i + 5000] for i in range(0, len(pids), 5000)]
+                pbsnodes = os.path.join(
+                    self.client_conf['PBS_EXEC'], 'bin', 'pbsnodes')
+                ret = self.du.run_cmd(
+                    self.hostname, [pbsnodes, '-v', host],
+                    logerr=False, level=logging.DEBUG, sudo=True)
+                for i in ret['out']:
+                    if "Mom" in i:
+                        host = (i.split('='))[1]
+                        break
                 for chunk in chunks:
                     self.du.run_cmd(host, ['kill', '-9'] + chunk,
                                     runas=ROOT_USER, logerr=False)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
In PTL, cleanup_jobs() method is not taking the actual hostname of moms when PTL creates multiple moms with create_moms. that time mom naming is mom-0, mom1,mom-2 so on , these are not the actual mom host machine name.


#### Describe Your Change
PTL cleanup_jobs()  method uses actual mom host name.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output

before changes
 
[perf_failed_case.txt](https://github.com/openpbs/openpbs/files/7004060/perf_failed_case.txt)


after changes
mom on server
Description: Tests from given sources on platforms UBUNTU1804, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, UBUNTU2004
Platforms: UBUNTU1804,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,UBUNTU2004
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|8452|3275|2|0|0|0|3273|

no mom on server
Description: Tests from given sources on platforms UBUNTU1804, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, UBUNTU2004
Platforms: UBUNTU1804,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,UBUNTU2004
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|8451|3275|12|8|0|12|3243|



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
