### PR TITLE
PTL create_moms() method creates moms if pbsnodes list is empty

### DIFF
--- a/test/fw/ptl/lib/ptl_server.py
+++ b/test/fw/ptl/lib/ptl_server.py
@@ -1860,7 +1860,14 @@ class Server(Wrappers):
             except PbsManagerError as e:
                 rc = e.rc
             if rc:
-                if len(self.status(NODE)) > 0:
+                node_length = 0
+                try:
+                    node_length = len(self.status(NODE))
+                except PbsStatusError as err:
+                    if "Server has no node list" not in err.msg[0]:
+                        self.logger.error("node sttus err is " + str(err))
+                        return False
+                if node_length > 0:
                     self.logger.error("create_moms: Error deleting all nodes")
                     return False
 

--- a/test/fw/ptl/lib/ptl_server.py
+++ b/test/fw/ptl/lib/ptl_server.py
@@ -1865,7 +1865,8 @@ class Server(Wrappers):
                     node_length = len(self.status(NODE))
                 except PbsStatusError as err:
                     if "Server has no node list" not in err.msg[0]:
-                        self.logger.error("node sttus err is " + str(err))
+                        self.logger.error(
+                            "Error while checking node length:" + str(err))
                         return False
                 if node_length > 0:
                     self.logger.error("create_moms: Error deleting all nodes")


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
PTL create_moms() method failed to create moms if pbsnodes list is empty.  This method  first delete all the existing nodes and checks the status of pbsnodes to confirm all nodes are deleted. After that it creates moms.
If pbsnodes list is empty, This method throws  PbsStatusError "Server has no node list" while checking the status of pbsnodes.



#### Describe Your Change
It accepts  "PbsStatusError" error "Server has no node list" because it is expected  while checking the empty pbsnodes list.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
before changes

[pbs_config_create_mom_before.txt](https://github.com/openpbs/openpbs/files/7049329/pbs_config_create_mom_before.txt)

After changes
[pbs_config_create_mom.txt](https://github.com/openpbs/openpbs/files/7049333/pbs_config_create_mom.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
