### PR TITLE
Cgroups unmanage ngpus

### DIFF
--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -931,18 +931,18 @@ class HookUtils(object):
             }
             if hasattr(pbs, "RESV_END"):
                 self.hook_events[pbs.RESV_END] = {
-                'name': 'resv_end',
-                'handler': None
+                    'name': 'resv_end',
+                    'handler': None
                 }
             if hasattr(pbs, "RESV_BEGIN"):
                 self.hook_events[pbs.RESV_BEGIN] = {
-                'name': 'resv_begin',
-                'handler': None
+                    'name': 'resv_begin',
+                    'handler': None
                 }
             if hasattr(pbs, "RESV_CONFIRM"):
                 self.hook_events[pbs.RESV_CONFIRM] = {
-                'name': 'resv_confirm',
-                'handler': None
+                    'name': 'resv_confirm',
+                    'handler': None
                 }
             self.hook_events[pbs.EXECJOB_BEGIN] = {
                 'name': 'execjob_begin',
@@ -1645,7 +1645,7 @@ class NodeUtils(object):
                             self.numa_nodes[numa_node]['nmics'] = 1
                         else:
                             self.numa_nodes[numa_node]['nmics'] += 1
-                    elif dclass == 'gpu':
+                    elif dclass == 'gpu' and not self.cfg['ngpus_ext_managed']:
                         if 'ngpus' not in self.numa_nodes[numa_node]:
                             self.numa_nodes[numa_node]['ngpus'] = 1
                         else:
@@ -2640,12 +2640,22 @@ class NodeUtils(object):
                 vnode_resc_avail = vnode_list[vnode_key].resources_available
                 # ensure that if no devices were discovered that
                 # ngpus is set to 0; otherwise MoM may still use stale value
-                vnode_resc_avail['ngpus'] = 0
+                # if ngpus_ext_managed is False then leave it alone --
+                # it's likely set in qmgr or using a v2 config file
+                if not self.cfg['ngpus_ext_managed']:
+                    vnode_resc_avail['ngpus'] = 0
                 if (vntype and self.cfg['propagate_vntype_to_server']):
                     vnode_resc_avail['vntype'] = vntype
             for key, val in sorted(self.numa_nodes[nnid].items()):
                 if key is None:
                     pbs.logmsg(pbs.EVENT_DEBUG4, '%s: key is None'
+                               % caller_name())
+                    continue
+                if key is 'ngpus' and self.cfg['ngpus_ext_managed']:
+                    pbs.logmsg(pbs.EVENT_DEBUG,
+                               '%s: key is ngpus but ngpus marked '
+                               'as externally managed; '
+                               'skipping resources_available.ngpus'
                                % caller_name())
                     continue
                 if val is None:
@@ -2755,6 +2765,9 @@ class NodeUtils(object):
                     # This unsets it if it was defined earlier and needs to
                     # disappear
                     host_resc_avail['cgswap'] = None
+                if (not self.cfg['ngpus_ext_managed']
+                        and 'ngpus' not in vnode_resc_avail):
+                    vnode_resc_avail['ngpus'] = 0
 
                 pbs.logmsg(pbs.EVENT_DEBUG4, '%s: %s vnode_resc_avail: %s' %
                            (caller_name(), vnode_key, vnode_resc_avail))
@@ -2906,6 +2919,11 @@ class CgroupUtils(object):
         # morph the strings that should become booleans
         # into booleans depending on host/vntype
         self.morph_config_dict_bools(self.cfg)
+
+        if self.cfg['discover_gpus'] and self.cfg['ngpus_ext_managed']:
+            pbs.logmsg(pbs.EVENT_ADMIN, "WARNING: discover_gpus disabled "
+                       "since ngpus_ext_managed is enabled")
+            self.cfg['discover_gpus'] = False
         pbs.logmsg(pbs.EVENT_DEBUG4, "Final cgroup cfg: %s" % repr(self.cfg))
 
         # Remove the added "enabled" in the cgroup section
@@ -3398,6 +3416,7 @@ class CgroupUtils(object):
         defaults['cgroup_lock_file'] = os.path.join(PBS_MOM_HOME, 'mom_priv',
                                                     'cgroups.lock')
         defaults['discover_gpus'] = True
+        defaults['ngpus_ext_managed'] = False
         defaults['nvidia-smi'] = os.path.join(os.sep, 'usr', 'bin',
                                               'nvidia-smi')
         defaults['exclude_hosts'] = []
@@ -4420,6 +4439,7 @@ class CgroupUtils(object):
         if 'mem' in requested or 'ngpus' in requested or 'nmics' in requested:
             # for multivnode systems asking memory/ngpus/nmics without asking
             # cpus is valid, need access to memory
+            # this is valid even if ngpus are externally managed
             assigned['cpuset.mems'] = socketlist
         if 'nmics' in requested and int(requested['nmics']) > 0:
             assigned['device_names'] = []
@@ -4440,7 +4460,8 @@ class CgroupUtils(object):
                 assigned['device_names'].append(val)
             for val in devices:
                 assigned['devices'].append(val)
-        if 'ngpus' in requested and int(requested['ngpus']) > 0:
+        if ('ngpus' in requested and int(requested['ngpus']) > 0
+                and not self.cfg['ngpus_ext_managed']):
             if 'device_names' not in assigned:
                 assigned['device_names'] = []
                 assigned['devices'] = []

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -5397,8 +5397,8 @@ sleep 300
         self.load_config(self.cfg18 % ('true' if vnode_per_numa_node else 'false'))
 
         # We assume no test node will _really_ have a billion GPUs
+        a = {'resources_available.ngpus': 1000000000}
         if not vnode_per_numa_node:
-            a = {'resources_available.ngpus': 1000000000}
             self.server.manager(MGR_CMD_SET, NODE, a,
                                 id=self.mom.shortname)
         else:


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->
(Selectively) disable ‘ngpus’ resource management in the cgroup hook

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Some customers would like the cgroup hook to stop managing the ngus resource completely on some nodes but manage it on others.

One use case is a site with test nodes with a single GPU that is to be shared by more than one job, mainly for testing. The site administrators plan to set it to a fixed number larger than one, using either v2 config files or using qmgr, to manage how much to oversubscribe the GPU resources.

The current hook does not allow this: it currently behaves as the manager of the ngpus resource on vnodes, and wil set resources_available.ngpus according to the ngpus which it can assign correctly. This entails that if the 'devices' controller is disabled  or if 'discover_gpus' is disabled, it will actively set it to 0 to indicate that there are no GPUs available to assign to jobs; that in turn means that jobs requesting the ngpus resource will never use vnodes on the host.

In the current hook there is thus no way to allow oversubscription of ngpus resources: resources_available.ngpus is set to the correct value of GPUs the hook knows it can manage and assign, and jobs that request ngpus resources are assigned one GPU per ngpus in the job's request for their exclusive use.
#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
This proposal introduces a new flag 'ngpus_ext_managed' in the main section of the configuration file; enabling the flag indicates that resources_available.ngpus is managed externally to the hook and that the hook should not assign GPUs to jobs when jobs request the ngpus resource.

By default it is false. If set to 'true' in the pbs_cgroups.CF configuration file:

+discover_gpus will be disabled, since there is no point in discovering GPUs if the hook is instructed not to manage GPU assignment

+the hook will never set resources_available.ngpus on the vnodes of the host, allowing a site to use v2 config files or qmgr to set it to any value (including values that do not correspond to the amount of GPUs on the node)

+the hook will not attempt to assign individual GPUs to the job; the hook will allow a job on a node regardless of the 'ngpus' resources requested by the job, leaving it to the external manager of resources_available.ngpus and the scheduler and server (which manages resources_assigned.ngpus) to manage the vnode resources 'ngpus'. 

Note: this entails that if the 'devices' subsection is enabled and configured for device isolation, all GPUs must be listed for jobs to be able to use them, unless a separate hook adds the GPU devices to the lists of devices allowed. The simplest way to deal with this is to disable the 'devices' controller selectively on nodes where 'ngpus_ext_managed' is enabled.

Since this is a boolean flag, it is possible to use the current config file syntax to enable ngpus to be managed by the hook on some nodes and to be externally managed on some other nodes.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
https://community.openpbs.org/t/selectively-disable-ngpus-resource-management-in-the-cgroup-hook/2781

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
PTL tests are in the PR. Will report test harness results. The PTL test sets resources_available.ngpus to one billion and then tries to run a one billion ngpus job. If this feature works correctly, that will succeed. 

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
