### PR TITLE
Refactor reconfirming reservations and nspec** -> vector

### DIFF
--- a/src/scheduler/buckets.cpp
+++ b/src/scheduler/buckets.cpp
@@ -806,7 +806,7 @@ chunk_to_nspec(status *policy, chunk *chk, node_info *node, char *aoename)
  * @param resresv - the job
  * @return vector<nspec*>
  * @retval nspec array to run the job on
- * @retval NULL on error
+ * @retval empty vector on error
  */
 std::vector<nspec *>
 bucket_to_nspecs(status *policy, chunk_map **cb_map, resource_resv *resresv)
@@ -1046,7 +1046,7 @@ find_correct_buckets(status *policy, node_bucket **buckets, resource_resv *resre
  * @param[out] err - schd_error structure to return reason why the job can't run
  * @return vector<nspec *>
  * @retval place job can run
- * @retval NULL if job can't run
+ * @retval empty vector if job can't run
  */
 std::vector<nspec *>
 check_node_buckets(status *policy, server_info *sinfo, queue_info *qinfo, resource_resv *resresv, schd_error *err)

--- a/src/scheduler/buckets.cpp
+++ b/src/scheduler/buckets.cpp
@@ -763,9 +763,7 @@ chunk_to_nspec(status *policy, chunk *chk, node_info *node, char *aoename)
 	if (policy == NULL || chk == NULL || node == NULL)
 		return NULL;
 
-	ns = new_nspec();
-	if (ns == NULL)
-		return NULL;
+	ns = new nspec();
 
 	ns->ninfo = node;
 	ns->seq_num = get_sched_rank();
@@ -776,7 +774,7 @@ chunk_to_nspec(status *policy, chunk *chk, node_info *node, char *aoename)
 			ns->go_provision = 1;
 			req = create_resource_req("aoe", aoename);
 			if (req == NULL) {
-				free_nspec(ns);
+				delete ns;
 				return NULL;
 			}
 			ns->resreq = req;
@@ -787,7 +785,7 @@ chunk_to_nspec(status *policy, chunk *chk, node_info *node, char *aoename)
 		if (cur_req->def->type.is_consumable && policy->resdef_to_check.find(cur_req->def) != policy->resdef_to_check.end()) {
 			req = dup_resource_req(cur_req);
 			if (req == NULL) {
-				free_nspec(ns);
+				delete ns;
 				return NULL;
 			}
 			if (prev_req == NULL)
@@ -806,11 +804,11 @@ chunk_to_nspec(status *policy, chunk *chk, node_info *node, char *aoename)
  * @param[in] policy - policy info
  * @param[in] cb_map - chunk_map->node_bits are the nodes to allocate
  * @param resresv - the job
- * @return nspec **
+ * @return vector<nspec*>
  * @retval nspec array to run the job on
  * @retval NULL on error
  */
-nspec **
+std::vector<nspec *>
 bucket_to_nspecs(status *policy, chunk_map **cb_map, resource_resv *resresv)
 {
 	int i;
@@ -818,18 +816,14 @@ bucket_to_nspecs(status *policy, chunk_map **cb_map, resource_resv *resresv)
 	int k;
 	int cnt = 1;
 	int n = 0;
-	nspec **ns_arr;
+	std::vector<nspec *> ns_arr;
 	server_info *sinfo;
 
 	if (policy == NULL || cb_map == NULL || resresv == NULL)
-		return NULL;
+		return {};
 
 	sinfo = resresv->server;
-	ns_arr = static_cast<nspec **>(calloc(resresv->select->total_chunks + 1, sizeof(nspec*)));
-	if (ns_arr == NULL) {
-		log_err(errno, __func__, MEM_ERR_MSG);
-		return NULL;
-	}
+	ns_arr.reserve(resresv->select->total_chunks);
 
 	for (i = 0; cb_map[i] != NULL; i++) {
 		int chunks_needed = cb_map[i]->chk->num_chunks;
@@ -852,16 +846,16 @@ bucket_to_nspecs(status *policy, chunk_map **cb_map, resource_resv *resresv)
 			 * For the final chunk, we might allocate less.
 			 */
 			for( ; cnt > 0 && chunks_needed > 0; cnt--, chunks_needed--, n++) {
-				ns_arr[n] = chunk_to_nspec(policy, cb_map[i]->chk, sinfo->unordered_nodes[j], resresv->aoename);
-				if (ns_arr[n] == NULL) {
+				auto ns = chunk_to_nspec(policy, cb_map[i]->chk, sinfo->unordered_nodes[j], resresv->aoename);
+				if (ns == NULL) {
 					free_nspecs(ns_arr);
-					return NULL;
+					return {};
 				}
+				ns_arr.push_back(ns);
 			}
 		}
 
 	}
-	ns_arr[n] = NULL;
 
 	return ns_arr;
 }
@@ -1050,20 +1044,20 @@ find_correct_buckets(status *policy, node_bucket **buckets, resource_resv *resre
  * @param[in] qinfo - the queue the job is in
  * @param[in] resresv - the job
  * @param[out] err - schd_error structure to return reason why the job can't run
- * @return nspec **
+ * @return vector<nspec *>
  * @retval place job can run
  * @retval NULL if job can't run
  */
-nspec **
+std::vector<nspec *>
 check_node_buckets(status *policy, server_info *sinfo, queue_info *qinfo, resource_resv *resresv, schd_error *err)
 {
 	node_partition **nodepart = NULL;
 
 	if (policy == NULL || sinfo == NULL || resresv == NULL || err == NULL)
-		return NULL;
+		return {};
 
 	if (resresv->is_job && qinfo == NULL)
-		return NULL;
+		return {};
 
 	if (resresv->is_job && qinfo->nodepart != NULL)
 		nodepart = qinfo->nodepart;
@@ -1097,18 +1091,18 @@ check_node_buckets(status *policy, server_info *sinfo, queue_info *qinfo, resour
 		if (failerr == NULL) {
 			failerr = new_schd_error();
 			if (failerr == NULL)
-				return NULL;
+				return {};
 		} else
 			clear_schd_error(failerr);
 
 		for (i = 0; nodepart[i] != NULL; i++) {
-			nspec **nspecs;
+			std::vector<nspec *> nspecs;
 			log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_JOB, LOG_DEBUG, resresv->name,
 				"Evaluating placement set: %s", nodepart[i]->name);
 
 			clear_schd_error(err);
 			nspecs = map_buckets(policy, nodepart[i]->bkts, resresv, err);
-			if (nspecs != NULL)
+			if (!nspecs.empty())
 				return nspecs;
 			if (err->status_code == NOT_RUN) {
 				if (failerr->status_code == SCHD_UNKWN)
@@ -1120,7 +1114,7 @@ check_node_buckets(status *policy, server_info *sinfo, queue_info *qinfo, resour
 		if (can_run == 0) {
 			if (sc_attrs.do_not_span_psets) {
 				set_schd_error_codes(err, NEVER_RUN, CANT_SPAN_PSET);
-				return NULL;
+				return {};
 			}
 			else {
 				log_event(PBSEVENT_DEBUG3, PBS_EVENTCLASS_JOB, LOG_DEBUG, resresv->name, "Request won't fit into any placement sets, will use all nodes");
@@ -1134,14 +1128,13 @@ check_node_buckets(status *policy, server_info *sinfo, queue_info *qinfo, resour
 	} else if (pbs_conf.pbs_num_servers > 1 && resresv->svr_inst_id != NULL) {
 		/* Restrict placement to local server when using buckets */
 		if (sinfo->svr_to_psets.find(resresv->svr_inst_id) != sinfo->svr_to_psets.end()) {
-			nspec **nspecs;
 
-			nspecs = map_buckets(policy, sinfo->svr_to_psets[resresv->svr_inst_id]->bkts, resresv, err);
-			if (nspecs != NULL)
+			auto nspecs = map_buckets(policy, sinfo->svr_to_psets[resresv->svr_inst_id]->bkts, resresv, err);
+			if (!nspecs.empty())
 				return nspecs;
 		} else {	/* No nodes associated with owner server, so reject the job/reservation */
 			set_schd_error_codes(err, NOT_RUN, NO_NODE_RESOURCES);
-			return NULL;
+			return {};
 		}
 	}
 
@@ -1158,18 +1151,17 @@ check_node_buckets(status *policy, server_info *sinfo, queue_info *qinfo, resour
  *
  * @return place resresv can run or NULL if it can't
  */
-nspec **
+std::vector<nspec *>
 map_buckets(status *policy, node_bucket **bkts, resource_resv *resresv, schd_error *err)
 {
 	chunk_map **cmap;
-	nspec **ns_arr;
 
 	if (policy == NULL || bkts == NULL || resresv == NULL || err == NULL)
-		return NULL;
+		return {};
 
 	cmap = find_correct_buckets(policy, bkts, resresv, err);
 	if (cmap == NULL)
-		return NULL;
+		return {};
 
 	clear_schd_error(err);
 	if (bucket_match(cmap, resresv, err) == 0) {
@@ -1177,10 +1169,10 @@ map_buckets(status *policy, node_bucket **bkts, resource_resv *resresv, schd_err
 			set_schd_error_codes(err, NOT_RUN, NO_NODE_RESOURCES);
 
 		free_chunk_map_array(cmap);
-		return NULL;
+		return {};
 	}
 
-	ns_arr = bucket_to_nspecs(policy, cmap, resresv);
+	auto ns_arr = bucket_to_nspecs(policy, cmap, resresv);
 
 	free_chunk_map_array(cmap);
 	return ns_arr;

--- a/src/scheduler/buckets.h
+++ b/src/scheduler/buckets.h
@@ -56,7 +56,7 @@ void free_node_bucket(node_bucket *nb);
 void free_node_bucket_array(node_bucket **buckets);
 
 /* find index of node_bucket in an array */
-int find_node_bucket_ind(node_bucket **buckets, schd_resource *rl, queue_info *queue, int priority);
+int find_node_bucket_ind(node_bucket **buckets, schd_resource *rl, queue_info *qinfo, int priority);
 
 /* create node_buckets an array of nodes */
 node_bucket **create_node_buckets(status *policy, node_info **nodes, std::vector<queue_info *> &queues, unsigned int flags);
@@ -67,7 +67,7 @@ char *create_node_bucket_name(status *policy, node_bucket *nb);
 /* match job's request to buckets and allocate */
 int bucket_match(chunk_map **cmap, resource_resv *resresv, schd_error *err);
 /* convert chunk_map->node_bits into nspec array */
-nspec **bucket_to_nspecs(status *policy, chunk_map **cmap, resource_resv *resresv);
+std::vector<nspec *>bucket_to_nspecs(status *policy, chunk_map **cb_map, resource_resv *resresv);
 
 /* can a job completely fit on a node before it is busy */
 int node_can_fit_job_time(int node_ind, resource_resv *resresv);
@@ -94,8 +94,8 @@ void log_chunk_map_array(resource_resv *resresv, chunk_map **cmap);
 
 
 /* Check to see if a job can run on nodes via the node_bucket codepath */
-nspec **check_node_buckets(status *policy, server_info *sinfo, queue_info *qinfo, resource_resv *resresv, schd_error *err);
-nspec **map_buckets(status *policy, node_bucket **bkts, resource_resv *resresv, schd_error *err);
+std::vector<nspec *>check_node_buckets(status *policy, server_info *sinfo, queue_info *qinfo, resource_resv *resresv, schd_error *err);
+std::vector<nspec *>map_buckets(status *policy, node_bucket **bkts, resource_resv *resresv, schd_error *err);
 
 /* map job to buckets that can satisfy */
 chunk_map **find_correct_buckets(status *policy, node_bucket **buckets, resource_resv *resresv, schd_error *err);

--- a/src/scheduler/check.h
+++ b/src/scheduler/check.h
@@ -55,7 +55,7 @@ enum sched_error_code is_ok_to_run_queue(status *policy, queue_info *qinfo);
 /*
  *	is_ok_to_run - check to see if it ok to run a job on the server
  */
-nspec **
+std::vector<nspec *>
 is_ok_to_run(status *policy, server_info *sinfo,
 	queue_info *qinfo, resource_resv *resresv, unsigned int flags, schd_error *perr);
 
@@ -64,36 +64,36 @@ is_ok_to_run(status *policy, server_info *sinfo,
  *	is_ok_to_run_STF - check to see if the STF job is OK to run.
  *
  */
-nspec **
+std::vector<nspec *>
 is_ok_to_run_STF(status *policy, server_info *sinfo,
 	queue_info *qinfo, resource_resv *njob, unsigned int flags, schd_error *err,
-	nspec **(*shrink_heuristic)(status *policy, server_info *sinfo,
+	std::vector<nspec *>(*shrink_heuristic)(status *policy, server_info *sinfo,
 	queue_info *qinfo, resource_resv *njob, unsigned int flags, schd_error *err));
 /*
  * shrink_job_algorithm - generic algorithm for shrinking a job
  */
-nspec **
+std::vector<nspec *>
 shrink_job_algorithm(status *policy, server_info *sinfo,
 	queue_info *qinfo, resource_resv *njob, unsigned int flags, schd_error *err);/* Generic shrinking heuristic */
 
 /*
  * shrink_to_boundary - Shrink job to dedicated/prime time boundary
  */
-nspec **
+std::vector<nspec *>
 shrink_to_boundary(status *policy, server_info *sinfo,
 	queue_info *qinfo, resource_resv *njob, unsigned int flags, schd_error *err);
 
 /*
  * shrink_to_minwt - Shrink job to it's minimum walltime
  */
-nspec **
+std::vector<nspec *>
 shrink_to_minwt(status *policy, server_info *sinfo,
 	queue_info *qinfo, resource_resv *njob, unsigned int flags, schd_error *err);
 
 /*
  * shrink_to_run_event - Shrink job before reservation or top job.
  */
-nspec **
+std::vector<nspec *>
 shrink_to_run_event(status *policy, server_info *sinfo,
 	queue_info *qinfo, resource_resv *njob, unsigned int flags, schd_error *err);
 
@@ -110,8 +110,8 @@ shrink_to_run_event(status *policy, server_info *sinfo,
  */
 long long
 check_avail_resources(schd_resource *reslist, resource_req *reqlist,
-	unsigned int flags, std::unordered_set<resdef *>& res_to_check,
-	enum sched_error_code fail_code, schd_error *err);
+	unsigned int flags, std::unordered_set<resdef *>& checklist,
+	enum sched_error_code fail_code, schd_error *perr);
 long long
 check_avail_resources(schd_resource *reslist, resource_req *reqlist,
 		      unsigned int flags, enum sched_error_code fail_code, schd_error *perr);
@@ -133,17 +133,17 @@ sch_resource_t dynamic_avail(schd_resource *res);
  *	cnt	- output param for address of the matching counts structure
  *	rreq	- output param for address of the matching resource_count structure
  */
-sch_resource_t find_counts_elm(counts_umap &cts_list, const std::string &name, resdef *res, counts **cnt, resource_count **rreq);
+sch_resource_t find_counts_elm(counts_umap &cts_list, const std::string &name, resdef *rdef, counts **rcount, resource_count **rreq);
 
 
 /*
  *      check_nodes - check to see if there is sufficient nodes available to
  *                    run a job/resv.
  */
-nspec **check_nodes(status *policy, server_info *sinfo, queue_info *qinfo, resource_resv *resresv, unsigned int flags, schd_error *err);
+std::vector<nspec *>check_nodes(status *policy, server_info *sinfo, queue_info *qinfo, resource_resv *resresv, unsigned int flags, schd_error *err);
 
 /* Normal node searching algorithm */
-nspec **
+std::vector<nspec *>
 check_normal_node_path(status *policy, server_info *sinfo, queue_info *qinfo, resource_resv *resresv, unsigned int flags, schd_error *err);
 
 
@@ -167,7 +167,7 @@ int dedtime_conflict(resource_resv *resresv);
 /*
  *      check_ded_time_boundary  - check to see if a job would cross into
  */
-enum sched_error_code check_ded_time_boundary(resource_resv *job);
+enum sched_error_code check_ded_time_boundary(resource_resv *resresv);
 
 /*
  *      check_prime_queue - Check primetime status of the queue.  If the queue

--- a/src/scheduler/constant.h
+++ b/src/scheduler/constant.h
@@ -385,11 +385,10 @@ enum incr_decr {
 };
 
 /* run update resresv flags is a bitfield = 0, 1, 2, 4, 8, ...*/
-enum run_update_resresv_flags
-{
+enum run_update_resresv_flags {
 	RURR_NO_FLAGS = 0,
 	RURR_ADD_END_EVENT = 1, /* add end events to calendar for job */
-	RURR_NOPRINT = 2       /* don't print messages */
+	RURR_NOPRINT = 2	/* don't print messages */
 	/* next value 4 */
 };
 

--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -79,7 +79,7 @@ struct prev_job_info;
 class group_info;
 struct usage_info;
 class counts;
-struct nspec;
+class nspec;
 struct node_partition;
 struct range;
 struct place;
@@ -113,7 +113,6 @@ typedef struct resource_req resource_req;
 typedef struct resource_count resource_count;
 typedef struct usage_info usage_info;
 typedef struct resv_info resv_info;
-typedef struct nspec nspec;
 typedef struct node_partition node_partition;
 typedef struct place place;
 typedef struct schd_error schd_error;
@@ -474,7 +473,7 @@ class server_info
 	share_head *share_head;	/* root of share info */
 #endif
 	// Class methods
-	server_info(const char *);
+	explicit server_info(const char *);
 	server_info() = delete;
 	server_info(const server_info &);
 	virtual ~server_info();
@@ -615,7 +614,7 @@ struct job_info
 
 	struct attrl *attr_updates;	/* used to federate all attr updates to server*/
 	float formula_value;		/* evaluated job sort formula value */
-	nspec **resreleased;		/* list of resources released by the job on each node */
+	std::vector<nspec *> resreleased;		/* list of resources released by the job on each node */
 	resource_req *resreq_rel;	/* list of resources released */
 	char *depend_job_str;		/* dependent jobs in a ':' separated string */
 	resource_resv **dependent_jobs; /* dependent jobs with runone depenency */
@@ -734,7 +733,7 @@ class node_info
 	node_partition **np_arr;	/* array of node partitions node is in */
 	char *svr_inst_id;
 
-	explicit node_info(const std::string& name);
+	explicit node_info(const std::string& nname);
 	virtual ~node_info();
 };
 
@@ -764,7 +763,7 @@ struct resv_info
 	char *partition;		/* name of the partition in which the reservation was confirmed */
 	selspec *select_orig;		/* original schedselect pre-alter */
 	selspec *select_standing;	/* original schedselect for standing reservations */
-	nspec **orig_nspec_arr;		/* original non-shrunk exec_vnode with exec_vnode chunk mapped to select chunk */
+	std::vector<nspec *> orig_nspec_arr;		/* original non-shrunk exec_vnode with exec_vnode chunk mapped to select chunk */
 };
 
 /* resource reservation - used for both jobs and advanced reservations */
@@ -809,7 +808,7 @@ class resource_resv
 
 	server_info *server;		/* pointer to server which owns res resv */
 	node_info **ninfo_arr; 		/* nodes belonging to res resv */
-	nspec **nspec_arr;		/* exec vnode of object in internal sched form (one nspec per node) */
+	std::vector<nspec *> nspec_arr;		/* exec vnode of object in internal sched form (one nspec per node) */
 
 	job_info *job;			/* pointer to job specific structure */
 	resv_info *resv;		/* pointer to reservation specific structure */
@@ -896,7 +895,7 @@ class prev_job_info
 	resource_req *resused;	/* resources used by the job */
 	prev_job_info(const std::string& pname, const std::string& ename, resource_req *rused);
 	prev_job_info(const prev_job_info &);
-	prev_job_info(prev_job_info &&) noexcept;
+	prev_job_info(prev_job_info &&);
 	prev_job_info& operator=(const prev_job_info&);
 	virtual ~prev_job_info();
 };
@@ -908,7 +907,7 @@ class counts
 	int running;			/* count of running jobs in object */
 	int soft_limit_preempt_bit;	/* Place to store preempt bit if entity is over limits */
 	resource_count *rescts;		/* resources used */
-	counts(const std::string &);
+	explicit counts(const std::string &);
 	counts(const counts &);
 	counts& operator=(const counts &);
 	virtual ~counts();
@@ -940,7 +939,7 @@ class fairshare_head
 class group_info
 {
 	public:
-	const std::string name;				/* name of user/group */
+	std::string name;				/* name of user/group */
 	int resgroup;				/* resgroup the group is in */
 	int cresgroup;				/* resgroup of the children of group */
 	int shares;				/* number of shares this group has */
@@ -961,8 +960,9 @@ class group_info
 	group_info *parent;			/* parent node */
 	group_info *sibling;			/* sibling node */
 	group_info *child;			/* child node */
-	group_info(const std::string& gname);
+	explicit group_info(const std::string& gname);
 	group_info(group_info&);
+	group_info &operator=(const group_info &);
 };
 
 /**
@@ -1003,10 +1003,10 @@ struct node_partition
 class np_cache
 {
 	public:
-	std::vector<std::string> resnames;		/* resource names used to create partitions */
 	node_info **ninfo_arr;		/* ptr to array of nodes used to create pools */
-	int num_parts;			/* number of partitions in nodepart */
+	std::vector<std::string> resnames;		/* resource names used to create partitions */
 	node_partition **nodepart;	/* node partitions */
+	int num_parts;			/* number of partitions in nodepart */
 	np_cache();
 	np_cache(node_info **, const std::vector<std::string>&, node_partition **, int);
 	np_cache(const np_cache &) = delete;
@@ -1108,8 +1108,9 @@ struct peer_queue
 	peer_queue(const char *lqueue, const char *rqueue, const char *rserver): local_queue(lqueue), remote_queue(rqueue), remote_server(rserver) {peer_sd = -1;}
 };
 
-struct nspec
+class nspec
 {
+	public:
 	bool end_of_chunk:1; /* used for putting parens into the execvnode */
 	bool go_provision:1; /* used to mark a node to be provisioned */
 	int seq_num;			/* sequence number of chunk */
@@ -1117,6 +1118,16 @@ struct nspec
 	node_info *ninfo;
 	resource_req *resreq;
 	chunk *chk;
+
+	nspec();
+	nspec(const nspec &, node_info **, selspec *);
+	~nspec();
+	/* We need to have the copy constructor dup everything inside the nspec
+	 * We can't have the default copy constructor copy everything, because
+	 * we'd end up with a pointer to the same resreq
+	 */
+	nspec(nspec&) = delete;
+	nspec &operator=(nspec &) = delete;
 };
 
 struct nameval
@@ -1281,7 +1292,7 @@ class sched_exception: public std::exception
 {
 	public:
 	sched_exception(const sched_exception &e);
-	sched_exception &operator=(const sched_exception &e);
+	sched_exception &operator=(const sched_exception &err);
 	sched_exception (const std::string &str, const enum sched_error_code e);
 	const char *what();
 	enum sched_error_code get_error_code() const;

--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -1126,8 +1126,8 @@ class nspec
 	 * We can't have the default copy constructor copy everything, because
 	 * we'd end up with a pointer to the same resreq
 	 */
-	nspec(nspec&) = delete;
-	nspec &operator=(nspec &) = delete;
+	nspec(const nspec&) = delete;
+	nspec &operator=(const nspec &) = delete;
 };
 
 struct nameval

--- a/src/scheduler/dedtime.h
+++ b/src/scheduler/dedtime.h
@@ -55,7 +55,7 @@ int parse_ded_file(const char *filename);
  *      cmp_ded_time - compare function for qsort for the ded time array
  *
  */
-bool cmp_ded_time(const timegap& v1, const timegap& v2);
+bool cmp_ded_time(const timegap& t1, const timegap& t2);
 
 /*
  *      is_ded_time - checks if it is currently dedicated time

--- a/src/scheduler/fairshare.cpp
+++ b/src/scheduler/fairshare.cpp
@@ -199,27 +199,6 @@ find_alloc_ginfo(const std::string& name, group_info *root)
 
 /**
  * @brief
- *		new_group_info - allocate a new group_info struct and initalize it
- *
- * @return	a ptr to the new group_info
- *
- */
-group_info::group_info(const std::string& gname) : name(gname)
-{
-	resgroup = UNSPECIFIED;
-	cresgroup = UNSPECIFIED;
-	shares = UNSPECIFIED;
-	tree_percentage = 0.0;
-	group_percentage = 0.0;
-	usage = FAIRSHARE_MIN_USAGE;
-	temp_usage = FAIRSHARE_MIN_USAGE;
-	usage_factor = 0.0;
-	parent = NULL;
-	sibling = NULL;
-	child = NULL;}
-
-/**
- * @brief
  * 		parse the resource group file
  *
  * @param[in]	fname	-	name of the file
@@ -836,19 +815,58 @@ over_fs_usage(group_info *ginfo)
 	return ginfo->gpath[0]->usage * ginfo->tree_percentage < ginfo->usage;
 }
 
-group_info::group_info(group_info& root) : name(root.name)
+/**
+ * @brief
+ *		new_group_info - allocate a new group_info struct and initalize it
+ *
+ * @return	a ptr to the new group_info
+ *
+ */
+group_info::group_info(const std::string &gname) : name(gname)
 {
-	resgroup = root.resgroup;
-	cresgroup = root.cresgroup;
-	shares = root.shares;
-	tree_percentage = root.tree_percentage;
-	group_percentage = root.group_percentage;
-	usage = root.usage;
-	usage_factor = root.usage_factor;
-	temp_usage = root.temp_usage;
+	resgroup = UNSPECIFIED;
+	cresgroup = UNSPECIFIED;
+	shares = UNSPECIFIED;
+	tree_percentage = 0.0;
+	group_percentage = 0.0;
+	usage = FAIRSHARE_MIN_USAGE;
+	temp_usage = FAIRSHARE_MIN_USAGE;
+	usage_factor = 0.0;
+	parent = NULL;
+	sibling = NULL;
+	child = NULL;
+}
+
+group_info::group_info(group_info& oginfo) : name(oginfo.name)
+{
+	resgroup = oginfo.resgroup;
+	cresgroup = oginfo.cresgroup;
+	shares = oginfo.shares;
+	tree_percentage = oginfo.tree_percentage;
+	group_percentage = oginfo.group_percentage;
+	usage = oginfo.usage;
+	usage_factor = oginfo.usage_factor;
+	temp_usage = oginfo.temp_usage;
 	sibling = NULL;
 	child = NULL;
 	parent = NULL;
+}
+
+group_info& group_info::operator=(const group_info& oginfo)
+{
+	resgroup = oginfo.resgroup;
+	cresgroup = oginfo.cresgroup;
+	shares = oginfo.shares;
+	tree_percentage = oginfo.tree_percentage;
+	group_percentage = oginfo.group_percentage;
+	usage = oginfo.usage;
+	usage_factor = oginfo.usage_factor;
+	temp_usage = oginfo.temp_usage;
+	sibling = NULL;
+	child = NULL;
+	parent = NULL;
+
+	return *this;
 }
 
 /**

--- a/src/scheduler/fifo.cpp
+++ b/src/scheduler/fifo.cpp
@@ -37,7 +37,6 @@
  * subject to Altair's trademark licensing policies.
  */
 
-
 /**
  * This file contains functions related to scheduling
  */
@@ -50,52 +49,53 @@
 #include <wchar.h>
 #endif
 
+#include <algorithm>
+
+#include "buckets.h"
+#include "check.h"
+#include "config.h"
+#include "constant.h"
+#include "dedtime.h"
+#include "fairshare.h"
+#include "fifo.h"
+#include "globals.h"
+#include "job_info.h"
+#include "libpbs.h"
+#include "limits_if.h"
+#include "misc.h"
+#include "multi_threading.h"
+#include "node_info.h"
+#include "node_partition.h"
+#include "parse.h"
+#include "pbs_internal.h"
+#include "pbs_python.h"
+#include "pbs_share.h"
+#include "pbs_version.h"
+#include "prev_job_info.h"
+#include "prime.h"
+#include "queue_info.h"
+#include "range.h"
+#include "resource.h"
+#include "resource_resv.h"
+#include "resv_info.h"
+#include "server_info.h"
+#include "simulate.h"
+#include "sort.h"
+#include <errno.h>
+#include <fcntl.h>
+#include <libutil.h>
+#include <log.h>
+#include <pbs_error.h>
+#include <pbs_ifl.h>
+#include <pwd.h>
+#include <sched_cmds.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <errno.h>
-#include <unistd.h>
-#include <libutil.h>
-#include <pbs_error.h>
-#include <pbs_ifl.h>
-#include <sched_cmds.h>
-#include <time.h>
-#include <log.h>
-#include <pwd.h>
-#include <sys/types.h>
 #include <sys/stat.h>
-#include <fcntl.h>
-#include "fifo.h"
-#include "queue_info.h"
-#include "server_info.h"
-#include "node_info.h"
-#include "check.h"
-#include "constant.h"
-#include "job_info.h"
-#include "misc.h"
-#include "config.h"
-#include "sort.h"
-#include "parse.h"
-#include "globals.h"
-#include "prev_job_info.h"
-#include "fairshare.h"
-#include "prime.h"
-#include "dedtime.h"
-#include "resv_info.h"
-#include "range.h"
-#include "resource_resv.h"
-#include "simulate.h"
-#include "node_partition.h"
-#include "resource.h"
-#include "resource_resv.h"
-#include "pbs_share.h"
-#include "pbs_internal.h"
-#include "limits_if.h"
-#include "pbs_version.h"
-#include "buckets.h"
-#include "multi_threading.h"
-#include "pbs_python.h"
-#include "libpbs.h"
+#include <sys/types.h>
+#include <time.h>
+#include <unistd.h>
 
 #ifdef NAS
 #include "site_code.h"
@@ -137,7 +137,7 @@ schedinit(int nthreads)
 		auto tmptr = localtime(&cstat.current_time);
 		if ((tmptr != NULL) && ((tmptr->tm_year + 1900) > conf.holiday_year))
 			log_event(PBSEVENT_ADMIN, PBS_EVENTCLASS_FILE, LOG_NOTICE, HOLIDAYS_FILE,
-				"The holiday file is out of date; please update it.");
+				  "The holiday file is out of date; please update it.");
 	}
 
 	parse_ded_file(DEDTIME_FILE);
@@ -175,9 +175,9 @@ schedinit(int nthreads)
 		"_err =\"\"\n"
 		"ex = None\n"
 		"try:\n"
-			"\tfrom math import *\n"
+		"\tfrom math import *\n"
 		"except ImportError as ex:\n"
-			"\t_err = str(ex)");
+		"\t_err = str(ex)");
 
 	module = PyImport_AddModule("__main__");
 	dict = PyModule_GetDict(module);
@@ -200,7 +200,7 @@ schedinit(int nthreads)
 	if (num_threads == 0 || (nthreads > 0 && nthreads != num_threads)) {
 		if (init_multi_threading(nthreads) != 1) {
 			log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_REQUEST, LOG_DEBUG,
-					  "", "Error initializing pthreads");
+				  "", "Error initializing pthreads");
 			return -1;
 		}
 	}
@@ -221,10 +221,10 @@ schedinit(int nthreads)
  *
  */
 void
-update_cycle_status(status& policy, time_t current_time)
+update_cycle_status(status &policy, time_t current_time)
 {
-	bool dedtime;			/* is it dedtime? */
-	enum prime_time prime;		/* current prime time status */
+	bool dedtime;	       /* is it dedtime? */
+	enum prime_time prime; /* current prime time status */
 	const char *primetime;
 
 	if (current_time == 0)
@@ -267,14 +267,13 @@ update_cycle_status(status& policy, time_t current_time)
 		auto ptm = localtime(&(policy.prime_status_end));
 		if (ptm != NULL) {
 			log_eventf(PBSEVENT_DEBUG2, PBS_EVENTCLASS_SERVER, LOG_DEBUG, "",
-				"It is %s.  It will end in %ld seconds at %02d/%02d/%04d %02d:%02d:%02d",
-				primetime, policy.prime_status_end - policy.current_time,
-				ptm->tm_mon + 1, ptm->tm_mday, ptm->tm_year + 1900,
-				ptm->tm_hour, ptm->tm_min, ptm->tm_sec);
-		}
-		else
+				   "It is %s.  It will end in %ld seconds at %02d/%02d/%04d %02d:%02d:%02d",
+				   primetime, policy.prime_status_end - policy.current_time,
+				   ptm->tm_mon + 1, ptm->tm_mday, ptm->tm_year + 1900,
+				   ptm->tm_hour, ptm->tm_min, ptm->tm_sec);
+		} else
 			log_eventf(PBSEVENT_DEBUG2, PBS_EVENTCLASS_SERVER, LOG_DEBUG, "",
-				"It is %s.  It will end at <UNKNOWN>", primetime);
+				   "It is %s.  It will end at <UNKNOWN>", primetime);
 	}
 
 	// Will be set in query_server()
@@ -310,7 +309,7 @@ update_cycle_status(status& policy, time_t current_time)
 int
 init_scheduling_cycle(status *policy, int pbs_sd, server_info *sinfo)
 {
-	group_info *user = NULL;	/* the user for the running jobs of the last cycle */
+	group_info *user = NULL; /* the user for the running jobs of the last cycle */
 	static schd_error *err;
 
 	if (err == NULL) {
@@ -337,8 +336,8 @@ init_scheduling_cycle(status *policy, int pbs_sd, server_info *sinfo)
 			 * one and calculate a new value
 			 */
 
-			for (const auto& lj : last_running) {
-				user = find_alloc_ginfo(lj.entity_name.c_str(), sinfo->fstree->root);
+			for (const auto &lj : last_running) {
+				user = find_alloc_ginfo(lj.entity_name, sinfo->fstree->root);
 
 				if (user != NULL) {
 					auto rj = find_resource_resv(sinfo->running_jobs, lj.name);
@@ -346,12 +345,12 @@ init_scheduling_cycle(status *policy, int pbs_sd, server_info *sinfo)
 					if (rj != NULL && rj->job != NULL && !rj->job->is_prerunning) {
 						/* just in case the delta is negative just add 0 */
 						auto delta = formula_evaluate(conf.fairshare_res.c_str(), rj, rj->job->resused) -
-							formula_evaluate(conf.fairshare_res.c_str(), rj, lj.resused);
+							     formula_evaluate(conf.fairshare_res.c_str(), rj, lj.resused);
 
 						delta = IF_NEG_THEN_ZERO(delta);
 
 						;
-						for (auto& g : user->gpath)
+						for (auto &g : user->gpath)
 							g->usage += delta;
 
 						resort = true;
@@ -367,7 +366,7 @@ init_scheduling_cycle(status *policy, int pbs_sd, server_info *sinfo)
 
 		auto t = policy->current_time;
 		while (conf.decay_time != SCHD_INFINITY &&
-			(t - sinfo->fstree->last_decay) > conf.decay_time) {
+		       (t - sinfo->fstree->last_decay) > conf.decay_time) {
 			log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_SERVER, LOG_DEBUG,
 				  "Fairshare", "Decaying Fairshare Tree");
 			if (fstree != NULL)
@@ -382,7 +381,8 @@ init_scheduling_cycle(status *policy, int pbs_sd, server_info *sinfo)
 			if (fstree != NULL)
 				fstree->last_decay =
 					policy->current_time - (policy->current_time -
-					sinfo->fstree->last_decay) % conf.decay_time;
+								sinfo->fstree->last_decay) %
+								       conf.decay_time;
 		}
 
 		if (decayed || !last_running.empty()) {
@@ -420,8 +420,6 @@ init_scheduling_cycle(status *policy, int pbs_sd, server_info *sinfo)
 					if (resresv->job->is_running)
 						if (!resresv->job->can_not_preempt)
 							sinfo->preempt_count[preempt_level(resresv->job->preempt)]++;
-
-
 				}
 				if (sinfo->job_sort_formula != NULL) {
 					double threshold = sc_attrs.job_sort_formula_threshold;
@@ -439,18 +437,17 @@ init_scheduling_cycle(status *policy, int pbs_sd, server_info *sinfo)
 						}
 					}
 				}
-
 			}
 		}
 	}
 
 	next_job(policy, sinfo, INITIALIZE);
 #ifdef NAS /* localmod 034 */
-	(void)site_pick_next_job(NULL);
-	(void)site_is_share_king(policy);
+	(void) site_pick_next_job(NULL);
+	(void) site_is_share_king(policy);
 #endif /* localmod 034 */
 
-	return 1;		/* SUCCESS */
+	return 1; /* SUCCESS */
 }
 
 /**
@@ -473,7 +470,6 @@ schedule(int sd, const sched_cmd *cmd)
 		case SCH_RULESET:
 			/* ignore and end cycle */
 			break;
-
 
 		case SCH_SCHEDULE_FIRST:
 			/*
@@ -515,7 +511,7 @@ schedule(int sd, const sched_cmd *cmd)
 #ifdef PYTHON
 			Py_Finalize();
 #endif
-			return 1;		/* have the scheduler exit nicely */
+			return 1; /* have the scheduler exit nicely */
 		default:
 			return 0;
 	}
@@ -535,7 +531,7 @@ schedule(int sd, const sched_cmd *cmd)
 int
 intermediate_schedule(int sd, const sched_cmd *cmd)
 {
-	int ret; /* to re schedule or not */
+	int ret;	   /* to re schedule or not */
 	int cycle_cnt = 0; /* count of cycles run */
 
 	do {
@@ -562,8 +558,7 @@ intermediate_schedule(int sd, const sched_cmd *cmd)
 			break;
 
 		cycle_cnt++;
-	}
-	while (ret == -1);
+	} while (ret == -1);
 
 	return 0;
 }
@@ -583,11 +578,11 @@ intermediate_schedule(int sd, const sched_cmd *cmd)
 int
 scheduling_cycle(int sd, const sched_cmd *cmd)
 {
-	server_info *sinfo;		/* ptr to the server/queue/job/node info */
-	int rc = SUCCESS;		/* return code from main_sched_loop() */
-	char log_msg[MAX_LOG_SIZE];	/* used to log the message why a job can't run*/
-	int error = 0;			/* error happened, don't run main loop */
-	status *policy;			/* policy structure used for cycle */
+	server_info *sinfo;	    /* ptr to the server/queue/job/node info */
+	int rc = SUCCESS;	    /* return code from main_sched_loop() */
+	char log_msg[MAX_LOG_SIZE]; /* used to log the message why a job can't run*/
+	int error = 0;		    /* error happened, don't run main loop */
+	status *policy;		    /* policy structure used for cycle */
 	schd_error *err = NULL;
 
 	log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_REQUEST, LOG_DEBUG,
@@ -613,7 +608,6 @@ scheduling_cycle(int sd, const sched_cmd *cmd)
 		return 0;
 	}
 	policy = sinfo->policy;
-
 
 	/* don't confirm reservations if we're handling a qrun request */
 	if (cmd->jid == NULL) {
@@ -649,19 +643,17 @@ scheduling_cycle(int sd, const sched_cmd *cmd)
 		}
 	}
 
-
 	if (init_scheduling_cycle(policy, sd, sinfo) == 0) {
 		log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_SERVER, LOG_DEBUG, sinfo->name, "init_scheduling_cycle failed.");
 		end_cycle_tasks(sinfo);
 		return 0;
 	}
 
-
 	if (sinfo->qrun_job != NULL) {
 		sinfo->qrun_job->can_not_run = 0;
 		if (sinfo->qrun_job->job != NULL) {
 			if (sinfo->qrun_job->job->is_waiting ||
-				sinfo->qrun_job->job->is_held) {
+			    sinfo->qrun_job->job->is_held) {
 				set_job_state("Q", sinfo->qrun_job->job);
 			}
 		}
@@ -745,7 +737,7 @@ get_high_prio_cmd(int *is_conn_lost, sched_cmd *high_prior_cmd)
 	svr_conn_t **svr_conns = get_conn_svr_instances(clust_secondary_sock);
 	if (svr_conns == NULL) {
 		log_event(PBSEVENT_SCHED, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__,
-			"Unable to fetch secondary connections");
+			  "Unable to fetch secondary connections");
 		return 0;
 	}
 
@@ -765,7 +757,7 @@ get_high_prio_cmd(int *is_conn_lost, sched_cmd *high_prior_cmd)
 
 		if (cmd.cmd == SCH_SCHEDULE_RESTART_CYCLE) {
 			*high_prior_cmd = cmd;
-			if (i == get_num_servers() - 1)  {
+			if (i == get_num_servers() - 1) {
 				/* We need to return only after checking all servers. This way even if multiple
 				 * servers send SCH_SCHEDULE_RESTART_CYCLE we only have to consider one such request
 				 */
@@ -811,21 +803,20 @@ get_high_prio_cmd(int *is_conn_lost, sched_cmd *high_prior_cmd)
 int
 main_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rerr)
 {
-	resource_resv *njob;		/* ptr to the next job to see if it can run */
-	int rc = 0;			/* return code to the function */
-	int num_topjobs = 0;		/* number of jobs we've added to the calendar */
-	int end_cycle = 0;		/* boolean  - end main cycle loop */
-	char log_msg[MAX_LOG_SIZE];	/* used to log an message about job */
-	char comment[MAX_LOG_SIZE];	/* used to update comment of job */
-	time_t cycle_start_time;	/* the time the cycle starts */
-	time_t cycle_end_time;		/* the time when the current cycle should end */
-	time_t cur_time;		/* the current time via time() */
-	nspec **ns_arr = NULL;		/* node solution for job */
+	resource_resv *njob;	     /* ptr to the next job to see if it can run */
+	int rc = 0;		     /* return code to the function */
+	int num_topjobs = 0;	     /* number of jobs we've added to the calendar */
+	int end_cycle = 0;	     /* boolean  - end main cycle loop */
+	char log_msg[MAX_LOG_SIZE];  /* used to log an message about job */
+	char comment[MAX_LOG_SIZE];  /* used to update comment of job */
+	time_t cycle_start_time;     /* the time the cycle starts */
+	time_t cycle_end_time;	     /* the time when the current cycle should end */
+	time_t cur_time;	     /* the current time via time() */
+	std::vector<nspec *> ns_arr; /* node solution for job */
 	int i;
 	int sort_again = DONT_SORT_JOBS;
 	schd_error *err;
 	schd_error *chk_lim_err;
-
 
 	if (policy == NULL || sinfo == NULL || rerr == NULL)
 		return -1;
@@ -835,10 +826,10 @@ main_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rerr)
 	cycle_end_time = cycle_start_time + sc_attrs.sched_cycle_length;
 
 	chk_lim_err = new_schd_error();
-	if(chk_lim_err == NULL)
+	if (chk_lim_err == NULL)
 		return -1;
 	err = new_schd_error();
-	if(err == NULL) {
+	if (err == NULL) {
 		free_schd_error(chk_lim_err);
 		return -1;
 	}
@@ -853,9 +844,10 @@ main_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rerr)
 	site_list_jobs(sinfo, sinfo->jobs);
 #endif
 	for (i = 0; !end_cycle &&
-		(njob = next_job(policy, sinfo, sort_again)) != NULL; i++) {
-		int should_use_buckets;		/* Should use node buckets for a job */
-		unsigned int flags = NO_FLAGS;	/* flags to is_ok_to_run @see is_ok_to_run() */
+		    (njob = next_job(policy, sinfo, sort_again)) != NULL;
+	     i++) {
+		int should_use_buckets;	       /* Should use node buckets for a job */
+		unsigned int flags = NO_FLAGS; /* flags to is_ok_to_run @see is_ok_to_run() */
 		auto qinfo = njob->job->queue;
 
 #ifdef NAS /* localmod 030 */
@@ -872,10 +864,10 @@ main_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rerr)
 		clear_schd_error(err);
 
 		log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_JOB, LOG_DEBUG,
-			njob->name, "Considering job to run");
+			  njob->name, "Considering job to run");
 
 		should_use_buckets = job_should_use_buckets(njob);
-		if(should_use_buckets)
+		if (should_use_buckets)
 			flags = USE_BUCKETS;
 
 		if (njob->is_shrink_to_fit) {
@@ -887,26 +879,16 @@ main_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rerr)
 		if (err->status_code == NEVER_RUN)
 			njob->can_never_run = 1;
 
-		if (ns_arr != NULL) { /* success! */
-			resource_resv *tj;
-			if (njob->job->is_array) {
-				tj = queue_subjob(njob, sinfo, qinfo);
-				if (tj == NULL) {
-					rc = SCHD_ERROR;
-					njob->can_not_run = 1;
-				}
-			} else
-				tj = njob;
-
+		if (!ns_arr.empty()) { /* success! */
 			if (rc != SCHD_ERROR) {
-				if(run_update_resresv(policy, sd, sinfo, qinfo, tj, ns_arr, RURR_ADD_END_EVENT, err) > 0 ) {
+				if (run_update_job(policy, sd, sinfo, qinfo, njob, ns_arr, RURR_ADD_END_EVENT, err)) {
 					rc = SUCCESS;
 					if (sinfo->has_soft_limit || qinfo->has_soft_limit)
 						sort_again = MUST_RESORT_JOBS;
 					else
 						sort_again = MAY_RESORT_JOBS;
 				} else {
-					/* if run_update_resresv() returns 0 and pbs_errno == PBSE_HOOKERROR,
+					/* if run_update_job() returns 0 and pbs_errno == PBSE_HOOKERROR,
 					 * then this job is required to be ignored in this scheduling cycle
 					 */
 					rc = err->error_code;
@@ -914,13 +896,11 @@ main_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rerr)
 				}
 			} else
 				free_nspecs(ns_arr);
-		}
-		else if (policy->preempting && in_runnable_state(njob) && (!njob -> can_never_run)) {
+		} else if (policy->preempting && in_runnable_state(njob) && (!njob->can_never_run)) {
 			if (find_and_preempt_jobs(policy, sd, njob, sinfo, err) > 0) {
 				rc = SUCCESS;
 				sort_again = MUST_RESORT_JOBS;
-			}
-			else
+			} else
 				sort_again = SORTED;
 		}
 
@@ -933,14 +913,13 @@ main_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rerr)
 		}
 #endif /* localmod 034 */
 
-		/* if run_update_resresv() returns an error, it's generally pretty serious.
+		/* if run_update_job() returns an error, it's generally pretty serious.
 		 * lets bail out of the cycle now
 		 */
 		if (rc == SCHD_ERROR || rc == PBSE_PROTOCOL || got_sigpipe) {
 			end_cycle = 1;
 			log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_JOB, LOG_WARNING, njob->name, "Leaving scheduling cycle because of an internal error.");
-		}
-		else if (rc != SUCCESS && rc != RUN_FAILURE) {
+		} else if (rc != SUCCESS && rc != RUN_FAILURE) {
 #ifdef NAS /* localmod 034 */
 			int bf_rc;
 			if ((bf_rc = site_should_backfill_with_job(policy, sinfo, njob, num_topjobs, num_topjobs_per_queues, err))) {
@@ -950,9 +929,8 @@ main_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rerr)
 				auto cal_rc = add_job_to_calendar(sd, policy, sinfo, njob, should_use_buckets);
 
 				if (cal_rc > 0) { /* Success! */
-#ifdef NAS /* localmod 034 */
-					switch(bf_rc)
-					{
+#ifdef NAS					  /* localmod 034 */
+					switch (bf_rc) {
 						case 1:
 							num_topjobs++;
 							break;
@@ -978,13 +956,12 @@ main_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rerr)
 						else
 							qinfo->num_topjobs++;
 					}
-#endif /* localmod 034 */
-				}
-				else if (cal_rc == -1) { /* recycle */
+#endif							   /* localmod 034 */
+				} else if (cal_rc == -1) { /* recycle */
 					end_cycle = 1;
 					rc = -1;
 					log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_SERVER, LOG_DEBUG,
-						njob->name, "Error in add_job_to_calendar");
+						  njob->name, "Error in add_job_to_calendar");
 				}
 				/* else cal_rc == 0: failed to add to calendar - continue on */
 			}
@@ -1002,7 +979,7 @@ main_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rerr)
 				clear_schd_error(chk_lim_err);
 				if (sinfo->qrun_job == NULL) {
 					chk_lim_err->error_code = static_cast<enum sched_error_code>(check_limits(sinfo,
-						qinfo, njob, chk_lim_err, CHECK_CUMULATIVE_LIMIT));
+														  qinfo, njob, chk_lim_err, CHECK_CUMULATIVE_LIMIT));
 					if (chk_lim_err->error_code != 0) {
 						update_accrue_err = chk_lim_err;
 					}
@@ -1021,14 +998,14 @@ main_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rerr)
 		if ((rc != SUCCESS) && (err->error_code != 0)) {
 			translate_fail_code(err, comment, log_msg);
 			if (comment[0] != '\0' &&
-				(!njob->job->is_array || !njob->job->is_begin))
+			    (!njob->job->is_array || !njob->job->is_begin))
 				update_job_comment(sd, njob, comment);
 			if (log_msg[0] != '\0')
 				log_event(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB,
-					LOG_INFO, njob->name, log_msg);
+					  LOG_INFO, njob->name, log_msg);
 
 			/* If this job couldn't run, the mark the equiv class so the rest of the jobs are discarded quickly.*/
-			if(sinfo->equiv_classes != NULL && njob->ec_index != UNSPECIFIED) {
+			if (sinfo->equiv_classes != NULL && njob->ec_index != UNSPECIFIED) {
 				resresv_set *ec = sinfo->equiv_classes[njob->ec_index];
 				if (rc != RUN_FAILURE &&  !ec->can_not_run) {
 					ec->can_not_run = 1;
@@ -1039,7 +1016,7 @@ main_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rerr)
 
 		if (njob->can_never_run) {
 			log_event(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_WARNING,
-				njob->name, "Job will never run with the resources currently configured in the complex");
+				  njob->name, "Job will never run with the resources currently configured in the complex");
 		}
 		if ((rc != SUCCESS) && njob->job->resv == NULL) {
 			/* jobs in reservations are outside of the law... they don't cause
@@ -1048,12 +1025,10 @@ main_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rerr)
 			if (policy->strict_fifo) {
 				set_schd_error_codes(err, NOT_RUN, STRICT_ORDERING);
 				update_jobs_cant_run(sd, qinfo->jobs, NULL, err, START_WITH_JOB);
-			}
-			else if (!policy->backfill && policy->strict_ordering) {
+			} else if (!policy->backfill && policy->strict_ordering) {
 				set_schd_error_codes(err, NOT_RUN, STRICT_ORDERING);
 				update_jobs_cant_run(sd, sinfo->jobs, NULL, err, START_WITH_JOB);
-			}
-			else if (policy->backfill && policy->strict_ordering && qinfo->backfill_depth == 0) {
+			} else if (policy->backfill && policy->strict_ordering && qinfo->backfill_depth == 0) {
 				set_schd_error_codes(err, NOT_RUN, STRICT_ORDERING);
 				update_jobs_cant_run(sd, qinfo->jobs, NULL, err, START_WITH_JOB);
 			}
@@ -1063,14 +1038,14 @@ main_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rerr)
 		if (cur_time >= cycle_end_time) {
 			end_cycle = 1;
 			log_eventf(PBSEVENT_SCHED, PBS_EVENTCLASS_SCHED, LOG_NOTICE, "toolong",
-				"Leaving the scheduling cycle: Cycle duration of %ld seconds has exceeded %s of %ld seconds",
-				(long)(cur_time - cycle_start_time), ATTR_sched_cycle_len, sc_attrs.sched_cycle_length);
+				   "Leaving the scheduling cycle: Cycle duration of %ld seconds has exceeded %s of %ld seconds",
+				   (long) (cur_time - cycle_start_time), ATTR_sched_cycle_len, sc_attrs.sched_cycle_length);
 		}
 		if (conf.max_jobs_to_check != SCHD_INFINITY && (i + 1) >= conf.max_jobs_to_check) {
 			/* i begins with 0, hence i + 1 */
 			end_cycle = 1;
 			log_eventf(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_INFO, "",
-				"Bailed out of main job loop after checking to see if %d jobs could run.", (i + 1));
+				   "Bailed out of main job loop after checking to see if %d jobs could run.", (i + 1));
 		}
 		if (!end_cycle) {
 			sched_cmd cmd;
@@ -1079,11 +1054,11 @@ main_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rerr)
 
 			if (is_conn_lost) {
 				log_event(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_WARNING,
-					njob->name, "We lost connection with the server, leaving scheduling cycle");
+					  njob->name, "We lost connection with the server, leaving scheduling cycle");
 				end_cycle = 1;
 			} else if ((rc == 1) && (cmd.cmd == SCH_SCHEDULE_RESTART_CYCLE)) {
 				log_event(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_WARNING,
-					njob->name, "Leaving scheduling cycle as requested by server.");
+					  njob->name, "Leaving scheduling cycle as requested by server.");
 				end_cycle = 1;
 			}
 		}
@@ -1091,8 +1066,7 @@ main_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rerr)
 #ifdef NAS /* localmod 030 */
 		if (check_for_cycle_interrupt(0)) {
 			consecutive_interrupted_cycles++;
-		}
-		else {
+		} else {
 			consecutive_interrupted_cycles = 0;
 		}
 #endif /* localmod 030 */
@@ -1128,11 +1102,11 @@ end_cycle_tasks(server_info *sinfo)
 	 */
 	if (sinfo != NULL) {
 		sinfo->fstree = NULL;
-		delete sinfo;	/* free server and queues and jobs */
+		delete sinfo; /* free server and queues and jobs */
 	}
 
 	/* close any open connections to peers */
-	for (auto& pq : conf.peer_queues) {
+	for (auto &pq : conf.peer_queues) {
 		if (pq.peer_sd >= 0) {
 			/* When peering "local", do not disconnect server */
 			if (!pq.remote_server.empty())
@@ -1148,7 +1122,7 @@ end_cycle_tasks(server_info *sinfo)
 	}
 
 	log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_REQUEST, LOG_DEBUG,
-		"", "Leaving Scheduling Cycle");
+		  "", "Leaving Scheduling Cycle");
 }
 
 /**
@@ -1170,9 +1144,9 @@ end_cycle_tasks(server_info *sinfo)
 int
 update_job_can_not_run(int pbs_sd, resource_resv *job, schd_error *err)
 {
-	char comment_buf[MAX_LOG_SIZE];	/* buffer for comment message */
-	char log_buf[MAX_LOG_SIZE];		/* buffer for log message */
-	int ret = 1;				/* return code for function */
+	char comment_buf[MAX_LOG_SIZE]; /* buffer for comment message */
+	char log_buf[MAX_LOG_SIZE];	/* buffer for log message */
+	int ret = 1;			/* return code for function */
 
 	if ((job == NULL) || (err == NULL) || (job->job == NULL))
 		return ret;
@@ -1193,67 +1167,48 @@ update_job_can_not_run(int pbs_sd, resource_resv *job, schd_error *err)
 
 		if (log_buf[0] != '\0')
 			log_event(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_INFO,
-				job->name, log_buf);
+				  job->name, log_buf);
 
 		/* We won't be looking at this job in main_sched_loop()
 		 * and we just updated some attributes just above.  Send Now.
 		 */
 		send_job_updates(pbs_sd, job);
-	}
-	else
+	} else
 		ret = 0;
 
 	return ret;
 }
 
 /**
- * @brief
- * 		run_job - handle the running of a pbs job.  If it's a peer job
- *	       first move it to the local server and then run it.
- *	       if it's a local job, just run it.
- *
- * @param[in]	pbs_sd	-	pbs connection descriptor to the LOCAL server
- * @param[in]	rjob	-	the job to run
- * @param[in]	execvnode	-	the execvnode to run a multi-node job on
- * @param[in]	has_runjob_hook	-	does server have a runjob hook?
- * @param[out]	err	-	error struct to return errors
- *
- *
- * @retval	0	: success
- * @retval	1	: failure
- * @retval -1	: error
+ * @brief move a peer job locally
+ * 
+ * @param[in] rr - the job
+ * @return int
+ * @retval return value from pbs_movejob()
  */
 int
-run_job(int pbs_sd, resource_resv *rjob, char *execvnode, int has_runjob_hook, schd_error *err)
+move_peer_job(resource_resv *rr)
 {
 	int rc = 0;
 
-	if (rjob == NULL || rjob->job == NULL || err == NULL)
-		return -1;
-
-	/* Server most likely crashed */
-	if (got_sigpipe) {
-		set_schd_error_codes(err, NEVER_RUN, SCHD_ERROR);
-		return -1;
-	}
-
-	if (rjob->is_peer_ob) {
+	if (rr == NULL)
+		return 1;
+	if (rr->is_peer_ob) {
 		char buf[100]; /* used to assemble queue@localserver */
 
-		if (rjob->server->name.find(':') == std::string::npos) {
+		if (rr->server->name.find(':') == std::string::npos) {
 #ifdef NAS /* localmod 005 */
-			sprintf(buf, "%s@%s:%u", rjob->job->queue->name.c_str(),
+			sprintf(buf, "%s@%s:%u", rr->job->queue->name.c_str(),
 #else
-			sprintf(buf, "%s@%s:%d", rjob->job->queue->name.c_str(),
+			sprintf(buf, "%s@%s:%d", rr->job->queue->name.c_str(),
 #endif /* localmod 005 */
-				rjob->server->name.c_str(), pbs_conf.batch_service_port);
-		}
-		else {
-			sprintf(buf, "%s@%s", rjob->job->queue->name.c_str(),
-				rjob->server->name.c_str());
+				rr->server->name.c_str(), pbs_conf.batch_service_port);
+		} else {
+			sprintf(buf, "%s@%s", rr->job->queue->name.c_str(),
+				rr->server->name.c_str());
 		}
 
-		rc = pbs_movejob(rjob->job->peer_sd, const_cast<char *>(rjob->name.c_str()), buf, NULL);
+		rc = pbs_movejob(rr->job->peer_sd, const_cast<char *>(rr->name.c_str()), buf, NULL);
 
 		/*
 		 * After successful transfer of the peer job to local server,
@@ -1261,45 +1216,134 @@ run_job(int pbs_sd, resource_resv *rjob, char *execvnode, int has_runjob_hook, s
 		 * a local job.
 		 */
 		if (rc == 0)
-			rjob->is_peer_ob = 0;
+			rr->is_peer_ob = 0;
+	}
+	return rc;
+}
+
+/**
+ * @brief
+ * 		run_job - handle the running of a pbs job.  If it's a peer job
+ *			first move it to the local server and then run it.
+ *			if it's a local job, just run it.
+ *
+ * @param[in]	pbs_sd	-	pbs connection descriptor to the server
+ * @param[in]	rr	-	the job to run
+ * @param[in]	ns_arr		where to run the job
+ * @param[out]	err	-	error struct to return errors
+ *
+ *
+ * @retval true - success
+ * @retval false - failure
+ * 
+ */
+bool
+run_job(status *policy, int pbs_sd, resource_resv *rr, std::vector<nspec *>& ns_arr, schd_error *err)
+{
+	bool ret = true;
+	int pbsrc = 0; /* Return code from IFL call, 0 success, 1 failure */
+
+	if (rr == NULL || rr->job == NULL || err == NULL)
+		return false;
+
+	/* Server most likely crashed */
+	if (got_sigpipe) {
+		set_schd_error_codes(err, NEVER_RUN, SCHD_ERROR);
+		return false;
 	}
 
-	if (!rc) {
-		if (rjob->is_shrink_to_fit) {
+#ifdef RESC_SPEC /* Hack to make rescspec work with new select code */
+	if (rr->is_job && rr->job->rspec != NULL && ns[0] != NULL) {
+		struct batch_status *bs; /* used for rescspec res assignment */
+		struct attrl *attrp;	 /* used for rescspec res assignment */
+		resource_req *req;
+		bs = rescspec_get_assignments(rr->job->rspec);
+		if (bs != NULL) {
+			attrp = bs->attribs;
+			while (attrp != NULL) {
+				req = find_alloc_resource_req_by_str(ns[0]->resreq, attrp->resource);
+				if (req != NULL)
+					set_resource_req(req, attrp->value);
+
+				if (rr->resreq == NULL)
+					rr->resreq = req;
+				attrp = attrp->next;
+			}
+			pbs_statfree(bs);
+		}
+	}
+#endif
+
+	if (rr->is_peer_ob)
+		pbsrc = move_peer_job(rr);
+
+	if (!pbsrc) {
+		auto execvnode = create_execvnode(ns_arr);
+
+#ifdef NAS /* localmod 031 */
+		/* debug dpr - Log vnodes assigned to job */
+		time_t tm = time(NULL);
+		struct tm *ptm = localtime(&tm);
+		printf("%04d-%02d-%02d %02d:%02d:%02d %s %s %s\n",
+		       ptm->tm_year + 1900, ptm->tm_mon + 1, ptm->tm_mday,
+		       ptm->tm_hour, ptm->tm_min, ptm->tm_sec,
+		       "Running", resresv->name.c_str(),
+		       execvnode != NULL ? execvnode : "(NULL)");
+		fflush(stdout);
+#endif /* localmod 031 */
+
+		if (rr->is_shrink_to_fit) {
 			char timebuf[TIMEBUF_SIZE] = {0};
-			rc = 1;
+			auto rc = 1;
 			/* The job is set to run, update it's walltime only if it is not a foerever job */
-			if (rjob->duration != JOB_INFINITY) {
-				convert_duration_to_str(rjob->duration, timebuf, TIMEBUF_SIZE);
-				rc = update_job_attr(pbs_sd, rjob, ATTR_l, "walltime", timebuf, NULL, UPDATE_NOW);
+			if (rr->duration != JOB_INFINITY) {
+				convert_duration_to_str(rr->duration, timebuf, TIMEBUF_SIZE);
+				rc = update_job_attr(pbs_sd, rr, ATTR_l, "walltime", timebuf, NULL, UPDATE_NOW);
 			}
 			if (rc > 0) {
 				if (strlen(timebuf) > 0)
-					log_eventf(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_NOTICE, rjob->name,
-						"Job will run for duration=%s", timebuf);
-				rc = send_run_job(pbs_sd, has_runjob_hook, rjob->name, execvnode, rjob->svr_inst_id);
-			}
+					log_eventf(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_NOTICE, rr->name,
+						   "Job will run for duration=%s", timebuf);
+				pbsrc = send_run_job(pbs_sd, rr->server->has_runjob_hook, rr->name, execvnode, rr->svr_inst_id);
+			} else
+				pbsrc = 1;
 		} else
-			rc = send_run_job(pbs_sd, has_runjob_hook, rjob->name, execvnode, rjob->svr_inst_id);
+			pbsrc = send_run_job(pbs_sd, rr->server->has_runjob_hook, rr->name, execvnode, rr->svr_inst_id);
 	}
 
-	if (rc) {
-		const char *errbuf; /* comes from pbs_geterrmsg() */
-		char buf[MAX_LOG_SIZE];
+#ifdef NAS_CLUSTER /* localmod 125 */
+	ret = translate_runjob_return_code(pbsrc, rr);
+#else
+	if (pbsrc)
+		ret = false;
+#endif /* localmod 125 */
 
-		set_schd_error_codes(err, NOT_RUN, RUN_FAILURE);
-		errbuf = pbs_geterrmsg(get_svr_inst_fd(pbs_sd, rjob->svr_inst_id));
-		if (errbuf == NULL)
-			errbuf = "";
-		set_schd_error_arg(err, ARG1, errbuf);
-		snprintf(buf, sizeof(buf), "%d", pbs_errno);
-		set_schd_error_arg(err, ARG2, buf);
+	if (!ret) {
+		/* received 'batch protocol error' */
+		if (pbs_errno == PBSE_PROTOCOL) {
+			set_schd_error_codes(err, NOT_RUN, static_cast<enum sched_error_code>(PBSE_PROTOCOL));
+			return false;
+		} else {
+			const char *errbuf; /* comes from pbs_geterrmsg() */
+			char buf[MAX_LOG_SIZE];
+
+			set_schd_error_codes(err, NOT_RUN, RUN_FAILURE);
+			errbuf = pbs_geterrmsg(get_svr_inst_fd(pbs_sd, rr->svr_inst_id));
+			if (errbuf == NULL)
+				errbuf = "";
+			set_schd_error_arg(err, ARG1, errbuf);
+			snprintf(buf, sizeof(buf), "%d", pbs_errno);
+			set_schd_error_arg(err, ARG2, buf);
 #ifdef NAS /* localmod 031 */
-		set_schd_error_arg(err, ARG3, rjob->name);
+			set_schd_error_arg(err, ARG3, rr->name);
 #endif /* localmod 031 */
+		}
 	}
+	rr->can_not_run = true;
+	if (rr->job->parent_job != NULL && range_next_value(rr->job->parent_job->job->queued_subjobs, -1) < 0)
+		rr->job->parent_job->can_not_run = true;
 
-	return rc;
+	return ret;
 }
 
 #ifdef NAS_CLUSTER /* localmod 125 */
@@ -1317,382 +1361,177 @@ run_job(int pbs_sd, resource_resv *rjob, char *execvnode, int has_runjob_hook, s
  * @retval	0	-	Job did not run
  * @retval	-1	-	Invalid function parameter
  */
-static int translate_runjob_return_code (int pbsrc, resource_resv *bjob)
+static int
+translate_runjob_return_code(int pbsrc, resource_resv *bjob)
 {
-    if ((bjob == NULL) || (pbsrc == PBSE_PROTOCOL))
-        return -1;
-    if (pbsrc == 0)
-        return 1;
-    switch (pbsrc)
-    {
-        case PBSE_HOOKERROR:
-            return 0;
-        default:
-	    log_eventf(PBSEVENT_ERROR, PBS_EVENTCLASS_JOB, LOG_WARNING, bjob->name,
-	    	"Transient job warning.  Job may get held if issue persists:%d",pbsrc);
-	    return 2;
-    }
+	if ((bjob == NULL) || (pbsrc == PBSE_PROTOCOL))
+		return -1;
+	if (pbsrc == 0)
+		return 1;
+	switch (pbsrc) {
+		case PBSE_HOOKERROR:
+			return 0;
+		default:
+			log_eventf(PBSEVENT_ERROR, PBS_EVENTCLASS_JOB, LOG_WARNING, bjob->name,
+				   "Transient job warning.  Job may get held if issue persists:%d", pbsrc);
+			return 2;
+	}
 }
 #endif /* localmod 125 */
 
 /**
+ * @brief resume a suspended job
+ * 
+ * @param[in] policy - policy info
+ * @param[in] pbs_sd - PBS connection descriptor
+ * @param[in] rr - the job
+ * @param[in] flags - flags to pass to update_universe_on_run()
+ * @param[out] err - error structure to return errors
+ * @return true job resumed successfully
+ * @return false job didn't resume
+ */
+bool
+resume_job(status *policy, int pbs_sd, resource_resv *rr, unsigned int flags, schd_error *err)
+{
+	auto pbsrc = send_sigjob(pbs_sd, rr, "resume", NULL);
+	if (pbsrc) {
+		char buf[COMMENT_BUF_SIZE] = {'\0'}; /* generic buffer - comments & logging*/
+		const char *err_txt = pbse_to_txt(pbsrc);
+		if (err_txt == NULL)
+			err_txt = "";
+		clear_schd_error(err);
+		set_schd_error_codes(err, NOT_RUN, RUN_FAILURE);
+		set_schd_error_arg(err, ARG1, err_txt);
+		snprintf(buf, sizeof(buf), "%d", pbsrc);
+		set_schd_error_arg(err, ARG2, buf);
+		return false;
+	}
+	update_universe_on_run(policy, pbs_sd, rr, flags);
+
+	return true;
+}
+/**
  * @brief
- * 		run a resource_resv (job or reservation) and
- *		update the local cache if it was successfully
- *		run.  Currently we only simulate the running
- *		of reservations.
+ * 		run a job and update the local cache if it was successfully run
+ * 		This overload should be used when the ns_arr is unknown or 
+ * 		the job is being rerun on its own ns_arr
  *
  * @param[in]	policy	-	policy info
- * @param[in]	pbs_sd	-	connection descriptor to pbs_server or
- *			  				SIMULATE_SD if we're simulating
+ * @param[in]	pbs_sd	-	connection descriptor to pbs_server
  * @param[in]	sinfo	-	server job is on
- * @param[in]	qinfo	-	queue job resides in or NULL if reservation
+ * @param[in]	qinfo	-	queue job resides in
  * @param[in]	resresv	-	the job/reservation to run
- * @param[in]	ns_arr	-	node solution of where job/resv should run
- *				  			needs to be attached to the job/resv or freed
  * @param[in]	flags	-	flags to modify procedure
  *							RURR_ADD_END_EVENT - add an end event to calendar for this job
- *							NO_ALLPART - do not update the allpart's metadata
+ * 							RURR_NOPRINT - Don't print anything
  * @param[out]	err	-	error struct to return errors
  *
- * @retval	1	: success
- * @retval	0	: failure (see err for more info)
- * @retval -1	: error
- *
+ * @retval	true	: success
+ * @retval	false	: failure (see err for more info)
  */
-int
-run_update_resresv(status *policy, int pbs_sd, server_info *sinfo,
-	queue_info *qinfo, resource_resv *resresv, nspec **ns_arr,
-	unsigned int flags, schd_error *err)
+bool
+run_update_job(status *policy, int pbs_sd, server_info *sinfo,
+	       queue_info *qinfo, resource_resv *rr,
+	       unsigned int flags, schd_error *err)
 {
-	int ret = 0;				/* return code */
-	int pbsrc;				/* return codes from pbs IFL calls */
-
-	/* used for jobs with nodes resource */
-	nspec **ns = NULL;
-	nspec **orig_ns = NULL;
-	char *execvnode = NULL;
-
-	/* used for resresv array */
-	resource_resv *array = NULL;		/* used to hold array ptr */
-
-	unsigned int eval_flags = NO_FLAGS;	/* flags to pass to eval_selspec() */
-	resource_resv *rr;
-	char old_state = 0;
-
-	if (resresv == NULL || sinfo == NULL) {
+	if (rr == NULL || sinfo == NULL || qinfo == NULL || !rr->is_job || rr->job == NULL) {
 		clear_schd_error(err);
 		set_schd_error_codes(err, NOT_RUN, SCHD_ERROR);
-		return -1;
+		return false;
 	}
+	if (!is_resource_resv_valid(rr, err))
+		return false;
 
-	if (resresv->is_job && qinfo == NULL)
-		ret = -1;
+	if (rr->job->is_suspended)
+		return resume_job(policy, pbs_sd, rr, flags, err);
+
+	if (rr->nspec_arr.empty()) {
+		auto nspec_arr = check_nodes(policy, sinfo, qinfo, rr, NO_FLAGS, err);
+		if (nspec_arr.empty()) {
+			/* Theoretically we've already make sure we can run, so this shouldn't happen */
+			log_event(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_NOTICE, rr->name,
+				  "Could not find node solution in run_update_job()");
+			set_schd_error_codes(err, NOT_RUN, SCHD_ERROR);
+			return false;
+		}
+		return run_update_job(policy, pbs_sd, sinfo, qinfo, rr, nspec_arr, flags, err);
+	} else {
+		/* We're going to use the job's nspec_arr, so just pass an empty vector that will be ignored */
+		std::vector<nspec *> empty_ns;
+		return run_update_job(policy, pbs_sd, sinfo, qinfo, rr, empty_ns, flags, err);
+	}
+}
+
+/**
+ * @brief
+ * 		run a job and update the local cache if it was successfully run
+ *
+ * @param[in]	policy	-	policy info
+ * @param[in]	pbs_sd	-	connection descriptor to pbs_server
+ * @param[in]	sinfo	-	server job is on
+ * @param[in]	qinfo	-	queue job resides in
+ * @param[in]	resresv	-	the job/reservation to run
+ * @param[in]	ns_arr	-	node solution of where job should run.  
+ * 				This will either be owned by the job or freed before we return.
+ * @param[in]	flags	-	flags to modify procedure
+ *							RURR_ADD_END_EVENT - add an end event to calendar for this job
+ * 							RURR_NOPRINT - Don't print anything
+ * @param[out]	err	-	error struct to return errors
+ *
+ * @retval	true	: success
+ * @retval	false	: failure (see err for more info)
+ *
+ */
+bool
+run_update_job(status *policy, int pbs_sd, server_info *sinfo,
+	       queue_info *qinfo, resource_resv *resresv, std::vector<nspec *> &nspec_arr,
+	       unsigned int flags, schd_error *err)
+{
+	bool ret;
+	resource_resv *rr;
+
+	if (resresv == NULL || sinfo == NULL || qinfo == NULL || !resresv->is_job) {
+		clear_schd_error(err);
+		set_schd_error_codes(err, NOT_RUN, SCHD_ERROR);
+		free_nspecs(nspec_arr);
+		return false;
+	}
 
 	if (!is_resource_resv_valid(resresv, err)) {
 		schdlogerr(PBSEVENT_DEBUG2, PBS_EVENTCLASS_SCHED, LOG_DEBUG, (char *) __func__, "Request not valid:", err);
-		ret = -1;
+		free_nspecs(nspec_arr);
+		return false;
 	}
 
-	if (ret == -1) {
-		clear_schd_error(err);
-		set_schd_error_codes(err, NOT_RUN, SCHD_ERROR);
-		free_nspecs(ns_arr);
-		return ret;
-	}
-
-	pbs_errno = PBSE_NONE;
-	if (resresv->is_job && resresv->job->is_suspended) {
-		if (pbs_sd != SIMULATE_SD) {
-			pbsrc = send_sigjob(pbs_sd, resresv, "resume", NULL);
-			if (!pbsrc)
-				ret = 1;
-			else {
-				char buf[COMMENT_BUF_SIZE] = {'\0'}; /* generic buffer - comments & logging*/
-				const char *err_txt = pbse_to_txt(pbsrc);
-				if (err_txt == NULL)
-					err_txt = "";
-				clear_schd_error(err);
-				set_schd_error_codes(err, NOT_RUN, RUN_FAILURE);
-				set_schd_error_arg(err, ARG1, err_txt);
-				snprintf(buf, sizeof(buf), "%d", pbsrc);
-				set_schd_error_arg(err, ARG2, buf);
-
-			}
-		}
-		else
-			ret = 1;
-
+	if (resresv->job->is_array)
+		rr = queue_subjob(resresv, sinfo, qinfo);
+	else
 		rr = resresv;
-		ns = resresv->nspec_arr;
-		/* we didn't use nspec_arr, we need to free it */
-		free_nspecs(ns_arr);
-		ns_arr = NULL;
+
+	if (rr->job->is_suspended) {
+		free_nspecs(nspec_arr);
+		return resume_job(policy, pbs_sd, rr, flags, err);
 	}
-	else {
-		if (resresv->is_job && resresv->job->is_subjob) {
-			array = find_resource_resv(sinfo->jobs, resresv->job->array_id);
-			rr = resresv;
-		} else if (resresv->is_job && resresv->job->is_array) {
-			array = resresv;
-			rr = queue_subjob(resresv, sinfo, qinfo);
-			if(rr == NULL) {
+	/* If the job/resv already has a location to run, use that */
+	if (!rr->nspec_arr.empty()) {
+		/* We're not using this, so free it */
+		free_nspecs(nspec_arr);
+		ret = run_job(policy, pbs_sd, rr, rr->nspec_arr, err);
+		if (ret) {
+			ret = update_universe_on_run(policy, pbs_sd, rr, flags);
+			if (!ret)
 				set_schd_error_codes(err, NOT_RUN, SCHD_ERROR);
-				free_nspecs(ns_arr);
-				return -1;
-			}
-		} else
-			rr = resresv;
-
-		/* Where should we run our resresv? */
-
-		/* 1) if the resresv knows where it should be run, run it there */
-		if (((rr->resv == NULL) && (rr->nspec_arr != NULL)) ||
-		    ((rr->resv != NULL) && (rr->resv->orig_nspec_arr != NULL))) {
-			if (rr->resv != NULL)
-				orig_ns = rr->resv->orig_nspec_arr;
-			else
-				orig_ns = rr->nspec_arr;
-			/* we didn't use nspec_arr, we need to free it */
-			free_nspecs(ns_arr);
-			ns_arr = NULL;
 		}
-		/* 2) if we were told by our caller through ns_arr, run the resresv there */
-		else if (ns_arr != NULL)
-			orig_ns = ns_arr;
-		/* 3) calculate where to run the resresv ourselves */
-		else
-			orig_ns = check_nodes(policy, sinfo, qinfo, rr, eval_flags, err);
-
-		if (orig_ns != NULL) {
-#ifdef RESC_SPEC /* Hack to make rescspec work with new select code */
-			if (rr->is_job && rr->job->rspec != NULL && ns[0] != NULL) {
-				struct batch_status *bs;	/* used for rescspec res assignment */
-				struct attrl *attrp;		/* used for rescspec res assignment */
-				resource_req *req;
-				bs = rescspec_get_assignments(rr->job->rspec);
-				if (bs != NULL) {
-					attrp = bs->attribs;
-					while (attrp != NULL) {
-						req = find_alloc_resource_req_by_str(ns[0]->resreq, attrp->resource);
-						if (req != NULL)
-							set_resource_req(req, attrp->value);
-
-						if (rr->resreq == NULL)
-							rr->resreq = req;
-						attrp = attrp->next;
-					}
-					pbs_statfree(bs);
-				}
-			}
-#endif
-
-			auto num_nspec = count_array(orig_ns);
-			if (num_nspec > 1)
-				qsort(orig_ns, num_nspec, sizeof(nspec *), cmp_nspec);
-
-			if (pbs_sd != SIMULATE_SD) {
-				if (rr->is_job) { /* don't bother if we're a reservation */
-					execvnode = create_execvnode(orig_ns);
-					if (execvnode != NULL) {
-						/* The nspec array coming out of the node selection code could
-						 * have a node appear multiple times.  This is how we need to
-						 * send the execvnode to the server.  We now need to combine
-						 * nodes into 1 entry for updating our local data structures
-						 */
-						ns = combine_nspec_array(orig_ns);
-						if (ns == NULL) {
- 							free_nspecs(ns_arr);
- 							return -1;
- 						}
-					}
-
-#ifdef NAS /* localmod 031 */
-					/* debug dpr - Log vnodes assigned to job */
-					time_t tm = time(NULL);
-					struct tm *ptm = localtime(&tm);
-					printf("%04d-%02d-%02d %02d:%02d:%02d %s %s %s\n",
-						ptm->tm_year+1900, ptm->tm_mon+1, ptm->tm_mday,
-						ptm->tm_hour, ptm->tm_min, ptm->tm_sec,
-						"Running", resresv->name.c_str(),
-						execvnode != NULL ? execvnode : "(NULL)");
-					fflush(stdout);
-#endif /* localmod 031 */
-					pbsrc = run_job(pbs_sd, rr, execvnode, sinfo->has_runjob_hook, err);
-
-#ifdef NAS_CLUSTER /* localmod 125 */
-					ret = translate_runjob_return_code(pbsrc, resresv);
-#else
-					if (!pbsrc)
-						ret = 1;
-#endif /* localmod 125 */
-				}
-				else
-					ret = 1;
-			}
-			else
-				/* if we're simulating, resresvs can't fail to run */
-				ret = 1;
-		}
-		else  { /* should never happen */
-			log_event(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_NOTICE, rr->name,
-				"Could not find node solution in run_update_resresv()");
-			set_schd_error_codes(err, NOT_RUN, SCHD_ERROR);
-			ret = 0;
-		}
-
-	}
-
-#ifdef NAS_CLUSTER /* localmod 125 */
-	if (ret > 0) { /* resresv has successfully been started */
-#else
-	if (ret != 0) { /* resresv has successfully been started */
-#endif /* localmod 125 */
-		/* any resresv marked can_not_run will be ignored by the scheduler
-		 * so just incase we run by this resresv again, we want to ignore it
-		 * since it is already running
-		 */
-		rr->can_not_run = 1;
-
-		if (rr->nspec_arr != NULL && rr->nspec_arr != ns && rr->nspec_arr != ns_arr && rr->nspec_arr != orig_ns)
-			free_nspecs(rr->nspec_arr);
-
-		if (orig_ns != ns_arr) {
-			free_nspecs(ns_arr);
-			ns_arr = NULL;
-		}
-		/* The nspec array coming out of the node selection code could
-		 * have a node appear multiple times.  This is how we need to
-		 * send the execvnode to the server.  We now need to combine
-		 * nodes into 1 entry for updating our local data structures
-		 */
-		if (ns == NULL)
-			ns = combine_nspec_array(orig_ns);
-
-		if (rr->resv != NULL)
-			rr->resv->orig_nspec_arr = orig_ns;
-		else
-			free_nspecs(orig_ns);
-
-		rr->nspec_arr = ns;
-
-		if (rr->is_job && !(flags & RURR_NOPRINT)) {
-				log_event(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB,
-					LOG_INFO, rr->name, "Job run");
-		}
-		if ((resresv->is_job) && (resresv->job->is_suspended ==1))
-			old_state = 'S';
-
-		update_resresv_on_run(rr, ns);
-
-		if ((flags & RURR_ADD_END_EVENT)) {
-			auto te = create_event(TIMED_END_EVENT, rr->end, rr, NULL, NULL);
-			if (te == NULL) {
+	} else {
+		std::sort(nspec_arr.begin(), nspec_arr.end(), cmp_nspec);
+		ret = run_job(policy, pbs_sd, rr, nspec_arr, err);
+		if (!ret)
+			free_nspecs(nspec_arr);
+		else {
+			ret = update_universe_on_run(policy, pbs_sd, rr, nspec_arr, flags);
+			if (!ret)
 				set_schd_error_codes(err, NOT_RUN, SCHD_ERROR);
-				return -1;
-			}
-			add_event(sinfo->calendar, te);
 		}
-
-		if (array != NULL) {
-			update_array_on_run(array->job, rr->job);
-
-			/* Subjobs inherit all attributes from their parent job array. This means
-			 * we need to make sure the parent resresv array has its accrue_type set
-			 * before running the subresresv.  If all subresresvs have run,
-			 * then resresv array's accrue_type becomes ineligible.
-			 */
-			if (array->is_job &&
-				range_next_value(array->job->queued_subjobs, -1) < 0)
-				update_accruetype(pbs_sd, sinfo, ACCRUE_MAKE_INELIGIBLE, SUCCESS, array);
-			else
-				update_accruetype(pbs_sd, sinfo, ACCRUE_MAKE_ELIGIBLE, SUCCESS, array);
-		}
-
-		if (ns != NULL) {
-			int sort_nodepart = 0;
-			for (int i = 0; ns[i] != NULL; i++) {
-				update_node_on_run(ns[i], rr, &old_state);
-				if (ns[i]->ninfo->np_arr != NULL) {
-					node_partition **npar = ns[i]->ninfo->np_arr;
-					for (int j = 0; npar[j] != NULL; j++) {
-						modify_resource_list(npar[j]->res, ns[i]->resreq, SCHD_INCR);
-						if (!ns[i]->ninfo->is_free)
-							npar[j]->free_nodes--;
-						sort_nodepart = 1;
-						update_buckets_for_node(npar[j]->bkts, ns[i]->ninfo);
-					}
-				}
-				/* if the node is being provisioned, it's brought down in
-				 * update_node_on_run().  We need to add an event in the calendar to
-				 * bring it back up.
-				 */
-				if (ns[i]->go_provision) {
-					if (add_prov_event(sinfo->calendar, sinfo->server_time + PROVISION_DURATION, ns[i]->ninfo) == 0) {
-						set_schd_error_codes(err, NOT_RUN, SCHD_ERROR);
-						return -1;
-					}
-				}
-			}
-			if (sort_nodepart)
-				sort_all_nodepart(policy, sinfo);
-		}
-
-		update_queue_on_run(qinfo, rr, &old_state);
-
-		update_server_on_run(policy, sinfo, qinfo, rr, &old_state);
-
-		/* update soft limits for jobs that are not in reservation */
-		if (rr->is_job && rr->job->resv_id == NULL) {
-			/* update the entity preempt bit */
-			update_soft_limits(sinfo, qinfo, resresv);
-			/* update the job preempt status */
-			set_preempt_prio(resresv, qinfo, sinfo);
-		}
-
-		/* update_preemption_priority() must be called post queue/server update */
-		update_preemption_priority(sinfo, rr);
-
-		if (sinfo->policy->fair_share)
-			update_usage_on_run(rr);
-#ifdef NAS /* localmod 057 */
-		site_update_on_run(sinfo, qinfo, resresv, ns);
-#endif /* localmod 057 */
-
-
-	}
-	else	 { /* resresv failed to start (server rejected) -- cleanup */
-		/*
-		 * nspec freeage:
-		 * 1) ns_arr is passed in and ours to free.  We need to free it.
-		 * 2) ns can be one of three things.
-		 *    a) ns_arr - handled by #1 above
-		 *    b) resresv -> nspec_arr - not ours, we can't free it
-		 *    c) allocated in this function - ours to free
-		 */
-		if (ns_arr != NULL)
-			free_nspecs(ns_arr);
-		if (ns != NULL && ns != rr->nspec_arr)
-			free_nspecs(ns);
-		if (orig_ns != NULL && ns_arr != orig_ns)
-			free_nspecs(orig_ns);
-
-		rr->can_not_run = 1;
-		if (array != NULL)
-			array->can_not_run = 1;
-
-		/* received 'batch protocol error' */
-		if (pbs_errno == PBSE_PROTOCOL) {
-			set_schd_error_codes(err, NOT_RUN, static_cast<enum sched_error_code>(PBSE_PROTOCOL));
-			return -1;
-		}
-	}
-
-	if (rr->is_job && rr->job->is_preempted && (ret != 0)) {
-		unset_job_attr(pbs_sd, rr, ATTR_sched_preempted, UPDATE_LATER);
-		rr->job->is_preempted = 0;
-		rr->job->time_preempted = UNSPECIFIED;
-		sinfo->num_preempted--;
 	}
 	return ret;
 }
@@ -1707,42 +1546,61 @@ run_update_resresv(status *policy, int pbs_sd, server_info *sinfo,
  * @param[in]	flags	-	flags to modify procedure
  *							RURR_ADD_END_EVENT - add an end event to calendar for this job
  *
- * @retval	1	: success
- * @retval	0	: failure
- * @retval	-1	: error
+ * @retval	true	: success
+ * @retval	false	: failure
  *
  */
-int
-sim_run_update_resresv(status *policy, resource_resv *resresv, nspec **ns_arr, unsigned int flags)
+bool
+sim_run_update_resresv(status *policy, resource_resv *resresv, std::vector<nspec *> &ns_arr, unsigned int flags)
 {
-	server_info *sinfo = NULL;
-	queue_info *qinfo = NULL;
-	static schd_error *err = NULL;
-
-	if(err == NULL)
-		err = new_schd_error();
+	bool ret = true;
+	resource_resv *rr;
 
 	if (resresv == NULL) {
 		free_nspecs(ns_arr);
-		return -1;
+		return false;
 	}
 
 	if (!is_resource_resv_valid(resresv, NULL)) {
 		free_nspecs(ns_arr);
-		return -1;
+		return false;
 	}
 
-	sinfo = resresv->server;
-	if (resresv->is_job)
-		qinfo = resresv->job->queue;
+	if (resresv->is_job && resresv->job->is_array)
+		rr = queue_subjob(resresv, resresv->server, resresv->job->queue);
+	else
+		rr = resresv;
 
-	clear_schd_error(err);
+	if (rr->nspec_arr.empty())
+		ret = update_universe_on_run(policy, SIMULATE_SD, rr, ns_arr, (flags | RURR_NOPRINT));
+	else
+		ret = update_universe_on_run(policy, SIMULATE_SD, rr, (flags | RURR_NOPRINT));
 
-	return run_update_resresv(policy, SIMULATE_SD, sinfo, qinfo,
-		resresv, ns_arr, flags | RURR_NOPRINT, err);
+	if (!ret)
+		free_nspecs(ns_arr);
 
+	return ret;
 }
 
+/**
+ * @brief
+ * 		simulate the running of a resource resv without ns_arr.  This is 
+ * 		used when we want to rerun the job on the same nodes its own ns_arr
+ *
+ * @param[in]	policy	-	policy info
+ * @param[in]	resresv	-	the resource resv to simulate running
+ * @param[in]	ns_arr  -	node solution of where a job/resv should run
+ * @param[in]	flags	-	flags to modify procedure
+ *							RURR_ADD_END_EVENT - add an end event to calendar for this job
+ *
+ * @retval	true	: success
+ * @retval	false	: failure */
+bool
+sim_run_update_resresv(status *policy, resource_resv *resresv, unsigned int flags)
+{
+	std::vector<nspec *> empty_ns;
+	return sim_run_update_resresv(policy, resresv, empty_ns, flags);
+}
 /**
  * @brief
  * 		should we call add_job_to_calendar() with job
@@ -1771,7 +1629,7 @@ should_backfill_with_job(status *policy, server_info *sinfo, resource_resv *resr
 		return 0;
 
 	/* jobs in reservations are not eligible for backfill */
-	if (resresv->job->resv !=NULL)
+	if (resresv->job->resv != NULL)
 		return 0;
 
 #ifndef NAS /* localmod 038 */
@@ -1807,12 +1665,11 @@ should_backfill_with_job(status *policy, server_info *sinfo, resource_resv *resr
 		return 0;
 
 	/* Job is preempted and we're helping preempted jobs resume -- add to the calendar*/
-	if (resresv->job->is_preempted && sc_attrs.sched_preempt_enforce_resumption
-	    && (resresv->job->preempt >= preempt_normal))
+	if (resresv->job->is_preempted && sc_attrs.sched_preempt_enforce_resumption && (resresv->job->preempt >= preempt_normal))
 		return 1;
 
 	/* Admin settable flag - don't add to calendar */
-	if(resresv->job->topjob_ineligible)
+	if (resresv->job->topjob_ineligible)
 		return 0;
 
 	if (policy->strict_ordering)
@@ -1847,16 +1704,16 @@ should_backfill_with_job(status *policy, server_info *sinfo, resource_resv *resr
  */
 int
 add_job_to_calendar(int pbs_sd, status *policy, server_info *sinfo,
-	resource_resv *topjob, int use_buckets)
+		    resource_resv *topjob, int use_buckets)
 {
-	server_info *nsinfo;		/* dup'd universe to simulate in */
-	resource_resv *njob;		/* the topjob in the dup'd universe */
-	resource_resv *bjob;		/* job pointer which becomes the topjob*/
-	resource_resv *tjob;		/* temporary job pointer for job arrays */
-	time_t start_time;		/* calculated start time of topjob */
+	server_info *nsinfo; /* dup'd universe to simulate in */
+	resource_resv *njob; /* the topjob in the dup'd universe */
+	resource_resv *bjob; /* job pointer which becomes the topjob*/
+	resource_resv *tjob; /* temporary job pointer for job arrays */
+	time_t start_time;   /* calculated start time of topjob */
 
 	if (policy == NULL || sinfo == NULL ||
-		topjob == NULL || topjob->job == NULL)
+	    topjob == NULL || topjob->job == NULL)
 		return 0;
 
 	if (sinfo->calendar != NULL) {
@@ -1878,21 +1735,20 @@ add_job_to_calendar(int pbs_sd, status *policy, server_info *sinfo,
 		return 0;
 	}
 
-
 #ifdef NAS /* localmod 031 */
 	log_eventf(PBSEVENT_DEBUG2, PBS_EVENTCLASS_JOB, LOG_DEBUG,
 		   topjob->name, "Estimating the start time for a top job (q=%s schedselect=%.1000s).", topjob->job->queue->name, topjob->job->schedsel);
 #else
 	log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_JOB, LOG_DEBUG,
-		topjob->name, "Estimating the start time for a top job.");
+		  topjob->name, "Estimating the start time for a top job.");
 #endif /* localmod 031 */
-	if(use_buckets)
-		start_time = calc_run_time(njob->name, nsinfo, SIM_RUN_JOB|USE_BUCKETS);
+	if (use_buckets)
+		start_time = calc_run_time(njob->name, nsinfo, SIM_RUN_JOB | USE_BUCKETS);
 	else
 		start_time = calc_run_time(njob->name, nsinfo, SIM_RUN_JOB);
 
 	if (start_time > 0) {
-		char *exec;	       /* used to hold execvnode for topjob */
+		char *exec; /* used to hold execvnode for topjob */
 		char log_buf[MAX_LOG_SIZE];
 
 		/* If our top job is a job array, we don't backfill around the
@@ -1911,7 +1767,7 @@ add_job_to_calendar(int pbs_sd, status *policy, server_info *sinfo,
 			njob = find_resource_resv(nsinfo->jobs, tjob->name);
 			if (njob == NULL) {
 				log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_JOB, LOG_DEBUG, __func__,
-					"Can't find new subjob in simulated universe");
+					  "Can't find new subjob in simulated universe");
 				delete nsinfo;
 				return 0;
 			}
@@ -1921,8 +1777,6 @@ add_job_to_calendar(int pbs_sd, status *policy, server_info *sinfo,
 		} else
 			bjob = topjob;
 
-
-
 		exec = create_execvnode(njob->nspec_arr);
 		if (exec != NULL) {
 #ifdef NAS /* localmod 068 */
@@ -1930,14 +1784,13 @@ add_job_to_calendar(int pbs_sd, status *policy, server_info *sinfo,
 			time_t tm = time(NULL);
 			struct tm *ptm = localtime(&tm);
 			printf("%04d-%02d-%02d %02d:%02d:%02d %s %s %s\n",
-				ptm->tm_year+1900, ptm->tm_mon+1, ptm->tm_mday,
-				ptm->tm_hour, ptm->tm_min, ptm->tm_sec,
-				"Backfill", njob->name.c_str(), exec);
+			       ptm->tm_year + 1900, ptm->tm_mon + 1, ptm->tm_mday,
+			       ptm->tm_hour, ptm->tm_min, ptm->tm_sec,
+			       "Backfill", njob->name.c_str(), exec);
 #endif /* localmod 068 */
-			if (bjob->nspec_arr != NULL)
-				free_nspecs(bjob->nspec_arr);
+			free_nspecs(bjob->nspec_arr);
 			bjob->nspec_arr = parse_execvnode(exec, sinfo, NULL);
-			if (bjob->nspec_arr != NULL) {
+			if (!bjob->nspec_arr.empty()) {
 				std::string selectspec;
 				if (bjob->ninfo_arr != NULL)
 					free(bjob->ninfo_arr);
@@ -1956,7 +1809,6 @@ add_job_to_calendar(int pbs_sd, status *policy, server_info *sinfo,
 			delete nsinfo;
 			return 0;
 		}
-
 
 		if (bjob->job->est_execvnode != NULL)
 			free(bjob->job->est_execvnode);
@@ -1980,15 +1832,14 @@ add_job_to_calendar(int pbs_sd, status *policy, server_info *sinfo,
 		add_event(sinfo->calendar, te_end);
 
 		if (update_estimated_attrs(pbs_sd, bjob, bjob->job->est_start_time,
-			bjob->job->est_execvnode, 0) <0) {
+					   bjob->job->est_execvnode, 0) < 0) {
 			log_event(PBSEVENT_SCHED, PBS_EVENTCLASS_SCHED, LOG_WARNING,
-				bjob->name, "Failed to update estimated attrs.");
+				  bjob->name, "Failed to update estimated attrs.");
 		}
 
-
-		for (int i = 0; bjob->nspec_arr[i] != NULL; i++) {
-			int ind = bjob->nspec_arr[i]->ninfo->node_ind;
-			add_te_list(&(bjob->nspec_arr[i]->ninfo->node_events), te_start);
+		for (auto ns : bjob->nspec_arr) {
+			int ind = ns->ninfo->node_ind;
+			add_te_list(&(ns->ninfo->node_events), te_start);
 
 			if (ind != -1 && sinfo->unordered_nodes[ind]->bucket_ind != -1) {
 				node_bucket *bkt;
@@ -2013,17 +1864,17 @@ add_job_to_calendar(int pbs_sd, status *policy, server_info *sinfo,
 			 */
 			update_usage_on_run(bjob);
 			log_eventf(PBSEVENT_DEBUG, PBS_EVENTCLASS_JOB, LOG_DEBUG, bjob->name,
-				"Fairshare usage of entity %s increased due to job becoming a top job.", bjob->job->ginfo->name.c_str());
+				   "Fairshare usage of entity %s increased due to job becoming a top job.", bjob->job->ginfo->name.c_str());
 		}
 
 		sprintf(log_buf, "Job is a top job and will run at %s",
 			ctime(&bjob->start));
 
-		log_buf[strlen(log_buf)-1] = '\0';	/* ctime adds a \n */
+		log_buf[strlen(log_buf) - 1] = '\0'; /* ctime adds a \n */
 		log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_JOB, LOG_DEBUG, bjob->name, log_buf);
 	} else if (start_time == 0) {
 		log_event(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_WARNING, topjob->name,
-			"Error in calculation of start time of top job");
+			  "Error in calculation of start time of top job");
 		delete nsinfo;
 		return 0;
 	}
@@ -2031,7 +1882,6 @@ add_job_to_calendar(int pbs_sd, status *policy, server_info *sinfo,
 
 	return 1;
 }
-
 
 /**
  * @brief
@@ -2084,7 +1934,7 @@ find_ready_resv_job(resource_resv **resvs)
 int
 find_runnable_resresv_ind(resource_resv **resresv_arr, int start_index)
 {
-#ifdef NAS      /* localmod 034 */
+#ifdef NAS /* localmod 034 */
 	return site_find_runnable_res(resresv_arr);
 #else
 	int i;
@@ -2098,7 +1948,6 @@ find_runnable_resresv_ind(resource_resv **resresv_arr, int start_index)
 	}
 	return -1;
 #endif /* localmod 034 */
-
 }
 
 /**
@@ -2115,7 +1964,8 @@ find_runnable_resresv_ind(resource_resv **resresv_arr, int start_index)
  *
  */
 int
-find_non_normal_job_ind(resource_resv **jobs, int start_index) {
+find_non_normal_job_ind(resource_resv **jobs, int start_index)
+{
 	int i;
 
 	if (jobs == NULL)
@@ -2170,8 +2020,8 @@ next_job(status *policy, server_info *sinfo, int flag)
 	 */
 	static int skip = SKIP_NOTHING;
 	static int sort_status = MAY_RESORT_JOBS; /* to decide whether to sort jobs or not */
-	static int queue_list_size; /* Count of number of priority levels in queue_list */
-	resource_resv *rjob = NULL;		/* the job to return */
+	static int queue_list_size;		  /* Count of number of priority levels in queue_list */
+	resource_resv *rjob = NULL;		  /* the job to return */
 	int ind = -1;
 
 	if ((policy == NULL) || (sinfo == NULL))
@@ -2183,8 +2033,7 @@ next_job(status *policy, server_info *sinfo, int flag)
 			last_queue_index = 0;
 			queue_list_size = count_array(sinfo->queue_list);
 
-		}
-		else if (policy->by_queue)
+		} else if (policy->by_queue)
 			last_queue = 0;
 		skip = SKIP_NOTHING;
 		sort_jobs(policy, sinfo);
@@ -2193,10 +2042,9 @@ next_job(status *policy, server_info *sinfo, int flag)
 		return NULL;
 	}
 
-
 	if (sinfo->qrun_job != NULL) {
 		if (!sinfo->qrun_job->can_not_run &&
-			in_runnable_state(sinfo->qrun_job)) {
+		    in_runnable_state(sinfo->qrun_job)) {
 			rjob = sinfo->qrun_job;
 		}
 		return rjob;
@@ -2209,8 +2057,7 @@ next_job(status *policy, server_info *sinfo, int flag)
 			skip |= SKIP_RESERVATIONS;
 	}
 
-	if ((sort_status != SORTED) || ((flag == MAY_RESORT_JOBS) && policy->fair_share)
-		|| (flag == MUST_RESORT_JOBS)) {
+	if ((sort_status != SORTED) || ((flag == MAY_RESORT_JOBS) && policy->fair_share) || (flag == MUST_RESORT_JOBS)) {
 		sort_jobs(policy, sinfo);
 		sort_status = SORTED;
 		last_job_index = 0;
@@ -2246,14 +2093,14 @@ next_job(status *policy, server_info *sinfo, int flag)
 		 */
 		int i = last_queue_index;
 
-		while((rjob == NULL) && (i < queue_list_size)) {
+		while ((rjob == NULL) && (i < queue_list_size)) {
 			/* Calculating number of queues at this priority level */
 			unsigned int queue_index_size = count_array(sinfo->queue_list[i]);
 			unsigned int queues_finished = 0;
 
 			for (unsigned int j = last_queue; j < queue_index_size; j++) {
 				ind = find_runnable_resresv_ind(sinfo->queue_list[i][j]->jobs, 0);
-				if(ind != -1)
+				if (ind != -1)
 					rjob = sinfo->queue_list[i][j]->jobs[ind];
 				else
 					rjob = NULL;
@@ -2300,8 +2147,8 @@ next_job(status *policy, server_info *sinfo, int flag)
 			}
 		}
 		if (skip & SKIP_NON_NORMAL_JOBS) {
-			while(last_queue < sinfo->queues.size() &&
-			     ((ind = find_runnable_resresv_ind(sinfo->queues[last_queue]->jobs, last_job_index)) == -1)) {
+			while (last_queue < sinfo->queues.size() &&
+			       ((ind = find_runnable_resresv_ind(sinfo->queues[last_queue]->jobs, last_job_index)) == -1)) {
 				last_queue++;
 				last_job_index = 0;
 			}
@@ -2313,11 +2160,10 @@ next_job(status *policy, server_info *sinfo, int flag)
 		}
 	} else { /* treat the entire system as one large queue */
 		ind = find_runnable_resresv_ind(sinfo->jobs, last_job_index);
-		if(ind != -1) {
+		if (ind != -1) {
 			rjob = sinfo->jobs[ind];
 			last_job_index = ind;
-		}
-		else
+		} else
 			rjob = NULL;
 	}
 	return rjob;
@@ -2376,7 +2222,7 @@ parse_sched_obj(int connector, struct batch_status *status)
 	char *tmp_log_dir = NULL;
 	static char *priv_dir = NULL;
 	static char *log_dir = NULL;
-	struct	attropl	*attribs;
+	struct attropl *attribs;
 	char *tmp_comment = NULL;
 	int clear_comment = 0;
 	int ret = 0;
@@ -2393,7 +2239,7 @@ parse_sched_obj(int connector, struct batch_status *status)
 	init_sc_attrs();
 
 	log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_REQUEST, LOG_DEBUG,
-			  "", "Updating scheduler attributes");
+		  "", "Updating scheduler attributes");
 
 	/* resetting the following before fetching from batch_status. */
 	while (attrp != NULL) {
@@ -2417,7 +2263,7 @@ parse_sched_obj(int connector, struct batch_status *status)
 			if (!strcasecmp(attrp->value, ATR_FALSE))
 				sc_attrs.sched_preempt_enforce_resumption = 0;
 			else
-				sc_attrs.sched_preempt_enforce_resumption  = 1;
+				sc_attrs.sched_preempt_enforce_resumption = 1;
 		} else if (!strcmp(attrp->name, ATTR_preempt_targets_enable)) {
 			if (!strcasecmp(attrp->value, ATR_FALSE))
 				sc_attrs.preempt_targets_enable = 0;
@@ -2468,7 +2314,7 @@ parse_sched_obj(int connector, struct batch_status *status)
 						i++;
 						sc_attrs.preempt_order[i].high_range = num;
 					} else {
-						for (j = 0; tok[j] != '\0' ; j++) {
+						for (j = 0; tok[j] != '\0'; j++) {
 							switch (tok[j]) {
 								case 'S':
 									sc_attrs.preempt_order[i].order[j] = PREEMPT_METHOD_SUSPEND;
@@ -2536,8 +2382,8 @@ parse_sched_obj(int connector, struct batch_status *status)
 			sc_attrs.job_sort_formula = read_formula();
 			if (!conf.prime_sort.empty() || !conf.non_prime_sort.empty())
 				log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_SCHED, LOG_DEBUG, __func__,
-						  "Job sorting formula and job_sort_key are incompatible.  "
-						  "The job sorting formula will be used.");
+					  "Job sorting formula and job_sort_key are incompatible.  "
+					  "The job sorting formula will be used.");
 		} else if (!strcmp(attrp->name, ATTR_sched_server_dyn_res_alarm)) {
 			num = strtol(attrp->value, &endp, 10);
 			if (*endp != '\0')
@@ -2605,8 +2451,8 @@ parse_sched_obj(int connector, struct batch_status *status)
 				patt->next = NULL;
 
 				err = pbs_manager(connector,
-					MGR_CMD_SET, MGR_OBJ_SCHED,
-					const_cast<char *>(sc_name), attribs, NULL);
+						  MGR_CMD_SET, MGR_OBJ_SCHED,
+						  const_cast<char *>(sc_name), attribs, NULL);
 				free(attribs);
 				if (err) {
 					log_eventf(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__,
@@ -2628,39 +2474,39 @@ parse_sched_obj(int connector, struct batch_status *status)
 		if (validate_priv_dir) {
 			int c;
 #if !defined(DEBUG) && !defined(NO_SECURITY_CHECK)
-				c = chk_file_sec_user(tmp_priv_dir, 1, 0, S_IWGRP|S_IWOTH, 1, getuid());
-				c |= chk_file_sec_user(pbs_conf.pbs_environment, 0, 0, S_IWGRP|S_IWOTH, 0, getuid());
-				if (c != 0) {
-					log_eventf(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__,
-						"PBS failed validation checks for directory %s", tmp_priv_dir);
-					strcpy(comment, "PBS failed validation checks for sched_priv directory");
-					priv_dir_update_fail = 1;
-				}
-#else  /* not DEBUG and not NO_SECURITY_CHECK */
+			c = chk_file_sec_user(tmp_priv_dir, 1, 0, S_IWGRP | S_IWOTH, 1, getuid());
+			c |= chk_file_sec_user(pbs_conf.pbs_environment, 0, 0, S_IWGRP | S_IWOTH, 0, getuid());
+			if (c != 0) {
+				log_eventf(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__,
+					   "PBS failed validation checks for directory %s", tmp_priv_dir);
+				strcpy(comment, "PBS failed validation checks for sched_priv directory");
+				priv_dir_update_fail = 1;
+			}
+#else /* not DEBUG and not NO_SECURITY_CHECK */
 			c = 0;
 #endif
 			if (c == 0) {
 				if (tmp_priv_dir == NULL || chdir(tmp_priv_dir) == -1) {
 					strcpy(comment, "PBS failed validation checks for sched_priv directory");
 					log_eventf(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__,
-						"PBS failed validation checks for directory %s", tmp_priv_dir);
+						   "PBS failed validation checks for directory %s", tmp_priv_dir);
 					priv_dir_update_fail = 1;
 				} else {
 					int lockfds;
-					lockfds = open("sched.lock", O_CREAT|O_WRONLY, 0644);
+					lockfds = open("sched.lock", O_CREAT | O_WRONLY, 0644);
 					if (lockfds < 0) {
 						strcpy(comment, "PBS failed validation checks for sched_priv directory");
 						log_eventf(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__,
-							"PBS failed validation checks for directory %s", tmp_priv_dir);
+							   "PBS failed validation checks for directory %s", tmp_priv_dir);
 						priv_dir_update_fail = 1;
 					} else {
 						/* write schedulers pid into lockfile */
-						(void)ftruncate(lockfds, (off_t)0);
-						(void)sprintf(log_buffer, "%d\n", getpid());
-						(void)write(lockfds, log_buffer, strlen(log_buffer));
+						(void) ftruncate(lockfds, (off_t) 0);
+						(void) sprintf(log_buffer, "%d\n", getpid());
+						(void) write(lockfds, log_buffer, strlen(log_buffer));
 						close(lockfds);
 						log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_SCHED, LOG_DEBUG, "reconfigure",
-							"scheduler priv directory has changed to %s", tmp_priv_dir);
+							   "scheduler priv directory has changed to %s", tmp_priv_dir);
 						if (tmp_comment != NULL)
 							clear_comment = 1;
 						free(priv_dir);
@@ -2671,7 +2517,6 @@ parse_sched_obj(int connector, struct batch_status *status)
 				}
 			}
 		}
-
 
 		if (priv_dir_update_fail) {
 			/* update the sched comment attribute with the reason for failure */
@@ -2690,12 +2535,12 @@ parse_sched_obj(int connector, struct batch_status *status)
 			patt->value = const_cast<char *>("0");
 			patt->next = NULL;
 			err = pbs_manager(connector,
-				MGR_CMD_SET, MGR_OBJ_SCHED,
-				const_cast<char *>(sc_name), attribs, NULL);
+					  MGR_CMD_SET, MGR_OBJ_SCHED,
+					  const_cast<char *>(sc_name), attribs, NULL);
 			free(attribs);
 			if (err) {
 				log_eventf(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__,
-					"Failed to update scheduler comment %s at the server", comment);
+					   "Failed to update scheduler comment %s at the server", comment);
 			}
 			goto cleanup;
 		}
@@ -2715,20 +2560,20 @@ parse_sched_obj(int connector, struct batch_status *status)
 		patt->value = static_cast<char *>(malloc(1));
 		if (patt->value == NULL) {
 			log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__,
-				"can't update scheduler attribs, malloc failed");
+				  "can't update scheduler attribs, malloc failed");
 			free(attribs);
 			goto cleanup;
 		}
 		patt->value[0] = '\0';
 		patt->next = NULL;
 		err = pbs_manager(connector,
-				MGR_CMD_UNSET, MGR_OBJ_SCHED,
-			const_cast<char *>(sc_name), attribs, NULL);
+				  MGR_CMD_UNSET, MGR_OBJ_SCHED,
+				  const_cast<char *>(sc_name), attribs, NULL);
 		free(attribs->value);
 		free(attribs);
 		if (err) {
 			log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__,
-				"Failed to update scheduler comment at the server");
+				  "Failed to update scheduler comment at the server");
 			goto cleanup;
 		}
 	}
@@ -2738,7 +2583,6 @@ cleanup:
 	free(tmp_priv_dir);
 	free(tmp_comment);
 	return ret;
-
 }
 
 /**
@@ -2800,7 +2644,8 @@ set_validate_sched_attrs(int connector)
  *	None
  */
 int
-validate_running_user(char *exename) {
+validate_running_user(char *exename)
+{
 	char buf[128];
 	if (pbs_conf.pbs_daemon_service_user) {
 		struct passwd *user = getpwnam(pbs_conf.pbs_daemon_service_user);

--- a/src/scheduler/fifo.h
+++ b/src/scheduler/fifo.h
@@ -129,19 +129,14 @@ int find_runnable_resresv_ind(resource_resv **resresv_arr, int start_index);
 /*
  *	find_non_normal_job_ind - find the index of the next runnable express,preempted
  */
-int find_non_normal_job_ind(resource_resv **resresv_arr, int start_index);
-
-/*
- *      update_backfill_on_run - update information needed for backfilling
- *                               when a job is run
- */
-void update_backfill_on_run(server_info *sinfo, resource_resv *resresv, nspec **ns);
+int find_non_normal_job_ind(resource_resv **jobs, int start_index);
 
 /*
  *
  *      sim_run_update_resresv - simulate the running of a job
  */
-int sim_run_update_resresv(status *policy, resource_resv *resresv, nspec **ns_arr, unsigned int flags);
+bool sim_run_update_resresv(status *policy, resource_resv *resresv, std::vector<nspec *>& ns_arr, unsigned int flags);
+bool sim_run_update_resresv(status *policy, resource_resv *resresv, unsigned int flags);
 
 /*
  *
@@ -163,10 +158,12 @@ int sim_run_update_resresv(status *policy, resource_resv *resresv, nspec **ns_ar
  *	return -1 on error
  *
  */
-int
-run_update_resresv(status *policy, int pbs_sd, server_info *sinfo, queue_info *qinfo,
-	resource_resv *rresv, nspec **ns_arr, unsigned int flags, schd_error *err);
+bool run_update_job(status *policy, int pbs_sd, server_info *sinfo, queue_info *qinfo,
+		    resource_resv *resresv, std::vector<nspec *> &nspec_arr, unsigned int flags, schd_error *err);
 
+bool
+run_update_job(status *policy, int pbs_sd, server_info *sinfo, queue_info *qinfo,
+		   resource_resv *rr, unsigned int flags, schd_error *err);
 
 /*
  *	update_job_can_not_run - do post job 'can't run' processing
@@ -192,8 +189,7 @@ int add_job_to_calendar(int pbs_sd, status *policy, server_info *sinfo, resource
  *	       first move it to the local server and then run it.
  *	       if it's a local job, just run it.
  */
-int run_job(int pbs_sd, resource_resv *rjob, char *execvnode, int had_runjob_hook,
-	    schd_error *err);
+int run_job(int pbs_sd, resource_resv *rjob, char *execvnode, schd_error *err);
 
 /*
  *	should_backfill_with_job - should we call add_job_to_calendar() with job

--- a/src/scheduler/job_info.h
+++ b/src/scheduler/job_info.h
@@ -87,7 +87,7 @@ update_job_attr(int pbs_sd, resource_resv *resresv, const char *attr_name,
 int send_job_updates(int pbs_sd, resource_resv *job);
 
 /* send delayed attributes to the server for a job */
-int send_attr_updates(int virtual_fd, resource_resv *resresv, struct attrl *pattr);
+int send_attr_updates(int virtual_sd, resource_resv *resresv, struct attrl *pattr);
 
 preempt_job_info *send_preempt_jobs(int virtual_sd, char **preempt_jobs_list);
 
@@ -120,7 +120,7 @@ unset_job_attr(int pbs_sd, resource_resv *resresv, const char *attr_name, unsign
  *      update_jobs_cant_run - update an array of jobs which can not run
  */
 void
-update_jobs_cant_run(int pbs_sd, resource_resv **jinfo_arr,
+update_jobs_cant_run(int pbs_sd, resource_resv **resresv_arr,
 	resource_resv *start, struct schd_error *err, int start_where);
 
 /*
@@ -152,15 +152,15 @@ int preempt_job(status *policy, int pbs_sd, resource_resv *jinfo, server_info *s
 /*
  *      find_and_preempt_jobs - find the jobs to preempt and then preempt them
  */
-int find_and_preempt_jobs(status *policy, int pbs_sd, resource_resv *hjinfo, server_info *sinfo, schd_error *err);
+int find_and_preempt_jobs(status *policy, int pbs_sd, resource_resv *hjob, server_info *sinfo, schd_error *err);
 
 /*
  *      find_jobs_to_preempt - find jobs to preempt in order to run a high
  *                             priority job
  */
 int *
-find_jobs_to_preempt(status *policy, resource_resv *jinfo,
-	server_info *sinfo, int *fail_list, int *count);
+find_jobs_to_preempt(status *policy, resource_resv *hjob,
+	server_info *sinfo, int *fail_list, int *no_of_jobs);
 
 /*
  *      select_job_to_preempt - select the best candidite out of the running
@@ -220,7 +220,7 @@ job_info *dup_job_info(job_info *ojinfo, queue_info *nqinfo, server_info * nsinf
  *		3 if jobname is a range
  *		0 if it is not a job array
  */
-int is_job_array(char *jobid);
+int is_job_array(char *jobname);
 
 /*
  *
@@ -371,7 +371,7 @@ void create_res_released(status *policy, resource_resv *pjob);
 /*
  *This function populates resreleased job structure for a particular job.
  */
-nspec **create_res_released_array(status *policy, resource_resv *resresv);
+std::vector<nspec *> create_res_released_array(status *policy, resource_resv *resresv);
 
 /*
  * @brief create a resource_rel array for a job by accumulating all of the RASSN
@@ -395,6 +395,6 @@ void associate_dependent_jobs(server_info *sinfo);
 int associate_array_parent(resource_resv *pjob, server_info *sinfo);
 
 /* Set start, end, duration, and possibly STF parts of the job */
-void set_job_times(int pbs_sd, resource_resv *reseresv, time_t server_time);
+void set_job_times(int pbs_sd, resource_resv *resresv, time_t server_time);
 
 #endif	/* _JOB_INFO_H */

--- a/src/scheduler/limits.cpp
+++ b/src/scheduler/limits.cpp
@@ -798,7 +798,6 @@ check_limits(server_info *si, queue_info *qi, resource_resv *rr, schd_error *err
 	limcounts *que_counts_max = NULL;
 	limcounts *server_lim = NULL;
 	limcounts *queue_lim = NULL;
-	counts *cts;
 	schd_error *prev_err = NULL;
 
 	if (si == NULL || qi == NULL || rr == NULL)
@@ -855,7 +854,7 @@ check_limits(server_info *si, queue_info *qi, resource_resv *rr, schd_error *err
 				if ((te_rr != rr) && te_rr->is_job) {
 					if (te->event_type == TIMED_RUN_EVENT) {
 						if (svr_counts != NULL) {
-							cts = find_alloc_counts(svr_counts->user, te_rr->user);
+							auto cts = find_alloc_counts(svr_counts->user, te_rr->user);
 							update_counts_on_run(cts, te_rr->resreq);
 							counts_max(svr_counts_max->user, cts);
 							if (svr_counts_max->user.size() == 0) {
@@ -891,7 +890,7 @@ check_limits(server_info *si, queue_info *qi, resource_resv *rr, schd_error *err
 						if (que_counts != NULL) {
 							if (te_rr->is_job && te_rr->job != NULL) {
 								if (te_rr->job->queue == qi) {
-									cts = find_alloc_counts(que_counts->user, te_rr->user);
+									auto cts = find_alloc_counts(que_counts->user, te_rr->user);
 									update_counts_on_run(cts, te_rr->resreq);
 									counts_max(que_counts_max->user, cts);
 									if (que_counts_max->user.size() == 0) {
@@ -928,7 +927,7 @@ check_limits(server_info *si, queue_info *qi, resource_resv *rr, schd_error *err
 					}
 					else if (te->event_type == TIMED_END_EVENT) {
 						if (svr_counts != NULL) {
-							cts = find_alloc_counts(svr_counts->user, te_rr->user);
+							auto cts = find_alloc_counts(svr_counts->user, te_rr->user);
 							update_counts_on_end(cts, te_rr->resreq);
 							cts = find_alloc_counts(svr_counts->group, te_rr->group);
 							update_counts_on_end(cts, te_rr->resreq);
@@ -940,7 +939,7 @@ check_limits(server_info *si, queue_info *qi, resource_resv *rr, schd_error *err
 						if (que_counts != NULL) {
 							if (te_rr->is_job && te_rr->job != NULL) {
 								if (te_rr->job->queue == qi) {
-									cts = find_alloc_counts(que_counts->user, te_rr->user);
+									auto cts = find_alloc_counts(que_counts->user, te_rr->user);
 									update_counts_on_end(cts, te_rr->resreq);
 									cts = find_alloc_counts(que_counts->group, te_rr->group);
 									update_counts_on_end(cts, te_rr->resreq);

--- a/src/scheduler/misc.cpp
+++ b/src/scheduler/misc.cpp
@@ -37,37 +37,35 @@
  * subject to Altair's trademark licensing policies.
  */
 
-
 /**
  * Miscellaneous functions of scheduler.
  */
 #include <pbs_config.h>
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <stdarg.h>
-#include <time.h>
-#include <ctype.h>
-#include <string.h>
-#include <errno.h>
-#include <math.h>
-#include <sstream>
-#include <algorithm>
-#include <pbs_ifl.h>
-#include <pbs_internal.h>
-#include <pbs_error.h>
-#include <log.h>
-#include <pbs_share.h>
-#include <libutil.h>
-#include <libpbs.h>
 #include "config.h"
 #include "constant.h"
-#include "misc.h"
-#include "globals.h"
 #include "fairshare.h"
-#include "resource_resv.h"
+#include "globals.h"
+#include "misc.h"
 #include "resource.h"
-
+#include "resource_resv.h"
+#include <algorithm>
+#include <ctype.h>
+#include <errno.h>
+#include <libpbs.h>
+#include <libutil.h>
+#include <log.h>
+#include <math.h>
+#include <pbs_error.h>
+#include <pbs_ifl.h>
+#include <pbs_internal.h>
+#include <pbs_share.h>
+#include <sstream>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
 
 /**
  * @brief
@@ -148,12 +146,12 @@ add_str_to_array(char ***str_arr, char *str)
 	else
 		cnt = count_array(*str_arr);
 
-	tmp_arr = static_cast<char **>(realloc(*str_arr, (cnt+2)*sizeof(char*)));
+	tmp_arr = static_cast<char **>(realloc(*str_arr, (cnt + 2) * sizeof(char *)));
 	if (tmp_arr == NULL)
 		return -1;
 
 	tmp_arr[cnt] = string_dup(str);
-	tmp_arr[cnt+1] = NULL;
+	tmp_arr[cnt + 1] = NULL;
 
 	*str_arr = tmp_arr;
 
@@ -177,13 +175,13 @@ add_str_to_array(char ***str_arr, char *str)
 sch_resource_t
 res_to_num(const char *res_str, struct resource_type *type)
 {
-	sch_resource_t count = SCHD_INFINITY_RES;	/* convert string resource to numeric */
-	sch_resource_t count2 = SCHD_INFINITY_RES;	/* convert string resource to numeric */
-	char *endp;				/* used for strtol() */
-	char *endp2;				/* used for strtol() */
-	long multiplier = 1;			/* multiplier to count */
-	int is_size = 0;			/* resource value is a size type */
-	int is_time = 0;			/* resource value is a time spec */
+	sch_resource_t count = SCHD_INFINITY_RES;  /* convert string resource to numeric */
+	sch_resource_t count2 = SCHD_INFINITY_RES; /* convert string resource to numeric */
+	char *endp;				   /* used for strtol() */
+	char *endp2;				   /* used for strtol() */
+	long multiplier = 1;			   /* multiplier to count */
+	int is_size = 0;			   /* resource value is a size type */
+	int is_time = 0;			   /* resource value is a time spec */
 
 	if (res_str == NULL)
 		return SCHD_INFINITY_RES;
@@ -194,67 +192,56 @@ res_to_num(const char *res_str, struct resource_type *type)
 			type->is_non_consumable = 1;
 		}
 		count = 1;
-	}
-	else if (!strcasecmp(ATR_FALSE, res_str)) {
+	} else if (!strcasecmp(ATR_FALSE, res_str)) {
 		if (type != NULL) {
 			type->is_boolean = 1;
 			type->is_non_consumable = 1;
 		}
 		count = 0;
-	}
-	else if (!is_num(res_str)) {
+	} else if (!is_num(res_str)) {
 		if (type != NULL) {
 			type->is_string = 1;
 			type->is_non_consumable = 1;
 		}
 		count = SCHD_INFINITY_RES;
-	}
-	else {
+	} else {
 		count = (sch_resource_t) strtod(res_str, &endp);
 
 		if (*endp == ':') { /* time resource -> convert to seconds */
-			count2 = (sch_resource_t) strtod(endp+1, &endp2);
+			count2 = (sch_resource_t) strtod(endp + 1, &endp2);
 			if (*endp2 == ':') { /* form of HH:MM:SS */
 				count *= 3600;
 				count += count2 * 60;
 				count += strtol(endp2 + 1, &endp, 10);
 				if (*endp != '\0')
 					count = SCHD_INFINITY_RES;
-			}
-			else			 { /* form of MM:SS */
+			} else { /* form of MM:SS */
 				count *= 60;
 				count += count2;
 			}
 			multiplier = 1;
 			is_time = 1;
-		}
-		else if (*endp == 'k' || *endp == 'K') {
+		} else if (*endp == 'k' || *endp == 'K') {
 			multiplier = 1;
 			is_size = 1;
-		}
-		else if (*endp == 'm' || *endp == 'M') {
+		} else if (*endp == 'm' || *endp == 'M') {
 			multiplier = MEGATOKILO;
 			is_size = 1;
-		}
-		else if (*endp == 'g' || *endp == 'G') {
+		} else if (*endp == 'g' || *endp == 'G') {
 			multiplier = GIGATOKILO;
 			is_size = 1;
-		}
-		else if (*endp == 't' || *endp == 'T') {
+		} else if (*endp == 't' || *endp == 'T') {
 			multiplier = TERATOKILO;
 			is_size = 1;
-		}
-		else if (*endp == 'b' || *endp == 'B') {
+		} else if (*endp == 'b' || *endp == 'B') {
 			count = ceil(count / KILO);
 			multiplier = 1;
 			is_size = 1;
-		}
-		else if (*endp == 'w') {
+		} else if (*endp == 'w') {
 			count = ceil(count / KILO);
 			multiplier = SIZEOF_WORD;
 			is_size = 1;
-		}
-		else	/* catch all */
+		} else /* catch all */
 			multiplier = 1;
 
 		if (*endp != '\0' && *(endp + 1) == 'w')
@@ -289,7 +276,7 @@ res_to_num(const char *res_str, struct resource_type *type)
 int
 skip_line(char *line)
 {
-	int skip = 0;				/* whether or not to skil the line */
+	int skip = 0; /* whether or not to skil the line */
 
 	if (line != NULL) {
 		while (isspace((int) *line))
@@ -320,8 +307,8 @@ skip_line(char *line)
  *	@return nothing
  */
 void
-schdlogerr(int event, int event_class, int sev, const std::string& name, const char *text,
-	schd_error *err)
+schdlogerr(int event, int event_class, int sev, const std::string &name, const char *text,
+	   schd_error *err)
 {
 
 	if (err == NULL)
@@ -352,7 +339,7 @@ schdlogerr(int event, int event_class, int sev, const std::string& name, const c
  * @return void
  */
 void
-log_eventf(int eventtype, int objclass, int sev, const std::string& objname, const char *fmt, ...)
+log_eventf(int eventtype, int objclass, int sev, const std::string &objname, const char *fmt, ...)
 {
 	va_list args;
 	va_start(args, fmt);
@@ -381,7 +368,7 @@ log_eventf(int eventtype, int objclass, int sev, const std::string& objname, con
  */
 
 void
-log_event(int eventtype, int objclass, int sev, const std::string& objname, const char *text)
+log_event(int eventtype, int objclass, int sev, const std::string &objname, const char *text)
 {
 	if (will_log_event(eventtype))
 		log_record(eventtype, objclass, sev, objname.c_str(), text);
@@ -411,10 +398,10 @@ log_event(int eventtype, int objclass, int sev, const std::string& objname, cons
  * @return	void ** filtered array.
  */
 void **
-filter_array(void **ptrarr, int (*filter_func)(void*, void*),
-	void *arg, int flags)
+filter_array(void **ptrarr, int (*filter_func)(void *, void *),
+	     void *arg, int flags)
 {
-	void **new_arr = NULL;                      /* the filtered array */
+	void **new_arr = NULL; /* the filtered array */
 	void **tmp;
 	int i, j;
 	int size;
@@ -438,7 +425,7 @@ filter_array(void **ptrarr, int (*filter_func)(void*, void*),
 	new_arr[j] = NULL;
 
 	if (!(flags & FILTER_FULL)) {
-		if ((tmp = static_cast<void **>(realloc(new_arr, (j+1) * sizeof(void *)))) == NULL) {
+		if ((tmp = static_cast<void **>(realloc(new_arr, (j + 1) * sizeof(void *)))) == NULL) {
 			log_err(errno, __func__, MEM_ERR_MSG);
 			free(new_arr);
 			return NULL;
@@ -463,7 +450,8 @@ filter_array(void **ptrarr, int (*filter_func)(void*, void*),
  * @retval	SA_NO_MATCH	: no match
  *
  */
-enum match_string_array_ret match_string_array(const char * const *strarr1, const char * const *strarr2)
+enum match_string_array_ret
+match_string_array(const char *const *strarr1, const char *const *strarr2)
 {
 	int match = 0;
 	int i;
@@ -492,14 +480,15 @@ enum match_string_array_ret match_string_array(const char * const *strarr1, cons
 	return SA_NO_MATCH;
 }
 // overloaded
-enum match_string_array_ret match_string_array(const std::vector<std::string> &strarr1, const std::vector<std::string> &strarr2)
+enum match_string_array_ret
+match_string_array(const std::vector<std::string> &strarr1, const std::vector<std::string> &strarr2)
 {
 	unsigned int match = 0;
 
 	if (strarr1.empty() || strarr2.empty())
 		return SA_NO_MATCH;
 
-	for (auto &str1: strarr1) {
+	for (auto &str1 : strarr1) {
 		if (std::find(strarr2.begin(), strarr2.end(), str1) != strarr2.end())
 			match++;
 	}
@@ -580,7 +569,7 @@ calc_used_walltime(resource_resv *resresv)
 	if (resresv == NULL)
 		return 0;
 
-	if (resresv->is_job && resresv->job !=NULL) {
+	if (resresv->is_job && resresv->job != NULL) {
 		used = find_resource_req(resresv->job->resused, allres["walltime"]);
 
 		/* If we can't find the used structure, we will just assume no usage */
@@ -609,9 +598,9 @@ calc_used_walltime(resource_resv *resresv)
  * 	@retval	-1	: on error
  */
 int
-calc_time_left_STF(resource_resv *resresv, sch_resource_t* min_time_left)
+calc_time_left_STF(resource_resv *resresv, sch_resource_t *min_time_left)
 {
-	time_t 		used_amount = 0;
+	time_t used_amount = 0;
 
 	if (min_time_left == NULL || resresv->duration == UNSPECIFIED)
 		return -1;
@@ -674,10 +663,10 @@ cstrcmp(const char *s1, const char *s2)
 	if (s1 == NULL && s2 == NULL)
 		return 0;
 
-	if (s1 == NULL && s2 != NULL)
+	else if (s1 == NULL && s2 != NULL)
 		return -1;
 
-	if (s1 != NULL && s2 == NULL)
+	else if (s1 != NULL && s2 == NULL)
 		return 1;
 
 	return strcmp(s1, s2);
@@ -723,7 +712,7 @@ is_num(const char *str)
 	if ((i == (str_len - 2)) || (i == (str_len - 1))) {
 		auto c = tolower(str[i]);
 		if (c == 'k' || c == 'm' || c == 'g' || c == 't') {
-			c = tolower(str[i+1]);
+			c = tolower(str[i + 1]);
 			if (c == 'b' || c == 'w' || c == '\0')
 				return 1;
 		} else if (i == (str_len - 1)) {
@@ -735,7 +724,7 @@ is_num(const char *str)
 
 	/* last but not least, make sure we didn't stop on a decmal point */
 	if (str[i] == '.') {
-		for (i++ ; i < str_len && isdigit(str[i]); i++)
+		for (i++; i < str_len && isdigit(str[i]); i++)
 			;
 
 		/* number is a float */
@@ -746,7 +735,6 @@ is_num(const char *str)
 	/* the string is not a number or a size or time */
 	return 0;
 }
-
 
 /**
  * @brief
@@ -791,12 +779,12 @@ dup_array(void *ptr)
 	void **arr;
 	int len = 0;
 
-	arr = (void **)ptr;
+	arr = (void **) ptr;
 	if (arr == NULL)
 		return NULL;
 
 	len = count_array(arr);
-	ret = static_cast<void **>(malloc((len +1) * sizeof(void *)));
+	ret = static_cast<void **>(malloc((len + 1) * sizeof(void *)));
 	if (ret == NULL)
 		return NULL;
 	memcpy(ret, arr, len * sizeof(void *));
@@ -908,7 +896,7 @@ is_valid_pbs_name(char *str, int len)
 		if (str[i] == '\0')
 			break;
 		if (!(isalpha(str[i]) || isdigit(str[i]) || str[i] == '.' ||
-			str[i] == '-' || str[i] == '_' || str[i] == ' ' || str[i] == ':')) {
+		      str[i] == '-' || str[i] == '_' || str[i] == ' ' || str[i] == ':')) {
 			valid = 0;
 		}
 	}
@@ -950,7 +938,8 @@ clear_schd_error(schd_error *err)
  * @retval	NULL	: Error
  */
 schd_error *
-new_schd_error() {
+new_schd_error()
+{
 	schd_error *err;
 	if ((err = static_cast<schd_error *>(calloc(1, sizeof(schd_error)))) == NULL) {
 		log_err(errno, __func__, MEM_ERR_MSG);
@@ -970,13 +959,14 @@ new_schd_error() {
  * @retval	NULL	: Error
  */
 schd_error *
-dup_schd_error(schd_error *oerr) {
+dup_schd_error(schd_error *oerr)
+{
 	schd_error *nerr;
-	if(oerr == NULL)
+	if (oerr == NULL)
 		return NULL;
 
 	nerr = new_schd_error();
-	if(nerr == NULL)
+	if (nerr == NULL)
 		return NULL;
 
 	nerr->rdef = oerr->rdef;
@@ -999,7 +989,8 @@ dup_schd_error(schd_error *oerr) {
  *
  * @return	nothing
  */
-void move_schd_error(schd_error *err, schd_error *oerr)
+void
+move_schd_error(schd_error *err, schd_error *oerr)
 {
 	if (oerr == NULL || err == NULL)
 		return;
@@ -1053,12 +1044,14 @@ copy_schd_error(schd_error *err, schd_error *oerr)
  *
  * @return	nothing
  */
-void set_schd_error_arg(schd_error *err, enum schd_error_args arg_field, const char *arg) {
+void
+set_schd_error_arg(schd_error *err, enum schd_error_args arg_field, const char *arg)
+{
 
-	if(err == NULL)
+	if (err == NULL)
 		return;
 
-	switch(arg_field) {
+	switch (arg_field) {
 		case ARG1:
 			free(err->arg1);
 			if (arg != NULL)
@@ -1090,7 +1083,6 @@ void set_schd_error_arg(schd_error *err, enum schd_error_args arg_field, const c
 		default:
 			log_event(PBSEVENT_DEBUG3, PBS_EVENTCLASS_SCHED, LOG_DEBUG, __func__, "Invalid schd_error arg message type");
 	}
-
 }
 
 /**
@@ -1106,13 +1098,14 @@ void set_schd_error_arg(schd_error *err, enum schd_error_args arg_field, const c
  *
  * @return	nothing
  */
-void set_schd_error_codes(schd_error *err, enum schd_err_status status_code, enum sched_error_code error_code)
+void
+set_schd_error_codes(schd_error *err, enum schd_err_status status_code, enum sched_error_code error_code)
 {
-	if(err == NULL)
+	if (err == NULL)
 		return;
-	if(status_code < SCHD_UNKWN || status_code >= SCHD_STATUS_HIGH)
+	if (status_code < SCHD_UNKWN || status_code >= SCHD_STATUS_HIGH)
 		return;
-	if(error_code < PBSE_NONE || error_code > ERR_SPECIAL)
+	if (error_code < PBSE_NONE || error_code > ERR_SPECIAL)
 		return;
 
 	err->status_code = status_code;
@@ -1128,7 +1121,7 @@ void set_schd_error_codes(schd_error *err, enum schd_err_status status_code, enu
 void
 free_schd_error(schd_error *err)
 {
-	if(err == NULL)
+	if (err == NULL)
 		return;
 
 	free(err->arg1);
@@ -1148,7 +1141,8 @@ free_schd_error(schd_error *err)
  * @param[in]	 err_list	-	Error list.
  */
 void
-free_schd_error_list(schd_error *err_list) {
+free_schd_error_list(schd_error *err_list)
+{
 	schd_error *err, *tmp;
 
 	err = err_list;
@@ -1157,7 +1151,6 @@ free_schd_error_list(schd_error *err_list) {
 		free_schd_error(err);
 		err = tmp;
 	}
-
 }
 
 /**
@@ -1169,11 +1162,12 @@ free_schd_error_list(schd_error *err_list) {
  *
  * @return	new schd_error
  */
-schd_error *create_schd_error(enum sched_error_code error_code, enum schd_err_status status_code)
+schd_error *
+create_schd_error(enum sched_error_code error_code, enum schd_err_status status_code)
 {
 	schd_error *nse;
 	nse = new_schd_error();
-	if(nse == NULL)
+	if (nse == NULL)
 		return NULL;
 	set_schd_error_codes(nse, status_code, error_code);
 	return nse;
@@ -1194,24 +1188,25 @@ schd_error *create_schd_error(enum sched_error_code error_code, enum schd_err_st
  *
  * @return	new schd_error
  */
-schd_error *create_schd_error_complex(enum sched_error_code error_code, enum schd_err_status status_code, char *arg1, char *arg2, char *arg3, char *specmsg)
+schd_error *
+create_schd_error_complex(enum sched_error_code error_code, enum schd_err_status status_code, char *arg1, char *arg2, char *arg3, char *specmsg)
 {
 	schd_error *nse;
 
 	nse = create_schd_error(error_code, status_code);
-	if(nse == NULL)
+	if (nse == NULL)
 		return NULL;
 
-	if(arg1 != NULL)
+	if (arg1 != NULL)
 		set_schd_error_arg(nse, ARG1, arg1);
 
-	if(arg2 != NULL)
+	if (arg2 != NULL)
 		set_schd_error_arg(nse, ARG2, arg2);
 
-	if(arg3 != NULL)
+	if (arg3 != NULL)
 		set_schd_error_arg(nse, ARG3, arg3);
 
-	if(specmsg != NULL)
+	if (specmsg != NULL)
 		set_schd_error_arg(nse, SPECMSG, specmsg);
 
 	return nse;
@@ -1242,20 +1237,20 @@ schd_error *create_schd_error_complex(enum sched_error_code error_code, enum sch
  *
  * @note	nothing stops duplicate entries from being added
  */
-void add_err(schd_error **prev_err, schd_error *err)
+void
+add_err(schd_error **prev_err, schd_error *err)
 {
 	schd_error *cur = NULL;
 
 	if (err == NULL || prev_err == NULL)
 		return;
 
-	if(*prev_err == NULL)
+	if (*prev_err == NULL)
 		(*prev_err) = err;
 	else
 		(*prev_err)->next = err;
 
-
-	if(err->next != NULL) {
+	if (err->next != NULL) {
 		for (cur = err; cur->next != NULL; cur = cur->next)
 			;
 		(*prev_err) = cur;
@@ -1294,7 +1289,6 @@ res_to_str(void *p, enum resource_fields fld)
 	}
 
 	return res_to_str_re(p, fld, &resbuf, &resbuf_size, NO_FLAGS);
-
 }
 
 /**
@@ -1315,7 +1309,7 @@ res_to_str(void *p, enum resource_fields fld)
  */
 char *
 res_to_str_c(sch_resource_t amount, resdef *def, enum resource_fields fld,
-	char *buf, int bufsize)
+	     char *buf, int bufsize)
 {
 	schd_resource res = {0};
 	resource_req req = {0};
@@ -1336,7 +1330,7 @@ res_to_str_c(sch_resource_t amount, resdef *def, enum resource_fields fld,
 			req.name = def->name.c_str();
 			req.type = def->type;
 			req.res_str = const_cast<char *>("unknown");
-			return res_to_str_re(((void*) &req), fld, &buf, &bufsize, NOEXPAND);
+			return res_to_str_re(((void *) &req), fld, &buf, &bufsize, NOEXPAND);
 			break;
 		case RF_AVAIL:
 		default:
@@ -1348,7 +1342,7 @@ res_to_str_c(sch_resource_t amount, resdef *def, enum resource_fields fld,
 			res.orig_str_avail = const_cast<char *>("unknown");
 			res.str_avail = const_cast<char **>(unknown);
 			res.str_assigned = const_cast<char *>("unknown");
-			return res_to_str_re(((void*) &res), fld, &buf, &bufsize, NOEXPAND);
+			return res_to_str_re(((void *) &res), fld, &buf, &bufsize, NOEXPAND);
 	}
 	return const_cast<char *>("");
 }
@@ -1392,7 +1386,7 @@ res_to_str_r(void *p, enum resource_fields fld, char *buf, int bufsize)
  */
 char *
 res_to_str_re(void *p, enum resource_fields fld, char **buf,
-	int *bufsize, unsigned int flags)
+	      int *bufsize, unsigned int flags)
 {
 	schd_resource *res = NULL;
 	resource_req *req = NULL;
@@ -1421,8 +1415,7 @@ res_to_str_re(void *p, enum resource_fields fld, char **buf,
 			if ((*buf = static_cast<char *>(malloc(1024))) == NULL) {
 				log_err(errno, __func__, MEM_ERR_MSG);
 				return const_cast<char *>("");
-			}
-			else
+			} else
 				*bufsize = 1024;
 		}
 	}
@@ -1487,30 +1480,27 @@ res_to_str_re(void *p, enum resource_fields fld, char **buf,
 			snprintf(*buf, *bufsize, "%s", str);
 		else
 			ret = pbs_strcat(buf, bufsize, str);
-	}
-	else if (rt->is_boolean) {
+	} else if (rt->is_boolean) {
 		if (flags & NOEXPAND)
 			snprintf(*buf, *bufsize, "%s", amount ? ATR_TRUE : ATR_FALSE);
 		else
 			ret = pbs_strcat(buf, bufsize, amount ? ATR_TRUE : ATR_FALSE);
-	}
-	else if (rt->is_size) {
+	} else if (rt->is_size) {
 		if (amount == 0) /* need to special case 0 or it falls into tb case */
 			snprintf(localbuf, sizeof(localbuf), "0kb");
-		else if (((long)amount % TERATOKILO) == 0)
-			snprintf(localbuf, sizeof(localbuf), "%ldtb", (long) (amount/TERATOKILO));
-		else if (((long)amount % GIGATOKILO) == 0)
-			snprintf(localbuf, sizeof(localbuf), "%ldgb", (long) (amount/GIGATOKILO));
-		else if (((long)amount % MEGATOKILO) == 0)
-			snprintf(localbuf, sizeof(localbuf), "%ldmb", (long) (amount/MEGATOKILO));
+		else if (((long) amount % TERATOKILO) == 0)
+			snprintf(localbuf, sizeof(localbuf), "%ldtb", (long) (amount / TERATOKILO));
+		else if (((long) amount % GIGATOKILO) == 0)
+			snprintf(localbuf, sizeof(localbuf), "%ldgb", (long) (amount / GIGATOKILO));
+		else if (((long) amount % MEGATOKILO) == 0)
+			snprintf(localbuf, sizeof(localbuf), "%ldmb", (long) (amount / MEGATOKILO));
 		else
 			snprintf(localbuf, sizeof(localbuf), "%ldkb", (long) amount);
 		if (flags & NOEXPAND)
 			snprintf(*buf, *bufsize, "%s", localbuf);
 		else
 			ret = pbs_strcat(buf, bufsize, localbuf);
-	}
-	else if (rt->is_num) {
+	} else if (rt->is_num) {
 		int const_print = 0;
 		if (amount == UNSPECIFIED_RES) {
 			if (flags & PRINT_INT_CONST) {
@@ -1535,7 +1525,7 @@ res_to_str_re(void *p, enum resource_fields fld, char **buf,
 		if (const_print == 0) {
 			if (rt->is_float)
 				snprintf(localbuf, sizeof(localbuf), "%.*f",
-					float_digits(amount, FLOAT_NUM_DIGITS), (double) amount);
+					 float_digits(amount, FLOAT_NUM_DIGITS), (double) amount);
 			else
 				snprintf(localbuf, sizeof(localbuf), "%ld", (long) amount);
 			if (flags & NOEXPAND)
@@ -1571,7 +1561,7 @@ free_ptr_array(void *inp)
 	if (inp == NULL)
 		return;
 
-	arr = (void **)inp;
+	arr = (void **) inp;
 
 	for (i = 0; arr[i] != NULL; i++)
 		free(arr[i]);

--- a/src/scheduler/misc.h
+++ b/src/scheduler/misc.h
@@ -122,7 +122,7 @@ char *string_array_to_str(char **strarr);
 /*
  *      calc_time_left - calculate the remaining time of a job
  */
-int calc_time_left(resource_resv *jinfo, int use_hard_duration);
+int calc_time_left(resource_resv *resresv, int use_hard_duration);
 
 /*
  *      cstrcmp - check string compare - compares two strings but doesn't bomb
@@ -247,7 +247,7 @@ free_schd_error_list(schd_error *err_list);
 schd_error *
 create_schd_error(enum sched_error_code error_code, enum schd_err_status status_code);
 schd_error *
-create_schd_error_complex(enum sched_error_code error_code, enum schd_err_status status_code, char *arg1, char *arg2, char *arg3, char *errbuf);
+create_schd_error_complex(enum sched_error_code error_code, enum schd_err_status status_code, char *arg1, char *arg2, char *arg3, char *specmsg);
 
 /* add schd_errors to linked list */
 void
@@ -275,7 +275,7 @@ void log_eventf(int eventtype, int objclass, int sev, const std::string& objname
 void log_event(int eventtype, int objclass, int sev, const std::string& objname, const char *text);
 
 /*
- * overloaded  break_comma_list function
+ * overloaded break_comma_list function
  */
-std::vector<std::string> break_comma_list(const std::string &list);
+std::vector<std::string> break_comma_list(const std::string &strlist);
 #endif	/* _MISC_H */

--- a/src/scheduler/node_info.h
+++ b/src/scheduler/node_info.h
@@ -171,56 +171,30 @@ node_info **copy_node_ptr_array(node_info  **oarr, node_info  **narr);
 /*
  *      create_execvnode - create an execvnode to run a multi-node job
  */
-char *create_execvnode(nspec **ns);
+char *create_execvnode(std::vector<nspec *>& ns_arr);
 
 /*
  *      parse_execvnode - parse an execvnode into an nspec array
  */
-nspec **parse_execvnode(char *execvnode, server_info *sinfo, selspec *sel);
-
-/*
- *      new_nspec - allocate a new nspec
- */
-#ifdef NAS /* localmod 005 */
-nspec *new_nspec(void);
-#else
-nspec *new_nspec();
-#endif /* localmod 005 */
-
-/*
- *      free_nspec - free the memory used for an nspec
- */
-void free_nspec(nspec *ns);
-
-/*
- *      dup_nspec - duplicate an nspec
- */
-nspec *dup_nspec(nspec *ons, node_info **ninfo_arr, selspec *sel);
+std::vector<nspec *> parse_execvnode(char *execvnode, server_info *sinfo, selspec *sel);
 
 /*
  *      dup_nspecs - duplicate an array of nspecs
  */
-nspec **dup_nspecs(nspec **onspecs, node_info **ninfo_arr, selspec *sel);
+std::vector<nspec *>dup_nspecs(const std::vector<nspec *>& onspecs, node_info **ninfo_arr, selspec *sel);
 
 /* find a chunk by a sequence number */
 chunk *find_chunk_by_seq_num(chunk **chunks, int seq_num);
 
 /*
- *	empty_nspec_array - free the contents of an nspec array but not
- *			    the array itself
- *	returns nothing
- */
-void empty_nspec_array(nspec **nspec_arr);
-
-/*
  *      free_nspecs - free a nspec array
  */
-void free_nspecs(nspec **ns);
+void free_nspecs(std::vector<nspec *>& nspec_arr);
 
 /*
  *      find_nspec - find an nspec in an array
  */
-nspec *find_nspec(nspec **nspec_arr, node_info *ninfo);
+nspec *find_nspec(std::vector<nspec *>& nspec_arr, node_info *ninfo);
 
 /*
  *      update_nodes_for_resvs - take a node array and make resource effects
@@ -241,7 +215,7 @@ node_info *dup_node_info(node_info *onode, server_info *nsinfo, unsigned int fla
 /*
  *      find_nspec_by_name - find an nspec in an array by nodename
  */
-nspec *find_nspec_by_rank(nspec **nspec_arr, int rank);
+nspec *find_nspec_by_rank(std::vector<nspec *>& nspec_arr, int rank);
 
 /* find node by unique rank and return index into ninfo_arr */
 int find_node_ind(node_info **ninfo_arr, int rank);
@@ -290,13 +264,13 @@ int compare_place(place *pl1, place *pl2);
 selspec *parse_selspec(const std::string& sspec);
 
 /* compare two selspecs to see if they are equal*/
-int compare_selspec(selspec *sel1, selspec *sel2);
+int compare_selspec(selspec *s1, selspec *s2);
 
 /*
  *	combine_nspec_array - find and combine any nspec's for the same node
  *				in an nspec array
  */
-nspec **combine_nspec_array(nspec **nspec_arr);
+std::vector<nspec *> combine_nspec_array(const std::vector<nspec *>& nspec_arr);
 
 /*
  *	eval_selspec - eval a select spec to see if it is satisifable
@@ -312,14 +286,14 @@ nspec **combine_nspec_array(nspec **nspec_arr);
  *	      EVAL_EXCLSET - allocate entire nodelist exclusively
  *	  OUT: nspec_arr - the node solution
  *
- *	returns 1 if the nodespec can be satisified
- *		0 if not
+ *	returns true if the nodespec can be satisified
+ *		false if not
  */
-int
+bool
 eval_selspec(status *policy, selspec *spec, place *placespec,
 	node_info **ninfo_arr, node_partition **nodepart,
 	resource_resv *resresv, unsigned int flags,
-	nspec ***nspec_arr, schd_error *err);
+	std::vector<nspec *>& nspec_arr, schd_error *err);
 
 /*
  *
@@ -333,13 +307,13 @@ eval_selspec(status *policy, selspec *spec, place *placespec,
  *	      EVAL_OKBREAK - ok to break chunck up across vnodes
  *	  OUT: nspec_arr - the node solution
  *
- *	returns 1 if the selspec can be satisified
- *		0 if not
+ *	returns true if the selspec can be satisified
+ *		false if not
  *
  */
-int
+bool
 eval_placement(status *policy, selspec *spec, node_info **ninfo_arr, place *pl,
-	resource_resv *resresv, unsigned int flags, nspec ***nspec_arr, schd_error *err);
+	resource_resv *resresv, unsigned int flags, std::vector<nspec *>& nspec_arr, schd_error *err);
 /*
  *	eval_complex_selspec - handle a complex (plus'd) select spec
  *
@@ -351,12 +325,12 @@ eval_placement(status *policy, selspec *spec, node_info **ninfo_arr, place *pl,
  *	      EVAL_OKBREAK - ok to break chunck up across vnodes
  *	  OUT: nspec_arr - the node solution
  *
- *	returns 1 if the selspec can be satisified
- *		0 if not
+ *	returns true if the selspec can be satisified
+ *		false if not
  */
-int
+bool
 eval_complex_selspec(status *policy, selspec *spec, node_info **ninfo_arr, place *pl,
-	resource_resv *resresv, unsigned int flags, nspec ***nspec_arr, schd_error *err);
+	resource_resv *resresv, unsigned int flags, std::vector<nspec *>& nspec_arr, schd_error *err);
 
 /*
  * 	eval_simple_selspec - eval a non-plused select spec for satasifiability
@@ -369,21 +343,22 @@ eval_complex_selspec(status *policy, selspec *spec, node_info **ninfo_arr, place
  *            EVAL_OKBREAK - ok to break chunck up across vnodes
  *	  OUT: nspec_arr - array of struct nspec's describing the chosen nodes
  *
- * 	returns 1 if the select spec is satifiable
- * 		0 if not
+ * 	returns true if the select spec is satifiable
+ * 		false if not
  */
-int
-eval_simple_selspec(status *policy, chunk *chk, node_info **ninfo_arr,
+bool
+eval_simple_selspec(status *policy, chunk *chk, node_info **pninfo_arr,
 	place *pl, resource_resv *resresv, unsigned int flags,
-	nspec ***nspec_arr, schd_error *err);
+	std::vector<nspec *>& nspec_arr, schd_error *err);
 
 /* evaluate one node to see if it is eligible at the job/resv level */
-int
+bool
 is_vnode_eligible(node_info *node, resource_resv *resresv,
 	struct place *pl, schd_error *err);
 
 /* check if a vnode is eligible for a chunk */
-int is_vnode_eligible_chunk(resource_req *specreq, node_info *node,
+bool
+is_vnode_eligible_chunk(resource_req *specreq, node_info *node,
 		resource_resv *resresv, schd_error *err);
 
 /*
@@ -403,7 +378,7 @@ int is_vnode_eligible_chunk(resource_req *specreq, node_info *node,
  *	returns 1 if resources were allocated from the node
  *		0 if sufficent resources are not available (err is set)
  */
-int
+bool
 resources_avail_on_vnode(resource_req *specreq_cons, node_info *node,
 	place *pl, resource_resv *resresv, unsigned int flags,
 	nspec *ns, schd_error *err);
@@ -431,7 +406,7 @@ check_resources_for_node(resource_req *resreq, node_info *ninfo,
  *				       ninfo pointers out of a nspec array
  *	returns new node_info array or NULL on error
  */
-node_info **create_node_array_from_nspec(nspec **nspec_arr);
+node_info **create_node_array_from_nspec(std::vector<nspec *>& nspec_arr);
 
 /*
  *	reorder_nodes - reorder nodes for smp_cluster_dist or
@@ -479,7 +454,7 @@ int is_exclhost(place *pl, enum vnode_sharing sharing);
  *	returns 1 on success
  *		0 on error -- nsa will be modified
  */
-int alloc_rest_nodepart(nspec **nsa, node_info **ninfo_arr);
+int alloc_rest_nodepart(std::vector<nspec*>& nsa, node_info **ninfo_arr);
 
 /*
  *	can_fit_on_vnode - see if a chunk fit on one vnode in node list
@@ -569,14 +544,13 @@ void
 check_node_eligibility_chunk(th_data_nd_eligible *data);
 
 /* check nodes for eligibility and mark them ineligible if not */
-void check_node_array_eligibility(node_info **ninfo_arr, resource_resv *resresv, place *pl,
-		int num_nodes, schd_error *err);
+void check_node_array_eligibility(node_info **ninfo_arr, resource_resv *resresv, place *pl, schd_error *err);
 
 int node_in_partition(node_info *ninfo, char *partition);
 /* add a node to a node array*/
 node_info **add_node_to_array(node_info **ninfo_arr, node_info *node);
 
-int add_event_to_nodes(timed_event *te, nspec **nspecs);
+bool add_event_to_nodes(timed_event *te, std::vector<nspec *>& nspecs);
 
 int add_node_events(timed_event *te, void *arg1, void *arg2);
 

--- a/src/scheduler/node_partition.cpp
+++ b/src/scheduler/node_partition.cpp
@@ -57,7 +57,6 @@
  * 	node_partition_update()
  * 	free_np_cache_array()
  * 	find_alloc_np_cache()
- * 	add_np_cache()
  * 	resresv_can_fit_nodepart()
  * 	create_specific_nodepart()
  * 	create_placement_sets()
@@ -748,12 +747,8 @@ np_cache::np_cache() {
 	num_parts = UNSPECIFIED;
 }
 // overloaded
-np_cache::np_cache(node_info **rninfo_arr, const std::vector<std::string>& rresnames, node_partition **rnodepart, int rnum_parts) {
-	ninfo_arr = rninfo_arr;
-	nodepart = rnodepart;
-	resnames = rresnames;
-	num_parts = rnum_parts;
-}
+np_cache::np_cache(node_info **rninfo_arr, const std::vector<std::string>& rresnames, node_partition **rnodepart, int rnum_parts) : 
+	ninfo_arr(rninfo_arr), resnames(rresnames), nodepart(rnodepart), num_parts(rnum_parts) { }
 // Destructor
 np_cache::~np_cache() {
 	if (nodepart != NULL)
@@ -878,45 +873,6 @@ find_alloc_np_cache(status *policy, std::vector<np_cache *> &pnpc_arr,
 	return npc;
 }
 
-
-/**
- * @brief
- *		add_np_cache - add an np_cache to an array
- *
- * @param[in]	policy	-	policy info
- * @param[in,out]	pnpc_arr	-	pointer to np_cache array -- if *npc_arr == NULL
- *
- * @return	1	: on success
- * @return	0	: on failure
- */
-int
-add_np_cache(np_cache ***npc_arr, np_cache *npc)
-
-{
-	np_cache **new_cache;
-	np_cache **cur_cache;
-	int ct;
-
-	if (npc_arr == NULL || npc == NULL)
-		return 0;
-
-	cur_cache = *npc_arr;
-
-	ct = count_array(cur_cache);
-
-	/* ct+2: 1 for new element 1 for NULL ptr */
-	new_cache = static_cast<np_cache **>(realloc(cur_cache, (ct+2) * sizeof(np_cache *)));
-
-	if (new_cache == NULL)
-		return 0;
-
-	new_cache[ct] = npc;
-	new_cache[ct+1] = NULL;
-
-	*npc_arr = new_cache;
-	return 1;
-}
-
 /**
  * @brief
  * 		do an initial check to see if a resresv can fit into a node partition
@@ -937,7 +893,7 @@ add_np_cache(np_cache ***npc_arr, np_cache *npc)
  */
 int
 resresv_can_fit_nodepart(status *policy, node_partition *np, resource_resv *resresv,
-	int flags, schd_error *err)
+	unsigned int flags, schd_error *err)
 {
 	int i;
 	schd_error *prev_err = NULL;

--- a/src/scheduler/node_partition.h
+++ b/src/scheduler/node_partition.h
@@ -192,17 +192,12 @@ np_cache *
 find_alloc_np_cache(status *policy, std::vector<np_cache *> &pnpc_arr,
 	const std::vector<std::string> &resnames, node_info **ninfo_arr,
 	int (*sort_func)(const void *, const void *));
-/*
- *	add_np_cache - add an np_cache to an array
- *	returns 1 on success - 0 on failure
- */
-int add_np_cache(np_cache ***npc_arr, np_cache *npc);
 
 /*
  * do an inital check to see if a resresv can fit into a node partition
  * based on the meta data we keep
  */
-int resresv_can_fit_nodepart(status *policy, node_partition *np, resource_resv *resresv, int total, schd_error *err);
+int resresv_can_fit_nodepart(status *policy, node_partition *np, resource_resv *resresv, unsigned int flags, schd_error *err);
 
 /*
  *	create_specific_nodepart - create a node partition with specific

--- a/src/scheduler/prev_job_info.cpp
+++ b/src/scheduler/prev_job_info.cpp
@@ -99,7 +99,7 @@ prev_job_info::prev_job_info(const prev_job_info& opj): name(opj.name), entity_n
 	resused = dup_resource_req_list(opj.resused);
 }
 
-prev_job_info::prev_job_info(prev_job_info&& opj) noexcept: name(std::move(opj.name)), entity_name(std::move(opj.entity_name))
+prev_job_info::prev_job_info(prev_job_info&& opj) : name(std::move(opj.name)), entity_name(std::move(opj.entity_name))
 {
 	resused = opj.resused;
 	opj.resused = NULL;

--- a/src/scheduler/prev_job_info.h
+++ b/src/scheduler/prev_job_info.h
@@ -46,6 +46,6 @@
  *      create_prev_job_info - create the prev_job_info array from an array
  *                              of jobs
  */
-void create_prev_job_info(resource_resv **resresv_arr);
+void create_prev_job_info(resource_resv **jobs);
 
 #endif	/* _PREV_JOB_INFO_H */

--- a/src/scheduler/queue_info.cpp
+++ b/src/scheduler/queue_info.cpp
@@ -110,9 +110,6 @@ query_queues(status *policy, int pbs_sd, server_info *sinfo)
 	/* array of pointers to internal scheduling structure for queues */
 	std::vector<queue_info *> qinfo_arr;
 
-	/* the current queue we are working on */
-	queue_info *qinfo;
-
 	/* return code */
 	sched_error_code ret;
 
@@ -152,6 +149,8 @@ query_queues(status *policy, int pbs_sd, server_info *sinfo)
 	}
 
 	for (cur_queue = queues; cur_queue != NULL && !err; cur_queue = cur_queue->next) {
+		queue_info *qinfo;
+
 		/* convert queue information from batch_status to queue_info */
 		if ((qinfo = query_queue_info(policy, cur_queue, sinfo)) == NULL) {
 			free_schd_error(sch_err);

--- a/src/scheduler/queue_info.h
+++ b/src/scheduler/queue_info.h
@@ -65,7 +65,7 @@ queue_info *new_queue_info(int limallocflag);
 /*
  *      free_queues - frees the memory for an array
  */
-void free_queues(std::vector<queue_info *> &qinfo);
+void free_queues(std::vector<queue_info *> &qarr);
 
 /*
  *      update_queue_on_run - update the information kept in a qinfo structure
@@ -91,7 +91,7 @@ std::vector<queue_info *> dup_queues(const std::vector<queue_info *> &oqueues, s
 queue_info *find_queue_info(std::vector<queue_info *> &qinfo_arr, const std::string& name);
 
 /*
- *      update_queue_on_end - update a queue when a job has finished running
+ *	update_queue_on_end - update a queue when a job has finished running
  */
 void
 update_queue_on_end(queue_info *qinfo, resource_resv *resresv,

--- a/src/scheduler/resource_resv.h
+++ b/src/scheduler/resource_resv.h
@@ -51,7 +51,7 @@ free_resource_resv_array_chunk(th_data_free_resresv *data);
 /*
  *      free_resource_resv_array - free an array of resource resvs
  */
-void free_resource_resv_array(resource_resv **resresv);
+void free_resource_resv_array(resource_resv **resresv_arr);
 
 
 /*
@@ -135,7 +135,7 @@ resource_req *find_alloc_resource_req_by_str(resource_req *reqlist, char *name);
 /*
  * find resource_count by resource definition or allocate
  */
-resource_count *find_alloc_resource_count(resource_count *reqlist, resdef *def);
+resource_count *find_alloc_resource_count(resource_count *rcountlist, resdef *def);
 
 /*
  *      free_resource_req_list - frees memory used by a resource_req list
@@ -150,7 +150,7 @@ void free_resource_req(resource_req *req);
 /*
  *      free_resource_count_list - frees memory used by a resource_count list
  */
-void free_resource_count_list(resource_count *list);
+void free_resource_count_list(resource_count *rcount);
 
 /*
  *	free_resource_count - free memory used by a resource_count structure
@@ -174,7 +174,7 @@ resource_req *dup_selective_resource_req_list(resource_req *oreq, std::unordered
 /*
  *	dup_resource_count_list - duplicate a resource_req list
  */
-resource_count *dup_resource_count_list(resource_count *oreq);
+resource_count *dup_resource_count_list(resource_count *orcount);
 
 /*
  *      dup_resource_req - duplicate a resource_req struct
@@ -184,13 +184,13 @@ resource_req *dup_resource_req(resource_req *oreq);
 /*
  *	dup_resource_count - duplicate a resource_count struct
  */
-resource_count *dup_resource_count(resource_count *oreq);
+resource_count *dup_resource_count(resource_count *orcount);
 
 /*
  *      update_resresv_on_run - update information kept in a resource_resv
  *                              struct when one is started
  */
-void update_resresv_on_run(resource_resv *resresv, nspec **nspec_arr);
+void update_resresv_on_run(resource_resv *resresv, std::vector<nspec *>& nspec_arr);
 
 /*
  *      update_resresv_on_end - update a resource_resv structure when
@@ -326,7 +326,7 @@ resource_req *create_resource_req(const char *name, const char *value);
  *
  * return converted select string
  */
-std::string create_select_from_nspec(nspec **nspec_array);
+std::string create_select_from_nspec(std::vector<nspec *>& nspec_arr);
 
 /* function returns true if job/resv is in a state which it can be run */
 int in_runnable_state(resource_resv *resresv);

--- a/src/scheduler/resv_info.cpp
+++ b/src/scheduler/resv_info.cpp
@@ -37,8 +37,6 @@
  * subject to Altair's trademark licensing policies.
  */
 
-
-
 /**
  * @file    resv_info.c
  *
@@ -55,39 +53,41 @@
  *	check_new_reservations()
  *	disable_reservation_occurrence()
  *	confirm_reservation()
- *	check_vnodes_unavailable()
  *	release_nodes()
  *	create_resv_nodes()
  *
  */
+
 #include <pbs_config.h>
 
+#include <algorithm>
+
+#include <errno.h>
+#include <libutil.h>
+#include <log.h>
+#include <pbs_ifl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <errno.h>
-#include <pbs_ifl.h>
-#include <log.h>
-#include <libutil.h>
 
-#include "data_types.h"
-#include "resv_info.h"
-#include "job_info.h"
-#include "queue_info.h"
-#include "server_info.h"
-#include "misc.h"
-#include "sort.h"
-#include "globals.h"
-#include "node_info.h"
-#include "resource_resv.h"
-#include "resource.h"
-#include "fifo.h"
 #include "check.h"
-#include "simulate.h"
 #include "constant.h"
+#include "data_types.h"
+#include "fifo.h"
+#include "globals.h"
+#include "job_info.h"
+#include "libpbs.h"
+#include "misc.h"
+#include "node_info.h"
 #include "node_partition.h"
 #include "pbs_internal.h"
-#include "libpbs.h"
+#include "queue_info.h"
+#include "resource.h"
+#include "resource_resv.h"
+#include "resv_info.h"
+#include "server_info.h"
+#include "simulate.h"
+#include "sort.h"
 
 /**
  * @brief
@@ -108,7 +108,7 @@ stat_resvs(int pbs_sd)
 			if (errmsg == NULL)
 				errmsg = "";
 			log_eventf(PBSEVENT_SCHED, PBS_EVENTCLASS_RESV, LOG_NOTICE, "resv_info",
-					"pbs_statresv failed: %s (%d)", errmsg, pbs_errno);
+				   "pbs_statresv failed: %s (%d)", errmsg, pbs_errno);
 		}
 		return NULL;
 	}
@@ -181,7 +181,7 @@ query_reservations(int pbs_sd, server_info *sinfo, struct batch_status *resvs)
 	for (cur_resv = resvs; cur_resv != NULL; cur_resv = cur_resv->next) {
 		int ignore_resv = 0;
 		clear_schd_error(err);
-		struct attrl	*attrp = NULL;
+		struct attrl *attrp = NULL;
 		/* Check if this reservation belongs to this scheduler */
 		for (attrp = cur_resv->attribs; attrp != NULL; attrp = attrp->next) {
 			if (strcmp(attrp->name, ATTR_partition) == 0) {
@@ -212,19 +212,18 @@ query_reservations(int pbs_sd, server_info *sinfo, struct batch_status *resvs)
 		 */
 		if (!is_resource_resv_valid(resresv, err) || resresv->is_invalid) {
 			schdlogerr(PBSEVENT_DEBUG, PBS_EVENTCLASS_RESV, LOG_DEBUG, resresv->name,
-				"Reservation is invalid - ignoring for this cycle", err);
+				   "Reservation is invalid - ignoring for this cycle", err);
 			ignore_resv = 1;
 		}
 		/* Make sure it is not a future reservation that is being deleted, if so ignore it */
 		else if ((resresv->resv->resv_state == RESV_BEING_DELETED) && (resresv->start > sinfo->server_time)) {
 			log_event(PBSEVENT_SCHED, PBS_EVENTCLASS_RESV, LOG_DEBUG,
-				resresv->name, "Future reservation is being deleted, ignoring this reservation");
+				  resresv->name, "Future reservation is being deleted, ignoring this reservation");
 			ignore_resv = 1;
-		}
-		else if ((resresv->resv->resv_state == RESV_BEING_DELETED) && (resresv->resv->resv_nodes != NULL) &&
-			(!is_string_in_arr(resresv->resv->resv_nodes[0]->resvs, resresv->name.c_str()))) {
+		} else if ((resresv->resv->resv_state == RESV_BEING_DELETED) && (resresv->resv->resv_nodes != NULL) &&
+			   (!is_string_in_arr(resresv->resv->resv_nodes[0]->resvs, resresv->name.c_str()))) {
 			log_event(PBSEVENT_SCHED, PBS_EVENTCLASS_RESV, LOG_DEBUG,
-				resresv->name, "Reservation is being deleted and not present on node, ignoring this reservation");
+				  resresv->name, "Reservation is being deleted and not present on node, ignoring this reservation");
 			ignore_resv = 1;
 		}
 
@@ -269,7 +268,7 @@ query_reservations(int pbs_sd, server_info *sinfo, struct batch_status *resvs)
 		if (resresv->resv->is_standing &&
 		    (resresv->resv->resv_state != RESV_UNCONFIRMED)) {
 			resource_resv *resresv_ocr = NULL; /* the occurrence's resource_resv */
-			char *execvnodes_seq; /* confirmed execvnodes sequence string */
+			char *execvnodes_seq;		   /* confirmed execvnodes sequence string */
 			char **execvnode_ptr = NULL;
 			char **tofree = NULL;
 			resource_resv **tmp = NULL;
@@ -278,8 +277,8 @@ query_reservations(int pbs_sd, server_info *sinfo, struct batch_status *resvs)
 			char *tz = NULL;
 			char start_time[128];
 			int count = 0;
-			int occr_count; /* occurrences count as reported by execvnodes_seq */
-			int occr_idx; /* the occurrence index of a standing reservation */
+			int occr_count;	  /* occurrences count as reported by execvnodes_seq */
+			int occr_idx;	  /* the occurrence index of a standing reservation */
 			int degraded_idx; /* index corrected to account for reconfirmation */
 
 			/* occr_idx refers to the soonest occurrence to run or currently running
@@ -297,7 +296,7 @@ query_reservations(int pbs_sd, server_info *sinfo, struct batch_status *resvs)
 			 */
 			if (occr_count == 0) {
 				log_event(PBSEVENT_SCHED, PBS_EVENTCLASS_RESV, LOG_DEBUG,
-					resresv->name, "Error processing standing reservation");
+					  resresv->name, "Error processing standing reservation");
 				free(execvnodes_seq);
 				sinfo->num_resvs--;
 				delete resresv;
@@ -331,7 +330,7 @@ query_reservations(int pbs_sd, server_info *sinfo, struct batch_status *resvs)
 
 			/* Resize the reservations array to append each occurrence */
 			if ((tmp = static_cast<resource_resv **>(realloc(resresv_arr,
-				sizeof(resource_resv *) * (sinfo->num_resvs + 1)))) == NULL) {
+									 sizeof(resource_resv *) * (sinfo->num_resvs + 1)))) == NULL) {
 				log_err(errno, __func__, MEM_ERR_MSG);
 				free_resource_resv_array(resresv_arr);
 				delete resresv;
@@ -384,8 +383,8 @@ query_reservations(int pbs_sd, server_info *sinfo, struct batch_status *resvs)
 						return NULL;
 					}
 					if (resresv->resv->resv_state == RESV_RUNNING ||
-						resresv->resv->resv_state == RESV_BEING_ALTERED ||
-						resresv->resv->resv_state == RESV_DELETING_JOBS) {
+					    resresv->resv->resv_state == RESV_BEING_ALTERED ||
+					    resresv->resv->resv_state == RESV_DELETING_JOBS) {
 						/* Each occurrence will be added to the simulation framework and
 						 * should not be in running state. Their state should be
 						 * Confirmed instead of possibly inheriting the Running state
@@ -427,7 +426,7 @@ query_reservations(int pbs_sd, server_info *sinfo, struct batch_status *resvs)
 				 */
 				if (j != 0 && resresv->resv->req_duration_standing != UNSPECIFIED)
 					resresv_ocr->hard_duration = resresv_ocr->duration = resresv->resv->req_duration_standing;
-				resresv_ocr->resv->req_end = next + resresv->duration;
+				resresv_ocr->resv->req_end = next + resresv_ocr->duration;
 				resresv_ocr->start = resresv_ocr->resv->req_start;
 				resresv_ocr->end = resresv_ocr->resv->req_end;
 				resresv_ocr->resv->resv_idx = occr_idx;
@@ -440,7 +439,7 @@ query_reservations(int pbs_sd, server_info *sinfo, struct batch_status *resvs)
 				strftime(start_time, sizeof(start_time), "%Y%m%d-%H:%M:%S", loc_time);
 
 				log_eventf(PBSEVENT_DEBUG2, PBS_EVENTCLASS_RESV, LOG_DEBUG, resresv->name,
-					"Occurrence %d/%d,%s", occr_idx, count, start_time);
+					   "Occurrence %d/%d,%s", occr_idx, count, start_time);
 			}
 			/* The parent reservation has already been added so move on to handling
 			 * the next reservation
@@ -451,9 +450,7 @@ query_reservations(int pbs_sd, server_info *sinfo, struct batch_status *resvs)
 			free(execvnode_ptr);
 
 			continue;
-		}
-		else
-		{
+		} else {
 			resresv_arr[idx++] = resresv;
 			resresv_arr[idx] = NULL;
 		}
@@ -463,7 +460,6 @@ query_reservations(int pbs_sd, server_info *sinfo, struct batch_status *resvs)
 
 	return resresv_arr;
 }
-
 
 /**
  * @brief
@@ -479,12 +475,12 @@ query_reservations(int pbs_sd, server_info *sinfo, struct batch_status *resvs)
 resource_resv *
 query_resv(struct batch_status *resv, server_info *sinfo)
 {
-	struct attrl *attrp = NULL;	/* linked list of attributes from server */
-	resource_resv *advresv = NULL;	/* resv_info to be created */
-	resource_req *resreq = NULL;	/* used for the ATTR_l resources */
-	char *endp = NULL;		/* used with strtol() */
-	long count = 0; 		/* used to convert string -> num */
-	char *resv_nodes = NULL;	/* used to hold the resv_nodes for later processing */
+	struct attrl *attrp = NULL;    /* linked list of attributes from server */
+	resource_resv *advresv = NULL; /* resv_info to be created */
+	resource_req *resreq = NULL;   /* used for the ATTR_l resources */
+	char *endp = NULL;	       /* used with strtol() */
+	long count = 0;		       /* used to convert string -> num */
+	char *resv_nodes = NULL;       /* used to hold the resv_nodes for later processing */
 
 	if (resv == NULL)
 		return NULL;
@@ -493,7 +489,7 @@ query_resv(struct batch_status *resv, server_info *sinfo)
 		return NULL;
 
 	if ((advresv->resv = new_resv_info()) == NULL) {
-		delete  advresv;
+		delete advresv;
 		return NULL;
 	}
 
@@ -517,26 +513,22 @@ query_resv(struct batch_status *resv, server_info *sinfo)
 					if (advresv->select->chunks[i]->req == NULL)
 						advresv->is_invalid = 1;
 			}
-		}
-		else if (!strcmp(attrp->name, ATTR_resv_start)) {
+		} else if (!strcmp(attrp->name, ATTR_resv_start)) {
 			count = strtol(attrp->value, &endp, 10);
 			if (*endp != '\0')
 				count = -1;
 			advresv->resv->req_start = count;
-		}
-		else if (!strcmp(attrp->name, ATTR_resv_end)) {
+		} else if (!strcmp(attrp->name, ATTR_resv_end)) {
 			count = strtol(attrp->value, &endp, 10);
 			if (*endp != '\0')
 				count = -1;
 			advresv->resv->req_end = count;
-		}
-		else if (!strcmp(attrp->name, ATTR_resv_duration)) {
+		} else if (!strcmp(attrp->name, ATTR_resv_duration)) {
 			count = strtol(attrp->value, &endp, 10);
 			if (*endp != '\0')
 				count = -1;
 			advresv->resv->req_duration = count;
-		}
-		else if (!strcmp(attrp->name, ATTR_resv_alter_revert)) {
+		} else if (!strcmp(attrp->name, ATTR_resv_alter_revert)) {
 			if (!strcmp(attrp->resource, "start_time")) {
 				count = strtol(attrp->value, &endp, 10);
 				if (*endp != '\0')
@@ -545,8 +537,7 @@ query_resv(struct batch_status *resv, server_info *sinfo)
 			} else if (!strcmp(attrp->resource, "walltime")) {
 				advresv->resv->req_duration_orig = (time_t) res_to_num(attrp->value, NULL);
 			}
-		}
-		else if (!strcmp(attrp->name, ATTR_resv_standing_revert)) {
+		} else if (!strcmp(attrp->name, ATTR_resv_standing_revert)) {
 			if (!strcmp(attrp->resource, "start_time")) {
 				count = strtol(attrp->value, &endp, 10);
 				if (*endp != '\0')
@@ -557,20 +548,17 @@ query_resv(struct batch_status *resv, server_info *sinfo)
 			} else if (!strcmp(attrp->resource, "select")) {
 				advresv->resv->select_standing = parse_selspec(attrp->value);
 			}
-		}
-		else if (!strcmp(attrp->name, ATTR_resv_retry)) {
+		} else if (!strcmp(attrp->name, ATTR_resv_retry)) {
 			count = strtol(attrp->value, &endp, 10);
 			if (*endp != '\0')
 				count = -1;
 			advresv->resv->retry_time = count;
-		}
-		else if (!strcmp(attrp->name, ATTR_resv_state)) {
+		} else if (!strcmp(attrp->name, ATTR_resv_state)) {
 			count = strtol(attrp->value, &endp, 10);
 			if (*endp != '\0')
 				count = -1;
 			advresv->resv->resv_state = (enum resv_states) count;
-		}
-		else if (!strcmp(attrp->name, ATTR_resv_substate)) {
+		} else if (!strcmp(attrp->name, ATTR_resv_substate)) {
 			count = strtol(attrp->value, &endp, 10);
 			if (*endp != '\0')
 				count = -1;
@@ -593,8 +581,7 @@ query_resv(struct batch_status *resv, server_info *sinfo)
 						advresv->is_invalid = 1;
 				}
 			}
-		}
-		else if (!strcmp(attrp->name, ATTR_resv_nodes))
+		} else if (!strcmp(attrp->name, ATTR_resv_nodes))
 			resv_nodes = attrp->value;
 		else if (!strcmp(attrp->name, ATTR_node_set))
 			advresv->node_set_str = break_comma_list(attrp->value);
@@ -609,8 +596,7 @@ query_resv(struct batch_status *resv, server_info *sinfo)
 		else if (!strcmp(attrp->name, ATTR_resv_standing)) {
 			count = atoi(attrp->value);
 			advresv->resv->is_standing = count;
-		}
-		else if (!strcmp(attrp->name, ATTR_resv_count))
+		} else if (!strcmp(attrp->name, ATTR_resv_count))
 			advresv->resv->count = atoi(attrp->value);
 		else if (!strcmp(attrp->name, ATTR_partition)) {
 			advresv->resv->partition = strdup(attrp->value);
@@ -676,9 +662,9 @@ query_resv(struct batch_status *resv, server_info *sinfo)
 	 * happen because the server will purge such reservations.
 	 */
 	if (advresv->resv->resv_state == RESV_UNCONFIRMED &&
-		get_num_occurrences(advresv->resv->rrule,
-		advresv->resv->req_start,
-		advresv->resv->timezone) == 0)
+	    get_num_occurrences(advresv->resv->rrule,
+				advresv->resv->req_start,
+				advresv->resv->timezone) == 0)
 		advresv->is_invalid = 1;
 
 	/* When a reservation is recognized as DEGRADED, it is converted into
@@ -738,7 +724,7 @@ query_resv(struct batch_status *resv, server_info *sinfo)
 	}
 	advresv->resv->resv_queue =
 		find_queue_info(sinfo->queues, advresv->resv->queuename);
-		
+
 	/* It's possible for an in-conflict reservation to be running with no nodes */
 	if (is_resresv_running(advresv) && advresv->ninfo_arr != NULL) {
 		for (int j = 0; advresv->ninfo_arr[j] != NULL; j++)
@@ -760,10 +746,7 @@ new_resv_info()
 {
 	resv_info *rinfo;
 
-	if ((rinfo = static_cast<resv_info *>(malloc(sizeof(resv_info)))) == NULL) {
-		log_err(errno, __func__, MEM_ERR_MSG);
-		return NULL;
-	}
+	rinfo = new resv_info();
 
 	rinfo->queuename = NULL;
 	rinfo->req_start = UNSPECIFIED;
@@ -789,7 +772,6 @@ new_resv_info()
 	rinfo->partition = NULL;
 	rinfo->select_orig = NULL;
 	rinfo->select_standing = NULL;
-	rinfo->orig_nspec_arr = NULL;
 
 	return rinfo;
 }
@@ -808,7 +790,7 @@ free_resv_info(resv_info *rinfo)
 {
 	if (rinfo == NULL)
 		return;
-	
+
 	if (rinfo->queuename != NULL)
 		free(rinfo->queuename);
 
@@ -836,11 +818,9 @@ free_resv_info(resv_info *rinfo)
 	if (rinfo->select_standing != NULL)
 		delete rinfo->select_standing;
 
-	if (rinfo->orig_nspec_arr != NULL)
-		free_nspecs(rinfo->orig_nspec_arr);
+	free_nspecs(rinfo->orig_nspec_arr);
 
-	free(rinfo);
-
+	delete rinfo;
 }
 
 /**
@@ -931,8 +911,8 @@ dup_resv_info(resv_info *rinfo, server_info *sinfo)
 int
 check_new_reservations(status *policy, int pbs_sd, resource_resv **resvs, server_info *sinfo)
 {
-	int count = 0;	/* new reservation count */
-	int pbsrc = 0;	/* return code from pbs_confirmresv() */
+	int count = 0; /* new reservation count */
+	int pbsrc = 0; /* return code from pbs_confirmresv() */
 
 	server_info *nsinfo = NULL;
 	resource_resv *nresv = NULL;
@@ -941,7 +921,7 @@ check_new_reservations(status *policy, int pbs_sd, resource_resv **resvs, server
 
 	char **occr_execvnodes_arr = NULL;
 	char **tofree = NULL;
-	int occr_count =1;
+	int occr_count = 1;
 	int have_alter_request = 0;
 	int i;
 	int j;
@@ -958,14 +938,14 @@ check_new_reservations(status *policy, int pbs_sd, resource_resv **resvs, server
 	if (err == NULL)
 		return -1;
 
-	qsort(sinfo->resvs, sinfo->num_resvs, sizeof(resource_resv*), cmp_resv_state);
+	qsort(sinfo->resvs, sinfo->num_resvs, sizeof(resource_resv *), cmp_resv_state);
 
 	for (i = 0; sinfo->resvs[i] != NULL; i++) {
 		if (sinfo->resvs[i]->resv == NULL) {
 			log_event(PBSEVENT_RESV, PBS_EVENTCLASS_RESV, LOG_INFO,
-				sinfo->resvs[i]->name,
-				"Error determining if reservation can be confirmed: "
-				"Could not find the reservation.");
+				  sinfo->resvs[i]->name,
+				  "Error determining if reservation can be confirmed: "
+				  "Could not find the reservation.");
 			continue;
 		}
 
@@ -990,9 +970,9 @@ check_new_reservations(status *policy, int pbs_sd, resource_resv **resvs, server
 			nresv = find_resource_resv_by_indrank(nsinfo->resvs, sinfo->resvs[i]->resresv_ind, sinfo->resvs[i]->rank);
 			if (nresv == NULL) {
 				log_event(PBSEVENT_RESV, PBS_EVENTCLASS_RESV, LOG_INFO,
-					sinfo->resvs[i]->name,
-					"Error determining if reservation can be confirmed: "
-					"Resource not found.");
+					  sinfo->resvs[i]->name,
+					  "Error determining if reservation can be confirmed: "
+					  "Resource not found.");
 				delete nsinfo;
 				return -1;
 			}
@@ -1003,7 +983,7 @@ check_new_reservations(status *policy, int pbs_sd, resource_resv **resvs, server
 			 * each occurrence is unrolled and attempted to be confirmed within the
 			 * function.
 			 */
-			pbsrc = confirm_reservation(policy, pbs_sd, nresv , nsinfo);
+			pbsrc = confirm_reservation(policy, pbs_sd, nresv, nsinfo);
 
 			/* confirm_reservation only returns success if all occurrences were
 			 * confirmed and the communication with the server returned no error
@@ -1032,13 +1012,12 @@ check_new_reservations(status *policy, int pbs_sd, resource_resv **resvs, server
 						nresv->resv->execvnodes_seq, &tofree);
 					if (occr_execvnodes_arr == NULL) {
 						log_event(PBSEVENT_RESV, PBS_EVENTCLASS_RESV, LOG_INFO,
-							sinfo->resvs[i]->name,
-							"Error unrolling standing reservation.");
+							  sinfo->resvs[i]->name,
+							  "Error unrolling standing reservation.");
 						delete nsinfo;
 						return -1;
 					}
-				}
-				else {
+				} else {
 					/* Since we will use occr_execvnodes_arr both for standing and advance
 					 * reservations, we create an array with a single entry to hold the
 					 * advance reservation's execvnode.
@@ -1072,16 +1051,15 @@ check_new_reservations(status *policy, int pbs_sd, resource_resv **resvs, server
 						 */
 						if (nresv->resv->resv_substate == RESV_DEGRADED || nresv->resv->resv_substate == RESV_IN_CONFLICT) {
 							nresv_copy = find_resource_resv_by_time(sinfo->all_resresv,
-								nresv_copy->name, nresv->resv->occr_start_arr[j]);
+												nresv_copy->name, nresv->resv->occr_start_arr[j]);
 							if (nresv_copy == NULL) {
 								log_event(PBSEVENT_RESV, PBS_EVENTCLASS_RESV,
-									LOG_INFO, nresv->name,
-									"Error determining if reservation can be confirmed: "
-									"Could not find reservation by time.");
+									  LOG_INFO, nresv->name,
+									  "Error determining if reservation can be confirmed: "
+									  "Could not find reservation by time.");
 								break;
 							}
-						}
-						else {
+						} else {
 							/* For a new, unconfirmed, reservation, we duplicate the parent
 							 * reservation
 							 */
@@ -1116,11 +1094,11 @@ check_new_reservations(status *policy, int pbs_sd, resource_resv **resvs, server
 						timed_event *te_start;
 						timed_event *te_end;
 						te_start = create_event(TIMED_RUN_EVENT, nresv_copy->start,
-							nresv_copy, NULL, NULL);
+									nresv_copy, NULL, NULL);
 						if (te_start == NULL)
 							break;
 						te_end = create_event(TIMED_END_EVENT, nresv_copy->end,
-							nresv_copy, NULL, NULL);
+								      nresv_copy, NULL, NULL);
 						if (te_end == NULL) {
 							free_timed_event(te_start);
 							break;
@@ -1159,12 +1137,12 @@ check_new_reservations(status *policy, int pbs_sd, resource_resv **resvs, server
 				if (nresv->resv->resv_substate == RESV_DEGRADED || nresv->resv->resv_substate == RESV_IN_CONFLICT) {
 					for (j = 0; j < nresv->resv->count; j++) {
 						nresv_copy = find_resource_resv_by_time(sinfo->all_resresv,
-							nresv->name, nresv->resv->occr_start_arr[j]);
+											nresv->name, nresv->resv->occr_start_arr[j]);
 						if (nresv_copy == NULL) {
 							log_event(PBSEVENT_RESV, PBS_EVENTCLASS_RESV,
-								LOG_INFO, nresv->name,
-								"Error determining if reservation can be confirmed: "
-								"Could not find reservation by time.");
+								  LOG_INFO, nresv->name,
+								  "Error determining if reservation can be confirmed: "
+								  "Could not find reservation by time.");
 							break;
 						}
 						/* Update the retry time such that occurrences of a standing
@@ -1228,9 +1206,9 @@ check_new_reservations(status *policy, int pbs_sd, resource_resv **resvs, server
  */
 static int
 disable_reservation_occurrence(timed_event *events,
-	resource_resv *resv)
+			       resource_resv *resv)
 {
-	if(resv == NULL)
+	if (resv == NULL)
 		return 0;
 
 	if (resv->run_event != NULL)
@@ -1261,39 +1239,38 @@ disable_reservation_occurrence(timed_event *events,
 int
 confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, server_info *nsinfo)
 {
-	time_t sim_time;			/* time in simulation */
-	unsigned int simrc = TIMED_NOEVENT;	/* ret code from simulate_events() */
+	time_t sim_time;		    /* time in simulation */
+	unsigned int simrc = TIMED_NOEVENT; /* ret code from simulate_events() */
 	schd_error *err;
-	int pbsrc = 0;				/* return code from pbs_confirmresv() */
+	int pbsrc = 0;				     /* return code from pbs_confirmresv() */
 	enum resv_conf rconf = RESV_CONFIRM_SUCCESS; /* assume reconf success */
 	char logmsg[MAX_LOG_SIZE];
 	char logmsg2[MAX_LOG_SIZE];
 
-	nspec **ns = NULL;
 	resource_resv *nresv = unconf_resv;
 	resource_resv **tmp_resresv = NULL;
 	resource_resv *nresv_copy = NULL;
 
-	resource_resv *nresv_parent = nresv;	/* the "original" / parent reservation */
+	resource_resv *nresv_parent = nresv; /* the "original" / parent reservation */
 
-	int confirmd_occr = 0;			/* the number of confirmed occurrence(s) */
+	int confirmd_occr = 0; /* the number of confirmed occurrence(s) */
 	int cur_count;
 
-	int vnodes_down = 0;			/* the number of vnodes that are down */
+	int vnodes_down = 0; /* the number of vnodes that are down */
 
 	/* resv_start_time is used both for calculating the time of an ASAP
 	 * reservation and to keep track of the start time of the first occurrence
 	 * of a standing reservation.
 	 */
-	time_t resv_start_time = 0;		/* estimated start time for resv */
-	time_t *occr_start_arr = NULL;		/* an array of occurrence start times */
+	time_t resv_start_time = 0;    /* estimated start time for resv */
+	time_t *occr_start_arr = NULL; /* an array of occurrence start times */
 
 	std::string execvnodes;
 	char *short_xc = NULL;
 	char *tmp = NULL;
 	time_t next;
 
-	char *rrule = nresv->resv->rrule; 	/* NULL for advance reservation */
+	char *rrule = nresv->resv->rrule; /* NULL for advance reservation */
 	time_t dtstart = nresv->resv->req_start;
 	char *tz = nresv->resv->timezone;
 	int occr_count = nresv->resv->count;
@@ -1304,7 +1281,6 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 	err = new_schd_error();
 	if (err == NULL)
 		return RESV_CONFIRM_FAIL;
-
 
 	/* If the number of occurrences is not set, this is a first time confirmation
 	 * otherwise it is a reconfirmation request
@@ -1327,7 +1303,6 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 		log_err(errno, __func__, MEM_ERR_MSG);
 		return RESV_CONFIRM_FAIL;
 	}
-
 
 	/* Each reservation attempts to confirm a set of nodes on which to run for
 	 * a given start and end time. When handling an advance reservation,
@@ -1371,11 +1346,11 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 			 */
 			if (nresv->resv->resv_substate == RESV_DEGRADED || nresv->resv->resv_substate == RESV_IN_CONFLICT) {
 				nresv_copy = find_resource_resv_by_time(nsinfo->all_resresv,
-					nresv->name, next);
+									nresv->name, next);
 				if (nresv_copy == NULL) {
 					log_event(PBSEVENT_RESV, PBS_EVENTCLASS_RESV, LOG_INFO, nresv->name,
-						"Error determining if reservation can be confirmed: "
-						"Could not find reservation by time.");
+						  "Error determining if reservation can be confirmed: "
+						  "Could not find reservation by time.");
 					rconf = RESV_CONFIRM_FAIL;
 					break;
 				}
@@ -1418,15 +1393,9 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 		 * reconfirmation proceeds.
 		 */
 		if (nresv->resv->resv_substate == RESV_DEGRADED || nresv->resv->resv_substate == RESV_IN_CONFLICT ||
-			nresv->resv->resv_state == RESV_BEING_ALTERED) {
-			/* determine the number of vnodes associated to the reservation that are
-			 * unavailable. If none, then this reservation or occurrence does not
-			 * require reconfirmation.
-			 */
-			if (nresv->resv->resv_state == RESV_BEING_ALTERED)
-				vnodes_down = ralter_reduce_chunks(nresv);
-			else
-				vnodes_down = check_vnodes_unavailable(nresv);
+		    nresv->resv->resv_state == RESV_BEING_ALTERED) {
+			selspec *spec = new selspec(*nresv->select);
+			vnodes_down = resv_reduce_chunks(nresv, spec);
 
 			if (vnodes_down < 0 && nresv->resv->resv_substate != RESV_IN_CONFLICT) {
 				if (vnodes_down == -1)
@@ -1437,23 +1406,44 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 				snprintf(logmsg, sizeof(logmsg), "Occurrence is ending, will try later");
 				rconf = RESV_CONFIRM_FAIL;
 			} else if (vnodes_down > 0 || nresv->resv->resv_substate == RESV_IN_CONFLICT ||
-				nresv->resv->resv_state == RESV_BEING_ALTERED) {
+				   nresv->resv->resv_state == RESV_BEING_ALTERED) {
 				if (nresv->resv->is_running) {
 					std::string sel;
-					int ind;
 					delete nresv->execselect;
-					/* Use resv->orig_nspec_arr over nspec_arr because
-					 * A) we modified it above in check_vnodes_unavailable() for reconfirmation
-					 * B) it will allow us to map the original select back to the new resv_nodes
-					 */
+
 					sel = create_select_from_nspec(nresv->resv->orig_nspec_arr);
 					nresv->execselect = parse_selspec(sel);
-					for (ind = 0; nresv->resv->orig_nspec_arr[ind] != NULL; ind++) {
-					    nresv->execselect->chunks[ind]->seq_num = nresv->resv->orig_nspec_arr[ind]->seq_num;
+					for (size_t ind = 0; ind < nresv->resv->orig_nspec_arr.size(); ind++) {
+						nresv->execselect->chunks[ind]->seq_num = nresv->resv->orig_nspec_arr[ind]->seq_num;
 					}
-
+					if (spec != NULL) {
+						if (nresv->execselect == NULL)
+							nresv->execselect = spec;
+						else {
+							/* Everything in that select has a running job on it.  Now add in the rest */
+							int num_exec_chunks = count_array(nresv->execselect->chunks);
+							chunk **tmp = static_cast<chunk **>(realloc(nresv->execselect->chunks, (num_exec_chunks + count_array(spec->chunks) + 1) * sizeof(chunk *)));
+							if (tmp == NULL) {
+								rconf = RESV_CONFIRM_FAIL;
+								break;
+							}
+							nresv->execselect->chunks = tmp;
+							int j = num_exec_chunks;
+							for (int i = 0; spec->chunks[i] != NULL; i++) {
+								if (spec->chunks[i]->num_chunks > 0) {
+									nresv->execselect->chunks[j] = spec->chunks[i];
+									nresv->execselect->total_chunks += spec->chunks[i]->num_chunks;
+									spec->chunks[i] = NULL;
+									j++;
+								}
+							}
+							nresv->execselect->chunks[j] = NULL;
+							delete spec;
+						}
+					}
 					release_running_resv_nodes(nresv, nsinfo);
-				}
+				} else
+					delete spec;
 				release_nodes(nresv);
 			} else if (vnodes_down == 0) {
 				/* this occurrence doesn't require reconfirmation so skip it by
@@ -1464,7 +1454,7 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 				tmp = create_execvnode(nresv->resv->orig_nspec_arr);
 				if (j == 0)
 					execvnodes = tmp;
-				else  { /* subsequent occurrences */
+				else { /* subsequent occurrences */
 					execvnodes += tmp;
 					execvnodes += TOKEN_SEPARATOR;
 				}
@@ -1497,14 +1487,15 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 		}
 		if (!(simrc & TIMED_ERROR) && resv_start_time >= 0) {
 			clear_schd_error(err);
-			if ((ns = is_ok_to_run(nsinfo->policy, nsinfo, NULL, nresv, NO_ALLPART, err)) != NULL) {
-				qsort(ns, count_array(ns), sizeof(nspec *), cmp_nspec);
+			auto ns = is_ok_to_run(nsinfo->policy, nsinfo, NULL, nresv, NO_ALLPART, err);
+			if (!ns.empty()) {
+				std::sort(ns.begin(), ns.end(), cmp_nspec);
 				tmp = create_execvnode(ns);
 				free_nspecs(ns);
 				if (tmp == NULL) {
 					log_event(PBSEVENT_RESV, PBS_EVENTCLASS_RESV, LOG_INFO, nresv->name,
-						"Error determining if reservation can be confirmed: "
-						"Creation of execvnode failed.");
+						  "Error determining if reservation can be confirmed: "
+						  "Creation of execvnode failed.");
 					rconf = RESV_CONFIRM_FAIL;
 					break;
 				}
@@ -1516,8 +1507,7 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 					 */
 					if (resv_start_time == 0)
 						resv_start_time = next;
-				}
-				else /* subsequent occurrences */
+				} else /* subsequent occurrences */
 					execvnodes += tmp;
 
 				confirmd_occr++;
@@ -1541,9 +1531,9 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 		} /* end of simulation */
 		else {
 			log_event(PBSEVENT_RESV, PBS_EVENTCLASS_RESV, LOG_INFO,
-				nresv->name,
-				"Error determining if reservation can be confirmed: "
-				"Simulation failed.");
+				  nresv->name,
+				  "Error determining if reservation can be confirmed: "
+				  "Simulation failed.");
 			rconf = RESV_CONFIRM_FAIL;
 		}
 	}
@@ -1560,7 +1550,7 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 			short_xc = condense_execvnode_seq(execvnodes.c_str());
 		else
 			short_xc = string_dup(execvnodes.c_str());
-		
+
 		if (short_xc == NULL || get_execvnodes_count(short_xc) != occr_count) {
 			log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_RESV, LOG_DEBUG, nresv_parent->name, "Invalid execvnode_seq while confirming reservation");
 			rconf = RESV_CONFIRM_RETRY;
@@ -1568,18 +1558,17 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 			char confirm_msg[LOG_BUF_SIZE] = {0};
 
 			log_eventf(PBSEVENT_RESV, PBS_EVENTCLASS_RESV, LOG_INFO, nresv_parent->name,
-				"Confirming %d Occurrences", occr_count);
+				   "Confirming %d Occurrences", occr_count);
 
 			/* Send a reservation confirm message, if anything goes wrong pbsrc
 			* will return an error
 			*/
 			snprintf(confirm_msg, LOG_BUF_SIZE, "%s:partition=%s", PBS_RESV_CONFIRM_SUCCESS,
-				sc_attrs.partition ? sc_attrs.partition : DEFAULT_PARTITION);
+				 sc_attrs.partition ? sc_attrs.partition : DEFAULT_PARTITION);
 
 			pbsrc = send_confirmresv(pbs_sd, nresv_parent, short_xc, resv_start_time, confirm_msg);
 		}
-	}
-	else {
+	} else {
 		/* This message is sent to inform that we could not confirm the reservation.
 		 * If the reservation was degraded then the retry time will be reset.
 		 * "null" is used satisfy the API but any string would do because we've
@@ -1598,20 +1587,20 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 		 */
 		if (rconf == RESV_CONFIRM_FAIL)
 			log_eventf(PBSEVENT_RESV, PBS_EVENTCLASS_RESV, LOG_INFO, nresv_parent->name,
-				"PBS Failed to confirm resv: %s", logmsg);
+				   "PBS Failed to confirm resv: %s", logmsg);
 		else {
 			const char *errmsg = pbs_geterrmsg(pbs_sd);
 			if (errmsg == NULL)
 				errmsg = "";
 			log_eventf(PBSEVENT_RESV, PBS_EVENTCLASS_RESV, LOG_INFO, nresv_parent->name,
-				"PBS Failed to confirm resv: %s (%d)", errmsg, pbs_errno);
+				   "PBS Failed to confirm resv: %s (%d)", errmsg, pbs_errno);
 			rconf = RESV_CONFIRM_RETRY;
 		}
 
 		if (nresv_parent->resv->resv_substate == RESV_DEGRADED) {
 			if (vnodes_down >= 0)
 				log_eventf(PBSEVENT_RESV, PBS_EVENTCLASS_RESV, LOG_INFO, nresv_parent->name,
-					"Reservation is in degraded mode");
+					   "Reservation is in degraded mode");
 
 			/* we failed to confirm the degraded reservation but we still need to
 			 * set the remaining occurrences start time to avoid looking at them
@@ -1631,7 +1620,7 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 	 */
 	else if (rconf == RESV_CONFIRM_SUCCESS) {
 		log_event(PBSEVENT_RESV, PBS_EVENTCLASS_RESV, LOG_INFO, nresv_parent->name,
-			"Reservation Confirmed");
+			  "Reservation Confirmed");
 
 		/* If handling a degraded reservation or while altering a standing reservation
 		 * we recreate a new execvnode sequence string, so the old should be cleared.
@@ -1655,71 +1644,56 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 }
 
 /**
- * @brief determine if a nspec superchunk/chunk has unavailable nodes
- * 		and checks for running jobs on the chunk
+ * @brief determine if a nspec superchunk/chunk has any running jobs on them
  * @param[in] resv - reservation to check
  * @param[in] chunk_ind - index of the chunk start
- *
- * @return int
- * @retval 1 - running jobs, no unavailable nodes
- * @retval 0 no unavailable nodes, no running jobs
- * @retval -1 unavailable nodes, but no running jobs on the chunk
- * @retval -2 unavailable nodes, running jobs within the chunk
- * @retval -3 error
+ * @param[out] running_jobs - are there running jobs on the nodes we're checking
+ * @return bool
+ * @retval true chunk has running jobs on it
+ * @retval false chunk does not have any running jobs on it
  *
  */
-int
-check_down_running(resource_resv *resv, int chunk_ind)
+bool
+check_chunk_running(resource_resv *resv, int chunk_ind, bool &down_run)
 {
-	int i, j, k;
-	int ret = 0;
-
+	bool found_running_jobs = false;
 	if (resv == NULL || chunk_ind < 0 || !resv->is_resv ||
 	    resv->resv == NULL || resv->resv->resv_queue == NULL)
-		return -3;
+		return false;
 
-	for (i = chunk_ind; resv->resv->orig_nspec_arr[i] != NULL && ret != -2; i++) {
-		nspec *ns = resv->resv->orig_nspec_arr[i];
-		node_info *ninfo = ns->ninfo;
+	for (size_t i = chunk_ind; i < resv->resv->orig_nspec_arr.size(); i++) {
+		auto ninfo = resv->resv->orig_nspec_arr[i]->ninfo;
 
 		if (ninfo != NULL) {
-			if (ninfo->is_down || ninfo->is_offline || ninfo->is_stale || ninfo->is_unknown || ninfo->is_maintenance || ninfo->is_sleeping) {
-				if (ret == 1)
-					ret = -2;
-				else
-					ret = -1;
-			}
-
 			if (resv->resv->resv_queue->running_jobs != NULL)
-				for (j = 0; resv->resv->resv_queue->running_jobs[j] != NULL && ret != -2; j++) {
+				for (int j = 0; resv->resv->resv_queue->running_jobs[j] != NULL; j++) {
 					resource_resv *job = resv->resv->resv_queue->running_jobs[j];
-					for (k = 0; job->ninfo_arr[k] != NULL && ret != -2; k++)
+					for (int k = 0; job->ninfo_arr[k] != NULL; k++) {
 						if (job->ninfo_arr[k]->rank == ninfo->rank) {
-							if (ret == -1)
-								ret = -2;
-							else
-								ret = 1;
+							found_running_jobs = true;
+							if (ninfo->is_stale || ninfo->is_offline || ninfo->is_down ||
+							    ninfo->is_unknown || ninfo->is_maintenance || ninfo->is_sleeping)
+								down_run = true;
 						}
+					}
 				}
 
-			if (ns->end_of_chunk)
+			if (resv->resv->orig_nspec_arr[i]->end_of_chunk)
 				break;
 		}
+		if (down_run)
+			return true;
 	}
-
-	return ret;
+	return found_running_jobs;
 }
 
 /**
- * @brief remove nodes from a reservation.  Per call, we remove one type of chunk based on the chunk's seq_num
- * 	We remove num_chunks if we can (or fail if we can't)  We remove based on node_type which controls whether
- * 	we are removing unavailable nodes or available nodes
+ * @brief remove nodes without running jobs from an nspec array.
  *
  * @param[in] resv - reservation to remove nodes from
  * @param[in] start_of_chk - index into resv->orig_nspec_arr of where to start
  * @param[in] chk_seq_num - sequence number of chunk to remove nodes from
- * @param[in] num_chks - number of nodes to remove.  Depending on node_type, it is OK to remove less than this
- * @param[in] node_type - type of node to remove: -1 unavailable, 0 normal, 1 either all with no running jobs
+ * @param[out] down_run - we found a running job on a downed node
  *
  * @note all nspec chunks to be removed will have their ninfo pointer NULL'd.  It up to the caller to actually remove them from the reservation.
  *
@@ -1727,46 +1701,47 @@ check_down_running(resource_resv *resv, int chunk_ind)
  * @retval number of chunks removed from the nspec array
  * @retval -1 nspecs are not mapped to select chunks
  */
-int ralter_remove_nodes(resource_resv *resv, int start_of_chk, int chk_seq_num, int num_chks, int node_type) {
-	int i,k;
-	int cur_chks;
+int
+remove_empty_nodes(resource_resv *resv, int start_of_chk, int chk_seq_num, bool &down_run)
+{
+	int chunks_removed = 0;
 
-	cur_chks = num_chks;
-	nspec **nspec_arr;
+	auto &nspec_arr = resv->resv->orig_nspec_arr;
 
-	nspec_arr = resv->resv->orig_nspec_arr;
-
-	for (i = start_of_chk; nspec_arr[i] != NULL && cur_chks; i++) {
-		int ret;
+	for (size_t i = start_of_chk; i < nspec_arr.size(); i++) {
+		bool running_jobs = false;
 		if (nspec_arr[i]->chk == NULL)
 			return -1;
 
 		if (nspec_arr[i]->chk->seq_num != chk_seq_num)
 			break;
-		ret = check_down_running(resv, i);
-		if (ret == node_type || node_type == 1) {
-			k = i;
+		running_jobs = check_chunk_running(resv, i, down_run);
+		if (!running_jobs) {
+			size_t k = i - 1;
 			do {
-				if (k != i)
-					k++;
+				k++;
 				nspec_arr[k]->ninfo = NULL;
 			} while (nspec_arr[k] != NULL && !nspec_arr[k]->end_of_chunk);
 
-			cur_chks--;
+			chunks_removed++;
 			/* In the case of a superchunk, we advance past it.  In the case of a normal chunk, k didn't move, so we reassign i to i */
 			i = k;
 		}
 	}
-	return num_chks - cur_chks;
+	return chunks_removed;
 }
 
 /**
- * @brief reduce nodes of a reservation based on it new altered select.
- * 	The original select's chunks have been already mapped onto the resv's nodes.
- * 	When choosing nodes to release, we will first choose nodes which are unavailable.
- * 	A node with a running job on it can not be released.
+ * @brief The output of this function will be an nspec array with nodes which only has
+ * 	running jobs on them, and a select spec of corrisponding chunks of what we released and need back.
+ * 	e.g. we had (vn1:ncpus=1)+(vn2:ncpus=1)+(vn3:ncpus=1) and a new select spec of 2:ncpus=1.
+ * 		There is a running job on vn2.  The resulting nspec array only has vn2 in it, and
+ * 		the select spec has 1:ncpus=1 which is what is left.
+ * 
+ * 	The idea is that the caller will create an execselect of 1:vnode=vn2:ncpus=1+1:ncpus=1
  *
  * @param[in] resv - the reservation to shrink
+ * @param[out] spec - The part of the new select that isn't kept from orig_nspec_arr
  *
  * @return int
  * @retval 1 the reservation has been successfully shrunk
@@ -1775,29 +1750,33 @@ int ralter_remove_nodes(resource_resv *resv, int start_of_chk, int chk_seq_num, 
  * @retval -2 can't reduce due to resv_nodes not correctly mapped to select_orig
  */
 int
-ralter_reduce_chunks(resource_resv *resv)
+resv_reduce_chunks(resource_resv *resv, selspec *spec)
 {
 	int cnt;
 	int start_of_chunk = 0;
-	int i, j, k;
+	int j, k;
 	chunk **chks_orig, **chks;
 
-	if (resv == NULL)
+	if (resv == NULL || spec == NULL)
 		return -2;
 
-	/* We're not altering the select, just return success */
-	if (resv->resv->select_orig == NULL)
-		return 0;
+	if (resv->resv->resv_state == RESV_BEING_ALTERED) {
+		/* We're not altering the select, just return success */
+		if (resv->resv->select_orig == NULL)
+			return 0;
+		chks_orig = resv->resv->select_orig->chunks;
+	} else
+		chks_orig = resv->select->chunks;
 
-	cnt = count_array(resv->resv->orig_nspec_arr);
+	cnt = resv->resv->orig_nspec_arr.size();
 	j = 0;
-	chks_orig = resv->resv->select_orig->chunks;
 	chks = resv->select->chunks;
-	for (i = 0; chks_orig[i] != NULL; i++) {
+	for (int i = 0; chks_orig[i] != NULL; i++) {
 		int num_chks = 0;
+		bool down_run = false;
+
+		num_chks = remove_empty_nodes(resv, start_of_chunk, chks_orig[i]->seq_num, down_run);
 		if (chks[j] == NULL || chks_orig[i]->seq_num != chks[j]->seq_num) {
-			/* We're removing the entire chunk, so remove all the nodes of the chunk */
-			num_chks = ralter_remove_nodes(resv, start_of_chunk, chks_orig[i]->seq_num, chks_orig[i]->num_chunks, 1);
 			if (num_chks == -1)
 				return -2;
 			/* If we didn't remove all the nodes, some of them must have running jobs on them */
@@ -1806,24 +1785,17 @@ ralter_reduce_chunks(resource_resv *resv)
 
 		} else {
 			int chk_diff = chks_orig[i]->num_chunks - chks[j]->num_chunks;
-			if (chk_diff > 0) {
-				int tot_num_chunks = 0;
-				/* First remove nodes that are unavailable */
-				num_chks = ralter_remove_nodes(resv, start_of_chunk, chks_orig[i]->seq_num, chk_diff, -1);
-				if (num_chks == -1)
-					return -2;
 
-				if (chk_diff - num_chks > 0) {
-					/* Once we have all the unavailable nodes, fill in the rest with available nodes */
-					tot_num_chunks = ralter_remove_nodes(resv, start_of_chunk, chks_orig[i]->seq_num, chk_diff - num_chks, 0);
-					if (tot_num_chunks == -1)
-						return -2;
-				}
-				tot_num_chunks += num_chks;
-				/* We weren't able to find enough nodes without runniung jobs on them.  Fail the alter */
-				if (tot_num_chunks < chk_diff)
-					return -1;
-			}
+			if (num_chks == -1)
+				return -2;
+
+			/* We are shrinking the reservation and can't find enough nodes to free without running jobs on them */
+			if (chk_diff > 0 && num_chks < chk_diff)
+				return -1;
+			if (resv->resv->resv_substate == RESV_DEGRADED && down_run)
+				return -1;
+
+			spec->chunks[j]->num_chunks -= (chks_orig[i]->num_chunks - num_chks);
 
 			j++;
 		}
@@ -1831,125 +1803,20 @@ ralter_reduce_chunks(resource_resv *resv)
 			;
 		start_of_chunk = k;
 	}
-	i = 0;
-	while (resv->resv->orig_nspec_arr[i] != NULL) {
-		if (resv->resv->orig_nspec_arr[i]->ninfo == NULL) {
-			free_nspec(resv->resv->orig_nspec_arr[i]);
-			for (j = i; resv->resv->orig_nspec_arr[j] != NULL; j++)
-				resv->resv->orig_nspec_arr[j] = resv->resv->orig_nspec_arr[j + 1];
-		} else
-			i++;
-	}
+	auto &ns = resv->resv->orig_nspec_arr;
+	/* We marked all nodes to remove by NULLing the ninfo ptr.  Remove them here from the vector */
+	ns.erase(std::remove_if(ns.begin(), ns.end(), [](nspec *n) {
+			 if (n->ninfo == NULL) {
+				 delete n;
+				 return true;
+			 }
+			 return false;
+		 }),
+		 ns.end());
 	free_nspecs(resv->nspec_arr);
 	resv->nspec_arr = combine_nspec_array(resv->resv->orig_nspec_arr);
 
 	return 1;
-}
-
-/**
- * @brief
- * 		Checks the state of all vnodes associated to a reservation and reports
- * 		if there are any unavailable.  The ninfo ptr of the nspec is cleared for
- * 		unavailable vnodes so they can be left out when creating the execselect
- *
- * @param[in]	resv	-	resv to check
- *
- * @return	1	: there is an unavailable vnode
- * @retval	0	: all nodes are up and happy
- * @retval	-1	: there is a running job on one of the unavailable nodes.
- * @retval	-2	: can't map original chunks to resv_nodes
- * @retval	-3	: error
- */
-int
-check_vnodes_unavailable(resource_resv *resv)
-{
-	int ret = 0;
-	int i;
-	int has_down_node = 0;
-	int has_superchunk = 0;
-	int num_chunks = 0;
-	nspec **chunks_to_remove = NULL;
-	int del_i = 0;
-
-	if (resv == NULL || resv->nspec_arr == NULL)
-		return -3;
-
-	for (i = 0; resv->resv->orig_nspec_arr[i] != NULL; i++) {
-		if (!resv->resv->orig_nspec_arr[i]->end_of_chunk)
-			has_superchunk = 1;
-		num_chunks++;
-	}
-
-	if (has_superchunk) {
-		if ((chunks_to_remove = static_cast<nspec **>(malloc((num_chunks + 1) * sizeof(nspec *)))) == NULL) {
-			log_err(errno, __func__, MEM_ERR_MSG);
-			return -3;
-		}
-	}
-
-	for (i = 0; resv->resv->orig_nspec_arr[i] != NULL; i++) {
-
-		/* If the original select chunks haven't been mapped to the resv_nodes and the reservation is running, we can't continue */
-		if (resv->resv->is_running && resv->resv->orig_nspec_arr[i]->chk == NULL) {
-			free(chunks_to_remove);
-			return -2;
-		}
-
-		/* Part of a superchunk we've already handled */
-		if (resv->resv->orig_nspec_arr[i]->ninfo == NULL)
-			continue;
-
-		ret = check_down_running(resv, i);
-		/* running jobs on unavailable nodes in chunk */
-		if (ret == -2) {
-			free(chunks_to_remove);
-			return -1;
-		}
-		/* unavailable nodes in chunk */
-		else if (ret == -1) {
-			int j;
-			has_down_node = 1;
-			for (j = i; resv->resv->orig_nspec_arr[j] != NULL && !resv->resv->orig_nspec_arr[j]->end_of_chunk; j++) {
-				resv->resv->orig_nspec_arr[j]->ninfo = NULL;
-				if (has_superchunk)
-					chunks_to_remove[del_i++] = resv->resv->orig_nspec_arr[j];
-			}
-			/* We ran into an error where we ran into the end of the array before the end of the chunk
-			 * The entire chunk is in chunks_to_remove, so we'll just remove it.
-			 */
-			if (resv->resv->orig_nspec_arr[j] == NULL)
-				break;
-
-			resv->resv->orig_nspec_arr[j]->ninfo = NULL;
-			/*
-			 * The nspec_arr only has consumable resources.  When replacing a vnode we need
-			 * to make sure to replace it with the right type of node matching the non-consumables
-			 */
-			free_resource_req_list(resv->resv->orig_nspec_arr[j]->resreq);
-			resv->resv->orig_nspec_arr[j]->resreq = dup_resource_req_list(resv->resv->orig_nspec_arr[j]->chk->req);
-			resv->resv->orig_nspec_arr[j]->sub_seq_num = 1;
-		} else /* Node is available for use */
-			resv->resv->orig_nspec_arr[i]->sub_seq_num = 0;
-	}
-
-	if (has_superchunk) {
-		chunks_to_remove[del_i] = NULL;
-
-		for(i = 0; chunks_to_remove[i] != NULL; i++) {
-			free_nspec(chunks_to_remove[i]);
-			remove_ptr_from_array(resv->resv->orig_nspec_arr, chunks_to_remove[i]);
-		}
-	}
-	if (has_down_node == 1)
-		/* Move all the specific chunks ahead of the generic chunks.
-		 * This will ensure that we get all the nodes back we need to,
-		 * before we start looking for replacements
-		 */
-		qsort(resv->resv->orig_nspec_arr, count_array(resv->resv->orig_nspec_arr), sizeof(nspec *), cmp_nspec_by_sub_seq);
-
-	free(chunks_to_remove);
-
-	return has_down_node;
 }
 
 /**
@@ -1970,10 +1837,8 @@ release_nodes(resource_resv *resresv)
 	resresv->ninfo_arr = NULL;
 
 	free_nspecs(resresv->nspec_arr);
-	resresv->nspec_arr = NULL;
 
 	free_nspecs(resresv->resv->orig_nspec_arr);
-	resresv->resv->orig_nspec_arr = NULL;
 
 	if (resresv->nodepart_name != NULL) {
 		free(resresv->nodepart_name);
@@ -1994,51 +1859,47 @@ release_nodes(resource_resv *resresv)
  * @retval	NULL	: on error
  */
 node_info **
-create_resv_nodes(nspec **nspec_arr, server_info *sinfo)
+create_resv_nodes(std::vector<nspec *> &nspec_arr, server_info *sinfo)
 {
-	node_info **nodes = NULL;
+	node_info **nodes;
 	schd_resource *res;
 	resource_req *req;
 
-	if (nspec_arr != NULL) {
-		int i;
-		for (i = 0; nspec_arr[i] != NULL; i++)
-			;
-		nodes = static_cast<node_info **>(malloc((i + 1) * sizeof(node_info *)));
-		if (nodes != NULL) {
-			for (i = 0; nspec_arr[i] != NULL; i++) {
-				/* please note - the new duplicated nodes will NOT be part
+	nodes = static_cast<node_info **>(malloc((nspec_arr.size() + 1) * sizeof(node_info *)));
+	if (nodes != NULL) {
+		size_t i;
+		for (i = 0; i < nspec_arr.size(); i++) {
+			/* please note - the new duplicated nodes will NOT be part
 				 * of sinfo.  This means that you can't find a node in
 				 * node -> server -> nodes.  We include the server because
 				 * it is expected that every node have a server pointer and
 				 * parts of the code gets cranky if it isn't there.
 				 */
-				nodes[i] = dup_node_info(nspec_arr[i]->ninfo, sinfo, DUP_INDIRECT);
-				nodes[i]->svr_node = nspec_arr[i]->ninfo;
+			nodes[i] = dup_node_info(nspec_arr[i]->ninfo, sinfo, DUP_INDIRECT);
+			nodes[i]->svr_node = nspec_arr[i]->ninfo;
 
-				/* reservation nodes in state resv_exclusive can be assigned to jobs
+			/* reservation nodes in state resv_exclusive can be assigned to jobs
 				 * within the reservation
 				 */
-				if (nodes[i]->is_resv_exclusive)
-					remove_node_state(nodes[i], ND_resv_exclusive);
+			if (nodes[i]->is_resv_exclusive)
+				remove_node_state(nodes[i], ND_resv_exclusive);
 
-				req = nspec_arr[i]->resreq;
-				while (req != NULL) {
-					res = find_alloc_resource(nodes[i]->res, req->def);
+			req = nspec_arr[i]->resreq;
+			while (req != NULL) {
+				res = find_alloc_resource(nodes[i]->res, req->def);
 
-					if (res != NULL) {
-						if (res->indirect_res != NULL)
-							res = res->indirect_res;
-						res->avail = req->amount;
-						memcpy(&(res->type), &(req->type), sizeof(struct resource_type));
-						if (res->type.is_consumable)
-							res->assigned = 0; /* clear now, set later */
-					}
-					req = req->next;
+				if (res != NULL) {
+					if (res->indirect_res != NULL)
+						res = res->indirect_res;
+					res->avail = req->amount;
+					memcpy(&(res->type), &(req->type), sizeof(struct resource_type));
+					if (res->type.is_consumable)
+						res->assigned = 0; /* clear now, set later */
 				}
+				req = req->next;
 			}
-			nodes[i] = NULL;
 		}
+		nodes[i] = NULL;
 	}
 	return nodes;
 }
@@ -2057,7 +1918,7 @@ create_resv_nodes(nspec **nspec_arr, server_info *sinfo)
 void
 release_running_resv_nodes(resource_resv *resv, server_info *sinfo)
 {
-	if (resv == NULL || sinfo == NULL )
+	if (resv == NULL || sinfo == NULL)
 		return;
 	if (resv->resv->is_running && (resv->resv->resv_substate == RESV_DEGRADED || resv->resv->resv_state == RESV_BEING_ALTERED)) {
 		auto resv_nodes = resv->ninfo_arr;
@@ -2076,16 +1937,18 @@ release_running_resv_nodes(resource_resv *resv, server_info *sinfo)
  * 	@retval 1 - will attempt confirmation
  * 	@retval 0 - will not attempt confirmation
  */
-int will_confirm(resource_resv *resv, time_t server_time) {
+int
+will_confirm(resource_resv *resv, time_t server_time)
+{
 	/* If the reservation is unconfirmed OR is degraded and not running, with a
 	 * retry time that is in the past, then the reservation has to be
 	 * respectively confirmed and reconfirmed.
 	 */
 	if (resv->resv->resv_state == RESV_UNCONFIRMED ||
-		resv->resv->resv_state == RESV_BEING_ALTERED ||
-		((resv->resv->resv_substate == RESV_DEGRADED || resv->resv->resv_substate == RESV_IN_CONFLICT) &&
-		resv->resv->retry_time != UNSPECIFIED &&
-		resv->resv->retry_time <= server_time))
+	    resv->resv->resv_state == RESV_BEING_ALTERED ||
+	    ((resv->resv->resv_substate == RESV_DEGRADED || resv->resv->resv_substate == RESV_IN_CONFLICT) &&
+	     resv->resv->retry_time != UNSPECIFIED &&
+	     resv->resv->retry_time <= server_time))
 		return 1;
 
 	return 0;
@@ -2097,11 +1960,12 @@ int will_confirm(resource_resv *resv, time_t server_time) {
  * @param[in] resresv - the reservation
  * @param[in] server_time - time current time in the server
  */
-void modify_jobs_nodes_for_resv(resource_resv *resresv, time_t server_time)
+void
+modify_jobs_nodes_for_resv(resource_resv *resresv, time_t server_time)
 {
 	if (resresv->resv == NULL || resresv->resv->resv_queue == NULL)
 		return;
-	
+
 	resresv->resv->resv_queue->resv = resresv;
 	if (resresv->resv->resv_queue->jobs != NULL) {
 		for (int j = 0; resresv->resv->resv_queue->jobs[j] != NULL; j++) {
@@ -2130,14 +1994,13 @@ void modify_jobs_nodes_for_resv(resource_resv *resresv, time_t server_time)
 				 * i.e. the universe of the reservation
 				 */
 				int k = 0;
-				for (; rjob->nspec_arr[k] != NULL; k++) {
-					auto ns = rjob->nspec_arr[k];
+				for (auto ns : rjob->nspec_arr) {
 					auto resvnode = find_node_info(resresv->resv->resv_nodes, ns->ninfo->name);
 
 					if (resvnode != NULL) {
 						/* update the ninfo to point to the ninfo in our universe */
 						ns->ninfo = resvnode;
-						rjob->ninfo_arr[k] = resvnode;
+						rjob->ninfo_arr[k++] = resvnode;
 
 						/* update resource assigned amounts on the nodes in the
 						 * reservation's universe
@@ -2150,19 +2013,11 @@ void modify_jobs_nodes_for_resv(resource_resv *resresv, time_t server_time)
 							}
 						}
 					} else {
-#ifdef NAS /* localmod 031 */
 						log_eventf(PBSEVENT_RESV, PBS_EVENTCLASS_RESV, LOG_INFO, rjob->name,
-							   "Job has been assigned a node that doesn't exist in its reservation: %s", ns->ninfo->name);
-#else
-						log_event(PBSEVENT_RESV, PBS_EVENTCLASS_RESV, LOG_INFO, rjob->name,
-							  "Job has been assigned a node which doesn't exist in its reservation");
-#endif /* localmod 031 */
+							   "Job has been assigned a node that doesn't exist in its reservation: %s", ns->ninfo->name.c_str());
 					}
 				}
-				if (rjob->ninfo_arr[k] != NULL) {
-					log_event(PBSEVENT_RESV, PBS_EVENTCLASS_RESV, LOG_INFO, rjob->name,
-						  "Job's node array has different length than nspec_arr in query_reservations()");
-				}
+				rjob->ninfo_arr[k] = NULL;
 			}
 		}
 		auto jobs_in_reservations = resource_resv_filter(resresv->resv->resv_queue->jobs,

--- a/src/scheduler/resv_info.h
+++ b/src/scheduler/resv_info.h
@@ -88,23 +88,17 @@ int check_new_reservations(status *policy, int pbs_sd, resource_resv **resvs, se
 /**
  *      confirm_reservation - attempts to confirm a resource reservation
  */
-int confirm_reservation(status *policy, int pbs_sd, resource_resv *nresv, server_info *sinfo);
-
-/**
- *      checks that vnodes associated to a reservation that are not
- *                               available
- */
-int check_vnodes_unavailable(resource_resv *resv);
+int confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, server_info *nsinfo);
 
 /**
  * Release reousrces allocated to a reservation
  */
-void release_nodes(resource_resv *resc_resv);
+void release_nodes(resource_resv *resresv);
 
 /*
  *	create_resv_nodes - create a node universe for a reservation
  */
-node_info **create_resv_nodes(nspec **nspec_arr, server_info *sinfo);
+node_info **create_resv_nodes(std::vector<nspec *>& nspec_arr, server_info *sinfo);
 
 /*
  *	release_running_resv_nodes - adjust nodes resources for reservations that
@@ -112,8 +106,8 @@ node_info **create_resv_nodes(nspec **nspec_arr, server_info *sinfo);
  */
 void release_running_resv_nodes(resource_resv *resv, server_info *sinfo);
 
-/* Reduce resv_nodes of a reservation on pbs_ralter -lselect for running jobs */
-int ralter_reduce_chunks(resource_resv *resv);
+/* release chunks of the resv_nodes without running jobs on them */
+int resv_reduce_chunks(resource_resv *resv, selspec *spec);
 
 /* Will we try and confirm this reservation in this cycle */
 int will_confirm(resource_resv *resv, time_t server_time);

--- a/src/scheduler/sched_exception.cpp
+++ b/src/scheduler/sched_exception.cpp
@@ -48,7 +48,7 @@ sched_exception::sched_exception(const sched_exception &e)
 }
 
 // Assignment Operator
-sched_exception &sched_exception::operator =(const sched_exception &e)
+sched_exception &sched_exception::operator=(const sched_exception &e)
 {
 	message = e.get_message();
 	error_code = e.get_error_code();
@@ -56,11 +56,7 @@ sched_exception &sched_exception::operator =(const sched_exception &e)
 }
 
 // Parametrized Constructor
-sched_exception::sched_exception(const std::string &str, const enum sched_error_code err)
-{
-    message = str;
-    error_code = err;
-}
+sched_exception::sched_exception(const std::string &str, const enum sched_error_code err) : message(str), error_code(err) { }
 
 // Getter function for error_code
 enum sched_error_code sched_exception::get_error_code() const

--- a/src/scheduler/server_info.h
+++ b/src/scheduler/server_info.h
@@ -55,13 +55,13 @@ enum counts_on_run {
  *      query_server - creates a structure of arrays consisting of a server
  *                      and all the queues and jobs that reside in that server
  */
-server_info *query_server(status *policy, int pbs_sd);
+server_info *query_server(status *pol, int pbs_sd);
 
 /*
  *	query_server_info - collect information out of a statserver call
  *			    into a server_info structure
  */
-server_info *query_server_info(status *policy, struct batch_status *server);
+server_info *query_server_info(status *pol, struct batch_status *server);
 
 /*
  * 	query_server_dyn_res - execute all configured server_dyn_res scripts
@@ -91,12 +91,12 @@ schd_resource *find_resource(schd_resource *reslist, resdef *def);
 /*
  *      free_resource - free a resource struct
  */
-void free_resource(schd_resource *res);
+void free_resource(schd_resource *resp);
 
 /*
  *      free_resource_list - free a resource list
  */
-void free_resource_list(schd_resource *res_list);
+void free_resource_list(schd_resource *reslist);
 
 /*
  *      new_resource - allocate and initialize new resoruce struct
@@ -288,6 +288,9 @@ int check_run_job(resource_resv *job, const void *arg);
  *      update_universe_on_end - update a pbs universe when a job/resv ends
  */
 void update_universe_on_end(status *policy, resource_resv *resresv, const char *job_state, unsigned int flags);
+
+bool update_universe_on_run(status *policy, int pbs_sd, resource_resv *rr, std::vector<nspec *> &orig_ns, unsigned int flags);
+bool update_universe_on_run(status *policy, int pbs_sd, resource_resv *rr, unsigned int flags);
 
 /*
  *

--- a/src/scheduler/simulate.h
+++ b/src/scheduler/simulate.h
@@ -54,7 +54,7 @@ simulate_events(status *policy, server_info *sinfo,
  *	is_timed - check if a resresv is a timed event
  * 			 (i.e. has a start and end time)
  */
-int is_timed(event_ptr_t *resresv);
+int is_timed(event_ptr_t *event_ptr);
 
 /*
  *      get_next_event - get the next_event from an event list
@@ -146,7 +146,7 @@ timed_event *find_timed_event(timed_event *te_list, time_t event_time);
  *
  *      \return the next event or NULL if there are no more events
  */
-timed_event *next_event(server_info *sinfo, int dont_move);
+timed_event *next_event(server_info *sinfo, int advance);
 
 /*
  *      perform_event - takes a timed_event and performs any actions
@@ -181,7 +181,7 @@ event_list *create_event_list(server_info *sinfo);
  *	returns 1: there exists a run event
  *		0: there doesn't exist a run event
  */
-int exists_run_event(event_list *calendar, time_t end_time);
+int exists_run_event(event_list *calendar, time_t end);
 
 /* Checks to see if there is a run event on a node before the end time */
 int exists_run_event_on_node(node_info *ninf, time_t end);
@@ -218,7 +218,7 @@ event_list *new_event_list();
  *
  *      \return duplicated event_list
  */
-event_list *dup_event_list(event_list *oel, server_info *nsinfo);
+event_list *dup_event_list(event_list *oelist, server_info *nsinfo);
 
 /*
  * free_event_list - event_list destructor

--- a/src/scheduler/sort.h
+++ b/src/scheduler/sort.h
@@ -53,12 +53,12 @@ int cmpres(sch_resource_t r1, sch_resource_t r2);
  * cmp_nspec - sort nspec by sequence number
  *
  */
-int cmp_nspec(const void *v1, const void *v2);
+bool cmp_nspec(const nspec *n1, const nspec *n2);
 
 /*
  * cmp_nspec_by_sub_seq - sort nspec by sub sequence number
  */
-int cmp_nspec_by_sub_seq(const void *v1, const void *v2);
+bool cmp_nspec_by_sub_seq(const nspec *n1, const nspec *n2);
 
 /*
  *	cmp_placement_sets - sort placement sets by
@@ -97,7 +97,7 @@ int cmp_preempt_priority_asc(const void *j1, const void *j2);
  *      cmp_preempt_stime_asc - used to soft jobs in ascending preemption
  *                              start time
  */
-int cmp_preempt_stime_asc(const void *v1, const void *v2);
+int cmp_preempt_stime_asc(const void *j1, const void *j2);
 
 /*
  *      multi_sort - a multi keyed sortint compare function

--- a/test/tests/functional/pbs_ralter.py
+++ b/test/tests/functional/pbs_ralter.py
@@ -2077,7 +2077,6 @@ class TestPbsResvAlter(TestFunctional):
 
         rid, start, end, rnodes = self.alter_select_initial(True, select)
 
-
         self.alter_select(
             rid, start, end, True, aselect1, 4, [], 1)
 
@@ -2149,7 +2148,6 @@ class TestPbsResvAlter(TestFunctional):
         aselect3 = "1:ncpus=1:mem=3gb"
 
         rid, start, end, rnodes = self.alter_select_initial(True, select)
-
 
         rnodes2 = self.alter_select(rid, start, end,
                                     True, aselect1, 5, [], 1)
@@ -2259,7 +2257,7 @@ class TestPbsResvAlter(TestFunctional):
 
         w = 1
         if not success:
-            w  = 3
+            w = 3
         self.alter_a_reservation(rid, start, end, select=selectN,
                                  confirm=confirm, sequence=seq, whichMessage=w)
 

--- a/test/tests/functional/pbs_ralter.py
+++ b/test/tests/functional/pbs_ralter.py
@@ -2077,14 +2077,11 @@ class TestPbsResvAlter(TestFunctional):
 
         rid, start, end, rnodes = self.alter_select_initial(True, select)
 
-        nodes = [4, rnodes, 0, [], 0, []]
 
         self.alter_select(
-            rid, start, end, True, aselect1, 4, nodes, 1)
+            rid, start, end, True, aselect1, 4, [], 1)
 
-        nodes = [2, rnodes, 0, [], 0, []]
-
-        self.alter_select(rid, start, end, True, aselect2, 2, nodes, 2)
+        self.alter_select(rid, start, end, True, aselect2, 2, [], 2)
 
     def test_alter_select_basic_running(self):
         """
@@ -2099,14 +2096,9 @@ class TestPbsResvAlter(TestFunctional):
 
         rid, start, end, rnodes = self.alter_select_initial(False, select)
 
-        nodes = [0, [], 4, rnodes[2:6], 0, []]
+        rnodes2 = self.alter_select(rid, start, end, False, aselect1, 4, [], 1)
 
-        rnodes2 = self.alter_select(
-            rid, start, end, False, aselect1, 4, nodes, 1)
-
-        nodes = [0, [], 2, rnodes2, 0, []]
-
-        self.alter_select(rid, start, end, False, aselect2, 2, nodes, 2)
+        self.alter_select(rid, start, end, False, aselect2, 2, [], 2)
 
     def test_alter_select_complex(self):
         """
@@ -2121,13 +2113,9 @@ class TestPbsResvAlter(TestFunctional):
 
         rid, start, end, rnodes = self.alter_select_initial(True, select)
 
-        nodes = [4, rnodes, 0, [], 0, []]
+        self.alter_select(rid, start, end, True, aselect1, 4, [], 1)
 
-        self.alter_select(rid, start, end, True, aselect1, 4, nodes, 1)
-
-        nodes = [1, rnodes, 0, [], 0, []]
-
-        self.alter_select(rid, start, end, True, aselect2, 1, nodes, 2)
+        self.alter_select(rid, start, end, True, aselect2, 1, [], 2)
 
     def test_alter_select_complex_running(self):
         """
@@ -2142,14 +2130,10 @@ class TestPbsResvAlter(TestFunctional):
 
         rid, start, end, rnodes = self.alter_select_initial(False, select)
 
-        nodes = [1, rnodes[0:2], 2, rnodes[2:6], 1, rnodes[6:]]
-
         rnodes2 = self.alter_select(rid, start, end, False,
-                                    aselect1, 4, nodes, 1)
+                                    aselect1, 4, [], 1)
 
-        nodes = [0, [], 1, rnodes2, 0, []]
-
-        self.alter_select(rid, start, end, False, aselect2, 1, nodes, 2)
+        self.alter_select(rid, start, end, False, aselect2, 1, [], 2)
 
     def test_alter_select_complex2(self):
         """
@@ -2166,18 +2150,13 @@ class TestPbsResvAlter(TestFunctional):
 
         rid, start, end, rnodes = self.alter_select_initial(True, select)
 
-        nodes = [5, rnodes, 0, [], 0, []]
 
         rnodes2 = self.alter_select(rid, start, end,
-                                    True, aselect1, 5, nodes, 1)
+                                    True, aselect1, 5, [], 1)
 
-        nodes = [2, rnodes, 0, [], 0, []]
+        self.alter_select(rid, start, end, True, aselect2, 2, [], 2)
 
-        self.alter_select(rid, start, end, True, aselect2, 2, nodes, 2)
-
-        nodes = [1, rnodes, 0, [], 0, []]
-
-        self.alter_select(rid, start, end, True, aselect3, 1, nodes, 3)
+        self.alter_select(rid, start, end, True, aselect3, 1, [], 3)
 
     def test_alter_select_complex_running2(self):
         """
@@ -2194,19 +2173,53 @@ class TestPbsResvAlter(TestFunctional):
 
         rid, start, end, rnodes = self.alter_select_initial(False, select)
 
-        nodes = [2, rnodes[0:3], 1, rnodes[3:5], 2, rnodes[5:]]
-
         rnodes2 = self.alter_select(rid, start, end,
-                                    False, aselect1, 5, nodes, 1)
-
-        nodes = [1, rnodes2[0:2], 0, [], 1, rnodes2[3:]]
+                                    False, aselect1, 5, [], 1)
 
         rnodes3 = self.alter_select(rid, start, end,
-                                    False, aselect2, 2, nodes, 2)
+                                    False, aselect2, 2, [], 2)
 
-        nodes = [0, [], 0, [], 1, rnodes3[1:]]
+        self.alter_select(rid, start, end, False, aselect3, 1, [], 3)
 
-        self.alter_select(rid, start, end, False, aselect3, 1, nodes, 3)
+    def test_alter_select_complex_running3(self):
+        """
+        A complex set of ralters with running jobs
+        """
+        select = "3:ncpus=1:mem=1gb+2:ncpus=1:mem=2gb+3:ncpus=1:mem=3gb"
+        aselect1 = "2:ncpus=1:mem=1gb+1:ncpus=1:mem=2gb+2:ncpus=1:mem=3gb"
+        aselect2 = "1:ncpus=1:mem=1gb+1:ncpus=1:mem=3gb"
+        aselect3 = "1:ncpus=1:mem=3gb"
+
+        rid, start, end, rnodes = self.alter_select_initial(False, select)
+        rq = rid.split('.')[0]
+
+        a = {'queue': rq, 'Resource_List.select': '1:ncpus=1:mem=3gb'}
+        J1 = Job(attrs=a)
+        jid1 = self.server.submit(J1)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
+
+        a['Resource_List.select'] = '1:ncpus=1:mem=1gb'
+        J2 = Job(attrs=a)
+        jid2 = self.server.submit(J2)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
+        st = self.server.status(JOB)
+
+        nodes1 = J1.get_vnodes(st[0]['exec_vnode'])
+        nodes2 = J2.get_vnodes(st[1]['exec_vnode'])
+        needed_nodes = [nodes1[0], nodes2[0]]
+
+        self.alter_select(rid, start, end, False, aselect1, 5, needed_nodes, 1)
+
+        self.alter_select(rid, start, end, False, aselect2, 2, needed_nodes, 2)
+
+        # Alter will fail because we're trying to release Jid2's node
+
+        self.alter_select(rid, start, end, False, aselect3, 2,
+                          needed_nodes, 1, False)
+
+        self.server.delete(jid2, wait=True)
+
+        self.alter_select(rid, start, end, False, aselect3, 1, nodes1, 3)
 
     def alter_select_initial(self, confirm, select):
         """
@@ -2239,13 +2252,16 @@ class TestPbsResvAlter(TestFunctional):
         return rid, start, end, resv_nodes
 
     def alter_select(self, rid, start, end,
-                     confirm, selectN, numnodes, nodes, seq):
+                     confirm, selectN, numnodes, nodes, seq, success=True):
         """
         Alter a reservation and make sure it is on the correct nodes
         """
 
+        w = 1
+        if not success:
+            w  = 3
         self.alter_a_reservation(rid, start, end, select=selectN,
-                                 confirm=confirm, sequence=seq)
+                                 confirm=confirm, sequence=seq, whichMessage=w)
 
         st = self.server.status(RESV)
         self.assertEquals(len(st[0]['resv_nodes'].split('+')), numnodes)
@@ -2253,16 +2269,9 @@ class TestPbsResvAlter(TestFunctional):
              'Resource_List.nodect': numnodes}
         self.server.expect(RESV, a, id=rid)
         resv_nodes = self.server.reservations[rid].get_vnodes()
-        # format is [N, [], N, [], N, []], we look at it in pairs
-        for i in range(0, len(nodes), 2):
-            if nodes[i]:
-                num = nodes[i]
-                for n in nodes[i + 1]:
-                    if n in resv_nodes:
-                        num -= 1
-                        if not num:
-                            break
-                self.assertFalse(num, 'Correct nodes not found after alter')
+        # nodes is a list of nodes we must keep
+        for n in nodes:
+            self.assertIn(n, resv_nodes, "Required node not in resv_nodes")
         return resv_nodes
 
     def test_alter_select_with_times(self):

--- a/test/tests/functional/pbs_reservations.py
+++ b/test/tests/functional/pbs_reservations.py
@@ -2279,8 +2279,12 @@ class TestReservations(TestFunctional):
         self.server.manager(MGR_CMD_SET, SERVER, a)
 
         solution = '(' + vn[0] + ':ncpus=2)+(' + resv_node2 + ':ncpus=1)'
-        a = {'reserve_substate': '5', 'resv_nodes': solution}
+        a = {'reserve_substate': '5'}
         self.server.expect(RESV, a, id=rid)
+        self.server.status(RESV)
+        rnodes = self.server.reservations[rid].get_vnodes()
+        self.assertIn(vn[0], rnodes, "Wrong node assigned to resv")
+        self.assertIn(resv_node2, rnodes, "Wrong node assigned to resv")
 
     def test_standing_resv_with_start_in_past(self):
         """


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

Problem description
Refactored the NULL terminated pointer nspec array into a vector. Also refactored reconfirming resvs (pbs_ralter -lselect and degraded resvs) to use a new method.

Solution description
The scheduler uses a number of NULL terminated pointer ** arrays. It used to use one for the nspec (exec_vnode) object. It has been refactored to use a vector.

The code paths for pbs_ralter -lselect and reconfirming degraded reservations have been merged. The old code path used to try and keep as many non-down nodes as it could, even if they didn't have running jobs on them. The two features used different code paths. Before we'd create an unwieldy select statement with one chunk per node. This could be somewhat slow to reconfirm. Now we walk the nspec array (now vector) and release any node that doesn't have a running job on it. We create that select, but instead of one chunk per node, we only have one chunk per node for nodes with running jobs. The rest is shrunk down to a normal looking select.

Let's say we have (vn1:ncpus=1:mem=10gb)...(vn10:ncpus=1:mem=10gb). Before we'd have one chunk for each node vn1..vn10. Let's say there is only one running job on vn5. Now we'd get 1:vnode=vn5:ncpus=1:mem=10gb+9:ncpus=1:mem=10gb.