### PR TITLE
Remove unneeded #ifdef NAS code

### DIFF
--- a/src/cmds/mpiexec.in
+++ b/src/cmds/mpiexec.in
@@ -204,16 +204,8 @@ init()
 	if [ -n "$PBS_MPI_DEBUG" ]
 	then
 		debug=1
-		if [ -n "$NASMODE" ] ; then
-			# NAS localmod 073
-			mpirunverbose=-v
-		fi
 	else
 		debug=0
-		if [ -n "$NASMODE" ] ; then
-			# NAS localmod 073
-			mpirunverbose=''
-		fi
 	fi
 }
 
@@ -321,12 +313,7 @@ reset_rank()
 usage()
 {
 	printf "Usage:\n"
-	if [ -n "$NASMODE" ] ; then
-		# NAS localmod 073
-		printf "\t%s\n" "mpiexec [-v] -n    <maxprocs>"
-	else
-		printf "\t%s\n" "mpiexec -n    <maxprocs>"
-	fi
+	printf "\t%s\n" "mpiexec -n    <maxprocs>"
 	printf "\t%s\n" "-soft  <        >"
 	printf "\t%s\n" "-host  <        >"
 	printf "\t%s\n" "-arch  <        >"
@@ -363,34 +350,18 @@ evalsimpleargs()
 		arg="$2"
 	fi
 
-	if [ -n "$NASMODE" ] ; then
-		case "$opt" in
-			"-n")		maxprocs=$arg	;;
-			"-np")		maxprocs=$arg	;;	# NAS localmod 073
-			"-soft")	set=$arg	;;	# unimplemented?
-			"-host")	host=$arg	;;
-			"-arch")	arch=$arg	;;
-			"-wdir")	wdir=$arg	;;
-			"-path")	path=$arg	;;
-			"-file")	file=$arg	;;
-			*)		logerr "internal error - option \"$opt\""
-					exit 1
-					;;
-		esac
-	else
-		case "$opt" in
-			"-n")		maxprocs=$arg	;;
-			"-soft")	set=$arg	;;	# unimplemented?
-			"-host")	host=$arg	;;
-			"-arch")	arch=$arg	;;
-			"-wdir")	wdir=$arg	;;
-			"-path")	path=$arg	;;
-			"-file")	file=$arg	;;
-			*)		logerr "internal error - option \"$opt\""
-					exit 1
-					;;
-		esac
-	fi
+	case "$opt" in
+		"-n")		maxprocs=$arg	;;
+		"-soft")	set=$arg	;;	# unimplemented?
+		"-host")	host=$arg	;;
+		"-arch")	arch=$arg	;;
+		"-wdir")	wdir=$arg	;;
+		"-path")	path=$arg	;;
+		"-file")	file=$arg	;;
+		*)		logerr "internal error - option \"$opt\""
+				exit 1
+				;;
+	esac
 }
 
 #	debugging hook
@@ -584,19 +555,10 @@ sgiconfig()
 		PBS_LIB_PATH=${PBS_EXEC}/lib64
 	fi
 
-	if [ -n "$NASMODE" ] ; then
-		# NAS localmod 073
-		awkfile=${awkfile:-${PBS_LIB_PATH}/MPI/sgiMPI.awk}
-		awk -f $awkfile				-v configfile="$1"	\
-							-v runfile="$runfile"	\
-							-v pbs_exec="$PBS_EXEC"	\
-							-v debug=$debug
-	else
-		awk -f ${PBS_LIB_PATH}/MPI/sgiMPI.awk	-v configfile="$1"	\
-							-v runfile="$runfile"	\
-							-v pbs_exec="$PBS_EXEC"	\
-							-v debug=$debug
-	fi
+	awk -f ${PBS_LIB_PATH}/MPI/sgiMPI.awk	-v configfile="$1"	\
+						-v runfile="$runfile"	\
+						-v pbs_exec="$PBS_EXEC"	\
+						-v debug=$debug
 }
 
 #	... and execute it.
@@ -621,18 +583,7 @@ sgimpirun()
 		a_opt="-a $PBS_MPI_SGIARRAY"
 	fi
 
-	if [ -n "$NASMODE" ] ; then
-		set -- $mpirunverbose "${mpirun_args[@]}" $a_opt -f $runfile
-		if [ $debug -eq 1 ]
-		then
-			report_run "$@"
-			exit
-		fi
-
-		mpirun "$@"
-	else
-		mpirun $a_opt -f $runfile
-	fi
+	mpirun $a_opt -f $runfile
 }
 
 #	debugging hooks
@@ -643,18 +594,12 @@ report_config()
 }
 report_run()
 {
-	# NAS localmod 073
-	if [ -n "$NASMODE" ] ; then
-		echo mpirun "$@"
+	if [ -n "$PBS_MPI_SGIARRAY" ]
+	then
+		echo "mpirun -a $PBS_MPI_SGIARRAY -f $runfile"
 	else
-		if [ -n "$PBS_MPI_SGIARRAY" ]
-		then
-			echo "mpirun -a $PBS_MPI_SGIARRAY -f $runfile"
-		else
-			echo "mpirun -f $runfile"
-	 	fi
+		echo "mpirun -f $runfile"
 	fi
-
 	echo "where $runfile contains:"
 	cat $runfile | sed -e 's/^/\t/'
 }
@@ -665,145 +610,65 @@ MyName="`basename $0`"					# must occur first
 
 init ${1+"$@"}
 
-if [ -n "$NASMODE" ] ; then
-	# NAS localmod 073
-	declare -a mpirun_args
-	in_rankdef=0
-	while [ $# -gt 0 ]
-	do
-		# NAS localmod 073
-		case "$1" in
-			"-n"|"-np"|"-soft"|"-host"|"-arch"|"-wdir"|"-path"|"-file")
-				in_rankdef=1
-				evalsimpleargs ${1+"$@"}
-				shift 2
-				;;
-			"-configfile")
-				if [ $in_rankdef -eq 1 ]
+in_rankdef=0
+while [ $# -gt 0 ]
+do
+	case "$1" in
+		"-n"|"-soft"|"-host"|"-arch"|"-wdir"|"-path"|"-file")
+			in_rankdef=1
+			evalsimpleargs ${1+"$@"}
+			shift 2
+			;;
+		"-configfile")
+			if [ $in_rankdef -eq 1 ]
+			then
+				logerr "-configfile in rank definition"
+				exit 1
+			fi
+			# first "-configfile" option terminates argument parsing
+			shift
+			configfile="$1"
+			vendor_config $configfile && vendor_run
+			exit $?
+			;;
+		":")
+			in_rankdef=0
+			shift
+			evalsimpleargs ${1+"$@"}
+			while [ $# -gt 0 -a "$1" != ":" ]
+			do
+				shift
+			done
+			;;
+		*)
+			prog="$1"
+			shift
+			while [ $# -gt 0 ]
+			do
+				if [ "$1" = ":" ]
 				then
-					logerr "-configfile in rank definition"
-					exit 1
-				fi
-				# first "-configfile" option terminates argument parsing
-				shift
-				configfile="$1"
-				vendor_config $configfile && vendor_run
-				exit $?
-				;;
-			# NAS localmod 073
-			"-v")
-				mpirunverbose=-v
-				shift
-				;;
-			":")
-				in_rankdef=0
-				shift
-				evalsimpleargs ${1+"$@"}
-				while [ $# -gt 0 -a "$1" != ":" ]
-				do
-					shift
-				done
-				;;
-			# NAS localmod 073
-			-*)
-				mpirun_args=("${mpirun_args[@]}" "$1")
-				shift
-				if [ "$1" = "${1#-}" ]; then
-					mpirun_args=("${mpirun_args[@]}" "$1")
-					shift
-				fi
-				;;
-			*)
-				prog="$1"
-				shift
-				while [ $# -gt 0 ]
-				do
-					if [ "$1" = ":" ]
-					then
-						in_rankdef=0
-						dorank
-						break
-					else
-						progargs="$progargs $1"
-					fi
-					shift
-				done
-				if [ $# -gt 0 ]
-				then
-					if [ `expr substr "$1" 1 1` = ":" ]
-					then
-						shift
-					fi
-				else
-					ranknum=`expr $ranknum + 1`
 					in_rankdef=0
 					dorank
-				fi
-				;;
-		esac
-	done
-else
-	in_rankdef=0
-	while [ $# -gt 0 ]
-	do
-		case "$1" in
-			"-n"|"-soft"|"-host"|"-arch"|"-wdir"|"-path"|"-file")
-				in_rankdef=1
-				evalsimpleargs ${1+"$@"}
-				shift 2
-				;;
-			"-configfile")
-				if [ $in_rankdef -eq 1 ]
-				then
-					logerr "-configfile in rank definition"
-					exit 1
-				fi
-				# first "-configfile" option terminates argument parsing
-				shift
-				configfile="$1"
-				vendor_config $configfile && vendor_run
-				exit $?
-				;;
-			":")
-				in_rankdef=0
-				shift
-				evalsimpleargs ${1+"$@"}
-				while [ $# -gt 0 -a "$1" != ":" ]
-				do
-					shift
-				done
-				;;
-			*)
-				prog="$1"
-				shift
-				while [ $# -gt 0 ]
-				do
-					if [ "$1" = ":" ]
-					then
-						in_rankdef=0
-						dorank
-						break
-					else
-						progargs="$progargs $1"
-					fi
-					shift
-				done
-				if [ $# -gt 0 ]
-				then
-					if [ `expr substr "$1" 1 1` = ":" ]
-					then
-						shift
-					fi
+					break
 				else
-					ranknum=`expr $ranknum + 1`
-					in_rankdef=0
-					dorank
+					progargs="$progargs $1"
 				fi
-				;;
-		esac
-	done
-
-fi
+				shift
+			done
+			if [ $# -gt 0 ]
+			then
+				if [ `expr substr "$1" 1 1` = ":" ]
+				then
+					shift
+				fi
+			else
+				ranknum=`expr $ranknum + 1`
+				in_rankdef=0
+				dorank
+			fi
+			;;
+	esac
+done
 
 if [ $in_rankdef -eq 1 -a -z "$prog" ]
 then

--- a/src/cmds/pbs_mpirun.in
+++ b/src/cmds/pbs_mpirun.in
@@ -61,12 +61,7 @@ if [ "${PBS_NODEFILE:-XX}" = "XX" ]; then
 fi
 
 list=""
-if [ -n "$NASMODE"] ; then
-# NAS localmod 074
-	usernp=1
-else
-	usernp=`cat ${PBS_NODEFILE} | wc -l`
-fi
+usernp=`cat ${PBS_NODEFILE} | wc -l`
 
 while [ $# -gt 0 ]; do
 	if [ "XX$1" = "XX-np" ]; then

--- a/src/cmds/qsub.c
+++ b/src/cmds/qsub.c
@@ -108,18 +108,10 @@
 #define ENV_PBS_JOBID "PBS_JOBID"
 #define CMDLINE 3
 
-
-#ifndef NAS /* localmod 004 */
 #undef DEBUG
-#endif /* localmod 004 */
-
 #undef DBPRT
 #ifdef DEBUG
-#ifdef NAS /* localmod 004 */
-#define DBPRT(x)	fprintf x;
-#else
 #define DBPRT(x)	printf x;
-#endif /* localmod 004 */
 #else
 #define DBPRT(x)
 #endif
@@ -851,11 +843,7 @@ block_port(void)
 	}
 	port = ntohs(myaddr.sin_port);
 	(void)sprintf(portstring, "%u", (unsigned int)port);
-#ifdef NAS /* localmod 004 */
-	DBPRT((stderr, "block_port: %s\n", portstring))
-#else
 	DBPRT(("block_port: %s\n", portstring))
-#endif /* localmod 004 */
 
 	if (listen(comm_sock, 1) < 0) {
 		perror("qsub: listen on block socket");
@@ -929,11 +917,7 @@ retry:
 		perror("qsub: accept error");
 		exit_qsub(1);
 	}
-#ifdef NAS /* localmod 004 */
-	DBPRT((stderr, "got connection from %s:%d\n", inet_ntoa(from.sin_addr), (int)ntohs(from.sin_port)))
-#else
 	DBPRT(("got connection from %s:%d\n", inet_ntoa(from.sin_addr), (int)ntohs(from.sin_port)))
-#endif /* localmod 004 */
 
 	/*
 	 * if SIGINT or SIGBREAK interrupt is raised, then child thread win_blockint()

--- a/src/lib/Libcmds/get_server.c
+++ b/src/lib/Libcmds/get_server.c
@@ -168,11 +168,7 @@ get_server(char *job_id_in, char *job_id_out, char *server_out)
 
 		strcat(job_id_out, ".");
 
-#ifdef NAS_CANON_JOBID /* localmod 086 */
-		strcat(job_id_out, host_server);
-#else
 		strcat(job_id_out, parent_server);
-#endif /* localmod 086 */
 		if (server_out[0] == '\0')
 			strcpy(server_out, parent_server);
 		free(parent_server);

--- a/src/lib/Libecl/pbs_client_thread.c
+++ b/src/lib/Libecl/pbs_client_thread.c
@@ -53,9 +53,6 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <pwd.h>
-#ifdef NAS /* localmod 005 */
-#include <unistd.h>
-#endif /* localmod 005 */
 #include "libpbs.h"
 #include "pbs_client_thread.h"
 

--- a/src/resmom/linux/mom_mach.c
+++ b/src/resmom/linux/mom_mach.c
@@ -86,9 +86,6 @@
 #include "pbs_ifl.h"
 #include "placementsets.h"
 #include "mom_vnode.h"
-#ifndef NAS /* localmod 113 */
-#include "hwloc.h"
-#endif /* localmod 113 */
 
 /**
  * @file
@@ -112,10 +109,6 @@
  *		idletime	seconds of idle time (see mom_main.c)
  *		walltime	wall clock time for a pid
  *		loadave		current load average
- #ifdef NAS
- localmod 090
- *		times		Epoch time host booted and current time
- #endif
  */
 
 
@@ -174,13 +167,6 @@ static char	*totmem		(struct rm_attribute *attrib);
 static char	*availmem	(struct rm_attribute *attrib);
 static char	*ncpus		(struct rm_attribute *attrib);
 static char	*walltime	(struct rm_attribute *attrib);
-#ifdef NAS
-/* localmod 005 */
-static void proc_new		(int, int);
-/* localmod 090 */
-static unsigned linux_time = 0;
-static char	*sys_clocks	(struct rm_attribute *attrib);
-#endif
 
 extern char	*loadave	(struct rm_attribute *attrib);
 extern char	*nullproc	(struct rm_attribute *attrib);
@@ -212,37 +198,10 @@ struct	config	dependent_config[] = {
 	{ "ncpus",	{ ncpus } },
 	{ "loadave",	{ loadave } },
 	{ "walltime",	{ walltime } },
-#ifdef NAS
-	/* localmod 090 */
-	{ "times",	{ sys_clocks } },
-#endif
 	{ NULL,		{ nullproc } },
 };
 
-#ifdef NAS
-/* localmod 090 */
-/**
- * @brief
- *	returns present time
- *
- * @return 	char *
- * @retval 	time
- *
- */
-
-static char *
-sys_clocks(struct rm_attribute *attrib)
-{
-	sprintf(ret_string, "%lu/%lu", (unsigned long) linux_time,
-		(unsigned long) time_now);
-	return ret_string;
-}
-
-#endif /* NAS */
-
-#ifndef NAS /* localmod 090 */
 unsigned linux_time = 0;
-#endif /* localmod 090 */
 /**
  * @brief
  * 	support routine for getting system time -- sets linux_time

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -109,9 +109,7 @@
 #include	"pbs_internal.h"
 #include	"pbs_idx.h"
 #ifdef HWLOC
-#ifndef NAS /* localmod 113 */
 #include	"hwloc.h"
-#endif /* localmod 113 */
 #endif
 #include	"hook.h"
 #include	"mom_hook_func.h"
@@ -9554,7 +9552,6 @@ check_busy(double mla)
 void
 mom_topology(void)
 {
-#ifndef NAS /* localmod 113 */
 	extern char mom_short_name[];
 	extern callfunc_t vn_callback;
 	int ret = -1;
@@ -9750,5 +9747,4 @@ bad:
 #else
 	;
 #endif
-#endif /* localmod 113 */
 }

--- a/src/resmom/start_exec.c
+++ b/src/resmom/start_exec.c
@@ -1293,16 +1293,6 @@ set_credential(job *pjob, char **shell, char ***argarray)
 				if (num >= 2) { /* num=# of !NULL argarray entries */
 					for (j=1; (*argarray)[j]; j++)
 						argv[i++] = (*argarray)[j];
-#ifdef NAS /* localmod 019 */
-					/*
-					 * Broken bash does not read .profile even with
-					 * "-" name prefix.
-					 */
-					if (strcmp(name, "bash") == 0) {
-						argv[i] = strdup("--login");
-						i++;
-					}
-#endif /* localmod 019 */
 				}
 			}
 			ret = becomeuser(pjob);

--- a/src/scheduler/fairshare.cpp
+++ b/src/scheduler/fairshare.cpp
@@ -593,11 +593,7 @@ rec_write_usage(group_info *root, FILE *fp)
 	 * usage defaults to 1 so don't bother writing those out either
 	 * It is possible that the unknown group is empty.  Don't want to write it out
 	 */
-#ifdef NAS /* localmod 043 */
-	if (root->child == NULL) {
-#else
 	if (root->usage != 1 && root->child == NULL && root->name != UNKNOWN_GROUP_NAME) {
-#endif /* localmod 043 */
 		memset(&grp, 0, sizeof(struct group_node_usage_v2));
 		snprintf(grp.name, sizeof(grp.name), "%s", root->name.c_str());
 		grp.usage = root->usage;

--- a/src/scheduler/fifo.cpp
+++ b/src/scheduler/fifo.cpp
@@ -1779,15 +1779,6 @@ add_job_to_calendar(int pbs_sd, status *policy, server_info *sinfo,
 
 		exec = create_execvnode(njob->nspec_arr);
 		if (exec != NULL) {
-#ifdef NAS /* localmod 068 */
-			/* debug dpr - Log vnodes reserved for job */
-			time_t tm = time(NULL);
-			struct tm *ptm = localtime(&tm);
-			printf("%04d-%02d-%02d %02d:%02d:%02d %s %s %s\n",
-			       ptm->tm_year + 1900, ptm->tm_mon + 1, ptm->tm_mday,
-			       ptm->tm_hour, ptm->tm_min, ptm->tm_sec,
-			       "Backfill", njob->name.c_str(), exec);
-#endif /* localmod 068 */
 			free_nspecs(bjob->nspec_arr);
 			bjob->nspec_arr = parse_execvnode(exec, sinfo, NULL);
 			if (!bjob->nspec_arr.empty()) {

--- a/src/scheduler/limits.cpp
+++ b/src/scheduler/limits.cpp
@@ -1100,11 +1100,6 @@ check_soft_limits(server_info *si, queue_info *qi, resource_resv *rr)
 	if (si == NULL || qi == NULL || rr == NULL)
 		return 0;
 
-#ifdef NAS /* localmod 097 */
-	if (!si->has_soft_limit) {
-		return rc;
-	}
-#endif /* localmod 097 */
 	if (si->has_soft_limit) {
 		if (si->has_user_limit)
 			rc |= find_preempt_bits(si->user_counts, rr->user, rr);

--- a/src/scheduler/node_info.cpp
+++ b/src/scheduler/node_info.cpp
@@ -2114,12 +2114,6 @@ eval_selspec(status *policy, selspec *spec, place *placespec,
 	 */
 	flags &= ~RETURN_ALL_ERR;
 
-#ifdef NAS /* localmod 063 */
-	/* Should be at least one chunk */
-	if (spec->total_chunks < 1)
-		return false;
-#endif /* localmod 063 */
-
 	if (failerr == NULL) {
 		failerr = new_schd_error();
 		if (failerr == NULL) {
@@ -2810,9 +2804,6 @@ eval_simple_selspec(status *policy, chunk *chk, node_info **pninfo_arr,
 
 	if (chk == NULL || pninfo_arr == NULL || resresv== NULL || pl == NULL)
 		return false;
-#ifdef NAS /* localmod 005 */
-	ns = NULL;			/* quiet compiler warnings */
-#endif /* localmod 005 */
 
 	if (failerr == NULL) {
 		failerr = new_schd_error();

--- a/src/scheduler/server_info.cpp
+++ b/src/scheduler/server_info.cpp
@@ -1875,29 +1875,11 @@ create_server_arrays(server_info *sinfo)
 	}
 	job_arr[i] = NULL;
 
-#ifdef NAS /* localmod 054 */
-	if (i != sinfo->sc.total) {
-		sprintf(log_buffer, "Expected %d jobs, but found %d", sinfo->sc.total, i);
-		log_err(-1, __func__, log_buffer);
-		sinfo->sc.total = i;
-	}
-#endif /* localmod 054 */
-
 	if (sinfo->resvs != NULL) {
 		for (j = 0; sinfo->resvs[j] != NULL; j++, i++) {
 			all_arr[i] = sinfo->resvs[j];
 			all_arr[i]->resresv_ind = i;
 		}
-#ifdef NAS /* localmod 054 */
-		if (j != sinfo->num_resvs) {
-			sprintf(log_buffer, "Expected %d resv, but found %d", sinfo->num_resvs, j);
-			log_err(-1, __func__, log_buffer);
-			if (j > sinfo->num_resvs) {
-				abort();
-			}
-			sinfo->num_resvs = j;
-		}
-#endif /* localmod 054 */
 	}
 	all_arr[i] = NULL;
 
@@ -2134,14 +2116,7 @@ server_info::server_info(const server_info &osinfo)
 	sc = osinfo.sc;
 
 	/* sets nsinfo -> jobs and nsinfo -> all_resresv */
-#ifdef NAS /* localmod 054 */
-	if (create_server_arrays(this) == 0) {
-		free_server_info();
-		throw sched_exception("Unable to duplicate server arrays", SCHD_ERROR);
-	}
-#else
 	copy_server_arrays(this, &osinfo);
-#endif /* localmod 054 */
 
 	equiv_classes = dup_resresv_set_array(osinfo.equiv_classes, this);
 

--- a/src/server/req_register.c
+++ b/src/server/req_register.c
@@ -247,11 +247,6 @@ req_register(struct batch_request *preq)
 	/*  make sure request is from a server */
 
 	if (!preq->rq_fromsvr) {
-#ifdef NAS /* localmod 109 */
-		sprintf(log_buffer, "Dependency request not from server");
-		log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_JOB, LOG_INFO,
-			preq->rq_ind.rq_register.rq_parent, log_buffer);
-#endif /* localmod 109 */
 		req_reject(PBSE_IVALREQ, 0, preq);
 		return;
 	}
@@ -412,11 +407,6 @@ req_register(struct batch_request *preq)
 
 
 				default:
-#ifdef NAS /* localmod 109 */
-					sprintf(log_buffer, "Unknown dep. op: %d", preq->rq_ind.rq_register.rq_op);
-					log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_JOB, LOG_INFO,
-						preq->rq_ind.rq_register.rq_parent, log_buffer);
-#endif /* localmod 109 */
 					rc = PBSE_IVALREQ;
 					break;
 			}
@@ -457,16 +447,7 @@ req_register(struct batch_request *preq)
 							}
 							break;
 						}
-#ifdef NAS /* localmod 109 */
-						sprintf(log_buffer, "Dep.rls. job not found: %d/%s", type, preq->rq_ind.rq_register.rq_child);
-					} else {
-						sprintf(log_buffer, "Dep.rls. type not found: %d", type);
-#endif /* localmod 109 */
 					}
-#ifdef NAS /* localmod 109 */
-					log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_JOB, LOG_INFO,
-						preq->rq_ind.rq_register.rq_parent, log_buffer);
-#endif /* localmod 109 */
 					rc = PBSE_IVALREQ;
 					break;
 				case JOB_DEPEND_TYPE_RUNONE:
@@ -1183,24 +1164,14 @@ struct depend *find_depend(int type, attribute *pattr)
 {
 	struct depend *pdep = NULL;
 
-#ifdef NAS /* localmod 109 */
-	sprintf(log_buffer, "find_depend: t=%d, p.f=%#x, p.t=%#x", type, (int)pattr->at_flags, (int)pattr->at_type);
-#endif /* localmod 109 */
 	if (is_attr_set(pattr)) {
 		pdep = (struct depend *)GET_NEXT(pattr->at_val.at_list);
 		while (pdep) {
-#ifdef NAS /* localmod 109 */
-			sprintf(log_buffer+strlen(log_buffer), " %#p t=%d", (void *)pdep, (int)pdep->dp_type);
-#endif /* localmod 109 */
 			if (pdep->dp_type == type)
 				break;
 			pdep = (struct depend *)GET_NEXT(pdep->dp_link);
 		}
 	}
-#ifdef NAS /* localmod 109 */
-	log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_JOB, LOG_INFO,
-		  "ibid", log_buffer);
-#endif /* localmod 109 */
 	return (pdep);
 }
 

--- a/src/server/req_rescq.c
+++ b/src/server/req_rescq.c
@@ -620,16 +620,6 @@ req_confirmresv(struct batch_request *preq)
 		}
 	}
 
-#ifdef NAS /* localmod 122 */
-	/* If an advance reservation has already been confirmed there's no
-	 * work to be done.
-	 */
-	if (presv->ri_qs.ri_state == RESV_CONFIRMED && !get_rattr_long(presv, RESV_ATR_resv_standing)) {
-		reply_ack(preq);
-		return;
-	}
-#endif /* localmod 122 */
-
 	if (is_being_altered)
 		free_rattr(presv, RESV_ATR_alter_revert);
 

--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -406,7 +406,6 @@ req_runjob(struct batch_request *preq)
 		return;
 	}
 
-#ifndef NAS /* localmod 133 */
 	if ((psched->sc_cycle_started != -1) && was_job_alteredmoved(parent)) {
 		/* Reject run request for altered/moved jobs if job_run_wait is set to "execjob_hook" */
 		if (!is_sched_attr_set(psched, SCHED_ATR_job_run_wait) ||
@@ -416,7 +415,6 @@ req_runjob(struct batch_request *preq)
 			return;
 		}
 	}
-#endif /* localmod 133 */
 
 	if (jt == IS_ARRAY_NO) {
 		/* just a regular job, pass it on down the line and be done */

--- a/src/server/user_func.c
+++ b/src/server/user_func.c
@@ -56,12 +56,6 @@
 #include <sys/param.h>
 #include <dirent.h>
 
-#ifdef NAS /* localmod 005 */
-#ifdef	linux
-#include <netdb.h>		/* for ruserok */
-#endif
-#endif /* localmod 005 */
-
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <ctype.h>

--- a/src/unsupported/sgigenvnodelist.awk
+++ b/src/unsupported/sgigenvnodelist.awk
@@ -99,7 +99,6 @@ BEGIN {
 	# Sort cpus, mems, and vnodes numerically
 	PROCINFO["sorted_in"] = "@ind_num_asc";
 
-	nas_mode = 0;			#	enable NAS mod 80
 	deftype = "m";			#	by default, output for pbs_mom
 	exitval = 0;			#	used to elide END actions
 	listsep = ", "
@@ -595,16 +594,7 @@ function printmompsdefs(			cpusfmt, cpuspernode, i, j, id,
 
 		#	Make sure that the vnode name we construct maps directly
 		#	to the node number in the sn_topology file.
-		# NAS localmod 080
-		if(nas_mode) { 
-			vnodename = nodename "[" id "]";
-			if (id ~ /#/) {
-				sub(/#.*\]$/, "]", vnodename);
-			}
-		}
-		else {
-			vnodename = nodename "[" nodenums[id] "]";
-		}
+		vnodename = nodename "[" nodenums[id] "]";
 
 		printf("%s:  sharing = default_excl\n", vnodename);
 
@@ -632,28 +622,25 @@ function printmompsdefs(			cpusfmt, cpuspernode, i, j, id,
 		} else
 			printf(memfmt, vnodename, 0);
 
-		# NAS localmod 080
-		if(nas_mode == 0) {
-			if ((cpuspernode > 0) || (meminfo > 0)) {
-				firsttime = 1;
-				ptmp = "";
-				#	Make sure that the router names in the placement
-				#	set values map directly to the router numbers in
-				#	the sn_topology file.
-				for (j = 0; j < nrouters; j++) {
-					rid = routerid[j];
-					if (index(nodesof[rid], id))
-						if (firsttime) {
-							firsttime = 0;
-							ptmp = pshort routernum[rid];
-						} else
-							ptmp = ptmp "," pshort routernum[rid];
-				}
-				if (ptmp != "") {
-					#	add a value for the whole machine
-					ptmp = ptmp "," nodename;
-					printf(psfmt, vnodename, ptype, ptmp);
-				}
+		if ((cpuspernode > 0) || (meminfo > 0)) {
+			firsttime = 1;
+			ptmp = "";
+			#	Make sure that the router names in the placement
+			#	set values map directly to the router numbers in
+			#	the sn_topology file.
+			for (j = 0; j < nrouters; j++) {
+				rid = routerid[j];
+				if (index(nodesof[rid], id))
+					if (firsttime) {
+						firsttime = 0;
+						ptmp = pshort routernum[rid];
+					} else
+						ptmp = ptmp "," pshort routernum[rid];
+			}
+			if (ptmp != "") {
+				#	add a value for the whole machine
+				ptmp = ptmp "," nodename;
+				printf(psfmt, vnodename, ptype, ptmp);
 			}
 		}
 	}
@@ -992,10 +979,7 @@ END {
 	}
 
 	numhops = genhops();
-	# NAS localmod 080
-	if( nas_mode == 0 ) {
-		genps(numhops);
-	}
+	genps(numhops);
 
 	if (type == "m") {
 		momprologue();


### PR DESCRIPTION
The OpenPBS sources contain several local modifications for NAS (NASA Advanced Supercomputing). The affected code is usually bracketed by #ifdef NAS / #endif lines. Over time, some of these modifications have become unused or unneeded. They can be removed to simplify the code and make maintenance easier.

This PR removes the code associated with NAS localmods for:

004 Put qsub DBPRT output on stderr, rather than stdout.

019 Work around bug in bash by adding --login to command line.

043 Allow pbsfs to display all groups, even those with default usage.

054 Additional sanity checks in scheduler's create_server_arrays(). The checks have not tripped in recent memory.

063 Return early from eval_selspec() if there are 0 chunks.

073 Add -v and -np options to mpiexec and allow supplying a custom sgiMPI.awk file.

074 Use 1 as the default for pbs_mpirun's -np argument.

080 Modify sgigenvnodelist to use (more nearly) constant names for Altix nodes, rather than have the nodes renamed when one blade is removed/powered down.

086 In get_server(), allow users to use hostname aliases for the server name portion of a job identifier.

090 Modify MoM to allow requesting the boot time and current clock for the MoM's host.

097 Modify check_soft_limits() to exit early if we know there are no soft limits set.

109 Extra debugging messages in server job dependency code.

113 Disable use of hwloc in the MoM.

122 If req_confirmresv() is asked to confirm an already confirmed advance reservation, return without side effects.

133 Stray piece of "Watson" code.

Also removes some of the code for localmod 005, which allowed code to build cleanly with Intel compiler.

#### Attach Test and Valgrind Logs/Output
Code builds okay with same warning as without the mod:

`/bin/sh ../../libtool  --tag=CC   --mode=link gcc  -g -O2 -all-static  -o pbs_sleep pbs_sleep.o  -ldl -lcrypt -lc -lc`
`libtool: link: warning: complete static linking is impossible in this configuration`

pbs_benchpress -t SmokeTest ran fine:

 `2021-09-18 12:24:01,514 INFO     ================================================================================`
`run: 52, succeeded: 52, failed: 0, errors: 0, skipped: 0, timedout: 0`
`Tests run in 0:22:39.864640`


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
