### PR TITLE
Fix job exit status upon qdel

### DIFF
--- a/src/server/reply_send.c
+++ b/src/server/reply_send.c
@@ -315,9 +315,14 @@ reply_send(struct batch_request *request)
 
 	/* if this is a child request, just move the error to the parent */
 	if (request->rq_parentbr) {
-		if ((request->rq_parentbr->rq_reply.brp_choice == BATCH_REPLY_CHOICE_NULL) && (request->rq_parentbr->rq_reply.brp_code == 0)) {
+		if (((request->rq_parentbr->rq_reply.brp_choice == BATCH_REPLY_CHOICE_NULL) || (request->rq_parentbr->rq_reply.brp_choice == BATCH_REPLY_CHOICE_Delete)) && (request->rq_parentbr->rq_reply.brp_code == 0)) {
 			request->rq_parentbr->rq_reply.brp_code = request->rq_reply.brp_code;
 			request->rq_parentbr->rq_reply.brp_auxcode = request->rq_reply.brp_auxcode;
+			if (request->rq_type == PBS_BATCH_DeleteJobList) {
+				request->rq_parentbr->rq_reply.brp_count = request->rq_reply.brp_count;
+				pbs_delstatfree(request->rq_parentbr->rq_reply.brp_un.brp_deletejoblist.brp_delstatc);
+				request->rq_parentbr->rq_reply.brp_un.brp_deletejoblist.brp_delstatc = request->rq_reply.brp_un.brp_deletejoblist.brp_delstatc;
+			}
 			if (request->rq_reply.brp_choice == BATCH_REPLY_CHOICE_Text) {
 				request->rq_parentbr->rq_reply.brp_choice =
 					request->rq_reply.brp_choice;

--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -1136,6 +1136,7 @@ complete_running(job *jobp)
 	if (jobp->ji_qs.ji_stime != 0)
 		return;		/* already called for this incarnation */
 
+	jobp->ji_terminated = 0;	/* reset terminated flag */
 	/**
 	 *	For a subjob, insure the parent array's state is set to 'B'
 	 *	and deal with any dependency on the parent.


### PR DESCRIPTION
* When a job array has been qdel-ed, and the primary mom is down, the failure to delete one of the subjobs due to "could not connect to MOM" is not returned by qdel.
```
++ qsub -J 1-10 -- /bin/sleep 60
+ jid='9[].djoko'
+ echo '9[].djoko'
9[].djoko
+ qstat -Jt
Job id            Name             User              Time Use S Queue
----------------  ---------------- ----------------  -------- - -----
9[1].djoko        STDIN            bayucan                  0 R workq           
9[2].djoko        STDIN            bayucan                  0 Q workq           
9[3].djoko        STDIN            bayucan                  0 Q workq           
9[4].djoko        STDIN            bayucan                  0 Q workq           
9[5].djoko        STDIN            bayucan                  0 Q workq           
9[6].djoko        STDIN            bayucan                  0 Q workq           
9[7].djoko        STDIN            bayucan                  0 Q workq           
9[8].djoko        STDIN            bayucan                  0 Q workq           
9[9].djoko        STDIN            bayucan                  0 Q workq           
9[10].djoko       STDIN            bayucan                  0 Q workq           
+ sudo PBS_START_SERVER=0 PBS_START_MOM=1 PBS_START_SCHED=0 PBS_START_COMM=0 /opt/pbs/libexec/pbs_init.d stop
Stopping PBS
PBS mom - was pid: 80569
Waiting for shutdown to complete
+ /opt/pbs/bin/qdel '9[].djoko'
+ echo 0
0
# NOTE: qdel still returned success even though on the mom_logs it shows:
"0/14/2021 09:15:32.398850;0001;Server@djoko;Req;;Server could not connect to MOM
10/14/2021 09:15:32.398853;0080;Server@djoko;Svr;update_deljob_rply;job 0[1].djoko has already been deleted from delete job list
10/14/2021 09:15:32.398857;0080;Server@djoko;Req;req_reject;Reject reply code=15070, aux=0, type=100, from bayucan@djoko.pbspro.com
10/14/2021 09:15:32.398864;0008;Server@djoko;Job;0[1].djoko;Delete failed 15070"
and job array still exists:
[bayucan@djoko tmp]$ qstat -Jt
Job id            Name             User              Time Use S Queue
----------------  ---------------- ----------------  -------- - -----
9[1].djoko        STDIN            bayucan                  0 Q workq           
9[2].djoko        STDIN            bayucan                  0 X workq           
9[3].djoko        STDIN            bayucan                  0 X workq           
9[4].djoko        STDIN            bayucan                  0 X workq           
9[5].djoko        STDIN            bayucan                  0 X workq           
9[6].djoko        STDIN            bayucan                  0 X workq           
9[7].djoko        STDIN            bayucan                  0 X workq           
9[8].djoko        STDIN            bayucan                  0 X workq           
9[9].djoko        STDIN            bayucan                  0 X workq           
9[10].djoko       STDIN            bayucan                  0 X workq           
[bayucan@djoko tmp]$

It should return something like:
qdel: Server could not connect to MOM 9[1].djoko
 222

```
* With job_history enabled, when a job is interrupted and is rerun, the substate still shows up as 91 (Terminated) instead of 92 (Finished) in the end.
```
+ sudo /opt/pbs/bin/qmgr -c 's s scheduling=true'
+ sudo /opt/pbs/bin/qmgr -c 's s job_history_enable=true'
+ sudo /opt/pbs/bin/qmgr -c 's s job_requeue_timeout=5'
+ sudo /opt/pbs/bin/qmgr -c 's s node_fail_requeue=5'
+ sudo /opt/pbs/bin/qmgr -c 's s scheduler_iteration=5'
++ qsub -- /bin/sleep 30
+ jid=6.djoko
+ echo 6.djoko
6.djoko
+ sleep 10
+ qstat -a

djoko: 
                                                            Req'd  Req'd   Elap
Job ID          Username Queue    Jobname    SessID NDS TSK Memory Time  S Time
--------------- -------- -------- ---------- ------ --- --- ------ ----- - -----
5[].djoko       bayucan  workq    STDIN         --    1   1    --    --  B   -- 
6.djoko         bayucan  workq    STDIN         --    1   1    --    --  Q   -- 
+ sudo /opt/pbs/bin/qmgr -c 's s scheduling=false'
+ sudo PBS_START_SERVER=0 PBS_START_MOM=1 PBS_START_SCHED=0 PBS_START_COMM=0 /opt/pbs/libexec/pbs_init.d stop
Stopping PBS
PBS mom - was pid: 89075
Waiting for shutdown to complete
qdel: Server could not connect to MOM 6.djoko
+ echo 222

+ qstat -a

djoko: 
                                                            Req'd  Req'd   Elap
Job ID          Username Queue    Jobname    SessID NDS TSK Memory Time  S Time
--------------- -------- -------- ---------- ------ --- --- ------ ----- - -----
5[].djoko       bayucan  workq    STDIN         --    1   1    --    --  B   -- 
+ sudo PBS_START_SERVER=0 PBS_START_MOM=1 PBS_START_SCHED=0 PBS_START_COMM=0 /opt/pbs/libexec/pbs_init.d start
Starting PBS
PBS mom
+ qstat -xf 6.djoko
+ grep state
    job_state = F
    substate = 91
# NOTE: After job finishes, the substate still shows "Terminated" 91 from the previous qdel status. It should be substate 92 (Finished).
```

#### Cause / Analysis
* On the reply_send() code in the server, the failure message and condition from the subjob deletion action was not getting propagated to the parent batch request.
* Server fails to clear the pjob->ji_terminated flag when job was restarted successfully.

#### Solution description
* Copy the the failure code and message from the subjob request to the parent request.
* Clear the pjob->ji_terminated flag in complete_running() function.

#### Testing
#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
[ptl.qdel_hstry_jobs_rerun.PASS.txt](https://github.com/openpbs/openpbs/files/7394701/ptl.qdel_hstry_jobs_rerun.PASS.txt)
[ptl.qdel_hstry_jobs_rerun.FAIL.txt](https://github.com/openpbs/openpbs/files/7394702/ptl.qdel_hstry_jobs_rerun.FAIL.txt)
[ptl.test_qdel_job_array_downed_mom.PASS.txt](https://github.com/openpbs/openpbs/files/7394703/ptl.test_qdel_job_array_downed_mom.PASS.txt)
[ptl.test_qdel_job_array_downed_mom.FAIL.txt](https://github.com/openpbs/openpbs/files/7394704/ptl.test_qdel_job_array_downed_mom.FAIL.txt)


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
