### PR TITLE
Make sure pythonpath is set correctly when running ptl.sh

### DIFF
--- a/test/fw/ptl.sh
+++ b/test/fw/ptl.sh
@@ -40,18 +40,6 @@
 
 # This file will set path variables in case of ptl installation
 
-setpythonpath(){
-	check_dir=$1
-	path=$2
-	if [ -z ${PYTHONPATH} ]; then
-		[ -d ${check_dir} ] && export PYTHONPATH="${path}"
-	else
-		[ -d ${check_dir} ] && export PYTHONPATH="${PYTHONPATH}:${path}"
-	fi
-	unset check_dir
-	unset path
-}
-
 if [ -f /etc/debian_version ]; then
     __ptlpkgname=$(dpkg -W -f='${binary:Package}\n' 2>/dev/null | grep -E '*-ptl$')
     if [ "x${__ptlpkgname}" != "x" ]; then
@@ -68,7 +56,7 @@ if [ "x${ptl_prefix_lib}" != "x" ]; then
 	prefix=$( dirname ${ptl_prefix_lib} )
 
 	export PATH=${prefix}/bin/:${PATH}
-	export PYTHONPATH=${prefix}/lib/${python_dir}/site-packages/:$PYTHONPATH
+	export PYTHONPATH=${prefix}/lib/${python_dir}/site-packages${PYTHONPATH:+:$PYTHONPATH}
 	unset python_dir
 	unset prefix
 	unset ptl_prefix_lib
@@ -82,9 +70,9 @@ else
 			PTL_PREFIX=$( dirname ${__PBS_EXEC} )/ptl
 			python_dir=$( /bin/ls -1 ${PTL_PREFIX}/lib )/site-packages
 			[ -d "${PTL_PREFIX}/bin" ] && export PATH="${PATH}:${PTL_PREFIX}/bin"
-			setpythonpath "${PTL_PREFIX}/lib/${python_dir}" "${PTL_PREFIX}/lib/${python_dir}"
-			setpythonpath "${__PBS_EXEC}/lib/python/altair" "${__PBS_EXEC}/lib/python/altair"
-			setpythonpath "${__PBS_EXEC}/lib64/python/altair" "${__PBS_EXEC}/lib64/python/altair"
+			[ -d "${PTL_PREFIX}/lib/${python_dir}" ] && export PYTHONPATH="${PYTHONPATH:+$PYTHONPATH:}${PTL_PREFIX}/lib/${python_dir}"
+			[ -d "${__PBS_EXEC}/lib/python/altair" ] && export PYTHONPATH="${PYTHONPATH:+$PYTHONPATH:}${__PBS_EXEC}/lib/python/altair"
+			[ -d "${__PBS_EXEC}/lib64/python/altair" ] && export PYTHONPATH="${PYTHONPATH:+$PYTHONPATH:}${__PBS_EXEC}/lib64/python/altair"
 		fi
 		unset __PBS_EXEC
 		unset PTL_PREFIX


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
> When run during login, if the 
> PYTHONPATH environment variable is empty or missing, the script 
> creates PYTHONPATH with an empty first element, which means python 
> searches the current working directory first when looking for modules.
> This is bad practice. It affects all users on the host, not just users of PTL

Incorrect path:
```
bash-4.2$ echo $PYTHONPATH
:/opt/ptl/lib/python3.6/site-packages:/opt/pbs/lib/python/altair
```
The correct path should be :
```
bash-4.2$ echo $PYTHONPATH
/opt/ptl/lib/python3.6/site-packages:/opt/pbs/lib/python/altair
```



#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Ensure that if PYTHONPATH variable is empty the path is set without the preceding ':'



#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

```
export PYTHONPATH=""
sanidhya@ubuntu:~/git_chng/pbspro$ . test/fw/ptl.sh 
sanidhya@ubuntu:~/git_chng/pbspro$ echo $PYTHONPATH
/opt/ptl/lib/python3.5/site-packages:/opt/pbs/lib/python/altair
```

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
