### PR TITLE
Add python_restart_enable server option

### DIFF
--- a/doc/man1/pbs_server_attributes.7B
+++ b/doc/man1/pbs_server_attributes.7B
@@ -1351,8 +1351,9 @@ Default:
 
 .IP python_restart_max_hooks 8
 The maximum number of hooks to be serviced before the Python
-interpreter is restarted.  If this number is exceeded, and the time
-limit set in 
+interpreter is restarted.  If this number is exceeded,
+.I python_restart_enable
+is true, and the time limit set in
 .I python_restart_min_interval 
 has elapsed, the Python interpreter is restarted.
 .br
@@ -1369,8 +1370,9 @@ Default:
 
 .IP python_restart_max_objects 8
 The maximum number of objects to be created before the Python
-interpreter is restarted.  If this number is exceeded, and the time
-limit set in 
+interpreter is restarted.  If this number is exceeded,
+.I python_restart_enable
+is true, and the time limit set in
 .I python_restart_min_interval 
 has elapsed, the Python interpreter is restarted.
 .br
@@ -1387,13 +1389,15 @@ Default:
 
 .IP python_restart_min_interval 8
 The minimum time interval before the Python interpreter is restarted.
-If this interval has elapsed, and either the maximum number of hooks
+If this interval has elapsed,
+.I python_restart_enable
+is true, and either the maximum number of hooks
 to be serviced (set in 
-.I python_restart_max_hooks
-) has been exceeded or
+.IR python_restart_max_hooks )
+has been exceeded or
 the maximum number of objects to be created (set in
-.I python_restart_max_objects
-) has been exceeded, the Python interpreter is restarted.
+.IR python_restart_max_objects )
+has been exceeded, the Python interpreter is restarted.
 .br
 Readable by all; settable by Manager.
 .br
@@ -1410,6 +1414,24 @@ Python type:
 .br
 Default: 
 .I 30
+
+.IP python_restart_enable 8
+Enables restarting of the Python interpreter at a frequency defined by
+.IR python_restart_max_hooks ,
+.IR python_restart_max_objects ,
+and
+.IR python_restart_min_interval .
+.br
+Readable by all; settable by Manager.
+.br
+Format:
+.I Boolean
+.br
+Python type:
+.I bool
+.br
+Default:
+.I True
 
 .IP query_other_jobs 8
 Controls whether unprivileged users are allowed to select or query the

--- a/src/include/pbs_ifl.h
+++ b/src/include/pbs_ifl.h
@@ -320,6 +320,7 @@ extern "C" {
 #define ATTR_python_restart_max_hooks "python_restart_max_hooks"
 #define ATTR_python_restart_max_objects "python_restart_max_objects"
 #define ATTR_python_restart_min_interval "python_restart_min_interval"
+#define ATTR_python_restart_enable "python_restart_enable"
 #define ATTR_power_provisioning "power_provisioning"
 #define ATTR_sync_mom_hookfiles_timeout "sync_mom_hookfiles_timeout"
 #define ATTR_max_job_sequence_id "max_job_sequence_id"

--- a/src/lib/Libattr/master_svr_attr_def.xml
+++ b/src/lib/Libattr/master_svr_attr_def.xml
@@ -1516,6 +1516,23 @@
       </member_verify_function>
    </attributes>
    <attributes>
+      <member_index>SVR_ATR_PythonRestartEnable</member_index>
+      <member_name>ATTR_python_restart_enable</member_name>
+      <member_at_decode>decode_b</member_at_decode>
+      <member_at_encode>encode_b</member_at_encode>
+      <member_at_set>set_b</member_at_set>
+      <member_at_comp>comp_b</member_at_comp>
+      <member_at_free>free_null</member_at_free>
+      <member_at_action>NULL_FUNC</member_at_action>
+      <member_at_flags>MGR_ONLY_SET</member_at_flags>
+      <member_at_type>ATR_TYPE_BOOL</member_at_type>
+      <member_at_parent>PARENT_TYPE_SERVER</member_at_parent>
+      <member_verify_function>
+         <ECL>verify_datatype_bool</ECL>
+         <ECL>NULL_VERIFY_VALUE_FUNC</ECL>
+      </member_verify_function>
+   </attributes>
+   <attributes>
       #include "site_svr_attr_def.h"
       <member_index>SVR_ATR_queued_jobs_threshold</member_index>
       <member_name>ATTR_queued_jobs_threshold</member_name>

--- a/src/lib/Libpython/pbs_python_svr_internal.c
+++ b/src/lib/Libpython/pbs_python_svr_internal.c
@@ -5262,7 +5262,7 @@ _pbs_python_event_set(unsigned int hook_event, char *req_user, char *req_host,
 		enable_restart = PBS_PYTHON_RESTART_ENABLE;
 	if (lval != enable_restart) {
 		snprintf(log_buffer, sizeof(log_buffer),
-			"python_disable_restart is now %ld", enable_restart);
+			"python_enable_restart is now %ld", enable_restart);
 		log_event(PBSEVENT_DEBUG3, PBS_EVENTCLASS_HOOK, LOG_INFO, __func__, log_buffer);
 	}
 


### PR DESCRIPTION
This PR adds a new server option, `python_restart_enable`, that allows the Python interpreter restart to be enabled or disabled.  The default value is enabled.  This PR is related to PR #2501.