### PR TITLE
kerberos: fix for setting of KRB5CCNAME env in jobs

### DIFF
--- a/src/resmom/renew_creds.c
+++ b/src/resmom/renew_creds.c
@@ -134,7 +134,7 @@ static int get_job_info_from_principal(const char *principal, const char *jobid,
 static krb5_error_code get_ticket_from_storage(struct krb_holder *ticket, char *errbuf, size_t errbufsz);
 static krb5_error_code get_ticket_from_ccache(struct krb_holder *ticket, char *errbuf, size_t errbufsz);
 static krb5_error_code get_renewed_creds(struct krb_holder *ticket, char *errbuf, size_t errbufsz);
-static int init_ticket(struct krb_holder *ticket, int cred_action);
+static int init_ticket(struct krb_holder *ticket, job *pjob, int cred_action);
 
 static svrcred_data *find_cred_data_by_jobid(char *jobid);
 
@@ -163,7 +163,7 @@ init_ticket_from_req(char *principal, char *jobid, struct krb_holder *ticket, in
 		return ret;
 	}
 
-	ret = init_ticket(ticket, cred_action);
+	ret = init_ticket(ticket, NULL, cred_action);
 	if (ret == 0) {
 		ticket->got_ticket = 1;
 	}
@@ -196,7 +196,7 @@ init_ticket_from_job(job *pjob, const task *ptask, struct krb_holder *ticket, in
 		return ret;
 	}
 
-	ret = init_ticket(ticket, cred_action);
+	ret = init_ticket(ticket, pjob, cred_action);
 	if (ret == 0) {
 		ticket->got_ticket = 1;
 	}
@@ -260,7 +260,7 @@ init_ticket_from_ccache(job *pjob, const task *ptask, struct krb_holder *ticket)
  * @retval	!= PBS_KRB5_OK on error
  */
 static int
-init_ticket(struct krb_holder *ticket, int cred_action)
+init_ticket(struct krb_holder *ticket, job *pjob, int cred_action)
 {
 	int ret;
 	char buf[LOG_BUF_SIZE];
@@ -296,8 +296,8 @@ init_ticket(struct krb_holder *ticket, int cred_action)
 			break;
 	}
 
-	if (vtable.v_envp != NULL)
-		bld_env_variables(&vtable, "KRB5CCNAME", ticket->job_info->ccache_name);
+	if (pjob != NULL && pjob->ji_env.v_envp != NULL)
+		bld_env_variables(&(pjob->ji_env), "KRB5CCNAME", ticket->job_info->ccache_name);
 	else
 		setenv("KRB5CCNAME", ticket->job_info->ccache_name, 1);
 

--- a/src/resmom/start_exec.c
+++ b/src/resmom/start_exec.c
@@ -4701,13 +4701,13 @@ start_process(task *ptask, char **argv, char **envp, bool nodemux)
 	}
 
 #if defined(PBS_SECURITY) && (PBS_SECURITY == KRB5)
-	if (ptask->ti_job->ji_tasks.ll_prior == ptask->ti_job->ji_tasks.ll_next) { /* create only on first task */
+	if (pjob->ji_tasks.ll_prior == pjob->ji_tasks.ll_next) { /* create only on first task */
 		cred_action = CRED_RENEWAL;
 	} else {
 		cred_action = CRED_SETENV;
 	}
 
-	if (cred_by_job(ptask->ti_job, cred_action) != PBS_KRB5_OK) {
+	if (cred_by_job(pjob, cred_action) != PBS_KRB5_OK) {
 		log_eventf(PBSEVENT_JOB, PBS_EVENTCLASS_JOB, LOG_ERR, pjob->ji_qs.ji_jobid,
 			   "failed to set credentials for task %8.8X",
 			   ptask->ti_qs.ti_task);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Using gss and kerberos, the KRB5CCNAME env variable is not set within job. PR #1980 introduced this bug. PR #1980 changed the &vtable argument of bld_env_variables() to &(pjob->ji_env) in function finish_exec(). The relevant bld_env_variables() is also called in renew_creds.c:init_ticket(). The KRB5CCNAME for jobs is set here.

#### Describe Your Change
This change changes argument of bld_env_variables() from &vtable to &(pjob->ji_env)  in renew_creds.c:init_ticket().


#### Attach Test and Valgrind Logs/Output

Before:
The ticket is created but the KRB5CCNAME is not set to desired value:
```
torque1.grid.cesnet.cz$ qsub -I
qsub: waiting for job 10.torque1.grid.cesnet.cz to start
qsub: job 10.torque1.grid.cesnet.cz ready

torque1.grid.cesnet.cz$ klist
klist: No ticket file: /tmp/krb5cc_13167
```
...but the ticket is created:

```
torque1.grid.cesnet.cz$ KRB5CCNAME=/tmp/krb5cc_pbsjob_10.torque1.grid.cesnet.cz klist
Credentials cache: FILE:/tmp/krb5cc_pbsjob_10.torque1.grid.cesnet.cz
        Principal: vchlum@META

  Issued                Expires               Principal
Dec 14 09:58:42 2021  Dec 15 09:58:41 2021  krbtgt/META@META
Dec 14 10:25:30 2021  Dec 15 09:58:41 2021  afs/ics.muni.cz@META
Dec 14 10:25:30 2021  Dec 15 09:58:41 2021  krbtgt/ZCU.CZ@META
Dec 14 10:25:30 2021  Dec 15 02:25:30 2021  afs/zcu.cz@ZCU.CZ
torque1.grid.cesnet.cz$ 
```

After:
The env KRB5CCNAME is set as desired:
```
torque1.grid.cesnet.cz$ qsub -I -l select=2 -l place=scatter
qsub: waiting for job 16.torque1.grid.cesnet.cz to start
qsub: job 16.torque1.grid.cesnet.cz ready

torque1.grid.cesnet.cz$ klist
Credentials cache: FILE:/tmp/krb5cc_pbsjob_16.torque1.grid.cesnet.cz
        Principal: vchlum@META

  Issued                Expires               Principal
Dec 14 11:03:55 2021  Dec 15 11:03:54 2021  krbtgt/META@META
Dec 14 11:06:19 2021  Dec 15 11:03:54 2021  afs/ics.muni.cz@META
Dec 14 11:06:19 2021  Dec 15 11:03:54 2021  krbtgt/ZCU.CZ@META
Dec 14 11:06:19 2021  Dec 15 03:06:19 2021  afs/zcu.cz@ZCU.CZ
torque1.grid.cesnet.cz$ pbsdsh klist
Credentials cache: FILE:/tmp/krb5cc_pbsjob_16.torque1.grid.cesnet.cz
        Principal: vchlum@META

  Issued                Expires               Principal
Dec 14 11:03:55 2021  Dec 15 11:03:54 2021  krbtgt/META@META
Dec 14 11:06:19 2021  Dec 15 11:03:54 2021  afs/ics.muni.cz@META
Dec 14 11:06:19 2021  Dec 15 11:03:54 2021  krbtgt/ZCU.CZ@META
Dec 14 11:06:19 2021  Dec 15 03:06:19 2021  afs/zcu.cz@ZCU.CZ
Credentials cache: FILE:/tmp/krb5cc_pbsjob_16.torque1.grid.cesnet.cz
        Principal: vchlum@META

  Issued                Expires               Principal
Dec 14 11:03:55 2021  Dec 15 11:03:54 2021  krbtgt/META@META
Dec 14 11:06:25 2021  Dec 15 11:03:54 2021  afs/ics.muni.cz@META
Dec 14 11:06:25 2021  Dec 15 11:03:54 2021  krbtgt/ZCU.CZ@META
Dec 14 11:06:25 2021  Dec 15 03:06:25 2021  afs/zcu.cz@ZCU.CZ
```



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
