### PR TITLE
PTL and TestFunctional fixes

### DIFF
--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -1771,12 +1771,30 @@ class PBSTestSuite(unittest.TestCase):
         for server in self.servers.values():
             server.cleanup_files()
 
+        for comm in self.comms.values():
+            if not comm.isUp(max_attempts=1):
+                # If the comm was stopped, killed or left in a bad state, bring
+                # the comm back up to avoid a possible delay or failure when
+                # starting the next test.
+                comm.start()
+
         for mom in self.moms.values():
             mom.cleanup_files()
+            if not mom.isUp(max_attempts=1):
+                # If the MoM was stopped, killed or left in a bad state, bring
+                # the MoM back up to avoid a possible delay or failure when
+                # starting the next test.
+                mom.start()
 
-        for sched in self.scheds:
-            self.scheds[sched].cleanup_files()
+        for sched in self.scheds.values():
+            sched.cleanup_files()
+            if not sched.isUp(max_attempts=1):
+                # If the scheduler was stopped, killed or left in a bad state,
+                # bring the scheduler back up to avoid a possible delay or
+                # failure when starting the next test.
+                sched.start()
         self.server.delete_sched_config()
+
         if self.use_cur_setup:
             self.delete_current_state(self.server, self.moms)
             ret = self.server.load_configuration(self.saved_file)

--- a/test/tests/functional/pbs_job_sort_formula.py
+++ b/test/tests/functional/pbs_job_sort_formula.py
@@ -46,6 +46,9 @@ class TestJobSortFormula(TestFunctional):
     Tests for the job_sort_formula
     """
 
+    # PBS server internal error (15011) in decode_attr_db, Action function
+    # failed for job_sort_formula attr, errn 15011
+    @skip("Issue 2475: server crashes during setup of subsequent tests")
     def test_job_sort_formula_negative_value(self):
         """
         Test to see that negative values in the

--- a/test/tests/functional/pbs_systemd.py
+++ b/test/tests/functional/pbs_systemd.py
@@ -53,6 +53,10 @@ class Test_systemd(TestFunctional):
         is_systemctl = self.du.which(exe='systemctl')
         if is_systemctl == 'systemctl':
             self.skipTest("Systemctl command not found")
+        ret = self.du.run_cmd(self.server.hostname, "systemctl is-active dbus")
+        if ret['rc'] == 1:
+            self.skipTest("Systemd not functional")
+
 
     def shutdown_all(self):
         if self.server.isUp():

--- a/test/tests/functional/pbs_systemd.py
+++ b/test/tests/functional/pbs_systemd.py
@@ -57,7 +57,6 @@ class Test_systemd(TestFunctional):
         if ret['rc'] == 1:
             self.skipTest("Systemd not functional")
 
-
     def shutdown_all(self):
         if self.server.isUp():
             self.server.stop()


### PR DESCRIPTION
These changes allow the suite of TestFunctional tests to run in a simple single node environment using the following command.
```
pbs_benchpress -F -t TestFunctional --follow-child
```
While some tests still fail, and many are skipped, the failures no longer cascade.  Without these modifications, a test leaving the server, a MoM or a comm in a bad state could result in the failure of all subsequent tests.

[pbs-test-ptl-fixes-20211215.json.txt](https://github.com/openpbs/openpbs/files/7729777/pbs-test-ptl-fixes-20211215.json.txt)
