### PR TITLE
Minor PTL issue setting job_sort_key

### DIFF
--- a/test/fw/ptl/lib/ptl_sched.py
+++ b/test/fw/ptl/lib/ptl_sched.py
@@ -468,19 +468,18 @@ class Scheduler(PBSService):
         """
         Parse a sceduling configuration file into a dictionary.
         Special handling of identical keys ``(e.g., node_sort_key)``
-        is done by appending a delimiter, '%', between each value
-        of the key. When printed back to file, each delimited entry
+        is done using a list of values as the value of the key.
+        When printed back to file, each entry in the list
         gets written on a line of its own. For example, the python
         dictionary entry:
 
         ``{'node_sort_key':
-        ["ncpus HIGH unusued" prime", "node_priority HIH"
-        non-prime"]}``
+        ['"ncpus HIGH unused" prime', '"node_priority HIGH" non-prime']}``
 
         will get written as:
 
-        ``node_sort_key: "ncpus HIGH unusued" prime``
-        ``node_sort_key: "node_priority HIGH"  non-prime``
+        ``node_sort_key: "ncpus HIGH unused" prime``
+        ``node_sort_key: "node_priority HIGH" non-prime``
 
         Returns sched_config dictionary that gets reinitialized
         every time this method is called.
@@ -631,7 +630,11 @@ class Scheduler(PBSService):
                         fd.write("\n")
                 for k, v in self.sched_config.items():
                     if k not in self._config_order:
-                        fd.write(k + ": " + str(v).strip() + "\n")
+                        if isinstance(v, list):
+                            for val in v:
+                                fd.write(k + ": " + str(val).strip() + "\n")
+                        else:
+                                fd.write(k + ": " + str(v).strip() + "\n")
 
                 if 'PTL_SCHED_CONFIG_TAIL' in self._sched_config_comments:
                     fd.write("\n".join(

--- a/test/tests/selftest/pbs_config_sched.py
+++ b/test/tests/selftest/pbs_config_sched.py
@@ -59,7 +59,7 @@ class TestSchedConfig(TestSelf):
         slines = [x for x in clines if re.match(r'[\w]', x)]
         return slines
 
-    def get_a_setting(self, slines, key, squash=True):
+    def get_a_setting(self, slines, key):
         """"
         Extract lines changing a particular setting from a list of lines
         """
@@ -68,8 +68,6 @@ class TestSchedConfig(TestSelf):
         for line in slines:
             if line.startswith(key_colon):
                 value = line[len(key_colon):].strip()
-                if squash:
-                    value = ' '.join(value.split())
                 vals.append(value)
         return vals
 
@@ -77,17 +75,28 @@ class TestSchedConfig(TestSelf):
         '''
         Test whether Scheduler.set_sched_config() works as expected.
         '''
-        self.our_sched = self.scheds['default']
 
-        # First, get default settings for a few values and verify
-        # they are what they should be as of this version of test.
+        def get_dflt(key):
+            '''Get default value as list'''
+            if key in dflts:
+                val = dflts[key]
+                if not isinstance(val, list):
+                    val = [val]
+            else:
+                val = []
+            return val
+
+        self.our_sched = self.scheds['default']
+        dflts = self.our_sched.sched_config
+
+        # First, fetch default values our way and compare to real defaults
         slines = self.set_and_get({})
         def_rr = self.get_a_setting(slines, 'round_robin')
         def_nsk = self.get_a_setting(slines, 'node_sort_key')
         def_jsk = self.get_a_setting(slines, 'job_sort_key')
-        self.assertEqual(def_rr, ["False all"])
-        self.assertEqual(def_nsk, ['"sort_priority HIGH" ALL'])
-        self.assertEqual(def_jsk, [])
+        self.assertEqual(def_rr, get_dflt('round_robin'))
+        self.assertEqual(def_nsk, get_dflt('node_sort_key'))
+        self.assertEqual(def_jsk, get_dflt('job_sort_key'))
 
         # See if we can change an existing value, and leave others alone
         slines = self.set_and_get({'round_robin': 'True ALL'})

--- a/test/tests/selftest/pbs_config_sched.py
+++ b/test/tests/selftest/pbs_config_sched.py
@@ -46,7 +46,7 @@ class TestSchedConfig(TestSelf):
     Test setting values in sched_config file.
     """
 
-    def set_and_get(self, confs={}, validate=False):
+    def set_and_get(self, confs, validate=False):
         """
         Change settings in scheduler config file and fetch the new
         file contents
@@ -81,7 +81,7 @@ class TestSchedConfig(TestSelf):
 
         # First, get default settings for a few values and verify
         # they are what they should be as of this version of test.
-        slines = self.set_and_get()
+        slines = self.set_and_get({})
         def_rr = self.get_a_setting(slines, 'round_robin')
         def_nsk = self.get_a_setting(slines, 'node_sort_key')
         def_jsk = self.get_a_setting(slines, 'job_sort_key')

--- a/test/tests/selftest/pbs_config_sched.py
+++ b/test/tests/selftest/pbs_config_sched.py
@@ -1,0 +1,133 @@
+# coding: utf-8
+
+# Copyright (C) 2022 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of both the OpenPBS software ("OpenPBS")
+# and the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# OpenPBS is free software. You can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# OpenPBS is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# PBS Pro is commercially licensed software that shares a common core with
+# the OpenPBS software.  For a copy of the commercial license terms and
+# conditions, go to: (http://www.pbspro.com/agreement.html) or contact the
+# Altair Legal Department.
+#
+# Altair's dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of OpenPBS and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair's trademarks, including but not limited to "PBS™",
+# "OpenPBS®", "PBS Professional®", and "PBS Pro™" and Altair's logos is
+# subject to Altair's trademark licensing policies.
+
+from tests.selftest import *
+import re
+
+
+class TestSchedConfig(TestSelf):
+    """
+    Test setting values in sched_config file.
+    """
+
+    def set_and_get(self, confs={}, validate=False):
+        """
+        Change settings in scheduler config file and fetch the new
+        file contents
+        """
+        sched = self.our_sched
+        sched.set_sched_config(confs, apply=True, validate=validate)
+        cfile = sched.sched_config_file
+        clines = self.du.cat(sched.hostname, cfile, sudo=True,
+                             level=logging.DEBUG2)['out']
+        slines = [x for x in clines if re.match(r'[\w]', x)]
+        return slines
+
+    def get_a_setting(self, slines, key, squash=True):
+        """"
+        Extract lines changing a particular setting from a list of lines
+        """
+        vals = []
+        key_colon = key + ':'
+        for line in slines:
+            if line.startswith(key_colon):
+                value = line[len(key_colon):].strip()
+                if squash:
+                    value = ' '.join(value.split())
+                vals.append(value)
+        return vals
+
+    def test_set_sched_config(self):
+        '''
+        Test whether Scheduler.set_sched_config() works as expected.
+        '''
+        self.our_sched = self.scheds['default']
+
+        # First, get default settings for a few values and verify
+        # they are what they should be as of this version of test.
+        slines = self.set_and_get()
+        def_rr = self.get_a_setting(slines, 'round_robin')
+        def_nsk = self.get_a_setting(slines, 'node_sort_key')
+        def_jsk = self.get_a_setting(slines, 'job_sort_key')
+        self.assertEqual(def_rr, ["False all"])
+        self.assertEqual(def_nsk, ['"sort_priority HIGH" ALL'])
+        self.assertEqual(def_jsk, [])
+
+        # See if we can change an existing value, and leave others alone
+        slines = self.set_and_get({'round_robin': 'True ALL'})
+        new_rr = self.get_a_setting(slines, 'round_robin')
+        new_nsk = self.get_a_setting(slines, 'node_sort_key')
+        new_jsk = self.get_a_setting(slines, 'job_sort_key')
+        self.assertEqual(new_rr, ["True ALL"])
+        def_rr = new_rr
+        self.assertEqual(new_nsk, def_nsk, "Change to unexpected setting")
+        self.assertEqual(new_jsk, def_jsk, "Change to unexpected setting")
+
+        # Repeat for initially missing setting
+        slines = self.set_and_get({'job_sort_key': '"ncpus HIGH"'})
+        new_rr = self.get_a_setting(slines, 'round_robin')
+        new_nsk = self.get_a_setting(slines, 'node_sort_key')
+        new_jsk = self.get_a_setting(slines, 'job_sort_key')
+        self.assertEqual(new_rr, def_rr, "Change to unexpected setting")
+        self.assertEqual(new_nsk, def_nsk, "Change to unexpected setting")
+        self.assertEqual(new_jsk, ['"ncpus HIGH"'])
+        def_jsk = new_jsk
+
+        # Test whether we can unset a value by setting to empty list
+        slines = self.set_and_get({'job_sort_key': []})
+        new_rr = self.get_a_setting(slines, 'round_robin')
+        new_nsk = self.get_a_setting(slines, 'node_sort_key')
+        new_jsk = self.get_a_setting(slines, 'job_sort_key')
+        self.assertEqual(new_rr, def_rr, "Change to unexpected setting")
+        self.assertEqual(new_nsk, def_nsk, "Change to unexpected setting")
+        self.assertEqual(new_jsk, [])
+        def_jsk = new_jsk
+
+        # Test whether we can set multiple values
+        slines = self.set_and_get({'job_sort_key':
+                                   ['"job_priority HIGH"', '"ncpus HIGH"']})
+        new_rr = self.get_a_setting(slines, 'round_robin')
+        new_nsk = self.get_a_setting(slines, 'node_sort_key')
+        new_jsk = self.get_a_setting(slines, 'job_sort_key')
+        self.assertEqual(new_rr, def_rr, "Change to unexpected setting")
+        self.assertEqual(new_nsk, def_nsk, "Change to unexpected setting")
+        self.assertEqual(new_jsk, ['"job_priority HIGH"', '"ncpus HIGH"'])
+
+        # Finally, check if the scheduler likes the final result
+        self.our_sched.set_sched_config(apply=True, validate=True)


### PR DESCRIPTION
The apply_config() routine in ptl_sched.py cannot handle some multi-valued options 

#### Describe Bug or Feature
The set_sched_config() routine in ptl_sched.py does not permit setting multiple values for job_sort_key. The problem is actually in apply_config(). More exactly, apply_config does not allow multiple values for any scheduler setting that does not appear in the default scheduler config. Thus, it works for node_sort_key, which appears uncommented in the default config; but not for job_sort_key, which appears only commented out.


#### Describe Your Change
The fix is to copy the code that handles existing options into the code block that handles unset options.


#### Link to Design Doc
none

#### Attach Test and Valgrind Logs/Output
The comments at the beginning of parse_sched_config() suggest that at one time the thought was to use '%' to separate multiple values for an option. However, what is now implemented is to expect a list of values instead of a single value  string.

The following dummy PTL test case was created to verify how apply_config() works. When run, it creates four sched_config files named 'result_A' through 'result_D'. 

```
# coding: utf-8

from tests.functional import *


class TestDummy(TestFunctional):
    """
    Test how Scheduler.apply_config deals with options with multiple
    values
    """
    def set_config(self, confs={}, path=None):
        sched = self.scheds['default']
        sched.parse_sched_config()
        sched.logger.info(sched.logprefix + 'config ' + str(confs))
        sched.sched_config = {**sched.sched_config, **confs}
        sched.apply_config(config=None, validate=False, path=path)

    def test_apply(self):
        # Test normal use
        attr = {'job_sort_key': '"job_priority HIGH"'}
        self.set_config(attr, path='result_A')
        # Test whether '%' works to separate values
        attr = {'job_sort_key': '"job_priority HIGH"%"ncpus HIGH"'}
        self.set_config(attr, path='result_B')
        # Test what happens if specify same value more than once
        attr = {'job_sort_key': '"job_priority HIGH"',
                'job_sort_key': '"ncpus HIGH"'}
        # Test if can use list of values
        self.set_config(attr, path='result_C')
        attr = {'job_sort_key': ['"job_priority HIGH"',
                                 '"ncpus HIGH"']}
        self.set_config(attr, path='result_D')
```

The test was run with
```
pbs_benchpress -t TestDummy -p "servers=server2"
```
where server2 is the test PBS server hostname. The values for job_sort_key were grepped out of the result_X files, yielding:

```
result_A:job_sort_key: "job_priority HIGH"
result_B:job_sort_key: "job_priority HIGH"%"ncpus HIGH"
result_C:job_sort_key: "ncpus HIGH"
result_D:job_sort_key: ['"job_priority HIGH"', '"ncpus HIGH"']
```
As can be seen, none of the inputs was able to create multiple job_sort_key lines.

After applying the fix, the dummy test was rerun and gave:

```
result_A:job_sort_key: "job_priority HIGH"
result_B:job_sort_key: "job_priority HIGH"%"ncpus HIGH"
result_C:job_sort_key: "ncpus HIGH"
result_D:job_sort_key: "job_priority HIGH"
result_D:job_sort_key: "ncpus HIGH"
```
Here, the 'D' test that supplied a list of values worked to produce multiple job_sort_key lines with the desired values.

The modified code passes the SmokeTest suite.
