### PR TITLE
Python sys.path check before append leak

### DIFF
--- a/src/modules/python/pbs/v1/_pmi_sgi.py
+++ b/src/modules/python/pbs/v1/_pmi_sgi.py
@@ -56,20 +56,27 @@ if pbsexec is None:
     raise BackendError("PBS_EXEC not found")
 
 py_version = str(sys.version_info.major) + "." + str(sys.version_info.minor)
-sys.path.append(os.path.join(pbsexec, "python", "lib", py_version))
-sys.path.append(os.path.join(pbsexec, "python", "lib", py_version,
-                "lib-dynload"))
+_path = os.path.join(pbsexec, "python", "lib", py_version)
+if _path not in sys.path:
+    sys.path.append(_path)
+_path = os.path.join(pbsexec, "python", "lib", py_version, "lib-dynload")
+if _path not in sys.path:
+    sys.path.append(_path)
 import encodings
 
 
 # Plug in the path for the HPE/SGI power API.
-if os.path.exists("/opt/clmgr/power-service"):
+_path = "/opt/clmgr/power-service"
+if os.path.exists(_path):
     # Look for HPCM support.
-    sys.path.append("/opt/clmgr/power-service")
+    if _path not in sys.path:
+        sys.path.append(_path)
     import hpe_clmgr_power_api as api
 else:
     # Look for SGIMC support.
-    sys.path.append("/opt/sgi/ta")
+    _path = "/opt/sgi/ta"
+    if _path not in sys.path:
+        sys.path.append(_path)
     import sgi_power_api as api
 
 

--- a/src/unsupported/NodeHealthCheck.py
+++ b/src/unsupported/NodeHealthCheck.py
@@ -93,7 +93,8 @@ try:
 
     if sys.path.__contains__(py_path + '/python' + py_version) == False:
         for my_path in my_paths:
-            sys.path.append(my_path)
+            if my_path not in sys.path:
+                sys.path.append(my_path)
 
 except ImportError:
     pass

--- a/src/unsupported/pbs_output.py
+++ b/src/unsupported/pbs_output.py
@@ -50,7 +50,8 @@ It is run by the Cray RUR system as an "output plugin".
 import os
 import sys
 rur_path = os.path.join(os.path.sep, 'opt', 'cray', 'rur', 'default', 'bin')
-sys.path.append(rur_path)
+if rur_path not in sys.path:
+    sys.path.append(rur_path)
 try:
     from rur_plugins import rur_output_args, get_plugin_name, rur_errorlog
 except Exception:


### PR DESCRIPTION
Adding a check for a path before appending it to sys.path to prevent it from being added more than once.  In hooks, sys.path remains for each call, resulting in a memory leak without this check.  It might be good to document somewhere that if a sys.path.append is required within a hook, that it must check the list first.  This was found while debugging #2501 by using gc.get_objects() and compare before and after hooks were run.

#### Describe Bug or Feature
Due to the way hooks are processed within pbs_server's embedded Python, appending to sys.path without checking grows the size of sys.path for every append.  While all the code modified are not hooks scripts, this will also prevent duplicates.

#### Describe Your Change
Inserted an if statement before appending to sys.path.