### PR TITLE
PTL petty param parse problem

### DIFF
--- a/test/fw/ptl/utils/plugins/ptl_test_runner.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_runner.py
@@ -71,6 +71,7 @@ from ptl.utils.pbs_testsuite import (MINIMUM_TESTCASE_TIMEOUT,
                                      REQUIREMENTS_KEY, TIMEOUT_KEY)
 from ptl.utils.plugins.ptl_test_info import get_effective_reqs
 from ptl.utils.pbs_testusers import PBS_ALL_USERS, PBS_USERS, PbsUser
+from ptl.lib.ptl_constants import (PTL_TRUE, PTL_FALSE)
 from io import StringIO
 
 log = logging.getLogger('nose.plugins.PTLTestRunner')
@@ -671,6 +672,15 @@ class PTLTestRunner(Plugin):
         Method to convert data in param into dictionary of cluster
         information
         """
+        def get_bool(v):
+            if v == None or v == '':
+                return False
+            if v in PTL_TRUE:
+                return True
+            if v in PTL_FALSE:
+                return False
+            raise ValueError("Need boolean value, not %s" % v)
+
         tparam_contents = {}
         nomomlist = []
         shortname = (socket.gethostname()).split('.', 1)[0]
@@ -696,11 +706,11 @@ class PTLTestRunner(Plugin):
                     elif k == 'nomom':
                         nomomlist = hosts
                     elif k == 'mom_on_server':
-                        tparam_contents['mom_on_server'] = v
+                        tparam_contents['mom_on_server'] = get_bool(v)
                     elif k == 'no_mom_on_server':
-                        tparam_contents['no_mom_on_server'] = v
+                        tparam_contents['no_mom_on_server'] = get_bool(v)
                     elif k == 'no_comm_on_mom':
-                        tparam_contents['no_comm_on_mom'] = v
+                        tparam_contents['no_comm_on_mom'] = get_bool(v)
         for pkey in ['servers', 'moms', 'comms', 'clients']:
             if not tparam_contents[pkey]:
                 tparam_contents[pkey] = set([shortname])

--- a/test/fw/ptl/utils/plugins/ptl_test_runner.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_runner.py
@@ -673,7 +673,7 @@ class PTLTestRunner(Plugin):
         information
         """
         def get_bool(v):
-            if v == None or v == '':
+            if v is None or v == '':
                 return False
             if v in PTL_TRUE:
                 return True

--- a/test/tests/selftest/pbs_param_dict.py
+++ b/test/tests/selftest/pbs_param_dict.py
@@ -1,0 +1,125 @@
+# coding: utf-8
+
+# Copyright (C) 2022 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of both the OpenPBS software ("OpenPBS")
+# and the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# OpenPBS is free software. You can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# OpenPBS is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# PBS Pro is commercially licensed software that shares a common core with
+# the OpenPBS software.  For a copy of the commercial license terms and
+# conditions, go to: (http://www.pbspro.com/agreement.html) or contact the
+# Altair Legal Department.
+#
+# Altair's dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of OpenPBS and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair's trademarks, including but not limited to "PBS™",
+# "OpenPBS®", "PBS Professional®", and "PBS Pro™" and Altair's logos is
+# subject to Altair's trademark licensing policies.
+
+
+from tests.selftest import *
+from ptl.utils.plugins.ptl_test_runner import PTLTestRunner
+
+
+class TestParamDict(TestSelf):
+    """
+    Test parsing the pbs_benchpress -p argument
+    """
+
+    def test_gpd(self):
+        """
+        Pass various -p param strings to __get_param_dictionary and check
+        that result is correct.
+        """
+        def try_one(runner, param):
+            """
+            Run get_param_dictionary to convert param string to dict
+            """
+            runner.param = param
+            try:
+                # Note that we call private routine directly to avoid
+                # possible side effects.
+                result = runner._PTLTestRunner__get_param_dictionary()
+            except ValueError:
+                result = None
+            return result
+
+        def compare(old, new, expect_none=False):
+            """
+            Compare new param dict to old
+            """
+            if new is None and not expect_none:
+                return 'Unexpected parse error'
+            if expect_none and new is not None:
+                return 'Should have failed'
+            all_keys = set(old.keys()) | set(new.keys())
+            diffs = []
+            for k in sorted(all_keys):
+                o = old.get(k, None)
+                n = new.get(k, None)
+                if o != n:
+                    diffs.append((k, n))
+            return diffs
+
+        def check_diffs(self, new, expected):
+            """
+            Validate changes between baseline and new param dict
+            """
+            if expected is None:
+                self.assertEqual(new, expected)
+                return
+            diffs = compare(self.base, new)
+            self.assertEqual(diffs, expected)
+
+        our_runner = PTLTestRunner()
+
+        # Create baseline dictionary
+        self.base = try_one(our_runner, '')
+
+        # Try simple key=value (boolean)
+        new = try_one(our_runner, 'mom_on_server=True')
+        check_diffs(self, new, [('mom_on_server', True)])
+
+        # Try one that generates a set of hostnames
+        new = try_one(our_runner, 'moms=foo')
+        check_diffs(self, new, [('moms', set(['foo']))])
+
+        # Test that unknown parameter is ignored
+        new = try_one(our_runner, 'nonsense')
+        check_diffs(self, new, [])
+
+        # Test more complicated host list
+        new = try_one(our_runner, 'comms=foo:bar@/path/to/bleem:baz')
+        check_diffs(self, new, [('comms', set(['foo', 'baz', 'bar']))])
+
+        # Test bad boolean arg
+        new = try_one(our_runner, 'mom_on_server=oops')
+        check_diffs(self, new, None)
+
+        # Test multiple options, one of which is default
+        new = try_one(our_runner,
+                      'server=foo2:bar,mom_on_server=y,comm_on_server=f')
+        expected = [('mom_on_server', True),
+                    ('servers', set(['foo2', 'bar']))]
+        check_diffs(self, new, expected)

--- a/test/tests/selftest/pbs_param_dict.py
+++ b/test/tests/selftest/pbs_param_dict.py
@@ -73,14 +73,8 @@ class TestParamDict(TestSelf):
                 return 'Unexpected parse error'
             if expect_none and new is not None:
                 return 'Should have failed'
-            all_keys = set(old.keys()) | set(new.keys())
-            diffs = []
-            for k in sorted(all_keys):
-                o = old.get(k, None)
-                n = new.get(k, None)
-                if o != n:
-                    diffs.append((k, n))
-            return diffs
+            diffs = [(k, new[k]) for k in old if old[k] != new[k]]
+            return sorted(diffs)
 
         def check_diffs(self, new, expected):
             """


### PR DESCRIPTION
[Very minor bug]
Some of the parameters to the pbs_benchpress -p option are booleans (e.g., mom_on_server). They are initialized to False. The routine __get_param_dictionary() splits the -p option into its various param=value pieces and builds a dictionary from the known params and their values. For the boolean params, it currently stores the value as received. I.e., as a string. This has the perverse result that specifying "-p mom_on_server=False" results in mom_on_server testing true in an 'if' statement, because any non-empty string is True in a boolean context.

The fix is to convert the string values into real booleans.

Log from running new TestParamDict selftest:
[param_dict.txt](https://github.com/openpbs/openpbs/files/7841304/param_dict.txt)

The normal SmokeTest also passed:

2022-01-10 11:30:56,150 INFO     ok

2022-01-10 11:30:56,150 INFO     ================================================================================
run: 52, succeeded: 52, failed: 0, errors: 0, skipped: 0, timedout: 0
Tests run in 0:21:54.934300


