### PR TITLE
fix wrong ATR_VFLAG_SET flag on attribute update from mom hook on node

### DIFF
--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -3794,7 +3794,7 @@ update2_to_vnode(vnal_t *pvnal, int new, mominfo_t *pmom, int *madenew, int from
 					/* restart */
 
 					pattr->at_flags &= ~ATR_VFLAG_DEFLT;
-					post_attr_set(pattr);
+					pattr->at_flags |= ATR_VFLAG_MODCACHE;
 					if (psrp->vna_val[0] != '\0')
 						pattr->at_flags |= (ATR_VFLAG_SET | ATR_VFLAG_MODIFY);
 					snprintf(log_buffer,


### PR DESCRIPTION


#### Describe Bug or Feature
Server crashes after mom start up hook updates vnodes values to NULL and user tries to update node values.


#### Describe Your Change
The fix is to reset the code back to what it was before PR 2188, so basically reinstate the line:
pattr->at_flags |= ATR_VFLAG_MODCACHE;



#### Attach Test and Valgrind Logs/Output
* *[server_crash_test.txt](https://github.com/openpbs/openpbs/files/7864690/server_crash_test.txt)*

#### Steps to reproduce
Use a single mom pbs setup on a single host.
Install the following hook as a exechost_startup hook.
The minimal hook content is as follows:
import pbs
import os
import sys
import time

e = pbs.event()
vnl = pbs.event().vnode_list
vkl = vnl.keys()
for k in vkl:
pbs.logmsg(pbs.LOG_DEBUG, "NODE %s ----------------->" % (k,))
vn=vnl[k]
vn.resources_available["file"] = None
vn.resources_available["ncpus"] = None
vn.comment = None
3. pkill -9 pbs_mom
4. restart the mom: pbs_mom
5. qmgr -c "s n pbs resources_available.ncpus=4" ---> assert crash

With the fix the server will no longer crash with the above test case


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
