### PR TITLE
Fix PTL script cleanup in DshUtils.run_cmd()

### DIFF
--- a/test/fw/ptl/utils/pbs_dshutils.py
+++ b/test/fw/ptl/utils/pbs_dshutils.py
@@ -984,13 +984,12 @@ class DshUtils(object):
                 ret['rc'] = p.returncode
 
             if as_script:
+                # Remove the script file. If we ran remotely, the file will
+                # be owned by the runas user. If we ran locally, the file
+                # is owned by the current user.
                 # must pass as_script=False otherwise it will loop infinite
-                if platform == 'shasta' and runas:
-                    self.rm(hostname, path=_script, as_script=False,
-                            level=level, runas=runas)
-                else:
-                    self.rm(hostname, path=_script, as_script=False,
-                            level=level)
+                self.rm(hostname, path=_script, as_script=False,
+                        level=level, runas=(_user if islocal else runas))
 
             # handle the case where stdout is not a PIPE
             if o is not None:

--- a/test/fw/ptl/utils/plugins/ptl_test_runner.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_runner.py
@@ -1054,8 +1054,8 @@ class PTLTestRunner(Plugin):
             self.logger.debug('Cleaning %s\'s home directory' % (str(user)))
             runas = PbsUser.get_user(user)
             for host in hosts:
-                ret = du.run_cmd(host, cmd=['echo', '$HOME'], sudo=True,
-                                 runas=runas, logerr=False, as_script=True,
+                ret = du.run_cmd(host, cmd=['printenv', 'HOME'], sudo=True,
+                                 runas=runas, logerr=False, as_script=False,
                                  level=logging.DEBUG)
                 if ret['rc'] == 0:
                     path = ret['out'][0].strip()

--- a/test/tests/selftest/pbs_dshutils_tests.py
+++ b/test/tests/selftest/pbs_dshutils_tests.py
@@ -203,7 +203,7 @@ class TestDshUtils(TestSelf):
                 break
 
         if remote is None:
-            self.skip_test("Provide a remote hostname")
+            self.skip_test("Provide a remote mom")
 
         # First, figure out where temp files are created
         pfx = 'PtlPbs'      # This should be a constant someplace

--- a/test/tests/selftest/pbs_dshutils_tests.py
+++ b/test/tests/selftest/pbs_dshutils_tests.py
@@ -43,6 +43,7 @@ from ptl.utils.pbs_dshutils import PbsConfigError
 import pwd
 import getpass
 import grp
+import os
 
 
 class TestDshUtils(TestSelf):
@@ -153,7 +154,7 @@ class TestDshUtils(TestSelf):
         """
 
         if len(self.moms) < 2:
-            self.skip_test("Test requires 2 moms: use -p mom1:mom2")
+            self.skip_test("Test requires 2 moms: use -p moms=mom1:mom2")
         remote = None
         for each in self.moms:
             if not self.du.is_localhost(each):
@@ -185,3 +186,85 @@ class TestDshUtils(TestSelf):
                                          asgroup=TSTGRP3)
         self.check_access(tmpdir, mode=0o770, user=TEST_USER2, group=TSTGRP3,
                           host=remote)
+
+    @requirements(num_moms=1)
+    def test_script_cleanup(self):
+        """
+        Make sure run_cmd with the as_script option cleans up the
+        temporary file it creates.
+        """
+
+        if len(self.moms) < 1:
+            self.skip_test("Test requires a mom: use -p mom=mom_host")
+        remote = None
+        for each in self.moms:
+            if not self.du.is_localhost(each):
+                remote = each
+                break
+
+        if remote is None:
+            self.skip_test("Provide a remote hostname")
+
+        # First, figure out where temp files are created
+        pfx = 'PtlPbs'      # This should be a constant someplace
+        tmpname = self.du.create_temp_file(prefix=pfx)
+        tmp_dir_path = os.path.dirname(tmpname)
+        long_pfx = os.path.join(tmp_dir_path, pfx)
+        self.du.rm(path=tmpname)
+
+        # Get current contents of temp file dir
+        before = self.du.listdir(path=tmp_dir_path, level=logging.DEBUG)
+
+        # Run an as_script command
+        example_cmd = "printenv HOME"
+        result = self.du.run_cmd(cmd=example_cmd, as_script=True,
+                                 level=logging.DEBUG)
+        self.assertEqual(result['rc'], 0)
+
+        # Get contents of temp file dir post script
+        after = self.du.listdir(path=tmp_dir_path, level=logging.DEBUG)
+
+        # Compare contents, looking for new PTL files
+        new_files = set(after) - set(before)
+        our_new_files = [x for x in new_files if x.startswith(long_pfx)]
+        self.assertEqual([], our_new_files, "script file not cleaned up")
+
+        # Repeat, running on remote host
+        before = self.du.listdir(hostname=remote, path=tmp_dir_path,
+                                 level=logging.DEBUG)
+        result = self.du.run_cmd(hosts=remote, cmd=example_cmd,
+                                 as_script=True, level=logging.DEBUG)
+        self.assertEqual(result['rc'], 0)
+        after = self.du.listdir(hostname=remote, path=tmp_dir_path,
+                                level=logging.DEBUG)
+        new_files = set(after) - set(before)
+        our_new_files = [x for x in new_files if x.startswith(long_pfx)]
+        self.assertEqual([], our_new_files,
+                         "remote script file not cleaned up")
+
+        # Repeat, running locally as a different user
+        before = self.du.listdir(path=tmp_dir_path, runas=TEST_USER,
+                                 level=logging.DEBUG)
+        result = self.du.run_cmd(cmd=example_cmd, as_script=True,
+                                 runas=TEST_USER, level=logging.DEBUG)
+        self.assertEqual(result['rc'], 0)
+        after = self.du.listdir(path=tmp_dir_path, runas=TEST_USER,
+                                level=logging.DEBUG)
+        new_files = set(after) - set(before)
+        our_new_files = [x for x in new_files if x.startswith(long_pfx)]
+        self.assertEqual([], our_new_files,
+                         "alternate user script file not cleaned up")
+
+        # Once more, with both remote host and different user
+        before = self.du.listdir(hostname=remote, path=tmp_dir_path,
+                                 runas=TEST_USER, level=logging.INFOCLI)
+        result = self.du.run_cmd(hosts=remote, cmd=example_cmd,
+                                 as_script=True, runas=TEST_USER,
+                                 level=logging.DEBUG)
+        self.assertEqual(result['rc'], 0)
+        after = self.du.listdir(hostname=remote, path=tmp_dir_path,
+                                runas=TEST_USER, level=logging.INFOCLI)
+        new_files = set(after) - set(before)
+        our_new_files = [x for x in new_files if x.startswith(long_pfx)]
+        self.assertEqual([], our_new_files,
+                         "alt user script file on remote not cleaned up")


### PR DESCRIPTION
When run_cmd() is called to run a command on a remote host with the as_script and runas arguments, it fails to remove the temporary script file from the remote host.

For example, when running pbs_benchpress, the initial and final cleanup sections issue messages like:

```
[...]
2022-01-12 13:04:05,070 INFO     user: dtalcott
2022-01-12 13:04:05,071 INFO     --------------------------------------------------------------------------------
2022-01-12 13:04:05,071 INFO     Cleaning up temporary files
2022-01-12 13:04:06,489 ERROR    <DshUtils.run_cmd>cmd:/usr/bin/rm /tmp/PtlPbspc_zvuhp err: ['/usr/bin/rm: cannot remove ‘/tmp/PtlPbspc_zvuhp’: Operation not permitted']
2022-01-12 13:04:07,870 ERROR    <DshUtils.run_cmd>cmd:/usr/bin/rm /tmp/PtlPbsti_x41hl err: ['/usr/bin/rm: cannot remove ‘/tmp/PtlPbsti_x41hl’: Operation not permitted']
2022-01-12 13:04:09,323 ERROR    <DshUtils.run_cmd>cmd:/usr/bin/rm /tmp/PtlPbs08zl2dbm err: ['/usr/bin/rm: cannot remove ‘/tmp/PtlPbs08zl2dbm’: Operation not permitted']
[...]
```
And /tmp on the remote MoM contains leftover script files:

```
[root@node3 ~]# ls -lrt /tmp
total 100
-rwxr-xr-x 1 pbsuser  tstgrp00 22 Jan 12 13:04 PtlPbspc_zvuhp
-rwxr-xr-x 1 pbsuser1 tstgrp00 22 Jan 12 13:04 PtlPbsti_x41hl
-rwxr-xr-x 1 pbsuser2 tstgrp00 22 Jan 12 13:04 PtlPbs08zl2dbm
-rwxr-xr-x 1 pbsuser3 tstgrp00 22 Jan 12 13:04 PtlPbso29hsuxt
-rwxr-xr-x 1 pbsuser4 tstgrp01 22 Jan 12 13:04 PtlPbsj7c89vcg
-rwxr-xr-x 1 pbsuser5 tstgrp02 22 Jan 12 13:04 PtlPbssh9tvxnn
-rwxr-xr-x 1 pbsuser6 tstgrp03 22 Jan 12 13:04 PtlPbsum5uhscr
-rwxr-xr-x 1 pbsuser7 tstgrp01 22 Jan 12 13:04 PtlPbsi7z50ffo
-rwxr-xr-x 1 pbsother tstgrp00 22 Jan 12 13:04 PtlPbs9r6cgs_p
-rwxr-xr-x 1 pbstest  tstgrp00 22 Jan 12 13:04 PtlPbsnm9rsfwv
[...]
```

The problem is that when run_cmd attempts to remove the script file on the remote host, it runs as the user invoking pbs_benchpress (e.g., dtalcott in the above), rather than as the owner of the script file (e.g., pbsuser).

#### Describe Your Change

The fix revolves around knowing which user owns the script file. The file is always initially created while running as the user invoking run_cmd. If the script is to be run remotely, that file is first copied over to the remote host where it is owned by the runas user. So, for a moment, two copies of the script exist, but the local copy is removed immediately after the scp.

After the script runs, run_cmd needs to delete it. For all cases when the script ran locally, the script is owned by the invoking user and can simply be removed. When run remotely, the rm command needs to be run on the remote host and as the runas user.

As a bonus, this patch also includes a change to the _cleanup() routine in PTLTestRunner where it determines a user's home directory. The original version used "echo $HOME" run as a script. This script is the source of the leftover files listed above. The patch replaces that with "printenv HOME" run directly, thus avoiding the whole mess associated with creating/removing the temporary script file. (I'm not able to test this with a Windows MoM. If it doesn't work there, this optimization can be removed.)

#### Link to Design Doc
none


#### Attach Test and Valgrind Logs/Output
Output from updated TestDshUtils selftest
[cleanup.txt](https://github.com/openpbs/openpbs/files/7864744/cleanup.txt)

