### PR TITLE
Fixes openpbs/openpbs#2507 in qsub man page

### DIFF
--- a/doc/man1/qsub.1B
+++ b/doc/man1/qsub.1B
@@ -201,7 +201,7 @@ For example, we have a Python job script that includes PBS directives:
 #!/usr/bin/python
 #PBS -l select=1:ncpus=3:mem=1gb
 #PBS -N HelloJob
-print "Hello" 
+print "Hello"
 .fi
 .RE
 
@@ -274,7 +274,7 @@ when the Windows command interpreter tries to execute that last line.
 To submit a PBS job by typing job specifications at the command line,
 you type:
 .br
-.I qsub [<options>] [\-] <return>
+.I qsub [<options>] [-] <return>
 .br
 then type any directives, then any tasks, followed by:
 .RS 3
@@ -1002,7 +1002,7 @@ If
 is relative, it is taken to be relative to 
 the current working directory of the
 .B qsub
-command, where it is executing on the current host.  
+command, where it is executing on the current host.
 
 If
 .I path
@@ -1448,7 +1448,11 @@ Dependency examples:
 .B "job1=`qsub first_step.sh`"
 .br
 .B "qsub -W depend=afterok:$job1 second_step.sh"
+.RE
+In this example, we saved the output from the first qsub (the jobid)
+into job1 so we could give it to the depend option on the second job.
 .sp
+.RS 3
 .B "qsub -W depend=before:234.host1.com:235.host1.com jobscript"
 .RE
 .RE

--- a/doc/man1/qsub.1B
+++ b/doc/man1/qsub.1B
@@ -619,13 +619,11 @@ Format:
 No checkpointing.
 .IP s 5
 Checkpoint only when the server is shut down.
-
 .IP u 5
 Unset.  Defaults to behavior when 
 .I interval
 argument is set to 
 .I s.
-.I 
 .LP
 Default: 
 .I u
@@ -776,7 +774,6 @@ Job arrays cannot be interactive.
 When used with 
 .I -Wblock=true, 
 no exit status is returned.
-
 
 .IP "-j <join>" 8
 Specifies whether and how to join the job's standard error and standard output streams.
@@ -1011,7 +1008,6 @@ the current host where the
 .B qsub
 command is executing.
 .IP hostname:path
-
 If 
 .I path
 is relative, it is taken to be relative to the user's 
@@ -1451,13 +1447,12 @@ Dependency example:
 In this example, we save the output (the jobid) from the first qsub into
 shell variable "jobid" so we can supply it to the depend option on the
 second job.
-.br
+.LP
 .B "jobid=`qsub first_step.sh`"
 .br
 .B "qsub -W depend=afterok:$jobid second_step.sh"
 .br
 .RE
-
 .RE
 
 .I "group_list=<group list>"
@@ -1655,7 +1650,7 @@ one of the following:
 .RS 3
 .I -I 
 .br
-.I -W interactive = true 
+.I -W interactive=true
 .B (deprecated)
 .RE
 
@@ -1672,8 +1667,6 @@ option.
 
 Not available under Windows.
 .RE
-
-.LP
 
 .IP "-z" 8
 Job identifier is not written to standard output.

--- a/doc/man1/qsub.1B
+++ b/doc/man1/qsub.1B
@@ -167,13 +167,14 @@ For example:
 .B qsub -S /bin/bash myscript.sh
 .RE
 
-In the first line of your script.  For example:
+You can specify a different interpreter in the first line of your script.
+For example:
 .RS 3
 .nf
 .B cat myscript.sh
-#!/bin/sh
+#!/bin/bash
 #PBS -N MyHelloJob
-print "Hello"
+echo "Hello"
 .fi
 .RE
 
@@ -200,22 +201,20 @@ For example, we have a Python job script that includes PBS directives:
 #!/usr/bin/python
 #PBS -l select=1:ncpus=3:mem=1gb
 #PBS -N HelloJob
-print "Hello"
+print "Hello" 
 .fi
 .RE
 
-To run a Python job script under Linux, use the Python path on the execution host:
+So long as the first line of the script is the "#!/usr/bin/python" line
+or similar, you don't need to do anything special to run a python script.
 .RS 3
-.I qsub -S <Python path on execution host> <script name>
-
-For example, 
-.br
-.B qsub -S $PBS_EXEC/bin/pbs_python <script name>
+.I qsub <script name>
 .RE
 
-To run a Python job script under Windows, use the Python path on the execution host: 
+To run a Python job script under Windows, use the path to the pbs_python
+executable on the execution host:
 .RS 3
-.I qsub -S <Python path on execution host> <script name>
+.I qsub -S <pbs_python path on execution host> <script name>
 
 For example, 
 .br
@@ -275,7 +274,7 @@ when the Windows command interpreter tries to execute that last line.
 To submit a PBS job by typing job specifications at the command line,
 you type:
 .br
-.I qsub [<options>]  [-] <return>  
+.I qsub [<options>] [\-] <return>
 .br
 then type any directives, then any tasks, followed by:
 .RS 3
@@ -321,6 +320,12 @@ For example, to run myprog with the arguments a and b:
 For example, to run myprog with the arguments a and b, naming the job "JobA":
 .RS 3
 .B qsub -N JobA -- myprog a b <return>
+.RE
+
+On Linux, you need to specify the path to myprog, so the previous example
+becomes:
+.RS 3
+.B qsub -N JobA -- /path/to/myprog a b <return>
 .RE
 
 .B Requesting Resources and Placing Jobs
@@ -641,7 +646,7 @@ argument is a null string, qsub
 does not scan the script file for directives.
 Overrides the PBS_DPREFIX environment variable and the default.
 The string "PBS_DPREFIX" cannot be used as a PBS directive.
-Length limit: 4096 charactes.
+Length limit: 4096 characters.
 
 .IP "-e <path>" 8
 Path to be used for the job's standard error stream.
@@ -995,13 +1000,16 @@ is interpreted as follows:
 If
 .I path 
 is relative, it is taken to be relative to 
-the current working directory of the command, where it is executing 
-on the current host.  
+the current working directory of the
+.B qsub
+command, where it is executing on the current host.  
 
 If
 .I path
 is absolute, it is taken to be an absolute path on 
-the current host where the command is executing.
+the current host where the
+.B qsub
+command is executing.
 .IP hostname:path
 
 If 
@@ -1214,9 +1222,9 @@ Default: job owner (username on submission host)
 
 .IP "-v <variable list>"
 Lists environment variables and shell functions to be exported to the job.
-This is the list of environment variables which is added to 
+This is the list of environment variables that are added to
 those already automatically exported.  These variables exist in
-the user's login environment, from which 
+the user's environment from which
 .B qsub
 is run.
 The job's 
@@ -1248,7 +1256,7 @@ enclose the value.  For example:
 .RS 3
 qsub -v "var1='A,B,C,D'" job.sh
 .br
-qsub -v a=10, "var2='A,B'", c=20, HOME=/home/zzz job.sh
+qsub -v "a=10,var2='A,B',c=20,d='Hello world'" job.sh
 .RE
 
 Default: no environment variables are added to the job's variable list.
@@ -1256,7 +1264,7 @@ Default: no environment variables are added to the job's variable list.
 
 .IP "-V" 8
 All environment variables and shell functions in the user's
-login environment where 
+environment where
 .B qsub
 is run are exported to the job.
 The job's
@@ -1437,9 +1445,11 @@ is sent to the job submitter stating the error.
 
 Dependency examples:
 .RS 3
-.B "qsub -W depend=afterok:123.host1.domain.com /tmp/script"
+.B "job1=`qsub first_step.sh`"
 .br
-.B "qsub -W depend=before:234.host1.com:235.host1.com /tmp/script"
+.B "qsub -W depend=afterok:$job1 second_step.sh"
+.sp
+.B "qsub -W depend=before:234.host1.com:235.host1.com jobscript"
 .RE
 .RE
 
@@ -1590,8 +1600,8 @@ The name
 .I storage_path
 is the path on 
 .I <hostname>. 
-The name can be relative to the staging and execution directory on the
-primary execution host, or it can be an absolute path.
+The storage_path can be absolute, or it can be relative to the user's home
+directory on hostname.
 
 If 
 .I path list
@@ -1619,7 +1629,7 @@ The following example allows group and world read on the job's output:
 .B -W umask=33
 .RE
 
-Format: One to four digits; typically two
+Format: One to four octal digits; typically two
 
 Default value: 
 .I 077
@@ -1654,6 +1664,8 @@ Can be used with
 option.
 
 Not available under Windows.
+.RE
+
 .LP
 
 .IP "-z" 8
@@ -1683,6 +1695,8 @@ Path to script.  Can be absolute or relative to current directory
 where 
 .B qsub 
 is run.
+The script must be the last argument to
+.BR qsub .
 .RE
 
 .I "-"
@@ -1697,10 +1711,9 @@ A single executable (preceded by two dashes) and its arguments
 
 The executable, and any arguments to the executable, are given on the
 qsub command line.  The executable is preceded by two dashes, "--".
-
-If a script or executable is specified, it must be the last argument
-to qsub.  The arguments to an executable must follow the name of the
-executable.
+All
+.B qsub
+options must come before the "--".
 
 When you run qsub this way, it runs the executable directly.  It does
 not start a shell, so no shell initialization scripts are run, and
@@ -1736,12 +1749,10 @@ Name of default server.
 Prefix string which identifies PBS directives.
 .RE
 
+PBS automatically exports the following environment variables to the job.
 Environment variables beginning with "PBS_O_" are created by 
-.B qsub.
-PBS automatically exports the following environment variables to the job, 
-and the job's 
-.I Variable_List 
-attribute is set to this list:
+.B qsub
+and included in the job's Variable_List.
 
 .IP PBS_ENVIRONMENT 8
 Set to 
@@ -1749,9 +1760,6 @@ Set to
 for a batch job.  Set to 
 .I PBS_INTERACTIVE
 for an interactive job.
-Created when 
-.B qsub
-is run.
 
 .IP PBS_JOBDIR 8
 Pathname of job's staging and execution directory on the
@@ -1759,21 +1767,13 @@ primary execution host.
 
 .IP PBS_JOBID 8
 Job identifier given by PBS when the job is submitted.
-Created when 
-.B qsub
-is run.
 
 .IP PBS_JOBNAME 8
 Job name specified by submitter.
-Created when 
-.B qsub
-is run.
 
 .IP PBS_NODEFILE 8
-Name of file containing the list of vnodes assigned to the job.
-Created when 
-.B qsub
-is run.
+Name of file containing the list of vnodes assigned to the job when
+the job runs.
 
 .IP PBS_O_HOME 8
 User's home directory.  
@@ -1802,7 +1802,7 @@ Name of the queue to which the job was submitted.
 Value taken from job submission, otherwise default queue.
 
 .IP PBS_O_SHELL 8
-Value taken from user's submission environment.
+Value of SHELL taken from user's submission environment.
 
 .IP PBS_O_SYSTEM 8
 Operating system, from 
@@ -1821,9 +1821,6 @@ Value taken from user's submission environment.
 
 .IP PBS_QUEUE 8
 Name of the queue from which the job is executed.
-Created when 
-.B qsub
-is run.
 
 .IP TMPDIR 8
 Pathname of job's scratch directory.  Set when PBS assigns it.
@@ -1851,7 +1848,8 @@ If the job is deleted without being run
 .B Warning About Exit Status with csh:
 .br
 If a job is run in csh and a .logout file
-exists in the home directory in which the job executes, the exit status
+exists in the user's home directory on the host where the job executes,
+the exit status
 of the job is that of the .logout script, not the job script.  This may
 impact any inter-job dependencies.  
 

--- a/doc/man1/qsub.1B
+++ b/doc/man1/qsub.1B
@@ -1390,6 +1390,9 @@ was deleted without ever having been run.
 Jobs in 
 .I arg list 
 may begin execution once this job has begun execution.
+It is uncommon for users to specify a before condition. Rather,
+PBS adds before dependencies automatically to the targets of
+after dependencies.
 
 .IP  "beforeok: <arg list>" 4
 Jobs in 
@@ -1443,18 +1446,18 @@ which the newly submitted job is performed after the job is queued.
 If an error is detected, the new job is deleted by the server.  Mail
 is sent to the job submitter stating the error.
 
-Dependency examples:
+Dependency example:
 .RS 3
-.B "job1=`qsub first_step.sh`"
+In this example, we save the output (the jobid) from the first qsub into
+shell variable "jobid" so we can supply it to the depend option on the
+second job.
 .br
-.B "qsub -W depend=afterok:$job1 second_step.sh"
+.B "jobid=`qsub first_step.sh`"
+.br
+.B "qsub -W depend=afterok:$jobid second_step.sh"
+.br
 .RE
-In this example, we saved the output from the first qsub (the jobid)
-into job1 so we could give it to the depend option on the second job.
-.sp
-.RS 3
-.B "qsub -W depend=before:234.host1.com:235.host1.com jobscript"
-.RE
+
 .RE
 
 .I "group_list=<group list>"


### PR DESCRIPTION
The submitter of ticket openpbs/openpbs#2507 is correct--in the example, the spaces don't belong. The argument to -v must be a single string as far as the shell is concerned.

#### Describe Your Change
Fixed by removing the spaces and tidying up the quoting. In addition, I dropped HOME from the -v list. When the job starts, HOME is always set to the user's home directory on the execution host. I also now show how to include a space in a value.

Further, I went through other examples in the qsub man page, testing and fixing them when needed, often using text from the User Guide. This included

* The explanation for the -S interpreter option is not correct for the current Linux implementation. In particular, the current default value for the "shell-pipe" configure option means that the only valid interpreters are those that expect to read the *path* to their script from stdin. This works with most shells, but not for interpreters like python or perl. So, the -S documentation for Linux needed some updating.

* On Linux, the specification of the "--" executable must be an absolute path or a path relative to $HOME.

* The descriptions for -e, -o, stagein, and stageout needed some clarity about exactly where paths are interpreted (on qsub host, on execution host, relative to PWD, relative to $HOME).

* The -W umask option expects an octal value.

* The ENVIRONMENT VARIABLES section was somewhat confusing about when and how certain environment variables were set. In particular, it often said some variables were created when qsub was run. In fact, the *values* are determined at qsub time, but the variables don't show up in the job's Variable_List attribute and don't exist until the job runs.

#### Link to Design Doc
None

#### Attach Test and Valgrind Logs/Output
Tested updated -v example in interactive job:

```
qsub -v "a=10,var2='A,B',c=20,d='Hello world'" -I
qsub: waiting for job 13752.server2 to start
qsub: job 13752.server2 ready

dtalcott@node3:~> printenv a var2 c d
10
A,B
20
Hello world
dtalcott@node3:~> exit
logout

qsub: job 13752.server2 completed

```
Other changed examples were tested similarly.

I don't have access to a Windows MoM and was not able to check examples on such hosts.