### PR TITLE
Fix max run subjobs and equivalence classes clash

### DIFF
--- a/src/scheduler/fifo.cpp
+++ b/src/scheduler/fifo.cpp
@@ -987,7 +987,9 @@ main_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rerr)
 					  LOG_INFO, njob->name, log_msg);
 
 			/* If this job couldn't run, the mark the equiv class so the rest of the jobs are discarded quickly.*/
-			if (sinfo->equiv_classes != NULL && njob->ec_index != UNSPECIFIED) {
+			/* Note: for MAX_RUN_SUBJOBS it concerns only this array, not the equivalence class!! */
+			if(sinfo->equiv_classes != NULL && njob->ec_index != UNSPECIFIED &&
+			   err->error_code != MAX_RUN_SUBJOBS) {
 				resresv_set *ec = sinfo->equiv_classes[njob->ec_index];
 				if (rc != RUN_FAILURE && !ec->can_not_run) {
 					ec->can_not_run = 1;

--- a/test/tests/functional/pbs_job_array.py
+++ b/test/tests/functional/pbs_job_array.py
@@ -777,6 +777,27 @@ e.accept()
         msg = "Number of concurrent running subjobs limit reached"
         self.scheduler.log_match(j_id + ';' + msg)
 
+    @skipOnCpuSet
+    def test_max_run_subjobs_equiv_class(self):
+        """
+        Test that if a job is submitted with 'max_run_subjobs' attribute
+        it does not stop jobs in equivalence class from running
+        """
+
+        a = {'resources_available.ncpus': 8}
+        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
+        j = Job(attrs={ATTR_J: '1-20%2', 'Resource_List.walltime': 3600,
+                       'Resource_List.select': 'ncpus=2'})
+        j_id = self.server.submit(j)
+        self.server.expect(JOB, {ATTR_state: 'B'}, id=j_id)
+        self.server.expect(JOB, {'job_state=R': 2}, extend='t')
+
+        j = Job(attrs={'Resource_List.walltime': 3600,
+                       'Resource_List.select': 'ncpus=2'})
+        j_id_equiv = self.server.submit(j)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=j_id_equiv)
+
+    @skipOnCpuSet
     def test_max_run_subjobs_calendar(self):
         """
         Test that if a job is submitted with 'max_run_subjobs' attribute

--- a/test/tests/functional/pbs_python_restart_settings.py
+++ b/test/tests/functional/pbs_python_restart_settings.py
@@ -307,7 +307,7 @@ pbs.event().accept()
         # every 3s
         logs = self.server.log_match(
             "Restarting Python interpreter to reduce mem usage",
-            allmatch=True, starttime=stime, max_attempts=8)
+            allmatch=True, starttime=stime, max_attempts=8, n="ALL")
         self.assertTrue(len(logs) > 1)
         log1 = logs[0][1]
         log2 = logs[1][1]
@@ -321,7 +321,12 @@ pbs.event().accept()
         self.logger.info("Time difference between log message is " +
                          str(diff) + " seconds")
         # Leave a little wiggle room for slow systems
-        self.assertTrue(diff >= 3 and diff <= 5)
+        self.assertTrue(diff > 2, "time between Python restart log messages"
+                        " (%s seconds) is too short;"
+                        " expected roughly 3 seconds" % str(diff))
+        self.assertTrue(diff <= 10, "time between Python restart log messages"
+                        " (%s seconds) is too long;"
+                        " expected roughly 3 seconds" % str(diff))
         # This message only gets printed if /proc/self/statm is present
         if os.path.isfile("/proc/self/statm"):
             self.server.log_match("Current memory usage:",

--- a/test/tests/functional/pbs_support_linux_hook_event_phase1_2.py
+++ b/test/tests/functional/pbs_support_linux_hook_event_phase1_2.py
@@ -90,11 +90,12 @@ else:
         test = []
         test += ['#PBS -l select=vnode=%s+vnode=%s\n' %
                  (self.hostA, self.hostB)]
-        test += ['%s -j $PBS_JOBID %s 30\n' %
-                 (self.pbs_attach, self.mom.sleep_cmd)]
-        test += ['%s %s %s %s 30\n' %
-                 (self.pbs_tmrsh, self.momB.hostname, self.pbs_attach,
-                  self.mom.sleep_cmd)]
+        test += ['setsid --fork %s -j $PBS_JOBID %s 3000\n'
+                 % (self.pbs_attach, self.mem.sleep_cmd)]
+        test += ['%s %s setsid --fork %s -j $PBS_JOBID %s 3000\n'
+                 % (self.pbs_tmrsh, self.momB.shortname, self.pbs_attach,
+                    self.mem.sleep_cmd)]
+        test += ['%s 3000\n' % self.mom.sleep_cmd]
 
         # Submit a job
         j = Job(TEST_USER)
@@ -179,11 +180,13 @@ e.accept()
         test = []
         test += ['#PBS -l select=vnode=%s+vnode=%s\n' %
                  (self.hostA, self.hostB)]
-        test += ['%s -j $PBS_JOBID %s 30\n' %
-                 (self.pbs_attach, self.mom.sleep_cmd)]
-        test += ['%s %s %s %s 30\n' %
-                 (self.pbs_tmrsh, self.momB.hostname, self.pbs_attach,
-                  self.mom.sleep_cmd)]
+
+        test += ['setsid --fork %s -j $PBS_JOBID %s 3000\n'
+                 % (self.pbs_attach, self.mom.sleep_cmd)]
+        test += ['%s %s setsid --fork %s -j $PBS_JOBID %s 3000\n'
+                 % (self.pbs_tmrsh, self.momB.shortname, self.pbs_attach,
+                    self.mom.sleep_cmd)]
+        test += ['%s 3000\n' % self.mom.sleep_cmd]
 
         # Submit a job
         j = Job(TEST_USER)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Currently, when an array hits the max_subjobs_run limit it marks the entire equivalence class as "can not run", which means that arrays and even non-array jobs that look 'too similar' also will not be considered in the cycle. In other words, if you submit two arrays with identical subjobs, one with -J 1-10%2 and one with -J 1-10%10, the first array runs two subjobs and the second simply runs none until the first array managed to run all subjobs.

#### Describe Your Change
If the reason for not running a job is MAX_RUN_SUBJOBS (which means it's an array subjob), then we should not mark the entire equivalence class as not able to run this cycle, since the error only pertains to THIS array.

#### Link to Design Doc
None

#### Attach Test and Valgrind Logs/Output
[test_job_array.txt](https://github.com/openpbs/openpbs/files/7998811/test_job_array.txt)
[test_preemption.txt](https://github.com/openpbs/openpbs/files/7998813/test_preemption.txt)
[test_python_restart.txt](https://github.com/openpbs/openpbs/files/7998814/test_python_restart.txt)
[test_support_hook.txt](https://github.com/openpbs/openpbs/files/7998815/test_support_hook.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
