### PR TITLE
Remove centos8 from azure pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,11 +18,6 @@ jobs:
     dependsOn: runcheck
     strategy:
       matrix:
-        "CentOS 8":
-           OS_TYPE: "centos:8"
-           PKG_INSTALL_CMD: "sed -i -e 's|mirrorlist=|#mirrorlist=|g' /etc/yum.repos.d/CentOS-* && sed -i -e 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* && yum -y install python3"
-           DOCKER_EXTRA_ARG: ""
-           CI_CMD: "./ci --local"
         "OpenSuse 15":
            OS_TYPE: "opensuse/leap:15"
            PKG_INSTALL_CMD: "zypper -n install python3"


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Centos8 support has ended, pulling from the vault is timing out on occasions causing failures in PR validations. Will be moving to a newer OS in future.


#### Describe Your Change
Removed centos8 from azure pipelines


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
