### PR TITLE
Fix server not starting with job_sort_formula set

### DIFF
--- a/src/server/attr_recov_db.c
+++ b/src/server/attr_recov_db.c
@@ -256,21 +256,20 @@ decode_attr_db(void *parent, pbs_list_head *attr_list, void *padef_idx, struct a
 				int act_rc = 0;
 				if (padef[index].at_action)
 					if ((act_rc = (padef[index].at_action(&pattr[index], parent, ATR_ACTION_RECOV)))) {
-						log_errf(act_rc, __func__, "Action function failed for %s attr, errn %d", (padef + index)->at_name, act_rc);
+						log_errf(act_rc, __func__, "Action function failed for %s attr, errn %d...unsetting attribute", (padef+index)->at_name, act_rc);
 						for (index++; index <= limit; index++) {
 							while (pal) {
 								tmp_pal = pal->al_sister;
+								delete_link(&pal->al_link);
 								free(pal);
 								pal = tmp_pal;
 							}
 							if (index < limit)
 								pal = palarray[index];
 						}
-						free(palarray);
-						/* bailing out from this function */
-						/* any previously allocated attrs will be */
-						/* freed by caller (parent obj recov function) */
-						return -1;
+						if (padef[index].at_free)
+							padef[index].at_free(&pattr[index]);
+						break;
 					}
 			}
 			(pattr + index)->at_flags = (pal->al_flags & ~ATR_VFLAG_MODIFY) | ATR_VFLAG_MODCACHE;

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -1061,18 +1061,6 @@ main(int argc, char **argv)
 
 	/* database connection code end */
 
-	/* Curses! pbsd_init() calls validate_job_formula() (in svr_recov()) */
-	/* which makes Python calls, so Python interpreter must be	     */
-	/* temporarily initialized. Can't call the real                      */
-	/* pbs_python_ext_start_interpreter() this early, as this loads PBS  */
-	/* attributes  and resources (including custom resources) into       */
-	/* Python world, which are made  complete after call to pbsd_init()! */
-	pbs_python_ext_quick_start_interpreter();
-
-	/* The real pbs_python_ext_start_interpreter() will be called later  */
-	/* for the permanent interpreter start.				     */
-	pbs_python_ext_quick_shutdown_interpreter();
-
 	if (stalone == 2) {
 		log_event(PBSEVENT_SYSTEM | PBSEVENT_FORCE, LOG_NOTICE,
 			  PBS_EVENTCLASS_SERVER, msg_daemonname, msg_svrdown);
@@ -1202,7 +1190,6 @@ main(int argc, char **argv)
 
 	if (pbsd_init(server_init_type) != 0) {
 		log_err(-1, msg_daemonname, "pbsd_init failed");
-		pbs_python_ext_quick_shutdown_interpreter();
 		stop_db();
 		return (3);
 	}

--- a/src/server/sched_func.c
+++ b/src/server/sched_func.c
@@ -162,8 +162,11 @@ validate_job_formula(attribute *pattr, void *pobject, int actmode)
 			return PBSE_SVR_SCHED_JSF_INCOMPAT;
 	}
 
-	if (!Py_IsInitialized())
+	if (!Py_IsInitialized()) {
+		if (actmode == ATR_ACTION_RECOV)
+			return 0;
 		return PBSE_INTERNAL;
+	}
 
 	globals1 = malloc(globals_size1);
 	if (globals1 == NULL) {

--- a/test/tests/functional/pbs_multi_sched.py
+++ b/test/tests/functional/pbs_multi_sched.py
@@ -1264,6 +1264,11 @@ class TestMultipleSchedulers(TestFunctional):
         self.server.expect(JOB, msg, id=jid_1)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid_2)
 
+        # test to make sure server can still start with job_sort_formula set
+        self.server.restart()
+        restart_msg = 'Failed to restart PBS'
+        self.assertTrue(self.server.isUp(), restart_msg)
+
     @staticmethod
     def cust_attr(name, totnodes, numnode, attrib):
         a = {}

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -1037,6 +1037,11 @@ class SmokeTest(PBSTestSuite):
         self.server.runjob(jobid=j1id)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=j1id)
 
+        # test to make sure server can still start with job_sort_formula set
+        self.server.restart()
+        restart_msg = 'Failed to restart PBS'
+        self.assertTrue(self.server.isUp(), restart_msg)
+
     def isSuspended(self, ppid):
         """
         Check wether <ppid> is in Suspended state, return True if


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* When job_sort_formula is set and server is restarted, server fails to come up and there's a crash after a message in server_logs:
```
9/08/2021 13:49:56.572343;0001;Server@djoko;Svr;Server@djoko;PBS server internal error (15011) in decode_attr_db, Action function failed for job_sort_formula attr, errn 15011
```
* This can be reproduced by running the  SmokeTest.test_job_sort_formula_threshold  or TestMultipleSchedulers.test_job_sort_formula_threshold test case, and
then restarting the server afterward. The following core file is generated:
```
#0  0x00007fb7f14bd277 in raise () from /usr/lib64/libc.so.6
#1  0x00007fb7f14be968 in abort () from /usr/lib64/libc.so.6
#2  0x00007fb7f14ffd37 in __libc_message () from /usr/lib64/libc.so.6
#3  0x00007fb7f1508499 in _int_free () from /usr/lib64/libc.so.6
#4  0x00000000004dbb48 in free_svrattrl (pal=0x35ffd90)
    at /home/bayucan/2022.0.0/2022.0.0.20210903051646/pbspro/src/lib/Libattr/attr_func.c:416
#5  0x00000000004dbb6d in free_attrlist (pattrlisthead=pattrlisthead@entry=0x7ffdd60f9e20)
    at /home/bayucan/2022.0.0/2022.0.0.20210903051646/pbspro/src/lib/Libattr/attr_func.c:382
#6  0x0000000000480473 in free_db_attr_list (attr_list=attr_list@entry=0x7ffdd60f9e18)
    at /home/bayucan/2022.0.0/2022.0.0.20210903051646/pbspro/src/server/pbs_db_func.c:596
#7  0x00000000004c414a in svr_recov_db ()
    at /home/bayucan/2022.0.0/2022.0.0.20210903051646/pbspro/src/server/svr_recov_db.c:238
#8  0x0000000000481fc5 in pbsd_init (type=1)
    at /home/bayucan/2022.0.0/2022.0.0.20210903051646/pbspro/src/server/pbsd_init.c:546
#9  0x0000000000453cbb in main (argc=<optimized out>, argv=0x7ffdd60fe478)
    at /home/bayucan/2022.0.0/2022.0.0.20210903051646/pbspro/src/server/pbsd_main.c:1210
```
Basically, a double free on the svrattrl entry for "job_sort_formula".
* Problem was that the validate_job_formula() function, where it gets called as part of the attribute recovery of 'job_sort_formula', failed as it detected that Python is not initialized:

```
 if (!Py_IsInitialized()) {
                return PBSE_INTERNAL;
        }

 ```
* Recent changes moved the pbsd_init() call (where attribute recovery takes place and where validate_job_formula() function is called) to another area code, leaving behind the quick python start call.
* . Server would not start and actually crashes due to a double free of the svrattrl entry of 'job_sort_formula.' The initial
   validate_formula_action() failure caused the svrattrl entry to be cleared   in one part of the code, and later in another area of code.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* Have validate_job_formula() still return success if Python is not initialized when attribute is being recovered.
* Get rid of the quick start and stop of interpreter which is now unnecessary with the fix above.
* Put in a fix to prevent double free failures related to attributes recovery.
* Allow server to still start even after an attribute's action function fails. In this case, server will report the message:
```
PBS server internal error (15011) in decode_attr_db, Action function failed for <attribute_name> attr, errn 15011...unsetting attribute
```
and this <attribute_name> will not be set when the server comes up. All other attributes are processed and set normally.

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

* [fail.txt](https://github.com/openpbs/openpbs/files/8632085/fail.txt)
* [pass.txt](https://github.com/openpbs/openpbs/files/8632086/pass.txt)
* [ptl.multi_sched.txt](https://github.com/openpbs/openpbs/files/8632087/ptl.multi_sched.txt)
* [ptl.smoketest.txt](https://github.com/openpbs/openpbs/files/8632089/ptl.smoketest.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
