### PR TITLE
added safe.directory

### DIFF
--- a/ci/etc/do.sh
+++ b/ci/etc/do.sh
@@ -163,6 +163,7 @@ fi
 mkdir -p ${_targetdirname}
 [[ -f Makefile ]] && make distclean || true
 if [ ! -f ./${SPEC_FILE} ]; then
+  git config --global --add safe.directory ${PBS_DIR}
   git checkout ${SPEC_FILE}
 fi
 if [ ! -f ./configure ]; then


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
2022-05-10T18:15:40.7665638Z + '[' '!' -f .//home/vsts/work/1/s/openpbs.spec ']'
2022-05-10T18:15:40.7666218Z + git checkout /home/vsts/work/1/s/openpbs.spec
2022-05-10T18:15:40.7681984Z fatal: unsafe repository ('/home/vsts/work/1/s' is owned by someone else)
2022-05-10T18:15:40.7682720Z To add an exception for this directory, call:
2022-05-10T18:15:40.7683022Z
2022-05-10T18:15:40.7683715Z git config --global --add safe.directory /home/vsts/work/1/s
2022-05-10T18:15:40.7926870Z ##[error]Bash exited with code '128'.


#### Describe Your Change
Addressing git security warning "fatal: unsafe repository "


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
