### PR TITLE
Removed @skip from test_job_sort_formula_negative_value

### DIFF
--- a/test/tests/functional/pbs_job_sort_formula.py
+++ b/test/tests/functional/pbs_job_sort_formula.py
@@ -46,9 +46,6 @@ class TestJobSortFormula(TestFunctional):
     Tests for the job_sort_formula
     """
 
-    # PBS server internal error (15011) in decode_attr_db, Action function
-    # failed for job_sort_formula attr, errn 15011
-    @skip("Issue 2475: server crashes during setup of subsequent tests")
     def test_job_sort_formula_negative_value(self):
         """
         Test to see that negative values in the


### PR DESCRIPTION
Since PR #2533 fixes issue #2475, the `@skip` has been removed from the
test_job_sort_formula_negative_value test.

```
% pbsdev-test.sh -t TestJobSortFormula,SmokeTest.test_submit_job
...
================
run: 2, succeeded: 2, failed: 0, errors: 0, skipped: 0, timedout: 0
Tests run in 0:00:54.172994
```