### PR TITLE
Install PBS env shell scripts in PBS_EXEC/etc

### DIFF
--- a/src/cmds/scripts/Makefile.am
+++ b/src/cmds/scripts/Makefile.am
@@ -96,7 +96,9 @@ dist_sbin_SCRIPTS = \
 	pbs_snapshot
 
 dist_sysconf_DATA = \
-	modulefile 
+	modulefile \
+	pbs.csh \
+	pbs.sh
 
 CLEANFILES = \
 	pbs_init.d \


### PR DESCRIPTION
pbs_postinstall expects pbs.[c]sh to exist in PBS_EXEC/etc if they haven't already been installed in /etc/profile.d.  When OpenPBS is installed via make install, the pbs.[c]sh files are presently only installed in /etc/profile.d on the build host and not in PBS_EXEC/etc as well. This results in pbs_postinstall failing to copy the scripts to /etc/profile.d on the compute (MoM) nodes from the shared installation directory and ultimately in unexpected environment differences for interactive jobs and ssh sessions on the compute nodes.