### PR TITLE
fix manpage typo listong -> listing

### DIFF
--- a/doc/man1/pbs_job_attributes.7B
+++ b/doc/man1/pbs_job_attributes.7B
@@ -628,7 +628,7 @@ Python type:
 Default: No default
 
 .IP "executable" 8
-JSDL-encoded listong of job's executable.  
+JSDL-encoded listing of job's executable.  
 Shown if job is submitted with "-- <executable> [<arg list>]".
 .br
 Can be read and set by user, Operator, Manager.


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Typo in man pages (`listong`)


#### Describe Your Change
Fixed the typo (`listing`). Pretty sure from the context it is supposed to be `listing` but please correct if I'm wrong.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
