### PR TITLE
Fix build on macOS

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -54,7 +54,7 @@ How to install PBS using the configure script.
   For macOS systems using MacPorts you should run the following command as root:
 
     port install autoconf automake libtool pkgconfig \
-      expat hwloc libedit libical openssl postgresql12 python38 \
+      expat hwloc libedit libical openssl postgresql14 python310 \
       swig-python tcl tk xorg-libX11 xorg-libXt
 
 2. Install the prerequisite packages for running PBS. In addition
@@ -93,7 +93,7 @@ How to install PBS using the configure script.
 
   For macOS systems using MacPorts you should run the following command as root:
 
-    port install expat libedit libical openssl postgresql12-server python38 \
+    port install expat libedit libical openssl postgresql14-server python310 \
       tcl tk
 
 3. Open a terminal as a normal (non-root) user, unpack the PBS
@@ -125,8 +125,8 @@ How to install PBS using the configure script.
 
   For macOS systems using MacPorts you should run the following commands:
 
-    export CPATH=/opt/local/include/postgresql12:/opt/local/include
-    export LIBRARY_PATH=/opt/local/lib/postgresql12:/opt/local/lib
+    export CPATH=/opt/local/include/postgresql14:/opt/local/include
+    export LIBRARY_PATH=/opt/local/lib/postgresql14:/opt/local/lib
     ./configure --with-swig=/opt/local --with-tcl=/opt/local
 
   If PTL needs to be installed along with PBS use the option

--- a/configure.ac
+++ b/configure.ac
@@ -188,7 +188,6 @@ AC_CHECK_HEADERS([ \
 	sys/types.h \
 	sys/uio.h \
 	sys/un.h \
-	sys/unistd.h \
 	sys/user.h \
 	sys/utsname.h \
 	sys/wait.h \

--- a/src/cmds/Makefile.am
+++ b/src/cmds/Makefile.am
@@ -92,7 +92,7 @@ common_cflags = \
 	@KRB5_CFLAGS@
 
 common_libs = \
-	$(top_builddir)/src/lib/Libpbs/.libs/libpbs.a \
+	$(top_builddir)/src/lib/Libpbs/libpbs.la \
 	$(top_builddir)/src/lib/Libnet/libnet.a \
 	$(top_builddir)/src/lib/Libsec/libsec.a \
 	$(top_builddir)/src/lib/Libutil/libutil.a \

--- a/src/iff/Makefile.am
+++ b/src/iff/Makefile.am
@@ -46,7 +46,7 @@ pbs_iff_CPPFLAGS = \
 	@KRB5_CFLAGS@
 
 pbs_iff_LDADD = \
-	$(top_builddir)/src/lib/Libpbs/.libs/libpbs.a \
+	$(top_builddir)/src/lib/Libpbs/libpbs.la \
 	$(top_builddir)/src/lib/Libutil/libutil.a \
 	$(top_builddir)/src/lib/Libnet/libnet.a \
 	$(top_builddir)/src/lib/Libsec/libsec.a \

--- a/src/lib/Libpbs/Makefile.am
+++ b/src/lib/Libpbs/Makefile.am
@@ -235,6 +235,7 @@ libpbs_la_SOURCES = \
 	../Libutil/pbs_aes_encrypt.c \
 	../Libutil/pbs_idx.c \
 	../Libutil/range.c \
+	../Libnet/get_hostaddr.c \
 	../Libnet/hnls.c \
 	../Libtpp/tpp_client.c \
 	../Libtpp/tpp_em.c \

--- a/src/modules/python/Makefile.am
+++ b/src/modules/python/Makefile.am
@@ -101,7 +101,8 @@ _pbs_ifl_la_LDFLAGS = \
 	-shared \
 	-export-dynamic \
 	-avoid-version \
-	-no-undefined
+	-no-undefined \
+	@PYTHON_LDFLAGS@
 _pbs_ifl_la_LIBADD = \
 	$(top_builddir)/src/lib/Libpbs/libpbs.la
 

--- a/src/resmom/Makefile.am
+++ b/src/resmom/Makefile.am
@@ -56,7 +56,7 @@ pbs_mom_LDADD = \
 	$(top_builddir)/src/lib/Libattr/libattr.a \
 	$(top_builddir)/src/lib/Liblog/liblog.a \
 	$(top_builddir)/src/lib/Libnet/libnet.a \
-	$(top_builddir)/src/lib/Libpbs/.libs/libpbs.a \
+	$(top_builddir)/src/lib/Libpbs/libpbs.la \
 	$(top_builddir)/src/lib/Libsec/libsec.a \
 	$(top_builddir)/src/lib/Libsite/libsite.a \
 	$(top_builddir)/src/lib/Libtpp/libtpp.a \

--- a/src/resmom/linux/alps.c
+++ b/src/resmom/linux/alps.c
@@ -4165,7 +4165,7 @@ inventory_to_vnodes(basil_response_t *brp)
 {
 	extern int internal_state_update;
 	extern int num_acpus;
-	extern ulong totalmem;
+	extern unsigned long totalmem;
 	int aflag = READ_WRITE | ATR_DFLAG_CVTSLT;
 	long order = 0;
 	char *attr;

--- a/src/resmom/linux/mom_mach.c
+++ b/src/resmom/linux/mom_mach.c
@@ -172,13 +172,13 @@ extern char *nullproc(struct rm_attribute *attrib);
 time_t wait_time = 10;
 
 typedef struct proc_mem {
-	ulong total;
-	ulong used;
-	ulong free;
+	unsigned long total;
+	unsigned long used;
+	unsigned long free;
 } proc_mem_t;
 
 int mom_does_chkpnt = 0;
-ulong totalmem;
+unsigned long totalmem;
 
 static int myproc_max = 0;    /* entries in Proc_lnks  */
 pbs_plinks *Proc_lnks = NULL; /* process links table head */
@@ -272,14 +272,14 @@ get_proc_mem(void)
 {
 	static proc_mem_t mm;
 	FILE *fp;
-	ulong m_tot, m_use, m_free;
-	ulong s_tot, s_use, s_free;
+	unsigned long m_tot, m_use, m_free;
+	unsigned long s_tot, s_use, s_free;
 	char strbuf[BUFSIZ];
 
 	if ((fp = fopen("/proc/meminfo", "r")) == NULL)
 		return NULL;
 
-	m_tot = m_free = s_tot = s_free = (ulong) 0;
+	m_tot = m_free = s_tot = s_free = (unsigned long) 0;
 	while (fgets(strbuf, sizeof(strbuf), fp) != NULL) {
 		sscanf(strbuf, "MemTotal: %ld k", &m_tot);
 		sscanf(strbuf, "MemFree: %ld k", &m_free);
@@ -473,22 +473,22 @@ injob(job *pjob, pid_t sid)
  *
  * @param[in] job - a job pointer.
  *
- * @return	ulong
+ * @return	unsigned long
  * @retval	sum of all cpu time consumed for all tasks executed by the job, in seconds,
  *		adjusted by cputfactor.
  *
  */
-static ulong
+static unsigned long
 cput_sum(job *pjob)
 {
 	int i;
-	ulong cputime = 0;
+	unsigned long cputime = 0;
 	int nps = 0;
 	int active_tasks = 0;
 	int taskprocs;
 	proc_stat_t *ps;
 	task *ptask;
-	ulong pcput, tcput;
+	unsigned long pcput, tcput;
 
 	for (ptask = (task *) GET_NEXT(pjob->ji_tasks);
 	     ptask != NULL;
@@ -629,7 +629,7 @@ cput_sum(job *pjob)
 		return 0;
 	}
 
-	return ((ulong) ((double) cputime * cputfactor));
+	return ((unsigned long) ((double) cputime * cputfactor));
 }
 
 /**
@@ -638,16 +638,16 @@ cput_sum(job *pjob)
  *
  * @param[in] job - job pointer
  *
- * @return	ulong
+ * @return	unsigned long
  * @retval	the total number of bytes of address
  *		space consumed by all current processes within the job.
  *
  */
-static ulong
+static unsigned long
 mem_sum(job *pjob)
 {
 	int i;
-	ulong segadd;
+	unsigned long segadd;
 	proc_stat_t *ps;
 
 	segadd = 0;
@@ -660,7 +660,7 @@ mem_sum(job *pjob)
 			continue;
 		segadd += ps->vsize;
 		DBPRT(("%s: pid: %d  pr_size: %lu  total: %lu\n",
-		       __func__, ps->pid, (ulong) ps->vsize, segadd))
+		       __func__, ps->pid, (unsigned long) ps->vsize, segadd))
 	}
 
 	return (segadd);
@@ -672,16 +672,16 @@ mem_sum(job *pjob)
  *
  * @param[in] pjob - job pointer
  *
- * @return	ulong
+ * @return	unsigned long
  * @retval	new resident set size 	Success
  * @retval	old resident set size	Error
  *
  */
-static ulong
+static unsigned long
 resi_sum(job *pjob)
 {
 	int i;
-	ulong resisize;
+	unsigned long resisize;
 	proc_stat_t *ps;
 
 	resisize = 0;
@@ -733,12 +733,12 @@ mom_set_limits(job *pjob, int set_mode)
 {
 	char *pname;
 	int retval;
-	ulong value; /* place in which to build resource value */
+	unsigned long value; /* place in which to build resource value */
 	resource *pres;
 	struct rlimit reslim;
-	ulong mem_limit = 0;
-	ulong vmem_limit = 0;
-	ulong cput_limit = 0;
+	unsigned long mem_limit = 0;
+	unsigned long vmem_limit = 0;
+	unsigned long cput_limit = 0;
 
 	DBPRT(("%s: entered\n", __func__))
 	assert(pjob != NULL);
@@ -820,7 +820,7 @@ mom_set_limits(job *pjob, int set_mode)
 		/* if either cput or pcput was given, set sys limit to lesser */
 		if (cput_limit != 0) {
 			reslim.rlim_cur = reslim.rlim_max =
-				(ulong) ((double) cput_limit / cputfactor);
+				(unsigned long) ((double) cput_limit / cputfactor);
 			if (setrlimit(RLIMIT_CPU, &reslim) < 0)
 				return (error("RLIMIT_CPU", PBSE_SYSTEM));
 		}
@@ -1077,7 +1077,7 @@ mom_set_use(job *pjob)
 	attribute *at_req;
 	resource_def *rd;
 	u_Long *lp_sz, lnum_sz;
-	ulong *lp, lnum, oldcput;
+	unsigned long *lp, lnum, oldcput;
 	long ncpus_req;
 
 	assert(pjob != NULL);
@@ -1121,7 +1121,7 @@ mom_set_use(job *pjob)
 		pres->rs_value.at_type = ATR_TYPE_LONG;
 		pres->rs_value.at_val.at_long = 0;
 	}
-	lp = (ulong *) &pres->rs_value.at_val.at_long;
+	lp = (unsigned long *) &pres->rs_value.at_val.at_long;
 	oldcput = *lp;
 	lnum = cput_sum(pjob);
 	lnum = MAX(*lp, lnum);
@@ -1582,7 +1582,7 @@ cput(struct rm_attribute *attrib)
 char *
 mem_job(pid_t sid)
 {
-	ulong memsize;
+	unsigned long memsize;
 	int i;
 	proc_stat_t *ps;
 
@@ -1635,7 +1635,7 @@ mem_proc(pid_t pid)
 		return NULL;
 	}
 
-	sprintf(ret_string, "%lukb", (ulong) ps->vsize >> 10); /* KB */
+	sprintf(ret_string, "%lukb", (unsigned long) ps->vsize >> 10); /* KB */
 	return ret_string;
 }
 
@@ -1697,7 +1697,7 @@ static char *
 resi_job(pid_t jobid)
 {
 	int i;
-	ulong resisize;
+	unsigned long resisize;
 	int found = 0;
 	proc_stat_t *ps;
 
@@ -1716,7 +1716,7 @@ resi_job(pid_t jobid)
 	}
 	if (found) {
 		/* in KB */
-		sprintf(ret_string, "%lukb", (resisize * (ulong) pagesize) >> 10);
+		sprintf(ret_string, "%lukb", (resisize * (unsigned long) pagesize) >> 10);
 		return ret_string;
 	}
 
@@ -1752,7 +1752,7 @@ resi_proc(pid_t pid)
 		return NULL;
 	}
 	/* in KB */
-	sprintf(ret_string, "%lukb", ((ulong) ps->rss * (ulong) pagesize) >> 10);
+	sprintf(ret_string, "%lukb", ((unsigned long) ps->rss * (unsigned long) pagesize) >> 10);
 	return ret_string;
 }
 
@@ -2102,7 +2102,7 @@ totmem(struct rm_attribute *attrib)
 		return NULL;
 	}
 	DBPRT(("%s: total mem=%lu\n", __func__, mm->total))
-	sprintf(ret_string, "%lukb", (ulong) mm->total >> 10); /* KB */
+	sprintf(ret_string, "%lukb", (unsigned long) mm->total >> 10); /* KB */
 	return ret_string;
 }
 
@@ -2132,7 +2132,7 @@ availmem(struct rm_attribute *attrib)
 		return NULL;
 	}
 	DBPRT(("%s: free mem=%lu\n", __func__, mm->free))
-	sprintf(ret_string, "%lukb", (ulong) mm->free >> 10); /* KB */
+	sprintf(ret_string, "%lukb", (unsigned long) mm->free >> 10); /* KB */
 	return ret_string;
 }
 
@@ -2656,7 +2656,7 @@ physmem(struct rm_attribute *attrib)
 	while (fgets(strbuf, 256, fp) != NULL) {
 		if (sscanf(strbuf, "MemTotal: %s k", ret_string) == 1) {
 			fclose(fp);
-			totalmem = (ulong) atol(ret_string);
+			totalmem = (unsigned long) atol(ret_string);
 
 			sprintf(ret_string, "%lukb",
 				totalmem * (num_acpus / num_pcpus));
@@ -2697,7 +2697,7 @@ size_fs(char *param)
 		return NULL;
 	}
 	sprintf(ret_string, "%lukb",
-		(ulong) (((double) fsbuf.f_bsize *
+		(unsigned long) (((double) fsbuf.f_bsize *
 			  (double) fsbuf.f_bfree) /
 			 1024.0)); /* KB */
 	return ret_string;
@@ -2733,7 +2733,7 @@ size_file(char *param)
 		return NULL;
 	}
 
-	sprintf(ret_string, "%lukb", (ulong) (sbuf.st_size >> 10)); /* KB */
+	sprintf(ret_string, "%lukb", (unsigned long) (sbuf.st_size >> 10)); /* KB */
 	return ret_string;
 }
 

--- a/src/resmom/linux/mom_mach.h
+++ b/src/resmom/linux/mom_mach.h
@@ -48,10 +48,6 @@ extern "C" {
  * Target System: linux
  */
 
-#ifndef __linux__
-typedef unsigned long ulong;
-#endif
-
 #ifndef PBS_MACH
 #define PBS_MACH "linux"
 #endif /* PBS_MACH */
@@ -85,7 +81,7 @@ typedef struct pbs_plinks { /* struct to link processes */
 	int pl_done;	    /* kill has been done */
 } pbs_plinks;
 
-extern ulong totalmem;
+extern unsigned long totalmem;
 extern int kill_session(pid_t pid, int sig, int dir);
 extern int bld_ptree(pid_t sid);
 
@@ -149,16 +145,16 @@ typedef struct proc_stat {
 						 Traced or stopped on signal */
 	pid_t ppid;	    /* parent pid */
 	pid_t pgrp;	    /* process group id */
-	ulong utime;	    /* utime this process */
-	ulong stime;	    /* stime this process */
-	ulong cutime;	    /* sum of children's utime */
-	ulong cstime;	    /* sum of children's stime */
+	unsigned long utime;	    /* utime this process */
+	unsigned long stime;	    /* stime this process */
+	unsigned long cutime;	    /* sum of children's utime */
+	unsigned long cstime;	    /* sum of children's stime */
 	pid_t pid;	    /* process id */
-	ulong vsize;	    /* virtual memory size for proc */
-	ulong rss;	    /* resident set size */
-	ulong start_time;   /* start time of this process */
-	ulong flags;	    /* the flags of the process */
-	ulong uid;	    /* uid of the process owner */
+	unsigned long vsize;	    /* virtual memory size for proc */
+	unsigned long rss;	    /* resident set size */
+	unsigned long start_time;   /* start time of this process */
+	unsigned long flags;	    /* the flags of the process */
+	unsigned long uid;	    /* uid of the process owner */
 	char comm[COMSIZE]; /* command name */
 } proc_stat_t;
 

--- a/src/scheduler/pbs_sched_utils.cpp
+++ b/src/scheduler/pbs_sched_utils.cpp
@@ -62,7 +62,7 @@
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <sys/types.h>
-#include <sys/unistd.h>
+#include <unistd.h>
 #ifdef _POSIX_MEMLOCK
 #include <sys/mman.h>
 #endif /* _POSIX_MEMLOCK */

--- a/src/server/Makefile.am
+++ b/src/server/Makefile.am
@@ -60,7 +60,7 @@ pbs_server_bin_LDADD = \
 	$(top_builddir)/src/lib/Libsite/libsite.a \
 	$(top_builddir)/src/lib/Libpython/libpbspython_svr.a \
 	$(top_builddir)/src/lib/Libdb/libpbsdb.la \
-	$(top_builddir)/src/lib/Libpbs/.libs/libpbs.a \
+	$(top_builddir)/src/lib/Libpbs/libpbs.la \
 	$(top_builddir)/src/lib/Liblicensing/liblicensing.la \
 	@expat_lib@ \
 	@libz_lib@ \
@@ -150,7 +150,7 @@ pbs_comm_LDADD = \
 	$(top_builddir)/src/lib/Libtpp/libtpp.a \
 	$(top_builddir)/src/lib/Liblog/liblog.a \
 	$(top_builddir)/src/lib/Libutil/libutil.a \
-	$(top_builddir)/src/lib/Libpbs/.libs/libpbs.a \
+	$(top_builddir)/src/lib/Libpbs/libpbs.la \
 	-lpthread \
 	@libz_lib@ \
 	@socket_lib@ \

--- a/src/server/daemon_info.c
+++ b/src/server/daemon_info.c
@@ -56,15 +56,15 @@
  * @brief initialize daemon info structure
  * This struct is common for all service end points
  * inlcluding mom/peer-svr
- * 
+ *
  * @param[in] pul - list of IP addresses of host; will be freed on error
  *			or saved in structure; caller must not free pul
- * @param[in] port - port of service end point 
+ * @param[in] port - port of service end point
  * @param[in] pmi - machine info struct
- * @return dmn_info_t* 
+ * @return dmn_info_t*
  */
 dmn_info_t *
-init_daemon_info(ulong *pul, uint port, struct machine_info *pmi)
+init_daemon_info(unsigned long *pul, uint port, struct machine_info *pmi)
 {
 	dmn_info_t *dmn_info = calloc(1, sizeof(dmn_info_t));
 	if (!dmn_info)
@@ -85,14 +85,14 @@ init_daemon_info(ulong *pul, uint port, struct machine_info *pmi)
 
 /**
  * @brief free up daemon info struct and associated data
- * 
+ *
  * @param[in] pmi - mom/peer-svr struct
  */
 void
 delete_daemon_info(struct machine_info *pmi)
 {
 	dmn_info_t *pdmninfo;
-	ulong *up;
+	unsigned long *up;
 
 	if (!pmi || !pmi->mi_dmn_info)
 		return;

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -139,7 +139,7 @@ pbs_tclsh_CPPFLAGS = \
 	@tcl_inc@
 
 pbs_tclsh_LDADD = \
-	$(top_builddir)/src/lib/Libpbs/.libs/libpbs.a \
+	$(top_builddir)/src/lib/Libpbs/libpbs.la \
 	$(top_builddir)/src/lib/Libtpp/libtpp.a \
 	$(top_builddir)/src/lib/Liblog/liblog.a \
 	$(top_builddir)/src/lib/Libutil/libutil.a \
@@ -166,7 +166,7 @@ pbs_wish_CPPFLAGS = \
 	@tk_inc@
 
 pbs_wish_LDADD = \
-	$(top_builddir)/src/lib/Libpbs/.libs/libpbs.a \
+	$(top_builddir)/src/lib/Libpbs/libpbs.la \
 	$(top_builddir)/src/lib/Libtpp/libtpp.a \
 	$(top_builddir)/src/lib/Liblog/liblog.a \
 	$(top_builddir)/src/lib/Libutil/libutil.a \

--- a/src/unsupported/Makefile.am
+++ b/src/unsupported/Makefile.am
@@ -77,7 +77,7 @@ pbs_rmget_LDADD = \
 	$(top_builddir)/src/lib/Libtpp/libtpp.a \
 	$(top_builddir)/src/lib/Liblog/liblog.a \
 	$(top_builddir)/src/lib/Libnet/libnet.a \
-	$(top_builddir)/src/lib/Libpbs/.libs/libpbs.a \
+	$(top_builddir)/src/lib/Libpbs/libpbs.la \
 	$(top_builddir)/src/lib/Libutil/libutil.a \
 	-lpthread \
 	@libz_lib@ \


### PR DESCRIPTION
#### Describe Bug or Feature
Doesn't build on macOS (and likely other POSIX systems eg. BSD).


#### Describe Your Change
- Use standard `unistd.h` header instead of non-standard `sys/unistd.h` (fixes `MCL_CURRENT` and `MCL_FUTURE` not defined)
- Use `unsigned long` instead of `ulong` everywhere which is not available outside Linux
- Link `pbs_ifl` with python (fixes undefined symbols eg. `"_PyArg_UnpackTuple", referenced from: _SwigPyObject_own`)
- Ensure `libpbs` is properly linked (fixes `symbol not found` when running binaries)
- Add `get_hostaddr` to libpbs (fixes `symbol not found` when running `pbs_ds_monitor`)
- Update macOS install instructions