### PR TITLE
Avoid hardcoding default configuration variables

### DIFF
--- a/m4/with_pbs_conf_file.m4
+++ b/m4/with_pbs_conf_file.m4
@@ -52,5 +52,6 @@ AC_DEFUN([PBS_AC_WITH_PBS_CONF_FILE],
     pbs_conf_file=[/etc/pbs.conf]
   )
   AC_MSG_RESULT([$pbs_conf_file])
+  AC_SUBST([PBS_CONF_FILE], ["$pbs_conf_file"])
   AC_DEFINE_UNQUOTED([PBS_CONF_FILE], ["$pbs_conf_file"], [Location of the PBS configuration file])
 ])

--- a/openpbs.spec.in
+++ b/openpbs.spec.in
@@ -56,7 +56,7 @@
 %endif
 
 %if !%{defined pbs_home}
-%define pbs_home /var/spool/pbs
+%define pbs_home @PBS_SERVER_HOME@
 %endif
 
 %if !%{defined pbs_dbuser}
@@ -427,7 +427,7 @@ if [ "$1" != "1" ]; then
 	# This is an uninstall, not an upgrade.
 	ldconfig %{_libdir}
 	echo
-	echo "NOTE: /etc/pbs.conf and the PBS_HOME directory must be deleted manually"
+	echo "NOTE: @PBS_CONF_FILE@ and the PBS_HOME directory must be deleted manually"
 	echo
 fi
 
@@ -436,7 +436,7 @@ if [ "$1" != "1" ]; then
 	# This is an uninstall, not an upgrade.
 	ldconfig %{_libdir}
 	echo
-	echo "NOTE: /etc/pbs.conf and the PBS_HOME directory must be deleted manually"
+	echo "NOTE: @PBS_CONF_FILE@ and the PBS_HOME directory must be deleted manually"
 	echo
 fi
 
@@ -445,7 +445,7 @@ if [ "$1" != "1" ]; then
 	# This is an uninstall, not an upgrade.
 	ldconfig %{_libdir}
 	echo
-	echo "NOTE: /etc/pbs.conf must be deleted manually"
+	echo "NOTE: @PBS_CONF_FILE@ must be deleted manually"
 	echo
 fi
 

--- a/src/cmds/mpiexec.in
+++ b/src/cmds/mpiexec.in
@@ -181,7 +181,7 @@ fi
 #	startup initializations
 init()
 {
-	pbsconffile=${PBS_CONF_FILE:-"/etc/pbs.conf"}
+	pbsconffile=${PBS_CONF_FILE:-"@PBS_CONF_FILE@"}
 	if [ -r $pbsconffile ]
 	then
 		. $pbsconffile

--- a/src/cmds/pbs_mpihp.in
+++ b/src/cmds/pbs_mpihp.in
@@ -669,7 +669,7 @@ transform_appfile ()
 # MAIN
 #####################################################
 
-. ${PBS_CONF_FILE:-/etc/pbs.conf}
+. ${PBS_CONF_FILE:-@PBS_CONF_FILE@}
 export PBS_TMPDIR="${PBS_TMPDIR:-${TMPDIR:-/var/tmp}}"
 
 # Global variables

--- a/src/cmds/pbs_mpirun.in
+++ b/src/cmds/pbs_mpirun.in
@@ -47,7 +47,7 @@ mpirun="mpirun"
 name=`basename $0`
 
 export PBS_RSHCOMMAND=${P4_RSHCOMMAND:-rsh}
-. ${PBS_CONF_FILE:-/etc/pbs.conf}
+. ${PBS_CONF_FILE:-@PBS_CONF_FILE@}
 export P4_RSHCOMMAND=${PBS_EXEC}/bin/pbs_remsh
 export MPICH_PROCESS_GROUP=no
 export PBS_TMPDIR="${PBS_TMPDIR:-${TMPDIR:-/var/tmp}}"

--- a/src/cmds/pbsrun.in
+++ b/src/cmds/pbsrun.in
@@ -327,7 +327,7 @@ else
    name=`basename $0`
 fi
 
-. ${PBS_CONF_FILE:-/etc/pbs.conf}
+. ${PBS_CONF_FILE:-@PBS_CONF_FILE@}
 export PBS_TMPDIR="${PBS_TMPDIR:-${TMPDIR:-/var/tmp}}"
 export PATH=$PATH:${PBS_EXEC}/bin
 

--- a/src/cmds/pbsrun_unwrap.in
+++ b/src/cmds/pbsrun_unwrap.in
@@ -55,7 +55,7 @@ exec_cmd () {
 
 }
 
-. ${PBS_CONF_FILE:-/etc/pbs.conf}
+. ${PBS_CONF_FILE:-@PBS_CONF_FILE@}
 export PBS_TMPDIR="${PBS_TMPDIR:-${TMPDIR:-/var/tmp}}"
 
 progname=`basename $0`

--- a/src/cmds/pbsrun_wrap.in
+++ b/src/cmds/pbsrun_wrap.in
@@ -53,7 +53,7 @@ exec_cmd () {
 
 }
 
-. ${PBS_CONF_FILE:-/etc/pbs.conf}
+. ${PBS_CONF_FILE:-@PBS_CONF_FILE@}
 export PBS_TMPDIR="${PBS_TMPDIR:-${TMPDIR:-/var/tmp}}"
 
 progname=`basename $0`

--- a/src/cmds/scripts/pbs_habitat.in
+++ b/src/cmds/scripts/pbs_habitat.in
@@ -146,7 +146,7 @@ check_hostname() {
 #
 # Start of the pbs_habitat script
 #
-conf=${PBS_CONF_FILE:-/etc/pbs.conf}
+conf=${PBS_CONF_FILE:-@PBS_CONF_FILE@}
 ostype=`uname 2>/dev/null`
 umask 022
 
@@ -293,7 +293,7 @@ if [ "${PBS_START_SERVER:-0}" != 0 ] ; then
 			echo "*** Error starting pbs server"
 			exit $ret
 		fi
-		server_started=1	
+		server_started=1
 
 		if is_cray_xt; then
 			${PBS_EXEC}/bin/qmgr <<-EOF > /dev/null

--- a/src/cmds/scripts/pbs_init.d.in
+++ b/src/cmds/scripts/pbs_init.d.in
@@ -449,7 +449,7 @@ stop_pbs() {
 				if [ -r "${PBS_HOME}/server_priv/qmgr_shutdown" ]; then
 					echo "pbs_server evaluating ${PBS_HOME}/server_priv/qmgr_shutdown"
 					${PBS_EXEC}/bin/qmgr <"${PBS_HOME}/server_priv/qmgr_shutdown"
-				fi	
+				fi
 				${PBS_EXEC}/bin/qterm -t quick
 				echo "PBS server - was pid: ${pbs_server_pid}"
 			elif [ ${is_secondary} -eq 1 ]; then
@@ -639,7 +639,7 @@ pre_start_pbs()
 env_save="/tmp/$$_$(date +'%s')_env_save"
 declare -x > "${env_save}"
 
-conf=${PBS_CONF_FILE:-/etc/pbs.conf}
+conf=${PBS_CONF_FILE:-@PBS_CONF_FILE@}
 [ -r "${conf}" ] && . "${conf}"
 
 # re-apply saved env variables

--- a/src/cmds/scripts/pbs_postinstall.in
+++ b/src/cmds/scripts/pbs_postinstall.in
@@ -92,7 +92,7 @@ createpath() {
 
 
 create_conf() {
-	# If we have an existing /etc/pbs.conf, save the old PBS_EXEC from
+	# If we have an existing @PBS_CONF_FILE@, save the old PBS_EXEC from
 	# the existing pbs.conf and make a backup. It may be a directory or
 	# a symbolic link so use cp rather than mv.
 	if [ -f "$conf" ] ; then
@@ -387,7 +387,7 @@ install_pbsinitd() {
 	fi
 	echo "***"
 
-	if [ "$conf" != "/etc/pbs.conf" ]; then
+	if [ "$conf" != "@PBS_CONF_FILE@" ]; then
 		echo "*** ======="
 		echo "*** NOTICE:"
 		echo "*** ======="
@@ -396,7 +396,7 @@ install_pbsinitd() {
 		echo "*** installation, a symbolic link must be created to the new"
 		echo "*** configuration file by manually issuing a command similar"
 		echo "*** to the following:"
-		echo "*** ln -s $conf /etc/pbs.conf"
+		echo "*** ln -s $conf @PBS_CONF_FILE@"
 		echo "***"
 	fi
 }
@@ -577,7 +577,7 @@ create_home() {
 			touch "$momconfig"
 			chmod 0644 "$momconfig"
 		fi
-		
+
 		if is_cray_xt; then
 			grep "^\$vnodedef_additive" "$momconfig" >/dev/null
 			if [ $? -ne 0 ] ; then
@@ -610,7 +610,7 @@ echo "*** Postinstall script called as follows:"
 printf "*** $0 "; printf "%q " "$@"; printf "\n"
 echo "***"
 PBS_VERSION='@PBS_VERSION@'
-conf="${PBS_CONF_FILE:-/etc/pbs.conf}"
+conf="${PBS_CONF_FILE:-@PBS_CONF_FILE@}"
 oldconfdir=`dirname "${conf}"`
 ostype=`uname 2>/dev/null`
 unset PBS_EXEC

--- a/src/cmds/scripts/pbsrun.poe.in
+++ b/src/cmds/scripts/pbsrun.poe.in
@@ -52,7 +52,7 @@ else
    name=`basename $0`
 fi
 
-. ${PBS_CONF_FILE:-/etc/pbs.conf}
+. ${PBS_CONF_FILE:-@PBS_CONF_FILE@}
 PBS_LIB_PATH="${PBS_EXEC}/lib"
 if [ ! -d ${PBS_LIB_PATH} -a -d ${PBS_EXEC}/lib64 ] ; then
 	PBS_LIB_PATH=${PBS_EXEC}/lib64

--- a/src/tools/wrap_tcl.sh.in
+++ b/src/tools/wrap_tcl.sh.in
@@ -51,7 +51,7 @@ EXEC_ARGS=$*
 
 LIBS_TO_LOAD=/opt/pbs/lib:/usr/pbs/lib:/usr/lib:/usr/local/lib
 
-PBS_CONF_FILE=${PBS_CONF_FILE:-/etc/pbs.conf}
+PBS_CONF_FILE=${PBS_CONF_FILE:-@PBS_CONF_FILE@}
 
 test -f $PBS_CONF_FILE && . $PBS_CONF_FILE
 


### PR DESCRIPTION
#### Describe Bug or Feature
The default PBS conf file and server home passed to the configure script are not always taken into consideration. This changes ensures that they are in all files processed by configure (*.in).

#### Describe Your Change
Specify a new autoconf substitution `PBS_CONF_FILE` and use it wherever `/etc/pbs.conf` is mentioned. Also, fix instances of `PBS_SERVER_HOME` not being used. There might be other places that still need changes, but this PR involves files that are already processed by configure.