### PR TITLE
Fix check for running systemd

### DIFF
--- a/src/lib/Libdb/pgsql/pbs_ds_systemd
+++ b/src/lib/Libdb/pgsql/pbs_ds_systemd
@@ -40,7 +40,7 @@
 
 is_systemd=1
 _status=$(systemctl is-system-running 2>/dev/null)
-if [ "x${_status}" == "xoffline" -o "x${_status}" == "xunknown" ] ; then
+if [ ! "${_status}" -o "x${_status}" = "xoffline" -o "x${_status}" = "xunknown" ] ; then
     is_systemd=0
 fi
 if [ $is_systemd -eq 1 ] ; then


### PR DESCRIPTION
#### Describe Bug or Feature
The current check for whether systemd is running does not take into account if the `systemctl` command is available.

#### Describe Your Change
Check if `systemctl is-system-running` fails. Also, use `=` checks for better POSIX compatibility.