### PR TITLE
Management Debug Hook Fix

### DIFF
--- a/src/server/hook_func.c
+++ b/src/server/hook_func.c
@@ -4085,6 +4085,10 @@ server_process_hooks(int rq_type, char *rq_user, char *rq_host, hook *phook,
 					CLEAR_HEAD(temp_req->rq_ind.rq_modify.rq_attr);
 					do_recreate = 1;
 					break;
+				case PBS_BATCH_Manager:
+					CLEAR_HEAD(temp_req->rq_ind.rq_manager.rq_attr);
+					do_recreate = 0;
+					break;
 				default:
 					do_recreate = 0;
 			}

--- a/test/tests/functional/pbs_hook_management.py
+++ b/test/tests/functional/pbs_hook_management.py
@@ -318,6 +318,95 @@ class TestHookManagement(TestFunctional):
 
         self.logger.info("**************** HOOK END ****************")
 
+    def test_hook_03(self):
+        """
+        By creating an import hook, it executes a management hook.
+        Also sets debug to True.
+        """
+        self.logger.info("**************** HOOK START ****************")
+        hook_name_a = "management_03a"
+        hook_msg_a = 'running management hook_03a'
+        hook_body_a = get_hook_body(hook_msg_a)
+        attrs = {'event': 'management', 'enabled': 'True', 'debug': 'True'}
+        start_time_a = time.time()
+        ret = self.server.create_hook(hook_name_a, attrs)
+        self.assertEqual(ret, True, f"Could not import hook {hook_name_a}")
+        ret = self.server.import_hook(hook_name_a, hook_body_a)
+        self.assertEqual(ret, True, f"Could not import hook {hook_name_a}")
+
+        self.server.add_resource("management_03_1_resource", type="string")
+
+        hook_name_b = "management_03b"
+        hook_msg_b = 'running management hook_03b'
+        hook_body_b = get_hook_body(hook_msg_b)
+        attrs = {'event': 'management', 'enabled': 'True', 'debug': 'True'}
+        start_time_b = time.time()
+        ret = self.server.create_hook(hook_name_b, attrs)
+        self.assertEqual(ret, True, f"Could not create hook {hook_name_b}")
+        ret = self.server.import_hook(hook_name_b, hook_body_b)
+        self.assertEqual(ret, True, f"Could not import hook {hook_name_b}")
+
+        self.server.add_resource("management_03_2_resource", type="string")
+        self.server.add_resource("management_03_3_resource", type="string")
+        self.server.delete_resources()
+
+        ret = self.server.delete_hook(hook_name_a)
+        self.assertEqual(ret, True, f"Could not delete hook {hook_name_a}")
+        ret = self.server.delete_hook(hook_name_b)
+        self.assertEqual(ret, True, f"Could not delete hook {hook_name_b}")
+
+        self.server.log_match(hook_msg_a, starttime=start_time_a)
+        self.server.log_match(hook_msg_b, starttime=start_time_b)
+        self.logger.info("**************** HOOK END ****************")
+
+    def test_hook_04(self):
+        """
+        By creating an import hook, it executes a management hook.
+        Also sets debug to False.
+        """
+        self.logger.info("**************** HOOK START ****************")
+        hook_name_a = "management_03a"
+        hook_msg_a = 'running management hook_03a'
+        hook_body_a = get_hook_body(hook_msg_a)
+        attrs = {'event': 'management', 'enabled': 'True',
+                 'debug': 'True', 'order': 2}
+        start_time_a = time.time()
+        ret = self.server.create_hook(hook_name_a, attrs)
+        self.assertEqual(ret, True, f"Could not import hook {hook_name_a}")
+        ret = self.server.import_hook(hook_name_a, hook_body_a)
+        self.assertEqual(ret, True, f"Could not import hook {hook_name_a}")
+
+        self.server.add_resource("management_03_1_resource", type="string")
+
+        hook_name_b = "management_03b"
+        hook_msg_b = 'running management hook_03b'
+        hook_body_b = get_hook_body(hook_msg_b)
+        attrs = {'event': 'management', 'enabled': 'False', 'debug': 'False'}
+        start_time_b = time.time()
+        ret = self.server.create_hook(hook_name_b, attrs)
+        self.assertEqual(ret, True, f"Could not create hook {hook_name_b}")
+        ret = self.server.import_hook(hook_name_b, hook_body_b)
+        self.assertEqual(ret, True, f"Could not import hook {hook_name_b}")
+        ret = self.server.import_hook(hook_name_b, hook_body_b)
+
+        attrs = {'enabled': 'true'}
+        self.logger.info(f"Enabling {hook_name_b}...")
+        rc = self.server.manager(MGR_CMD_SET, HOOK, attrs, id=hook_name_b)
+        self.logger.info(f"Result for {hook_name_b}->{rc}")
+
+        self.server.add_resource("management_03_2_resource", type="string")
+        self.server.add_resource("management_03_3_resource", type="string")
+        self.server.delete_resources()
+
+        ret = self.server.delete_hook(hook_name_a)
+        self.assertEqual(ret, True, f"Could not delete hook {hook_name_a}")
+        ret = self.server.delete_hook(hook_name_b)
+        self.assertEqual(ret, True, f"Could not delete hook {hook_name_b}")
+
+        self.server.log_match(hook_msg_a, starttime=start_time_a)
+        self.server.log_match(hook_msg_b, starttime=start_time_b)
+        self.logger.info("**************** HOOK END ****************")
+
     def test_hook_str_00(self):
         """
         By creating an import hook, it executes a management hook.

--- a/test/tests/functional/pbs_hook_management.py
+++ b/test/tests/functional/pbs_hook_management.py
@@ -330,7 +330,7 @@ class TestHookManagement(TestFunctional):
         attrs = {'event': 'management', 'enabled': 'True', 'debug': 'True'}
         start_time_a = time.time()
         ret = self.server.create_hook(hook_name_a, attrs)
-        self.assertEqual(ret, True, f"Could not import hook {hook_name_a}")
+        self.assertEqual(ret, True, f"Could not create hook {hook_name_a}")
         ret = self.server.import_hook(hook_name_a, hook_body_a)
         self.assertEqual(ret, True, f"Could not import hook {hook_name_a}")
 
@@ -372,7 +372,7 @@ class TestHookManagement(TestFunctional):
                  'debug': 'True', 'order': 2}
         start_time_a = time.time()
         ret = self.server.create_hook(hook_name_a, attrs)
-        self.assertEqual(ret, True, f"Could not import hook {hook_name_a}")
+        self.assertEqual(ret, True, f"Could not create hook {hook_name_a}")
         ret = self.server.import_hook(hook_name_a, hook_body_a)
         self.assertEqual(ret, True, f"Could not import hook {hook_name_a}")
 


### PR DESCRIPTION
#### Describe Bug or Feature
Segmentation Fault due to adding multiple management hooks or order=2 with debug=true will cause the pbs_server.bin to segfault.

#### Describe Your Change
Code was added to handle the recreation of the request object specifically for the PBS_BATCH_Manager hook request inside server_process_hooks.  This code is similar to the PBS_BATCH_ModifyJob and PBS_BATCH_QueueJob that calls CLEAR_HEAD(temp_req->rq_ind.rq_queuejob.rq_attr);.  Two tests were added that expose the problem in 2 different ways with two different errors.  One segfaults on hook call, the other on hook import, which in turn, calls the hook itself.

#### Segmentation Fault 1
```
Thread 1 "pbs_server.bin" received signal SIGSEGV, Segmentation fault.
0x00000000004e86ce in free_attrlist (pattrlisthead=0x1a94178) at /home/pbsdev/pbs/source/src/lib/Libattr/attr_func.c:380
380	        free_svrattrl((svrattrl *) GET_NEXT(*pattrlisthead));
(gdb) where
#0  0x00000000004e86ce in free_attrlist (pattrlisthead=0x1a94178) at /home/pbsdev/pbs/source/src/lib/Libattr/attr_func.c:380
#1  0x0000000000478246 in freebr_manage (pmgr=0x1a94058) at /home/pbsdev/pbs/source/src/server/process_request.c:1698
#2  0x0000000000478132 in free_br (preq=0x1a93cb0) at /home/pbsdev/pbs/source/src/server/process_request.c:1660
#3  0x000000000044c8c5 in server_process_hooks (rq_type=9, rq_user=0x1a41618 "root", rq_host=0x1a41719 "pdw-s1.pdw.local", phook=0x1acd910,
    hook_event=2097152, pjob=0x0, req_ptr=0x7fffbd6a1ac0, hook_msg=0x7fffbd6a1ba0 "", msg_len=3172, pyinter_func=0x509484 <pbs_python_set_interrupt>,
    num_run=0x7fffbd6a1abc, event_initialized=0x7fffbd6a1ab8) at /home/pbsdev/pbs/source/src/server/hook_func.c:4105
#4  0x000000000044c284 in process_hooks (preq=0x1a415d0, hook_msg=0x7fffbd6a1ba0 "", msg_len=3172, pyinter_func=0x509484 <pbs_python_set_interrupt>)
    at /home/pbsdev/pbs/source/src/server/hook_func.c:3902
#5  0x000000000048ca7a in req_manager (preq=0x1a415d0) at /home/pbsdev/pbs/source/src/server/req_manager.c:4614
#6  0x0000000000476f35 in dispatch_request (sfds=18, request=0x1a415d0) at /home/pbsdev/pbs/source/src/server/process_request.c:898
#7  0x0000000000476b4d in process_request (sfds=18) at /home/pbsdev/pbs/source/src/server/process_request.c:695
#8  0x000000000050496f in process_socket (sock=18) at /home/pbsdev/pbs/source/src/lib/Libnet/net_server.c:510
#9  0x0000000000504c86 in wait_request (waittime=2, priority_context=0x1795ed0) at /home/pbsdev/pbs/source/src/lib/Libnet/net_server.c:623
#10 0x0000000000475312 in main (argc=1, argv=0x7fffbd6a59a8) at /home/pbsdev/pbs/source/src/server/pbsd_main.c:1396
```

#### Segmentation Fault 2 (same fault as above, different method)
```
sudo /opt/pbs/bin/qmgr -c "import hook pbs_admin_hook_management_log application/x-python default pbs_admin_hook_management_log.py"
qmgr obj=pbs_admin_hook_management_log svr=default: End of File
qmgr: Protocol error, server disconnected
```

#### Management Test Output attached.  See test_hook_03 and test_hook_04.
[test-20220907193820.log](https://github.com/openpbs/openpbs/files/9509151/test-20220907193820.log)
