### PR TITLE
reject job if uid is not found instead of offlining vnode

### DIFF
--- a/src/modules/python/pbs_hooks/PBS_cray_atom.PY
+++ b/src/modules/python/pbs_hooks/PBS_cray_atom.PY
@@ -365,6 +365,16 @@ def retry_post(data):
     log_with_caller(pbs.EVENT_DEBUG, 'Job %s registered' % jid)
     return
 
+def get_uid(user):
+    """
+    get uid for the user
+    """
+    try:
+        return pwd.getpwnam(user).pw_uid
+    except:
+        pbs.logmsg(pbs.EVENT_DEBUG, "Error while reading user uid from the"
+                   " machine.")
+        raise RejectError(f"Unable to get uid for {user}")
 
 def handle_execjob_begin():
     """
@@ -373,7 +383,7 @@ def handle_execjob_begin():
     log_function_name()
     event = pbs.event()
     jid = event.job.id
-    uid = pwd.getpwnam(event.job.euser).pw_uid
+    uid = get_uid(event.job.euser)
     log_with_caller(pbs.EVENT_DEBUG4, 'UID is %d' % uid)
     excl = HookHelper.is_it_exclusive(event.job)
     data = {


### PR DESCRIPTION

#### Describe Bug or Feature
Cray ATOM hook will offline nodes if a user name is not yet visible from an execution host


#### Describe Your Change
Handling getting uid issue using try..except if user not found then raise RejectError which will reject the job instead of raising an unhandled exception which will end making vnode offline.


#### Attach Test and Valgrind Logs/Output

Didn't test it on cray shasta platform as I dont have access. But created the hook which will do the same. Used below hook to reproduce and check the solution:

```python
root@BLRLAP903:~# cat test.py
import pbs
import pwd



class RejectError(Exception):
    """
    Exception that will reject the event
    """
    pass


def get_uid(user):
    """
    get uid for the user
    """
    try:
        return pwd.getpwnam(user).pw_uid
    except:
        pbs.logmsg(pbs.EVENT_DEBUG, "Error while reading user uid from the machine.")
        raise RejectError(f"Unable to get uid for {user}")

try:
    event = pbs.event()
    uid = get_uid('test')
except RejectError:
    pbs.event().reject()
```


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
