### PR TITLE
Fix: run job which got -default- group

### DIFF
--- a/src/resmom/start_exec.c
+++ b/src/resmom/start_exec.c
@@ -272,6 +272,7 @@ check_pwd(job *pjob)
 	struct passwd *pwdp;
 	struct group *grpp;
 	struct stat sb;
+	attribute *jb_group;
 
 	pwdp = getpwnam(get_jattr_str(pjob, JOB_ATR_euser));
 	if (pwdp == NULL) {
@@ -304,7 +305,8 @@ check_pwd(job *pjob)
 
 	/* get the group and supplimentary under which the job is to be run */
 
-	if (is_jattr_set(pjob, JOB_ATR_egroup)) {
+	jb_group = get_jattr(pjob, JOB_ATR_egroup);
+	if ((jb_group->at_flags & (ATR_VFLAG_SET | ATR_VFLAG_DEFLT)) == ATR_VFLAG_SET) {
 
 		/* execution group specified - not defaulting to login group */
 

--- a/test/tests/functional/pbs_job_default_group.py
+++ b/test/tests/functional/pbs_job_default_group.py
@@ -59,8 +59,13 @@ class TestJobDefaultGroup(TestFunctional):
         self.user_name = "ptlpbstestuser1"
         try:
             pwd.getpwnam(self.user_name)
-            self.skipTest(
-                f"{self.user_name} should not be present " "on server host")
+            # user is present in server host, must delete user before
+            # qsub
+            cmd = f"userdel {self.user_name}"
+            res = self.du.run_cmd(self.server.hostname, cmd=cmd, sudo=True)
+            if res["rc"] != 0:
+                raise PtlException("Unable to delete user on server host")
+            self.logger.info(f"Delete {self.user_name} on server host.")
         except KeyError:
             # good! user is not present on server host
             # just as we needed

--- a/test/tests/functional/pbs_job_default_group.py
+++ b/test/tests/functional/pbs_job_default_group.py
@@ -59,8 +59,8 @@ class TestJobDefaultGroup(TestFunctional):
         self.user_name = "ptlpbstestuser1"
         try:
             pwd.getpwnam(self.user_name)
-            self.skipTest(f"{self.user_name} should not be present "
-                           "on server host")
+            self.skipTest(
+                f"{self.user_name} should not be present " "on server host")
         except KeyError:
             # good! user is not present on server host
             # just as we needed

--- a/test/tests/functional/pbs_job_default_group.py
+++ b/test/tests/functional/pbs_job_default_group.py
@@ -65,7 +65,7 @@ class TestJobDefaultGroup(TestFunctional):
         attr = {'flatuid': True}
         self.server.manager(MGR_CMD_SET, SERVER, attr)
         starttime = int(time.time())
-        user = PbsUser("testpbsuser1")
+        user = PbsUser(self.user_name)
         self.server.client = self.mom.hostname
         jid = self.server.submit(Job(user), submit_dir='/tmp')
         self.server.client = self.server.hostname

--- a/test/tests/functional/pbs_job_default_group.py
+++ b/test/tests/functional/pbs_job_default_group.py
@@ -65,7 +65,7 @@ class TestJobDefaultGroup(TestFunctional):
             res = self.du.run_cmd(self.server.hostname, cmd=cmd, sudo=True)
             if res["rc"] != 0:
                 raise PtlException("Unable to delete user on server host")
-            self.logger.info(f"Delete {self.user_name} on server host.")
+            self.logger.info(f"Deleted {self.user_name} on server host.")
         except KeyError:
             # good! user is not present on server host
             # just as we needed

--- a/test/tests/functional/pbs_job_default_group.py
+++ b/test/tests/functional/pbs_job_default_group.py
@@ -37,6 +37,9 @@
 # "OpenPBS®", "PBS Professional®", and "PBS Pro™" and Altair's logos is
 # subject to Altair's trademark licensing policies.
 
+import random
+import string
+
 from tests.functional import *
 
 
@@ -53,13 +56,14 @@ class TestJobDefaultGroup(TestFunctional):
         """
         if self.server.hostname == self.mom.hostname:
             self.skipTest("Server and Execution host must be different")
-        attr = {'flatuid': True}
-        self.server.manager(MGR_CMD_SET, SERVER, attr)
         # add a temporary new user on execution host
-        cmd = "useradd -m testpbsuser1"
+        self.user_name =  'temppbs' + ''.join(random.choices(string.ascii_letters, k=5))
+        cmd = f"useradd -m {self.user_name}"
         res = self.du.run_cmd(self.mom.hostname, cmd=cmd, sudo=True)
         if res['rc'] != 0:
             raise PtlException('Unable to create user on execution host')
+        attr = {'flatuid': True}
+        self.server.manager(MGR_CMD_SET, SERVER, attr)
         starttime = int(time.time())
         user = PbsUser("testpbsuser1")
         self.server.client = self.mom.hostname
@@ -73,5 +77,5 @@ class TestJobDefaultGroup(TestFunctional):
 
     def tearDown(self):
         super().tearDown()
-        cmd = "userdel testpbsuser1"
+        cmd = f"userdel {self.user_name}"
         self.du.run_cmd(self.mom.hostname, cmd=cmd, sudo=True)

--- a/test/tests/functional/pbs_job_default_group.py
+++ b/test/tests/functional/pbs_job_default_group.py
@@ -1,0 +1,77 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2022 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of both the OpenPBS software ("OpenPBS")
+# and the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# OpenPBS is free software. You can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# OpenPBS is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# PBS Pro is commercially licensed software that shares a common core with
+# the OpenPBS software.  For a copy of the commercial license terms and
+# conditions, go to: (http://www.pbspro.com/agreement.html) or contact the
+# Altair Legal Department.
+#
+# Altair's dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of OpenPBS and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair's trademarks, including but not limited to "PBS™",
+# "OpenPBS®", "PBS Professional®", and "PBS Pro™" and Altair's logos is
+# subject to Altair's trademark licensing policies.
+
+from tests.functional import *
+
+
+class TestJobDefaultGroup(TestFunctional):
+    """
+    This test suite contains test for job which gets default group
+    """
+
+    def test_job_with_default_group(self):
+        """
+        When a user group is not present on server machine
+        then job will get a "-default-" group set on it.
+        And MOM should be able to run that job
+        """
+        if self.server.hostname == self.mom.hostname:
+            self.skipTest("Server and Execution host must be different")
+        attr = {'flatuid': True}
+        self.server.manager(MGR_CMD_SET, SERVER, attr)
+        # add a temporary new user on execution host
+        cmd = "useradd -m testpbsuser1"
+        res = self.du.run_cmd(self.mom.hostname, cmd=cmd, sudo=True)
+        if res['rc'] != 0:
+            raise PtlException('Unable to create user on execution host')
+        starttime = int(time.time())
+        user = PbsUser("testpbsuser1")
+        self.server.client = self.mom.hostname
+        jid = self.server.submit(Job(user), submit_dir='/tmp')
+        self.server.client = self.server.hostname
+        attr = {'job_state': 'R'}
+        self.server.expect(JOB, attr, id=jid)
+        self.mom.log_match(f'Job;{jid};No Group Entry for Group -default-',
+                           starttime=starttime, existence=False,
+                           max_attempts=30)
+
+    def tearDown(self):
+        super().tearDown()
+        cmd = "userdel testpbsuser1"
+        self.du.run_cmd(self.mom.hostname, cmd=cmd, sudo=True)

--- a/test/tests/functional/pbs_job_default_group.py
+++ b/test/tests/functional/pbs_job_default_group.py
@@ -57,23 +57,27 @@ class TestJobDefaultGroup(TestFunctional):
         if self.server.hostname == self.mom.hostname:
             self.skipTest("Server and Execution host must be different")
         # add a temporary new user on execution host
-        self.user_name =  'temppbs' + ''.join(random.choices(string.ascii_letters, k=5))
+        self.user_name = "temppbs" + \
+            "".join(random.choices(string.ascii_letters, k=5))
         cmd = f"useradd -m {self.user_name}"
         res = self.du.run_cmd(self.mom.hostname, cmd=cmd, sudo=True)
-        if res['rc'] != 0:
-            raise PtlException('Unable to create user on execution host')
-        attr = {'flatuid': True}
+        if res["rc"] != 0:
+            raise PtlException("Unable to create user on execution host")
+        attr = {"flatuid": True}
         self.server.manager(MGR_CMD_SET, SERVER, attr)
         starttime = int(time.time())
         user = PbsUser(self.user_name)
         self.server.client = self.mom.hostname
-        jid = self.server.submit(Job(user), submit_dir='/tmp')
+        jid = self.server.submit(Job(user), submit_dir="/tmp")
         self.server.client = self.server.hostname
-        attr = {'job_state': 'R'}
+        attr = {"job_state": "R"}
         self.server.expect(JOB, attr, id=jid)
-        self.mom.log_match(f'Job;{jid};No Group Entry for Group -default-',
-                           starttime=starttime, existence=False,
-                           max_attempts=30)
+        self.mom.log_match(
+            f"Job;{jid};No Group Entry for Group -default-",
+            starttime=starttime,
+            existence=False,
+            max_attempts=30,
+        )
 
     def tearDown(self):
         super().tearDown()


### PR DESCRIPTION

#### Describe Bug or Feature
user that has the default login group job gets Held with "No Group Entry for Group -default-" in the mom log


#### Describe Your Change
the user has no group, submits a job, it gets assigned the egroup "default" Job tries to run 21 times and gets put in the "Held" state. Mom logs show "No Group Entry for Group default"

The problem: the code stopped verifying that ATR_VFLAG_DEFLT was NOT set before entering a code path. In https://github.com/openpbs/openpbs/pull/2188 in resmom/start_exec.c: the original code: if ((pjob->ji_wattr\[(int)JOB_ATR_egroup\].at_flags & (ATR_VFLAG_SET | ATR_VFLAG_DEFLT)) == ATR_VFLAG_SET) {

the PR-2188 new code: if (is_jattr_set(pjob, JOB_ATR_egroup)) {

But is_jattr_set only checks that ATR_VFLAG_SET is set. A check for ATR_VFLAG_DEFLT NOT set should also be added to make the code behave as it used to.

In the case where the user does not have a group, they should fall into the "else" case of the code.



#### Attach Test and Valgrind Logs/Output

* *[before_fix.txt](https://github.com/openpbs/openpbs/files/10032569/before_fix.txt)*
* *[after_fix.txt](https://github.com/openpbs/openpbs/files/10032576/after_fix.txt)*



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
