### PR TITLE
Remove python interpreter restart on resource CRUD ops

### DIFF
--- a/src/include/pbs_python.h
+++ b/src/include/pbs_python.h
@@ -242,6 +242,7 @@ extern void pbs_python_ext_quick_start_interpreter(void);
 extern void pbs_python_ext_quick_shutdown_interpreter(void);
 extern int set_py_progname(void);
 extern int get_py_progname(char **);
+extern int pbs_python_reload_python_resource_type();
 
 /* -- END pbs_python_external.c implementations -- */
 

--- a/src/include/resource.h
+++ b/src/include/resource.h
@@ -134,7 +134,7 @@ extern resource_def *find_resc_def(resource_def *, char *);
 extern resource *find_resc_entry(const attribute *, resource_def *);
 extern int update_resource_def_file(char *name, resdef_op_t op, int type, int perms);
 extern int add_resource_def(char *name, int type, int perms);
-extern int restart_python_interpreter(const char *);
+extern int reload_python_resources(const char *);
 extern long long to_kbsize(char *val);
 extern int alloc_svrleaf(char *resc_name, svr_entlim_leaf_t **pplf);
 extern int parse_resc_type(char *val, int *resc_type_p);

--- a/src/lib/Libpython/pbs_python_svr_internal.c
+++ b/src/lib/Libpython/pbs_python_svr_internal.c
@@ -1282,6 +1282,24 @@ ERROR_EXIT:
 
 /**
  * @brief
+ *    Reload the PBS python resource types initialized
+ *
+ * @return      int
+ * @retval      -1      :       failure
+ * @retval      0       :       success
+ */
+
+int
+pbs_python_reload_python_resource_type()
+{
+	int rc;
+	pbs_python_free_py_types_array(&py_svr_resc_types);   /* all resources */
+	rc = pbs_python_setup_python_resource_type();
+	return rc;
+}
+
+/**
+ * @brief
  *    Unload all the PBS python types initialized, as well as static Python
  *    objects created during the initial loading of the interpreter.
  *

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -3697,7 +3697,7 @@ mgr_resource_create(struct batch_request *preq)
 	}
 	reply_ack(preq);
 
-	restart_python_interpreter(__func__);
+	reload_python_resources(__func__);
 	deferred_send_rescdef();
 
 	return;
@@ -3890,7 +3890,7 @@ mgr_resource_delete(struct batch_request *preq)
 
 	reply_ack(preq);
 
-	restart_python_interpreter(__func__);
+	reload_python_resources(__func__);
 	deferred_send_rescdef();
 	set_scheduler_flag(SCH_CONFIGURE, NULL);
 
@@ -4121,7 +4121,7 @@ mgr_resource_set(struct batch_request *preq)
 
 	reply_ack(preq);
 
-	restart_python_interpreter(__func__);
+	reload_python_resources(__func__);
 	deferred_send_rescdef();
 	set_scheduler_flag(SCH_CONFIGURE, NULL);
 
@@ -4342,7 +4342,7 @@ mgr_resource_unset(struct batch_request *preq)
 
 	reply_ack(preq);
 
-	restart_python_interpreter(__func__);
+	reload_python_resources(__func__);
 	deferred_send_rescdef();
 	set_scheduler_flag(SCH_CONFIGURE, NULL);
 

--- a/src/server/setup_resc.c
+++ b/src/server/setup_resc.c
@@ -77,16 +77,15 @@ struct resc_sum *svr_resc_sum;
  * @param[in]	caller	-	The name of the calling function (for logging)
  */
 int
-restart_python_interpreter(const char *caller)
+reload_python_resources(const char *caller)
 {
 	int rc;
 	log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_HOOK,
 		  LOG_INFO, (char *) caller,
-		  "Restarting Python interpreter as resourcedef file has changed.");
-	pbs_python_ext_shutdown_interpreter(&svr_interp_data);
-	rc = pbs_python_ext_start_interpreter(&svr_interp_data);
+		  "Reload python resource objects as resourcedef file has changed.");
+	rc = pbs_python_reload_python_resource_type();
 	if (rc != 0) {
-		log_err(PBSE_INTERNAL, (char *) caller, "Failed to restart Python interpreter");
+		log_err(PBSE_INTERNAL, (char *) caller, "Failed to reload resources in PBS Python");
 	}
 	return rc;
 }


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Avoid python interpreter restarts on CRUD operations on resources


#### Describe Your Change
Shutting down python interpreter (using PyFinalize) has some memory leaks. And in PBS python interpreter is getting restarted for every update on resources. Basically, we need to re-initialize resource types in python for every update which can be done just by clear global variable "py_svr_resc_types" and resetting resources for python.





#### Attach Test and Valgrind Logs/Output
* *[server_logs_before_fix.txt](https://github.com/openpbs/openpbs/files/10033944/server_logs_before_fix.txt)*
* *[server_logs_after_fix.txt](https://github.com/openpbs/openpbs/files/10033946/server_logs_after_fix.txt)*
* *[smoke_tests.txt](https://github.com/openpbs/openpbs/files/10033948/smoke_tests.txt)*
* *[smoke_tag_tests.txt](https://github.com/openpbs/openpbs/files/10033959/smoke_tag_tests.txt)*



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
