### PR TITLE
fix server crash due to invalid python writes

### DIFF
--- a/src/include/pbs_python.h
+++ b/src/include/pbs_python.h
@@ -234,6 +234,10 @@ extern int pbs_python_run_code_in_namespace(
 
 extern void pbs_python_ext_free_python_script(
 	struct python_script *py_script);
+extern void	pbs_python_ext_free_code_obj(
+	struct python_script *py_script);
+extern void	pbs_python_ext_free_global_dict(
+	struct python_script *py_script);
 extern int pbs_python_ext_alloc_python_script(
 	const char *script_path,
 	struct python_script **py_script);
@@ -242,6 +246,7 @@ extern void pbs_python_ext_quick_start_interpreter(void);
 extern void pbs_python_ext_quick_shutdown_interpreter(void);
 extern int set_py_progname(void);
 extern int get_py_progname(char **);
+extern void pbs_python_clear_attributes();
 
 /* -- END pbs_python_external.c implementations -- */
 
@@ -454,8 +459,6 @@ extern int pbs_python_event_set(
 	char *req_host,
 	hook_input_param_t *req_params,
 	char *perf_label);
-
-extern void pbs_python_event_unset(void);
 
 extern int pbs_python_event_to_request(unsigned int hook_event,
 				       hook_output_param_t *req_params, char *perf_label, char *perf_action);

--- a/src/lib/Libpython/pbs_python_svr_external.c
+++ b/src/lib/Libpython/pbs_python_svr_external.c
@@ -71,8 +71,6 @@ extern int _pbs_python_event_mark_readonly(void);
 extern int _pbs_python_event_set(unsigned int hook_event, char *req_user,
 				 char *req_host, hook_input_param_t *req_params, char *perf_label);
 
-extern void _pbs_python_event_unset(void);
-
 extern int _pbs_python_event_to_request(unsigned int hook_event, hook_output_param_t *req_params, char *perf_label, char *perf_action);
 
 extern int _pbs_python_event_set_attrval(char *name, char *value);
@@ -245,18 +243,6 @@ pbs_python_event_set(unsigned int hook_event, char *req_user,
 #endif
 }
 
-/**
- * @brief
- * 	This discards the Python event object if set, hopefully freeing up any
- * 	memory allocated to it.
- */
-void
-pbs_python_event_unset(void)
-{
-#ifdef PYTHON
-	_pbs_python_event_unset();
-#endif
-}
 
 /**
  *

--- a/src/lib/Libpython/pbs_python_svr_internal.c
+++ b/src/lib/Libpython/pbs_python_svr_internal.c
@@ -11992,7 +11992,7 @@ pbs_python_set_os_environ(char *env_var, char *env_val)
 
 	if (env_val == NULL) {
 
-		if (temp_item = PyObject_GetItem(os_mod_env, pystr_env_var) != NULL) {
+		if ((temp_item = PyObject_GetItem(os_mod_env, pystr_env_var)) != NULL) {
 			if (PyObject_DelItem(os_mod_env,
 					     pystr_env_var) == -1) {
 				snprintf(log_buffer, sizeof(log_buffer),

--- a/src/tools/pbs_python.c
+++ b/src/tools/pbs_python.c
@@ -2743,6 +2743,8 @@ main(int argc, char *argv[], char *envp[])
 		if ((fp_server_out != NULL) && (fp_server_out != stdout))
 			fclose(fp_server_out);
 
+		pbs_python_ext_free_global_dict(py_script);
+		pbs_python_clear_attributes();
 		pbs_python_ext_shutdown_interpreter(&svr_interp_data);
 
 		free_attrlist(&event_vnode);


### PR DESCRIPTION


#### Describe Bug or Feature
PBS server crashes due to python interpreter: During restart (mainly stopping interpreter), we were not clearing few python objects. Instead we were clearing them in the next hook run after re-start which was causing the pbs server to crash.


#### Describe Your Change
Clear the global python objects after usage



#### Attach Test Logs/Output
[server_crash_tests.txt](https://github.com/openpbs/openpbs/files/10349971/server_crash_tests.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
