### PR TITLE
fix scheduler registering with kerberos

### DIFF
--- a/src/include/pbs_internal.h
+++ b/src/include/pbs_internal.h
@@ -244,6 +244,7 @@ struct pbs_config
 	unsigned int pbs_log_highres_timestamp; /* high resolution logging */
 	unsigned int pbs_sched_threads;	/* number of threads for scheduler */
 	char *pbs_daemon_service_user; /* user the scheduler runs as */
+	char *pbs_daemon_service_auth_user; /* auth user the scheduler runs as */
 	char current_user[PBS_MAXUSER+1]; /* current running user */
 #ifdef WIN32
 	char *pbs_conf_remote_viewer; /* Remote viewer client executable for PBS GUI jobs, along with launch options */
@@ -310,6 +311,7 @@ extern struct pbs_config pbs_conf;
 #define PBS_CONF_LOG_HIGHRES_TIMESTAMP	"PBS_LOG_HIGHRES_TIMESTAMP"
 #define PBS_CONF_SCHED_THREADS	"PBS_SCHED_THREADS"
 #define PBS_CONF_DAEMON_SERVICE_USER "PBS_DAEMON_SERVICE_USER"
+#define PBS_CONF_DAEMON_SERVICE_AUTH_USER "PBS_DAEMON_SERVICE_AUTH_USER"
 #ifdef WIN32
 #define PBS_CONF_REMOTE_VIEWER "PBS_REMOTE_VIEWER"	/* Executable for remote viewer application alongwith its launch options, for PBS GUI jobs */
 #endif

--- a/src/lib/Libifl/pbs_loadconf.c
+++ b/src/lib/Libifl/pbs_loadconf.c
@@ -128,6 +128,7 @@ struct pbs_config pbs_conf = {
 	0,			    /* high resolution timestamp logging */
 	0,			    /* number of scheduler threads */
 	NULL,			    /* default scheduler user */
+	NULL,			    /* default scheduler auth user */
 	{'\0'}			    /* current running user */
 #ifdef WIN32
 	,
@@ -554,6 +555,9 @@ __pbs_loadconf(int reload)
 			} else if (!strcmp(conf_name, PBS_CONF_DAEMON_SERVICE_USER)) {
 				free(pbs_conf.pbs_daemon_service_user);
 				pbs_conf.pbs_daemon_service_user = strdup(conf_value);
+			} else if (!strcmp(conf_name, PBS_CONF_DAEMON_SERVICE_AUTH_USER)) {
+				free(pbs_conf.pbs_daemon_service_auth_user);
+				pbs_conf.pbs_daemon_service_auth_user = strdup(conf_value);
 			}
 			/* iff_path is inferred from pbs_conf.pbs_exec_path - see below */
 		}
@@ -765,6 +769,11 @@ __pbs_loadconf(int reload)
 	if ((gvalue = getenv(PBS_CONF_DAEMON_SERVICE_USER)) != NULL) {
 		free(pbs_conf.pbs_daemon_service_user);
 		pbs_conf.pbs_daemon_service_user = strdup(gvalue);
+	}
+
+	if ((gvalue = getenv(PBS_CONF_DAEMON_SERVICE_AUTH_USER)) != NULL) {
+		free(pbs_conf.pbs_daemon_service_auth_user);
+		pbs_conf.pbs_daemon_service_auth_user = strdup(gvalue);
 	}
 
 #ifdef WIN32


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
While using GSS/Kerberos, the scheduler is not able to contact the server due to a permission error. This bug is in req_register_sched(). Here, the `conn->cn_username` stores part of the host principal of the scheduler (e.g: "host/hostname"). Not the user e.g. 'root'. (Note: The realm of the principal is stored in `conn->cn_hostname`.) The function req_register_sched() thus compares wrong values. I think PR #1505 introduced this bug. 

<!--- Describe the problem, ideally from the customer's viewpoint  -->


#### Describe Your Change
I suggest adding a new environmental variable PBS_DAEMON_SERVICE_AUTH_USER. Adding this value to /etc/pbs.conf means it will be preferred over PBS_DAEMON_SERVICE_USER for authentication only.

While compiled with GSS/Kerberos the function req_register_sched() concates the `conn->cn_username`  and `conn->cn_hostname` of the client into Kerberos principal like 'host/hostname@REALM', which is compared with the value of PBS_DAEMON_SERVICE_AUTH_USER.

<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
While testing,  `scheduler_iteration` is set to 10 seconds. All test logs contain the following steps:
1. start PBS service
2. (un)successful attempt to contact the server by the scheduler
3. stopping PBS service

Test logs:
- before patch:
   * GSS (this shows the fixed problem):
      [server_log-GSS-before.txt](https://github.com/openpbs/openpbs/files/10836667/server_log-GSS-before.txt)
      [sched_log-GSS-before.txt](https://github.com/openpbs/openpbs/files/10836668/sched_log-GSS-before.txt)

- after patch:
   * GSS (with PBS_DAEMON_SERVICE_AUTH_USER set):
      [server_log-GSS-after.txt](https://github.com/openpbs/openpbs/files/10836678/server_log-GSS-after.txt)
      [sched_log-GSS-after.txt](https://github.com/openpbs/openpbs/files/10836680/sched_log-GSS-after.txt)
   * non-GSS (to prove non-GSS is OK):
      [server_log-nonGSS-after.txt](https://github.com/openpbs/openpbs/files/10836684/server_log-nonGSS-after.txt)
      [sched_log-nonGSS-after.txt](https://github.com/openpbs/openpbs/files/10836686/sched_log-nonGSS-after.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
