### PR TITLE
Fixed Compilation Warnings

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ pr:
   - release_*
 
 pool:
-  vmImage: 'ubuntu-18.04'
+  vmImage: 'ubuntu-20.04'
 
 jobs:
   - job: runcheck

--- a/src/cmds/pbs_ds_password.c
+++ b/src/cmds/pbs_ds_password.c
@@ -327,14 +327,9 @@ change_ownership(char *path, char *userid)
 	char dirfile[MAXPATHLEN + 1];
 	struct stat stbuf;
 
-<<<<<<< HEAD
 	if (chown(path, pwent->pw_uid, (gid_t) -1) == -1) {
 		fprintf(stderr, "%s : chown failed : ERR : %s\n"
 				,__func__, strerror(errno));
-=======
-	if ( chown(path, pwent->pw_uid, (gid_t) -1) == -1) {
-		fprintf(stderr, "%s : chown failed : ERR : %s\n",__func__, strerror(errno));
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 		return -1;
 	}
 	dir = opendir(path);
@@ -349,12 +344,9 @@ change_ownership(char *path, char *userid)
 
 		sprintf(dirfile, "%s/%s", path, pdirent->d_name);
 		if (chown(dirfile, pwent->pw_uid, (gid_t) -1) == -1) {
-<<<<<<< HEAD
 			fprintf(stderr, "%s : chown failed : ERR : %s\n"
 					,__func__, strerror(errno));
-=======
 			fprintf(stderr, "%s : chown failed : ERR : %s\n",__func__, strerror(errno));
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 			continue;
 		}
 		stat(dirfile, &stbuf);

--- a/src/cmds/pbs_ds_password.c
+++ b/src/cmds/pbs_ds_password.c
@@ -189,6 +189,7 @@ read_password(char *passwd)
 
 	if (fgets(passwd, MAX_PASSWORD_LEN, stdin) == NULL) {
 		fprintf(stderr, "%s : fgets failed", __func__);
+		return -1;
 	}
 
 	if (system("stty echo") != 0)
@@ -328,6 +329,7 @@ change_ownership(char *path, char *userid)
 
 	if ( chown(path, pwent->pw_uid, (gid_t) -1) == -1) {
 		fprintf(stderr, "%s : chown failed : ERR : %s\n",__func__, strerror(errno));
+		return -1;
 	}
 	dir = opendir(path);
 	if (dir == NULL) {
@@ -342,6 +344,7 @@ change_ownership(char *path, char *userid)
 		sprintf(dirfile, "%s/%s", path, pdirent->d_name);
 		if (chown(dirfile, pwent->pw_uid, (gid_t) -1) == -1) {
 			fprintf(stderr, "%s : chown failed : ERR : %s\n",__func__, strerror(errno));
+			continue;
 		}
 		stat(dirfile, &stbuf);
 		if (stbuf.st_mode & S_IFDIR) {

--- a/src/cmds/pbs_ds_password.c
+++ b/src/cmds/pbs_ds_password.c
@@ -327,8 +327,14 @@ change_ownership(char *path, char *userid)
 	char dirfile[MAXPATHLEN + 1];
 	struct stat stbuf;
 
+<<<<<<< HEAD
+	if (chown(path, pwent->pw_uid, (gid_t) -1) == -1) {
+		fprintf(stderr, "%s : chown failed : ERR : %s\n"
+				,__func__, strerror(errno));
+=======
 	if ( chown(path, pwent->pw_uid, (gid_t) -1) == -1) {
 		fprintf(stderr, "%s : chown failed : ERR : %s\n",__func__, strerror(errno));
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 		return -1;
 	}
 	dir = opendir(path);
@@ -343,7 +349,12 @@ change_ownership(char *path, char *userid)
 
 		sprintf(dirfile, "%s/%s", path, pdirent->d_name);
 		if (chown(dirfile, pwent->pw_uid, (gid_t) -1) == -1) {
+<<<<<<< HEAD
+			fprintf(stderr, "%s : chown failed : ERR : %s\n"
+					,__func__, strerror(errno));
+=======
 			fprintf(stderr, "%s : chown failed : ERR : %s\n",__func__, strerror(errno));
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 			continue;
 		}
 		stat(dirfile, &stbuf);

--- a/src/cmds/pbs_ds_password.c
+++ b/src/cmds/pbs_ds_password.c
@@ -187,7 +187,9 @@ read_password(char *passwd)
 	if (system("stty -echo") != 0)
 		return -1;
 
-	fgets(passwd, MAX_PASSWORD_LEN, stdin);
+	if (fgets(passwd, MAX_PASSWORD_LEN, stdin) == NULL) {
+		fprintf(stderr, "%s : fgets failed", __func__);
+	}
 
 	if (system("stty echo") != 0)
 		return -1;
@@ -324,7 +326,9 @@ change_ownership(char *path, char *userid)
 	char dirfile[MAXPATHLEN + 1];
 	struct stat stbuf;
 
-	chown(path, pwent->pw_uid, (gid_t) -1);
+	if ( chown(path, pwent->pw_uid, (gid_t) -1) == -1) {
+		fprintf(stderr, "%s : chown failed : ERR : %s\n",__func__, strerror(errno));
+	}
 	dir = opendir(path);
 	if (dir == NULL) {
 		return -1;
@@ -336,7 +340,9 @@ change_ownership(char *path, char *userid)
 			continue;
 
 		sprintf(dirfile, "%s/%s", path, pdirent->d_name);
-		chown(dirfile, pwent->pw_uid, (gid_t) -1);
+		if (chown(dirfile, pwent->pw_uid, (gid_t) -1) == -1) {
+			fprintf(stderr, "%s : chown failed : ERR : %s\n",__func__, strerror(errno));
+		}
 		stat(dirfile, &stbuf);
 		if (stbuf.st_mode & S_IFDIR) {
 			change_ownership(dirfile, userid);

--- a/src/cmds/qsub.c
+++ b/src/cmds/qsub.c
@@ -2167,11 +2167,9 @@ env_array_to_varlist(char **envp)
 	len += len; /* Double it for all the commas, etc. */
 
 	// len check to avoid warning "destination object of size 0 allocated by ‘malloc’"
-	if (len > 0) {
-		if ((job_env = (char *) malloc(len)) == NULL) {
+	if ((len > 0) && ((job_env = (char *) malloc(len)) == NULL)) {
 			fprintf(stderr, "env_array_to_varlist: malloc failure errno=%d", errno);
 			return NULL;
-		}
 	} else {
 		return NULL;
 	}

--- a/src/cmds/qsub.c
+++ b/src/cmds/qsub.c
@@ -2166,8 +2166,13 @@ env_array_to_varlist(char **envp)
 	}
 	len += len; /* Double it for all the commas, etc. */
 
-	if ((job_env = (char *) malloc(len)) == NULL) {
-		fprintf(stderr, "env_array_to_varlist: malloc failure errno=%d", errno);
+	// len check to avoid warning "destination object of size 0 allocated by ‘malloc’"
+	if (len > 0) {
+		if ((job_env = (char *) malloc(len)) == NULL) {
+			fprintf(stderr, "env_array_to_varlist: malloc failure errno=%d", errno);
+			return NULL;
+		}
+	} else {
 		return NULL;
 	}
 

--- a/src/cmds/qsub.c
+++ b/src/cmds/qsub.c
@@ -2166,7 +2166,10 @@ env_array_to_varlist(char **envp)
 	}
 	len += len; /* Double it for all the commas, etc. */
 
+<<<<<<< HEAD
+=======
 	// len check to avoid warning "destination object of size 0 allocated by ‘malloc’"
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 	if ((len > 0) && ((job_env = (char *) malloc(len)) == NULL)) {
 			fprintf(stderr, "env_array_to_varlist: malloc failure errno=%d", errno);
 			return NULL;

--- a/src/cmds/qsub.c
+++ b/src/cmds/qsub.c
@@ -2166,10 +2166,6 @@ env_array_to_varlist(char **envp)
 	}
 	len += len; /* Double it for all the commas, etc. */
 
-<<<<<<< HEAD
-=======
-	// len check to avoid warning "destination object of size 0 allocated by ‘malloc’"
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 	if ((len > 0) && ((job_env = (char *) malloc(len)) == NULL)) {
 			fprintf(stderr, "env_array_to_varlist: malloc failure errno=%d", errno);
 			return NULL;

--- a/src/lib/Libtpp/tpp_em.c
+++ b/src/lib/Libtpp/tpp_em.c
@@ -1092,7 +1092,7 @@ tpp_mbox_read(tpp_mbox_t *mbox, unsigned int *tfd, int *cmdval, void **data)
 #ifdef HAVE_SYS_EVENTFD_H
 		if (read(mbox->mbox_eventfd, &u, sizeof(uint64_t)) == -1) {
 			tpp_log(LOG_CRIT, __func__, "Unable to read from msg box");
-			tpp_unlock(%mbox->mbox_mutex);
+			tpp_unlock(&mbox->mbox_mutex);
 			return -1;
 		}
 #else

--- a/src/lib/Libtpp/tpp_em.c
+++ b/src/lib/Libtpp/tpp_em.c
@@ -1092,6 +1092,7 @@ tpp_mbox_read(tpp_mbox_t *mbox, unsigned int *tfd, int *cmdval, void **data)
 #ifdef HAVE_SYS_EVENTFD_H
 		if (read(mbox->mbox_eventfd, &u, sizeof(uint64_t)) == -1) {
 			tpp_log(LOG_CRIT, __func__, "Unable to read from msg box");
+			tpp_unlock(%mbox->mbox_mutex);
 			return -1;
 		}
 #else

--- a/src/lib/Libtpp/tpp_em.c
+++ b/src/lib/Libtpp/tpp_em.c
@@ -1092,6 +1092,7 @@ tpp_mbox_read(tpp_mbox_t *mbox, unsigned int *tfd, int *cmdval, void **data)
 #ifdef HAVE_SYS_EVENTFD_H
 		if (read(mbox->mbox_eventfd, &u, sizeof(uint64_t)) == -1) {
 			tpp_log(LOG_CRIT, __func__, "Unable to read from msg box");
+			return -1;
 		}
 #else
 		while (tpp_pipe_read(mbox->mbox_pipe[0], &b, sizeof(char)) == sizeof(char))

--- a/src/lib/Libtpp/tpp_em.c
+++ b/src/lib/Libtpp/tpp_em.c
@@ -1090,7 +1090,9 @@ tpp_mbox_read(tpp_mbox_t *mbox, unsigned int *tfd, int *cmdval, void **data)
 	if (cmd == NULL) {
 		mbox->mbox_size = 0;
 #ifdef HAVE_SYS_EVENTFD_H
-		read(mbox->mbox_eventfd, &u, sizeof(uint64_t));
+		if (read(mbox->mbox_eventfd, &u, sizeof(uint64_t)) == -1) {
+			tpp_log(LOG_CRIT, __func__, "Unable to read from msg box");
+		}
 #else
 		while (tpp_pipe_read(mbox->mbox_pipe[0], &b, sizeof(char)) == sizeof(char))
 			;

--- a/src/lib/Libutil/daemon_protect.c
+++ b/src/lib/Libutil/daemon_protect.c
@@ -43,8 +43,10 @@
 #include <string.h>
 #include <stdio.h>
 #include <fcntl.h>
+#include <errno.h>
 #include "server_limits.h"
 #include "pbs_ifl.h"
+#include "log.h"
 
 /**
  * @brief
@@ -95,15 +97,18 @@ daemon_protect(pid_t pid, enum PBS_Daemon_Protect action)
 	 */
 	snprintf(fname, MAXPATHLEN, oom_protect_new.oom_path, pid);
 	if ((fd = open(fname, O_WRONLY | O_TRUNC)) != -1) {
-		write(fd, oom_protect_new.oom_value[(int) action], strlen(oom_protect_new.oom_value[(int) action]));
-
+		if ( write(fd, oom_protect_new.oom_value[(int) action], strlen(oom_protect_new.oom_value[(int) action])) == -1) {
+				log_errf(-1, __func__, "write failed. ERR: %s", strerror(errno));
+		}
 	} else {
 
 		/* failed to open "oom_score_adj", now try "oom_adj" */
 		/* found in older Linux kernels			     */
 		snprintf(fname, MAXPATHLEN, oom_protect_old.oom_path, pid);
 		if ((fd = open(fname, O_WRONLY | O_TRUNC)) != -1) {
-			write(fd, oom_protect_old.oom_value[(int) action], strlen(oom_protect_old.oom_value[(int) action]));
+			if (write(fd, oom_protect_old.oom_value[(int) action], strlen(oom_protect_old.oom_value[(int) action])) == -1) {
+				log_errf(-1, __func__, "write failed. ERR: %s", strerror(errno));
+			}
 		}
 	}
 	if (fd != -1)

--- a/src/lib/Libutil/daemon_protect.c
+++ b/src/lib/Libutil/daemon_protect.c
@@ -97,28 +97,16 @@ daemon_protect(pid_t pid, enum PBS_Daemon_Protect action)
 	 */
 	snprintf(fname, MAXPATHLEN, oom_protect_new.oom_path, pid);
 	if ((fd = open(fname, O_WRONLY | O_TRUNC)) != -1) {
-<<<<<<< HEAD
 		if (write(fd, oom_protect_new.oom_value[(int) action], strlen(oom_protect_new.oom_value[(int) action])) == -1) 
 				log_errf(-1, __func__, "write failed. ERR: %s", strerror(errno));
-=======
-		if ( write(fd, oom_protect_new.oom_value[(int) action], strlen(oom_protect_new.oom_value[(int) action])) == -1) {
-				log_errf(-1, __func__, "write failed. ERR: %s", strerror(errno));
-		}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 	} else {
 
 		/* failed to open "oom_score_adj", now try "oom_adj" */
 		/* found in older Linux kernels			     */
 		snprintf(fname, MAXPATHLEN, oom_protect_old.oom_path, pid);
 		if ((fd = open(fname, O_WRONLY | O_TRUNC)) != -1) {
-<<<<<<< HEAD
 			if (write(fd, oom_protect_old.oom_value[(int) action], strlen(oom_protect_old.oom_value[(int) action])) == -1) 
 				log_errf(-1, __func__, "write failed. ERR: %s", strerror(errno));
-=======
-			if (write(fd, oom_protect_old.oom_value[(int) action], strlen(oom_protect_old.oom_value[(int) action])) == -1) {
-				log_errf(-1, __func__, "write failed. ERR: %s", strerror(errno));
-			}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 		}
 	}
 	if (fd != -1)

--- a/src/lib/Libutil/daemon_protect.c
+++ b/src/lib/Libutil/daemon_protect.c
@@ -97,18 +97,28 @@ daemon_protect(pid_t pid, enum PBS_Daemon_Protect action)
 	 */
 	snprintf(fname, MAXPATHLEN, oom_protect_new.oom_path, pid);
 	if ((fd = open(fname, O_WRONLY | O_TRUNC)) != -1) {
+<<<<<<< HEAD
+		if (write(fd, oom_protect_new.oom_value[(int) action], strlen(oom_protect_new.oom_value[(int) action])) == -1) 
+				log_errf(-1, __func__, "write failed. ERR: %s", strerror(errno));
+=======
 		if ( write(fd, oom_protect_new.oom_value[(int) action], strlen(oom_protect_new.oom_value[(int) action])) == -1) {
 				log_errf(-1, __func__, "write failed. ERR: %s", strerror(errno));
 		}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 	} else {
 
 		/* failed to open "oom_score_adj", now try "oom_adj" */
 		/* found in older Linux kernels			     */
 		snprintf(fname, MAXPATHLEN, oom_protect_old.oom_path, pid);
 		if ((fd = open(fname, O_WRONLY | O_TRUNC)) != -1) {
+<<<<<<< HEAD
+			if (write(fd, oom_protect_old.oom_value[(int) action], strlen(oom_protect_old.oom_value[(int) action])) == -1) 
+				log_errf(-1, __func__, "write failed. ERR: %s", strerror(errno));
+=======
 			if (write(fd, oom_protect_old.oom_value[(int) action], strlen(oom_protect_old.oom_value[(int) action])) == -1) {
 				log_errf(-1, __func__, "write failed. ERR: %s", strerror(errno));
 			}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 		}
 	}
 	if (fd != -1)

--- a/src/mom_rcp/rcp.c
+++ b/src/mom_rcp/rcp.c
@@ -725,10 +725,16 @@ source(int argc, char *argv[])
 #ifdef WIN32
 			(void) send(rem, buf, strlen(buf), 0);
 #else
+<<<<<<< HEAD
+			if (write(rem, buf, strlen(buf)) == -1) 
+				errx(-1, __func__, "write failed. ERR : %s",
+						strerror(errno));				
+=======
 			if (write(rem, buf, strlen(buf)) == -1) {
 				errx(-1, __func__, "write failed. ERR : %s",
 						strerror(errno));				
 			}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 #endif
 			if (response() < 0)
 				goto next;
@@ -751,10 +757,16 @@ source(int argc, char *argv[])
 #ifdef WIN32
 		(void) send(rem, buf, strlen(buf), 0);
 #else
+<<<<<<< HEAD
+		if (write(rem, buf, strlen(buf)) == -1) 
+			errx(-1, __func__, "write failed. ERR : %s",
+					strerror(errno));				
+=======
 		if (write(rem, buf, strlen(buf)) == -1) {
 			errx(-1, __func__, "write failed. ERR : %s",
 					strerror(errno));				
 		}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 #endif
 		if (response() < 0)
 			goto next;
@@ -781,10 +793,16 @@ source(int argc, char *argv[])
 #ifdef WIN32
 				(void) send(rem, bp->buf, amt, 0);
 #else
+<<<<<<< HEAD
+				if (write(rem, bp->buf, amt) == -1) 
+					errx(-1, __func__, "write fail. ERR:%s",
+							strerror(errno));				
+=======
 				if (write(rem, bp->buf, amt) == -1) {
 					errx(-1, __func__, "write fail. ERR:%s",
 							strerror(errno));				
 				}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 #endif
 			} else {
 #ifdef WIN32
@@ -825,6 +843,14 @@ source(int argc, char *argv[])
 #ifdef WIN32
 			(void) send(rem, "", 1, 0);
 #else
+<<<<<<< HEAD
+			if (write(rem, "", 1) == -1) 
+				errx(-1, __func__, "write failed. ERR : %s",strerror(errno));			
+#endif
+		} else 
+			run_err("%s: %s", name, strerror(haderr));
+		
+=======
 			if (write(rem, "", 1) == -1) {
 				errx(-1, __func__, "write failed. ERR : %s",strerror(errno));			
 			}
@@ -832,6 +858,7 @@ source(int argc, char *argv[])
 		} else {
 			run_err("%s: %s", name, strerror(haderr));
 		}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 		(void) response();
 	}
 }
@@ -876,9 +903,14 @@ rsource(char *name, pbs_stat_struct *statp)
 #ifdef WIN32
 		(void) send(rem, path, strlen(path), 0);
 #else
+<<<<<<< HEAD
+		if (write(rem, path, strlen(path)) == -1) 
+			errx(-1, __func__, "write failed. ERR : %s",strerror(errno));				
+=======
 		if (write(rem, path, strlen(path)) == -1) {
 			errx(-1, __func__, "write failed. ERR : %s",strerror(errno));				
 		}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 #endif
 		if (response() < 0) {
 			closedir(dirp);
@@ -891,9 +923,14 @@ rsource(char *name, pbs_stat_struct *statp)
 #ifdef WIN32
 	(void) send(rem, path, strlen(path), 0);
 #else
+<<<<<<< HEAD
+	if (write(rem, path, strlen(path)) == -1) 
+		errx(-1, __func__, "write failed. ERR : %s",strerror(errno));		
+=======
 	if (write(rem, path, strlen(path)) == -1) {
 		errx(-1, __func__, "write failed. ERR : %s",strerror(errno));		
 	}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 #endif
 	if (response() < 0) {
 		closedir(dirp);
@@ -925,9 +962,14 @@ rsource(char *name, pbs_stat_struct *statp)
 #ifdef WIN32
 	(void) send(rem, "E\n", 2, 0);
 #else
+<<<<<<< HEAD
+	if (write(rem, "E\n", 2) == -1) 
+		errx(-1, __func__, "write failed. ERR : %s",strerror(errno));
+=======
 	if (write(rem, "E\n", 2) == -1) {
 		errx(-1, __func__, "write failed. ERR : %s",strerror(errno));
 	}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 #endif
 	(void) response();
 }
@@ -1006,9 +1048,14 @@ sink(int argc, char *argv[])
 #ifdef WIN32
 	(void) send(rem, "", 1, 0);
 #else
+<<<<<<< HEAD
+	if (write(rem, "", 1) == -1) 
+		errx(-1, __func__, "write failed. ERR : %s",strerror(errno));
+=======
 	if (write(rem, "", 1) == -1) {
 		errx(-1, __func__, "write failed. ERR : %s",strerror(errno));
 	}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 #endif
 	if (pbs_stat(targ, &stb) == 0 && S_ISDIR(stb.st_mode))
 		targisdir = 1;
@@ -1037,9 +1084,15 @@ sink(int argc, char *argv[])
 		if (buf[0] == '\01' || buf[0] == '\02') {
 			if (iamremote == 0)
 				if ( write(STDERR_FILENO,
+<<<<<<< HEAD
+					     buf + 1, strlen(buf + 1)) == -1) 
+					errx(-1, __func__, "write failed. ERR : %s",strerror(errno));
+
+=======
 					     buf + 1, strlen(buf + 1)) == -1) {
 					errx(-1, __func__, "write failed. ERR : %s",strerror(errno));
 					}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 			if (buf[0] == '\02')
 				exit(1);
 			++errs;
@@ -1049,9 +1102,14 @@ sink(int argc, char *argv[])
 #ifdef WIN32
 			(void) send(rem, "", 1, 0);
 #else
+<<<<<<< HEAD
+			if (write(rem, "", 1) == -1) 
+				errx(-1, __func__, "write failed. ERR : %s",strerror(errno));
+=======
 			if (write(rem, "", 1) == -1) {
 				errx(-1, __func__, "write failed. ERR : %s",strerror(errno));
 			}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 #endif
 			return;
 		}
@@ -1083,9 +1141,14 @@ sink(int argc, char *argv[])
 #ifdef WIN32
 			(void) send(rem, "", 1, 0);
 #else
+<<<<<<< HEAD
+			if ( write(rem, "", 1) == -1) 
+				errx(-1, __func__, "write failed. ERR : %s",strerror(errno));
+=======
 			if ( write(rem, "", 1) == -1) {
 				errx(-1, __func__, "write failed. ERR : %s",strerror(errno));
 			}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 #endif
 			continue;
 		}
@@ -1189,9 +1252,14 @@ sink(int argc, char *argv[])
 #ifdef WIN32
 		(void) send(rem, "", 1, 0);
 #else
+<<<<<<< HEAD
+		if (write(rem, "", 1) == -1) 
+			errx(-1, __func__, "write failed. ERR : %s",strerror(errno));
+=======
 		if (write(rem, "", 1) == -1) {
 			errx(-1, __func__, "write failed. ERR : %s",strerror(errno));
 		}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 #endif
 		if ((bp = allocbuf(&buffer, ofd, RCP_BUFFER_SIZE)) == NULL) {
 			(void) close(ofd);
@@ -1315,9 +1383,14 @@ sink(int argc, char *argv[])
 #ifdef WIN32
 				(void) send(rem, "", 1, 0);
 #else
+<<<<<<< HEAD
+				if (write(rem, "", 1) == -1) 
+					errx(-1, __func__, "fchown failed. ERR : %s",strerror(errno));
+=======
 				if (write(rem, "", 1) == -1) {
 					errx(-1, __func__, "fchown failed. ERR : %s",strerror(errno));
 				}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 #endif
 				break;
 			case DISPLAYED:
@@ -1440,9 +1513,14 @@ response()
 			} while (cp < &rbuf[RCP_BUFFER_SIZE] && ch != '\n');
 
 			if (!iamremote)
+<<<<<<< HEAD
+				if (write(STDERR_FILENO, rbuf, cp - rbuf) == -1) 
+					errx(-1, __func__, "fchown failed. ERR : %s",strerror(errno));
+=======
 				if (write(STDERR_FILENO, rbuf, cp - rbuf) == -1) {
 					errx(-1, __func__, "fchown failed. ERR : %s",strerror(errno));
 				}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 			++errs;
 			if (resp == 1)
 				return (-1);

--- a/src/mom_rcp/rcp.c
+++ b/src/mom_rcp/rcp.c
@@ -725,7 +725,9 @@ source(int argc, char *argv[])
 #ifdef WIN32
 			(void) send(rem, buf, strlen(buf), 0);
 #else
-			(void) write(rem, buf, strlen(buf));
+			if (write(rem, buf, strlen(buf)) == -1) {
+				errx(-1, __func__, "write failed. ERR : %s",strerror(errno));				
+			}
 #endif
 			if (response() < 0)
 				goto next;
@@ -748,7 +750,9 @@ source(int argc, char *argv[])
 #ifdef WIN32
 		(void) send(rem, buf, strlen(buf), 0);
 #else
-		(void) write(rem, buf, strlen(buf));
+		if (write(rem, buf, strlen(buf)) == -1) {
+			errx(-1, __func__, "write failed. ERR : %s",strerror(errno));				
+		}
 #endif
 		if (response() < 0)
 			goto next;
@@ -775,7 +779,9 @@ source(int argc, char *argv[])
 #ifdef WIN32
 				(void) send(rem, bp->buf, amt, 0);
 #else
-				(void) write(rem, bp->buf, amt);
+				if (write(rem, bp->buf, amt) == -1) {
+					errx(-1, __func__, "write failed. ERR : %s",strerror(errno));				
+				}
 #endif
 			else {
 #ifdef WIN32
@@ -816,7 +822,9 @@ source(int argc, char *argv[])
 #ifdef WIN32
 			(void) send(rem, "", 1, 0);
 #else
-			(void) write(rem, "", 1);
+			if (write(rem, "", 1) == -1) {
+				errx(-1, __func__, "write failed. ERR : %s",strerror(errno));			
+			}
 #endif
 		else
 			run_err("%s: %s", name, strerror(haderr));
@@ -864,7 +872,9 @@ rsource(char *name, pbs_stat_struct *statp)
 #ifdef WIN32
 		(void) send(rem, path, strlen(path), 0);
 #else
-		(void) write(rem, path, strlen(path));
+		if (write(rem, path, strlen(path)) == -1) {
+			errx(-1, __func__, "write failed. ERR : %s",strerror(errno));				
+		}
 #endif
 		if (response() < 0) {
 			closedir(dirp);
@@ -877,7 +887,9 @@ rsource(char *name, pbs_stat_struct *statp)
 #ifdef WIN32
 	(void) send(rem, path, strlen(path), 0);
 #else
-	(void) write(rem, path, strlen(path));
+	if (write(rem, path, strlen(path)) == -1) {
+		errx(-1, __func__, "write failed. ERR : %s",strerror(errno));		
+	}
 #endif
 	if (response() < 0) {
 		closedir(dirp);
@@ -909,7 +921,9 @@ rsource(char *name, pbs_stat_struct *statp)
 #ifdef WIN32
 	(void) send(rem, "E\n", 2, 0);
 #else
-	(void) write(rem, "E\n", 2);
+	if (write(rem, "E\n", 2) == -1) {
+		errx(-1, __func__, "write failed. ERR : %s",strerror(errno));
+	}
 #endif
 	(void) response();
 }
@@ -988,7 +1002,9 @@ sink(int argc, char *argv[])
 #ifdef WIN32
 	(void) send(rem, "", 1, 0);
 #else
-	(void) write(rem, "", 1);
+	if (write(rem, "", 1) == -1) {
+		errx(-1, __func__, "write failed. ERR : %s",strerror(errno));
+	}
 #endif
 	if (pbs_stat(targ, &stb) == 0 && S_ISDIR(stb.st_mode))
 		targisdir = 1;
@@ -1016,8 +1032,10 @@ sink(int argc, char *argv[])
 
 		if (buf[0] == '\01' || buf[0] == '\02') {
 			if (iamremote == 0)
-				(void) write(STDERR_FILENO,
-					     buf + 1, strlen(buf + 1));
+				if ( write(STDERR_FILENO,
+					     buf + 1, strlen(buf + 1)) == -1) {
+					errx(-1, __func__, "write failed. ERR : %s",strerror(errno));
+					}
 			if (buf[0] == '\02')
 				exit(1);
 			++errs;
@@ -1027,7 +1045,9 @@ sink(int argc, char *argv[])
 #ifdef WIN32
 			(void) send(rem, "", 1, 0);
 #else
-			(void) write(rem, "", 1);
+			if (write(rem, "", 1) == -1) {
+				errx(-1, __func__, "write failed. ERR : %s",strerror(errno));
+			}
 #endif
 			return;
 		}
@@ -1059,7 +1079,9 @@ sink(int argc, char *argv[])
 #ifdef WIN32
 			(void) send(rem, "", 1, 0);
 #else
-			(void) write(rem, "", 1);
+			if ( write(rem, "", 1) == -1) {
+				errx(-1, __func__, "write failed. ERR : %s",strerror(errno));
+			}
 #endif
 			continue;
 		}
@@ -1163,7 +1185,9 @@ sink(int argc, char *argv[])
 #ifdef WIN32
 		(void) send(rem, "", 1, 0);
 #else
-		(void) write(rem, "", 1);
+		if (write(rem, "", 1) == -1) {
+			errx(-1, __func__, "write failed. ERR : %s",strerror(errno));
+		}
 #endif
 		if ((bp = allocbuf(&buffer, ofd, RCP_BUFFER_SIZE)) == NULL) {
 			(void) close(ofd);
@@ -1287,7 +1311,9 @@ sink(int argc, char *argv[])
 #ifdef WIN32
 				(void) send(rem, "", 1, 0);
 #else
-				(void) write(rem, "", 1);
+				if (write(rem, "", 1) == -1) {
+					errx(-1, __func__, "fchown failed. ERR : %s",strerror(errno));
+				}
 #endif
 				break;
 			case DISPLAYED:
@@ -1410,7 +1436,9 @@ response()
 			} while (cp < &rbuf[RCP_BUFFER_SIZE] && ch != '\n');
 
 			if (!iamremote)
-				(void) write(STDERR_FILENO, rbuf, cp - rbuf);
+				if (write(STDERR_FILENO, rbuf, cp - rbuf) == -1) {
+					errx(-1, __func__, "fchown failed. ERR : %s",strerror(errno));
+				}
 			++errs;
 			if (resp == 1)
 				return (-1);

--- a/src/mom_rcp/rcp.c
+++ b/src/mom_rcp/rcp.c
@@ -725,16 +725,9 @@ source(int argc, char *argv[])
 #ifdef WIN32
 			(void) send(rem, buf, strlen(buf), 0);
 #else
-<<<<<<< HEAD
 			if (write(rem, buf, strlen(buf)) == -1) 
 				errx(-1, __func__, "write failed. ERR : %s",
 						strerror(errno));				
-=======
-			if (write(rem, buf, strlen(buf)) == -1) {
-				errx(-1, __func__, "write failed. ERR : %s",
-						strerror(errno));				
-			}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 #endif
 			if (response() < 0)
 				goto next;
@@ -757,16 +750,9 @@ source(int argc, char *argv[])
 #ifdef WIN32
 		(void) send(rem, buf, strlen(buf), 0);
 #else
-<<<<<<< HEAD
 		if (write(rem, buf, strlen(buf)) == -1) 
 			errx(-1, __func__, "write failed. ERR : %s",
 					strerror(errno));				
-=======
-		if (write(rem, buf, strlen(buf)) == -1) {
-			errx(-1, __func__, "write failed. ERR : %s",
-					strerror(errno));				
-		}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 #endif
 		if (response() < 0)
 			goto next;
@@ -793,16 +779,9 @@ source(int argc, char *argv[])
 #ifdef WIN32
 				(void) send(rem, bp->buf, amt, 0);
 #else
-<<<<<<< HEAD
 				if (write(rem, bp->buf, amt) == -1) 
 					errx(-1, __func__, "write fail. ERR:%s",
 							strerror(errno));				
-=======
-				if (write(rem, bp->buf, amt) == -1) {
-					errx(-1, __func__, "write fail. ERR:%s",
-							strerror(errno));				
-				}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 #endif
 			} else {
 #ifdef WIN32
@@ -843,22 +822,12 @@ source(int argc, char *argv[])
 #ifdef WIN32
 			(void) send(rem, "", 1, 0);
 #else
-<<<<<<< HEAD
 			if (write(rem, "", 1) == -1) 
 				errx(-1, __func__, "write failed. ERR : %s",strerror(errno));			
 #endif
 		} else 
 			run_err("%s: %s", name, strerror(haderr));
 		
-=======
-			if (write(rem, "", 1) == -1) {
-				errx(-1, __func__, "write failed. ERR : %s",strerror(errno));			
-			}
-#endif
-		} else {
-			run_err("%s: %s", name, strerror(haderr));
-		}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 		(void) response();
 	}
 }
@@ -903,14 +872,8 @@ rsource(char *name, pbs_stat_struct *statp)
 #ifdef WIN32
 		(void) send(rem, path, strlen(path), 0);
 #else
-<<<<<<< HEAD
 		if (write(rem, path, strlen(path)) == -1) 
 			errx(-1, __func__, "write failed. ERR : %s",strerror(errno));				
-=======
-		if (write(rem, path, strlen(path)) == -1) {
-			errx(-1, __func__, "write failed. ERR : %s",strerror(errno));				
-		}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 #endif
 		if (response() < 0) {
 			closedir(dirp);
@@ -923,14 +886,8 @@ rsource(char *name, pbs_stat_struct *statp)
 #ifdef WIN32
 	(void) send(rem, path, strlen(path), 0);
 #else
-<<<<<<< HEAD
 	if (write(rem, path, strlen(path)) == -1) 
 		errx(-1, __func__, "write failed. ERR : %s",strerror(errno));		
-=======
-	if (write(rem, path, strlen(path)) == -1) {
-		errx(-1, __func__, "write failed. ERR : %s",strerror(errno));		
-	}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 #endif
 	if (response() < 0) {
 		closedir(dirp);
@@ -962,14 +919,8 @@ rsource(char *name, pbs_stat_struct *statp)
 #ifdef WIN32
 	(void) send(rem, "E\n", 2, 0);
 #else
-<<<<<<< HEAD
 	if (write(rem, "E\n", 2) == -1) 
 		errx(-1, __func__, "write failed. ERR : %s",strerror(errno));
-=======
-	if (write(rem, "E\n", 2) == -1) {
-		errx(-1, __func__, "write failed. ERR : %s",strerror(errno));
-	}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 #endif
 	(void) response();
 }
@@ -1048,14 +999,8 @@ sink(int argc, char *argv[])
 #ifdef WIN32
 	(void) send(rem, "", 1, 0);
 #else
-<<<<<<< HEAD
 	if (write(rem, "", 1) == -1) 
 		errx(-1, __func__, "write failed. ERR : %s",strerror(errno));
-=======
-	if (write(rem, "", 1) == -1) {
-		errx(-1, __func__, "write failed. ERR : %s",strerror(errno));
-	}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 #endif
 	if (pbs_stat(targ, &stb) == 0 && S_ISDIR(stb.st_mode))
 		targisdir = 1;
@@ -1084,15 +1029,9 @@ sink(int argc, char *argv[])
 		if (buf[0] == '\01' || buf[0] == '\02') {
 			if (iamremote == 0)
 				if ( write(STDERR_FILENO,
-<<<<<<< HEAD
 					     buf + 1, strlen(buf + 1)) == -1) 
 					errx(-1, __func__, "write failed. ERR : %s",strerror(errno));
 
-=======
-					     buf + 1, strlen(buf + 1)) == -1) {
-					errx(-1, __func__, "write failed. ERR : %s",strerror(errno));
-					}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 			if (buf[0] == '\02')
 				exit(1);
 			++errs;
@@ -1102,14 +1041,8 @@ sink(int argc, char *argv[])
 #ifdef WIN32
 			(void) send(rem, "", 1, 0);
 #else
-<<<<<<< HEAD
 			if (write(rem, "", 1) == -1) 
 				errx(-1, __func__, "write failed. ERR : %s",strerror(errno));
-=======
-			if (write(rem, "", 1) == -1) {
-				errx(-1, __func__, "write failed. ERR : %s",strerror(errno));
-			}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 #endif
 			return;
 		}
@@ -1141,14 +1074,8 @@ sink(int argc, char *argv[])
 #ifdef WIN32
 			(void) send(rem, "", 1, 0);
 #else
-<<<<<<< HEAD
 			if ( write(rem, "", 1) == -1) 
 				errx(-1, __func__, "write failed. ERR : %s",strerror(errno));
-=======
-			if ( write(rem, "", 1) == -1) {
-				errx(-1, __func__, "write failed. ERR : %s",strerror(errno));
-			}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 #endif
 			continue;
 		}
@@ -1252,14 +1179,8 @@ sink(int argc, char *argv[])
 #ifdef WIN32
 		(void) send(rem, "", 1, 0);
 #else
-<<<<<<< HEAD
 		if (write(rem, "", 1) == -1) 
 			errx(-1, __func__, "write failed. ERR : %s",strerror(errno));
-=======
-		if (write(rem, "", 1) == -1) {
-			errx(-1, __func__, "write failed. ERR : %s",strerror(errno));
-		}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 #endif
 		if ((bp = allocbuf(&buffer, ofd, RCP_BUFFER_SIZE)) == NULL) {
 			(void) close(ofd);
@@ -1383,14 +1304,8 @@ sink(int argc, char *argv[])
 #ifdef WIN32
 				(void) send(rem, "", 1, 0);
 #else
-<<<<<<< HEAD
 				if (write(rem, "", 1) == -1) 
 					errx(-1, __func__, "fchown failed. ERR : %s",strerror(errno));
-=======
-				if (write(rem, "", 1) == -1) {
-					errx(-1, __func__, "fchown failed. ERR : %s",strerror(errno));
-				}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 #endif
 				break;
 			case DISPLAYED:
@@ -1513,14 +1428,8 @@ response()
 			} while (cp < &rbuf[RCP_BUFFER_SIZE] && ch != '\n');
 
 			if (!iamremote)
-<<<<<<< HEAD
 				if (write(STDERR_FILENO, rbuf, cp - rbuf) == -1) 
 					errx(-1, __func__, "fchown failed. ERR : %s",strerror(errno));
-=======
-				if (write(STDERR_FILENO, rbuf, cp - rbuf) == -1) {
-					errx(-1, __func__, "fchown failed. ERR : %s",strerror(errno));
-				}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 			++errs;
 			if (resp == 1)
 				return (-1);

--- a/src/mom_rcp/rcp.c
+++ b/src/mom_rcp/rcp.c
@@ -726,7 +726,8 @@ source(int argc, char *argv[])
 			(void) send(rem, buf, strlen(buf), 0);
 #else
 			if (write(rem, buf, strlen(buf)) == -1) {
-				errx(-1, __func__, "write failed. ERR : %s",strerror(errno));				
+				errx(-1, __func__, "write failed. ERR : %s",
+						strerror(errno));				
 			}
 #endif
 			if (response() < 0)
@@ -751,7 +752,8 @@ source(int argc, char *argv[])
 		(void) send(rem, buf, strlen(buf), 0);
 #else
 		if (write(rem, buf, strlen(buf)) == -1) {
-			errx(-1, __func__, "write failed. ERR : %s",strerror(errno));				
+			errx(-1, __func__, "write failed. ERR : %s",
+					strerror(errno));				
 		}
 #endif
 		if (response() < 0)
@@ -780,7 +782,8 @@ source(int argc, char *argv[])
 				(void) send(rem, bp->buf, amt, 0);
 #else
 				if (write(rem, bp->buf, amt) == -1) {
-					errx(-1, __func__, "write failed. ERR : %s",strerror(errno));				
+					errx(-1, __func__, "write fail. ERR:%s",
+							strerror(errno));				
 				}
 #endif
 			} else {

--- a/src/mom_rcp/rcp.c
+++ b/src/mom_rcp/rcp.c
@@ -774,7 +774,7 @@ source(int argc, char *argv[])
 				if (result != amt)
 					haderr = result >= 0 ? EIO : errno;
 			}
-			if (haderr)
+			if (haderr) {
 
 #ifdef WIN32
 				(void) send(rem, bp->buf, amt, 0);
@@ -783,7 +783,7 @@ source(int argc, char *argv[])
 					errx(-1, __func__, "write failed. ERR : %s",strerror(errno));				
 				}
 #endif
-			else {
+			} else {
 #ifdef WIN32
 				result = send(rem, bp->buf, amt, 0);
 #else
@@ -817,7 +817,7 @@ source(int argc, char *argv[])
 		}
 #endif /* USELOG */
 
-		if (!haderr)
+		if (!haderr){
 
 #ifdef WIN32
 			(void) send(rem, "", 1, 0);
@@ -826,8 +826,9 @@ source(int argc, char *argv[])
 				errx(-1, __func__, "write failed. ERR : %s",strerror(errno));			
 			}
 #endif
-		else
+		} else {
 			run_err("%s: %s", name, strerror(haderr));
+		}
 		(void) response();
 	}
 }

--- a/src/resmom/catch_child.c
+++ b/src/resmom/catch_child.c
@@ -791,6 +791,14 @@ scan_for_exiting(void)
 		if (pjob->ji_grpcache) {
 			if ((is_jattr_set(pjob, JOB_ATR_sandbox)) && (strcasecmp(get_jattr_str(pjob, JOB_ATR_sandbox), "PRIVATE") == 0)) {
 				/* in "sandbox=PRIVATE" mode so run epilogue in PBS_JOBDIR */
+<<<<<<< HEAD
+				if (chdir(jobdirname(pjob->ji_qs.ji_jobid, pjob->ji_grpcache->gc_homedir)) == -1) 
+					log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));
+			} else {
+				/* else run in usr's home */
+				if (chdir(pjob->ji_grpcache->gc_homedir) == -1) 
+					log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));
+=======
 				if (chdir(jobdirname(pjob->ji_qs.ji_jobid, pjob->ji_grpcache->gc_homedir)) == -1) {
 					log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));
 				}
@@ -800,6 +808,7 @@ scan_for_exiting(void)
 					log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));
 
 				}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 			}
 		}
 
@@ -824,9 +833,14 @@ scan_for_exiting(void)
 
 		send_obit(pjob, i);
 		/* restore MOM's home if we are foreground */
+<<<<<<< HEAD
+		if (chdir(mom_home) == -1) 
+			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));
+=======
 		if (chdir(mom_home) == -1) {
 			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));
 		}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 	}
 	if (pjob == NULL)
 		exiting_tasks = 0; /* went through all jobs */

--- a/src/resmom/catch_child.c
+++ b/src/resmom/catch_child.c
@@ -791,24 +791,12 @@ scan_for_exiting(void)
 		if (pjob->ji_grpcache) {
 			if ((is_jattr_set(pjob, JOB_ATR_sandbox)) && (strcasecmp(get_jattr_str(pjob, JOB_ATR_sandbox), "PRIVATE") == 0)) {
 				/* in "sandbox=PRIVATE" mode so run epilogue in PBS_JOBDIR */
-<<<<<<< HEAD
 				if (chdir(jobdirname(pjob->ji_qs.ji_jobid, pjob->ji_grpcache->gc_homedir)) == -1) 
 					log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));
 			} else {
 				/* else run in usr's home */
 				if (chdir(pjob->ji_grpcache->gc_homedir) == -1) 
 					log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));
-=======
-				if (chdir(jobdirname(pjob->ji_qs.ji_jobid, pjob->ji_grpcache->gc_homedir)) == -1) {
-					log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));
-				}
-			} else {
-				/* else run in usr's home */
-				if (chdir(pjob->ji_grpcache->gc_homedir) == -1) {
-					log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));
-
-				}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 			}
 		}
 
@@ -833,14 +821,8 @@ scan_for_exiting(void)
 
 		send_obit(pjob, i);
 		/* restore MOM's home if we are foreground */
-<<<<<<< HEAD
 		if (chdir(mom_home) == -1) 
 			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));
-=======
-		if (chdir(mom_home) == -1) {
-			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));
-		}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 	}
 	if (pjob == NULL)
 		exiting_tasks = 0; /* went through all jobs */

--- a/src/resmom/catch_child.c
+++ b/src/resmom/catch_child.c
@@ -791,10 +791,15 @@ scan_for_exiting(void)
 		if (pjob->ji_grpcache) {
 			if ((is_jattr_set(pjob, JOB_ATR_sandbox)) && (strcasecmp(get_jattr_str(pjob, JOB_ATR_sandbox), "PRIVATE") == 0)) {
 				/* in "sandbox=PRIVATE" mode so run epilogue in PBS_JOBDIR */
-				(void) chdir(jobdirname(pjob->ji_qs.ji_jobid, pjob->ji_grpcache->gc_homedir));
+				if (chdir(jobdirname(pjob->ji_qs.ji_jobid, pjob->ji_grpcache->gc_homedir)) == -1) {
+					log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));
+				}
 			} else {
 				/* else run in usr's home */
-				(void) chdir(pjob->ji_grpcache->gc_homedir);
+				if (chdir(pjob->ji_grpcache->gc_homedir) == -1) {
+					log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));
+
+				}
 			}
 		}
 
@@ -819,7 +824,9 @@ scan_for_exiting(void)
 
 		send_obit(pjob, i);
 		/* restore MOM's home if we are foreground */
-		(void) chdir(mom_home);
+		if (chdir(mom_home) == -1) {
+			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));
+		}
 	}
 	if (pjob == NULL)
 		exiting_tasks = 0; /* went through all jobs */

--- a/src/resmom/linux/mom_mach.c
+++ b/src/resmom/linux/mom_mach.c
@@ -218,11 +218,17 @@ proc_get_btime(void)
 		return;
 
 	while (!feof(fp)) {
-		fscanf(fp, "%s", label);
+		if (fscanf(fp, "%s", label) == EOF) {
+			log_errf(-1, __func__, "fscanf failed. ERR : %s", strerror(errno));
+		}
 		if (strcmp(label, "btime")) {
-			fscanf(fp, "%*[^\n]%*c");
+			if (fscanf(fp, "%*[^\n]%*c") == EOF) {
+				log_errf(-1, __func__, "fscanf failed. ERR : %s", strerror(errno));				
+			}
 		} else {
-			fscanf(fp, "%u", &linux_time);
+			if (fscanf(fp, "%u", &linux_time)) {
+				log_errf(-1, __func__, "fscanf failed. ERR : %s", strerror(errno));				
+			}
 			fclose(fp);
 			return;
 		}

--- a/src/resmom/linux/mom_mach.c
+++ b/src/resmom/linux/mom_mach.c
@@ -218,6 +218,16 @@ proc_get_btime(void)
 		return;
 
 	while (!feof(fp)) {
+<<<<<<< HEAD
+		if (fscanf(fp, "%s", label) == EOF) 
+			log_errf(-1, __func__, "fscanf failed. ERR : %s", strerror(errno));
+		if (strcmp(label, "btime")) {
+			if (fscanf(fp, "%*[^\n]%*c") == EOF) 
+				log_errf(-1, __func__, "fscanf failed. ERR : %s", strerror(errno));				
+		} else {
+			if (fscanf(fp, "%u", &linux_time)) 
+				log_errf(-1, __func__, "fscanf failed. ERR : %s", strerror(errno));				
+=======
 		if (fscanf(fp, "%s", label) == EOF) {
 			log_errf(-1, __func__, "fscanf failed. ERR : %s", strerror(errno));
 		}
@@ -229,6 +239,7 @@ proc_get_btime(void)
 			if (fscanf(fp, "%u", &linux_time)) {
 				log_errf(-1, __func__, "fscanf failed. ERR : %s", strerror(errno));				
 			}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 			fclose(fp);
 			return;
 		}

--- a/src/resmom/linux/mom_mach.c
+++ b/src/resmom/linux/mom_mach.c
@@ -218,7 +218,6 @@ proc_get_btime(void)
 		return;
 
 	while (!feof(fp)) {
-<<<<<<< HEAD
 		if (fscanf(fp, "%s", label) == EOF) 
 			log_errf(-1, __func__, "fscanf failed. ERR : %s", strerror(errno));
 		if (strcmp(label, "btime")) {
@@ -227,19 +226,6 @@ proc_get_btime(void)
 		} else {
 			if (fscanf(fp, "%u", &linux_time)) 
 				log_errf(-1, __func__, "fscanf failed. ERR : %s", strerror(errno));				
-=======
-		if (fscanf(fp, "%s", label) == EOF) {
-			log_errf(-1, __func__, "fscanf failed. ERR : %s", strerror(errno));
-		}
-		if (strcmp(label, "btime")) {
-			if (fscanf(fp, "%*[^\n]%*c") == EOF) {
-				log_errf(-1, __func__, "fscanf failed. ERR : %s", strerror(errno));				
-			}
-		} else {
-			if (fscanf(fp, "%u", &linux_time)) {
-				log_errf(-1, __func__, "fscanf failed. ERR : %s", strerror(errno));				
-			}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 			fclose(fp);
 			return;
 		}

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -7752,6 +7752,14 @@ main(int argc, char *argv[])
 			exit(1);
 		}
 	}
+<<<<<<< HEAD
+	if (freopen(NULL_DEVICE, "r", stdin) == NULL) 
+		log_errf(-1, __func__, "freopen failed. ERR : %s", strerror(errno));
+	if (freopen(NULL_DEVICE, "w", stdout) == NULL) 
+		log_errf(-1, __func__, "freopen failed. ERR : %s", strerror(errno));	
+	if (freopen(NULL_DEVICE, "w", stderr) == NULL) 
+		log_errf(-1, __func__, "freopen failed. ERR : %s", strerror(errno));		
+=======
 	if (freopen(NULL_DEVICE, "r", stdin) == NULL) {
 		log_errf(-1, __func__, "freopen failed. ERR : %s", strerror(errno));
 	}
@@ -7761,6 +7769,7 @@ main(int argc, char *argv[])
 	if (freopen(NULL_DEVICE, "w", stderr) == NULL) {
 		log_errf(-1, __func__, "freopen failed. ERR : %s", strerror(errno));		
 	}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 #else  /* DEBUG */
 	setvbuf(stdout, NULL, _IONBF, 0);
 	setvbuf(stderr, NULL, _IONBF, 0);
@@ -7772,12 +7781,19 @@ main(int argc, char *argv[])
 
 	mom_pid = getpid();
 	sprintf(log_buffer, "%d\n", mom_pid);
+<<<<<<< HEAD
+	if (ftruncate(lockfds, 0) == -1) 
+		log_errf(-1, __func__, "ftruncate failed. ERR : %s", strerror(errno));		
+	if (write(lockfds, log_buffer, strlen(log_buffer)) == -1) 
+		log_errf(-1, __func__, "write failed. ERR : %s", strerror(errno));		
+=======
 	if (ftruncate(lockfds, 0) == -1) {
 		log_errf(-1, __func__, "ftruncate failed. ERR : %s", strerror(errno));		
 	}
 	if (write(lockfds, log_buffer, strlen(log_buffer)) == -1) {
 		log_errf(-1, __func__, "write failed. ERR : %s", strerror(errno));		
 	}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 
 #ifndef WIN32 /* ------------------------------------------------------------*/
 
@@ -8805,12 +8821,19 @@ main(int argc, char *argv[])
 										  pjob->ji_qs.ji_jobid, log_buffer);
 								} else {
 									if (write(fd, get_jattr_str(pjob, JOB_ATR_Cookie),
+<<<<<<< HEAD
+									      strlen(get_jattr_str(pjob, JOB_ATR_Cookie))) == -1) 
+											log_errf(-1, __func__, "write failed. ERR : %s", strerror(errno));					
+									if (write(fd, kill_msg, strlen(kill_msg)) == -1) 
+										log_errf(-1, __func__, "write failed. ERR : %s", strerror(errno));
+=======
 									      strlen(get_jattr_str(pjob, JOB_ATR_Cookie))) == -1) {
 											log_errf(-1, __func__, "write failed. ERR : %s", strerror(errno));					
 										  }
 									if (write(fd, kill_msg, strlen(kill_msg)) == -1) {
 										log_errf(-1, __func__, "write failed. ERR : %s", strerror(errno));
 									}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 									(void) close(fd);
 								}
 							}
@@ -9564,9 +9587,14 @@ mom_topology(void)
 	int pid;
 
 #ifndef WIN32
+<<<<<<< HEAD
+	if (pipe(fd) == -1) 
+		log_errf(-1, __func__, "pipe API failed. ERR : %s", strerror(errno));
+=======
 	if (pipe(fd) == -1) {
 		log_errf(-1, __func__, "pipe API failed. ERR : %s", strerror(errno));
 	}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 
 	if ((pid = fork()) == -1) {
 		log_err(PBSE_SYSTEM, __func__, "fork failed");
@@ -9603,6 +9631,14 @@ mom_topology(void)
 		if (ret != 0)
 			ret = -1;
 
+<<<<<<< HEAD
+		if (write(fd[1], &ret, (sizeof(ret))) == -1) 
+			log_errf(-1, __func__, "write failed. ERR : %s", strerror(errno));
+		if (write(fd[1], &xmllen, (sizeof(xmllen))) == -1) 
+			log_errf(-1, __func__, "write failed. ERR : %s", strerror(errno));			
+		if (write(fd[1], xmlbuf, xmllen) == -1) 
+			log_errf(-1, __func__, "write failed. ERR : %s", strerror(errno));			
+=======
 		if (write(fd[1], &ret, (sizeof(ret))) == -1) {
 			log_errf(-1, __func__, "write failed. ERR : %s", strerror(errno));
 		}
@@ -9612,6 +9648,7 @@ mom_topology(void)
 		if (write(fd[1], xmlbuf, xmllen) == -1) {
 			log_errf(-1, __func__, "write failed. ERR : %s", strerror(errno));			
 		}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 
 		hwloc_free_xmlbuffer(topology, xmlbuf);
 		hwloc_topology_destroy(topology);
@@ -9620,20 +9657,32 @@ mom_topology(void)
 	} else {
 		close(fd[1]);
 
+<<<<<<< HEAD
+		if (read(fd[0], &ret, sizeof(ret)) == -1) 
+			log_errf(-1, __func__, "read failed. ERR : %s", strerror(errno));
+		if (read(fd[0], &xmllen, sizeof(xmllen)) == -1) 
+			log_errf(-1, __func__, "read failed. ERR : %s", strerror(errno));			
+=======
 		if (read(fd[0], &ret, sizeof(ret)) == -1) {
 			log_errf(-1, __func__, "read failed. ERR : %s", strerror(errno));
 		}
 		if (read(fd[0], &xmllen, sizeof(xmllen)) == -1) {
 			log_errf(-1, __func__, "read failed. ERR : %s", strerror(errno));			
 		}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 		if ((xmlbuf = malloc(xmllen + 1)) == NULL) {
 			log_err(PBSE_SYSTEM, __func__, "malloc failed");
 			return;
 		}
 		xmlbuf[xmllen] = '\0';
+<<<<<<< HEAD
+		if (read(fd[0], xmlbuf, xmllen) == -1) 
+			log_errf(-1, __func__, "read failed. ERR : %s", strerror(errno));
+=======
 		if (read(fd[0], xmlbuf, xmllen) == -1) {
 			log_errf(-1, __func__, "read failed. ERR : %s", strerror(errno));
 		}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 
 		close(fd[0]);
 

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -7752,24 +7752,12 @@ main(int argc, char *argv[])
 			exit(1);
 		}
 	}
-<<<<<<< HEAD
 	if (freopen(NULL_DEVICE, "r", stdin) == NULL) 
 		log_errf(-1, __func__, "freopen failed. ERR : %s", strerror(errno));
 	if (freopen(NULL_DEVICE, "w", stdout) == NULL) 
 		log_errf(-1, __func__, "freopen failed. ERR : %s", strerror(errno));	
 	if (freopen(NULL_DEVICE, "w", stderr) == NULL) 
 		log_errf(-1, __func__, "freopen failed. ERR : %s", strerror(errno));		
-=======
-	if (freopen(NULL_DEVICE, "r", stdin) == NULL) {
-		log_errf(-1, __func__, "freopen failed. ERR : %s", strerror(errno));
-	}
-	if (freopen(NULL_DEVICE, "w", stdout) == NULL) {
-		log_errf(-1, __func__, "freopen failed. ERR : %s", strerror(errno));	
-	}
-	if (freopen(NULL_DEVICE, "w", stderr) == NULL) {
-		log_errf(-1, __func__, "freopen failed. ERR : %s", strerror(errno));		
-	}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 #else  /* DEBUG */
 	setvbuf(stdout, NULL, _IONBF, 0);
 	setvbuf(stderr, NULL, _IONBF, 0);
@@ -7781,19 +7769,10 @@ main(int argc, char *argv[])
 
 	mom_pid = getpid();
 	sprintf(log_buffer, "%d\n", mom_pid);
-<<<<<<< HEAD
 	if (ftruncate(lockfds, 0) == -1) 
 		log_errf(-1, __func__, "ftruncate failed. ERR : %s", strerror(errno));		
 	if (write(lockfds, log_buffer, strlen(log_buffer)) == -1) 
 		log_errf(-1, __func__, "write failed. ERR : %s", strerror(errno));		
-=======
-	if (ftruncate(lockfds, 0) == -1) {
-		log_errf(-1, __func__, "ftruncate failed. ERR : %s", strerror(errno));		
-	}
-	if (write(lockfds, log_buffer, strlen(log_buffer)) == -1) {
-		log_errf(-1, __func__, "write failed. ERR : %s", strerror(errno));		
-	}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 
 #ifndef WIN32 /* ------------------------------------------------------------*/
 
@@ -8821,19 +8800,10 @@ main(int argc, char *argv[])
 										  pjob->ji_qs.ji_jobid, log_buffer);
 								} else {
 									if (write(fd, get_jattr_str(pjob, JOB_ATR_Cookie),
-<<<<<<< HEAD
 									      strlen(get_jattr_str(pjob, JOB_ATR_Cookie))) == -1) 
 											log_errf(-1, __func__, "write failed. ERR : %s", strerror(errno));					
 									if (write(fd, kill_msg, strlen(kill_msg)) == -1) 
 										log_errf(-1, __func__, "write failed. ERR : %s", strerror(errno));
-=======
-									      strlen(get_jattr_str(pjob, JOB_ATR_Cookie))) == -1) {
-											log_errf(-1, __func__, "write failed. ERR : %s", strerror(errno));					
-										  }
-									if (write(fd, kill_msg, strlen(kill_msg)) == -1) {
-										log_errf(-1, __func__, "write failed. ERR : %s", strerror(errno));
-									}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 									(void) close(fd);
 								}
 							}
@@ -9587,14 +9557,8 @@ mom_topology(void)
 	int pid;
 
 #ifndef WIN32
-<<<<<<< HEAD
 	if (pipe(fd) == -1) 
 		log_errf(-1, __func__, "pipe API failed. ERR : %s", strerror(errno));
-=======
-	if (pipe(fd) == -1) {
-		log_errf(-1, __func__, "pipe API failed. ERR : %s", strerror(errno));
-	}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 
 	if ((pid = fork()) == -1) {
 		log_err(PBSE_SYSTEM, __func__, "fork failed");
@@ -9631,24 +9595,12 @@ mom_topology(void)
 		if (ret != 0)
 			ret = -1;
 
-<<<<<<< HEAD
 		if (write(fd[1], &ret, (sizeof(ret))) == -1) 
 			log_errf(-1, __func__, "write failed. ERR : %s", strerror(errno));
 		if (write(fd[1], &xmllen, (sizeof(xmllen))) == -1) 
 			log_errf(-1, __func__, "write failed. ERR : %s", strerror(errno));			
 		if (write(fd[1], xmlbuf, xmllen) == -1) 
 			log_errf(-1, __func__, "write failed. ERR : %s", strerror(errno));			
-=======
-		if (write(fd[1], &ret, (sizeof(ret))) == -1) {
-			log_errf(-1, __func__, "write failed. ERR : %s", strerror(errno));
-		}
-		if (write(fd[1], &xmllen, (sizeof(xmllen))) == -1) {
-			log_errf(-1, __func__, "write failed. ERR : %s", strerror(errno));			
-		}
-		if (write(fd[1], xmlbuf, xmllen) == -1) {
-			log_errf(-1, __func__, "write failed. ERR : %s", strerror(errno));			
-		}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 
 		hwloc_free_xmlbuffer(topology, xmlbuf);
 		hwloc_topology_destroy(topology);
@@ -9657,32 +9609,17 @@ mom_topology(void)
 	} else {
 		close(fd[1]);
 
-<<<<<<< HEAD
 		if (read(fd[0], &ret, sizeof(ret)) == -1) 
 			log_errf(-1, __func__, "read failed. ERR : %s", strerror(errno));
 		if (read(fd[0], &xmllen, sizeof(xmllen)) == -1) 
 			log_errf(-1, __func__, "read failed. ERR : %s", strerror(errno));			
-=======
-		if (read(fd[0], &ret, sizeof(ret)) == -1) {
-			log_errf(-1, __func__, "read failed. ERR : %s", strerror(errno));
-		}
-		if (read(fd[0], &xmllen, sizeof(xmllen)) == -1) {
-			log_errf(-1, __func__, "read failed. ERR : %s", strerror(errno));			
-		}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 		if ((xmlbuf = malloc(xmllen + 1)) == NULL) {
 			log_err(PBSE_SYSTEM, __func__, "malloc failed");
 			return;
 		}
 		xmlbuf[xmllen] = '\0';
-<<<<<<< HEAD
 		if (read(fd[0], xmlbuf, xmllen) == -1) 
 			log_errf(-1, __func__, "read failed. ERR : %s", strerror(errno));
-=======
-		if (read(fd[0], xmlbuf, xmllen) == -1) {
-			log_errf(-1, __func__, "read failed. ERR : %s", strerror(errno));
-		}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 
 		close(fd[0]);
 

--- a/src/resmom/prolog.c
+++ b/src/resmom/prolog.c
@@ -296,9 +296,14 @@ int pe_io_type;
 
 		if (fd_input != 0) {
 			(void) close(STDIN_FILENO);
+<<<<<<< HEAD
+			if (dup(fd_input) == -1) 
+				log_errf(-1, __func__, "dup failed. ERR : %s", strerror(errno));				
+=======
 			if (dup(fd_input) == -1) {
 				log_errf(-1, __func__, "dup failed. ERR : %s", strerror(errno));				
 			}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 			(void) close(fd_input);
 		}
 

--- a/src/resmom/prolog.c
+++ b/src/resmom/prolog.c
@@ -296,14 +296,8 @@ int pe_io_type;
 
 		if (fd_input != 0) {
 			(void) close(STDIN_FILENO);
-<<<<<<< HEAD
 			if (dup(fd_input) == -1) 
 				log_errf(-1, __func__, "dup failed. ERR : %s", strerror(errno));				
-=======
-			if (dup(fd_input) == -1) {
-				log_errf(-1, __func__, "dup failed. ERR : %s", strerror(errno));				
-			}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 			(void) close(fd_input);
 		}
 

--- a/src/resmom/prolog.c
+++ b/src/resmom/prolog.c
@@ -296,7 +296,9 @@ int pe_io_type;
 
 		if (fd_input != 0) {
 			(void) close(STDIN_FILENO);
-			(void) dup(fd_input);
+			if (dup(fd_input) == -1) {
+				log_errf(-1, __func__, "dup failed. ERR : %s", strerror(errno));				
+			}
 			(void) close(fd_input);
 		}
 

--- a/src/resmom/requests.c
+++ b/src/resmom/requests.c
@@ -346,14 +346,8 @@ fork_to_user(struct batch_request *preq, job *pjob)
 		/* used the good stuff cached in the job structure */
 		useruid = pjob->ji_qs.ji_un.ji_momt.ji_exuid;
 		usergid = pjob->ji_qs.ji_un.ji_momt.ji_exgid;
-<<<<<<< HEAD
 		if (chdir(pjob->ji_grpcache->gc_homedir) == -1) 
 			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));		
-=======
-		if (chdir(pjob->ji_grpcache->gc_homedir) == -1) {
-			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));		
-		}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 		user_rgid = pjob->ji_grpcache->gc_rgid;
 		/* Account ID used to be set her for Cray via acctid(). */
 	} else {
@@ -370,14 +364,8 @@ fork_to_user(struct batch_request *preq, job *pjob)
 				frk_err(PBSE_BADUSER, preq); /* no return */
 			usergid = grpp->gr_gid;
 		}
-<<<<<<< HEAD
 		if (chdir(pwdp->pw_dir) == -1)  /* change to user`s home directory */
 			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));
-=======
-		if (chdir(pwdp->pw_dir) == -1) { /* change to user`s home directory */
-			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));
-		}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 	}
 
 #if defined(PBS_SECURITY) && (PBS_SECURITY == KRB5)
@@ -2192,14 +2180,8 @@ del_files(struct rq_cpyfile *rqcpf, job *pjob, char **pbadfile)
 			pbs_jobdir = jobdirname(rqcpf->rq_jobid, pjob->ji_grpcache->gc_homedir);
 		else
 			pbs_jobdir = jobdirname(rqcpf->rq_jobid, NULL);
-<<<<<<< HEAD
 		if (chdir(pbs_jobdir) == -1) 
 			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));		
-=======
-		if (chdir(pbs_jobdir) == -1) {
-			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));		
-		}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 	}
 
 	pair = (struct rqfpair *) GET_NEXT(rqcpf->rq_pair);
@@ -3195,14 +3177,8 @@ req_cpyfile(struct batch_request *preq)
 
 	/* chdir to job pbs_jobdir directory if "sandbox=PRIVATE" mode is requested */
 	if (stage_inout.sandbox_private) {
-<<<<<<< HEAD
 		if (chdir(pbs_jobdir) == -1) 
 			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));			
-=======
-		if (chdir(pbs_jobdir) == -1) {
-			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));			
-		}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 	}
 
 #if defined(PBS_SECURITY) && (PBS_SECURITY == KRB5)
@@ -3257,14 +3233,8 @@ req_cpyfile(struct batch_request *preq)
 	if ((dir == STAGE_DIR_IN) && stage_inout.sandbox_private && stage_inout.bad_files) {
 		/* cd to user's home to be out of   */
 		/* the sandbox so it can be deleted */
-<<<<<<< HEAD
 		if (chdir(pwdp->pw_dir) == -1) 
 			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));			
-=======
-		if (chdir(pwdp->pw_dir) == -1) {
-			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));			
-		}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 		rmjobdir(rqcpf->rq_jobid, pbs_jobdir, useruid, usergid, 0);
 	}
 
@@ -3575,27 +3545,14 @@ mom_checkpoint_job(job *pjob, int abort)
 			/* "sandbox=PRIVATE" mode is enabled, so restart job in PBS_JOBDIR */
 			pwdp = getpwnam(get_jattr_str(pjob, JOB_ATR_euser));
 			if (pwdp != NULL) {
-<<<<<<< HEAD
 				if (chdir(jobdirname(pjob->ji_qs.ji_jobid, pwdp->pw_dir)) == -1) 
 					log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));					
-=======
-				if (chdir(jobdirname(pjob->ji_qs.ji_jobid, pwdp->pw_dir)) == -1) {
-					log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));					
-				}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 			}
 		} else {
 			pwdp = getpwnam(get_jattr_str(pjob, JOB_ATR_euser));
 			if (pwdp != NULL)
-<<<<<<< HEAD
 				if (chdir(pwdp->pw_dir) == -1) 
 					log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));
-=======
-				if (chdir(pwdp->pw_dir) == -1) {
-				log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));
-					
-				}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 		}
 	}
 #endif
@@ -3638,14 +3595,8 @@ mom_checkpoint_job(job *pjob, int abort)
 	/* Checkpoint successful */
 	/* return to MOM's rightful lair */
 	if (cwdname) {
-<<<<<<< HEAD
 		if (chdir(cwdname) == -1) 
 			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));		
-=======
-		if (chdir(cwdname) == -1) {
-			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));		
-		}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 		free(cwdname);
 	}
 
@@ -3695,14 +3646,8 @@ errout:
 
 	/* return to MOM's rightful lair */
 	if (cwdname) {
-<<<<<<< HEAD
 		if (chdir(cwdname) == -1) 
 			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));		
-=======
-		if (chdir(cwdname) == -1) {
-			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));		
-		}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 		free(cwdname);
 	}
 
@@ -4160,27 +4105,14 @@ mom_restart_job(job *pjob)
 			pwdp = getpwnam(get_jattr_str(pjob, JOB_ATR_euser));
 			if (pwdp != NULL) {
 				if (chdir(jobdirname(pjob->ji_qs.ji_jobid,
-<<<<<<< HEAD
 					save_actual_homedir(pwdp, pjob))) == -1) 
 					log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));				
-=======
-					save_actual_homedir(pwdp, pjob))) == -1) {
-					log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));				
-				}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 			}
 		} else {
 			pwdp = getpwnam(get_jattr_str(pjob, JOB_ATR_euser));
 			if (pwdp != NULL)
-<<<<<<< HEAD
 				if (chdir(save_actual_homedir(pwdp, pjob)) == -1) 
 					log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));
-=======
-				if (chdir(save_actual_homedir(pwdp, pjob)) == -1) {
-					log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));
-				
-			}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 		}
 	}
 #else
@@ -4190,14 +4122,8 @@ mom_restart_job(job *pjob)
 			/* "sandbox=PRIVATE" mode is enabled, so restart job in PBS_JOBDIR */
 			pwdp = getpwnam(get_jattr_str(pjob, JOB_ATR_euser));
 			if (pwdp != NULL)
-<<<<<<< HEAD
 				if (chdir(jobdirname(pjob->ji_qs.ji_jobid, pwdp->pw_dir)) == -1) 
 					log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));		
-=======
-				if (chdir(jobdirname(pjob->ji_qs.ji_jobid, pwdp->pw_dir)) == -1) {
-					log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));		
-			}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 		} else {
 			pwdp = getpwnam(get_jattr_str(pjob, JOB_ATR_euser));
 			if (pwdp != NULL)
@@ -4295,14 +4221,8 @@ done:
 
 	/* return to MOM's rightful lair */
 	if (cwdname) {
-<<<<<<< HEAD
 		if (chdir(cwdname) == -1) 
 			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));		
-=======
-		if (chdir(cwdname) == -1) {
-			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));		
-		}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 		free(cwdname);
 	}
 	return rserr;

--- a/src/resmom/requests.c
+++ b/src/resmom/requests.c
@@ -346,9 +346,14 @@ fork_to_user(struct batch_request *preq, job *pjob)
 		/* used the good stuff cached in the job structure */
 		useruid = pjob->ji_qs.ji_un.ji_momt.ji_exuid;
 		usergid = pjob->ji_qs.ji_un.ji_momt.ji_exgid;
+<<<<<<< HEAD
+		if (chdir(pjob->ji_grpcache->gc_homedir) == -1) 
+			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));		
+=======
 		if (chdir(pjob->ji_grpcache->gc_homedir) == -1) {
 			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));		
 		}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 		user_rgid = pjob->ji_grpcache->gc_rgid;
 		/* Account ID used to be set her for Cray via acctid(). */
 	} else {
@@ -365,9 +370,14 @@ fork_to_user(struct batch_request *preq, job *pjob)
 				frk_err(PBSE_BADUSER, preq); /* no return */
 			usergid = grpp->gr_gid;
 		}
+<<<<<<< HEAD
+		if (chdir(pwdp->pw_dir) == -1)  /* change to user`s home directory */
+			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));
+=======
 		if (chdir(pwdp->pw_dir) == -1) { /* change to user`s home directory */
 			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));
 		}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 	}
 
 #if defined(PBS_SECURITY) && (PBS_SECURITY == KRB5)
@@ -2182,9 +2192,14 @@ del_files(struct rq_cpyfile *rqcpf, job *pjob, char **pbadfile)
 			pbs_jobdir = jobdirname(rqcpf->rq_jobid, pjob->ji_grpcache->gc_homedir);
 		else
 			pbs_jobdir = jobdirname(rqcpf->rq_jobid, NULL);
+<<<<<<< HEAD
+		if (chdir(pbs_jobdir) == -1) 
+			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));		
+=======
 		if (chdir(pbs_jobdir) == -1) {
 			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));		
 		}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 	}
 
 	pair = (struct rqfpair *) GET_NEXT(rqcpf->rq_pair);
@@ -3180,9 +3195,14 @@ req_cpyfile(struct batch_request *preq)
 
 	/* chdir to job pbs_jobdir directory if "sandbox=PRIVATE" mode is requested */
 	if (stage_inout.sandbox_private) {
+<<<<<<< HEAD
+		if (chdir(pbs_jobdir) == -1) 
+			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));			
+=======
 		if (chdir(pbs_jobdir) == -1) {
 			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));			
 		}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 	}
 
 #if defined(PBS_SECURITY) && (PBS_SECURITY == KRB5)
@@ -3237,9 +3257,14 @@ req_cpyfile(struct batch_request *preq)
 	if ((dir == STAGE_DIR_IN) && stage_inout.sandbox_private && stage_inout.bad_files) {
 		/* cd to user's home to be out of   */
 		/* the sandbox so it can be deleted */
+<<<<<<< HEAD
+		if (chdir(pwdp->pw_dir) == -1) 
+			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));			
+=======
 		if (chdir(pwdp->pw_dir) == -1) {
 			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));			
 		}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 		rmjobdir(rqcpf->rq_jobid, pbs_jobdir, useruid, usergid, 0);
 	}
 
@@ -3550,17 +3575,27 @@ mom_checkpoint_job(job *pjob, int abort)
 			/* "sandbox=PRIVATE" mode is enabled, so restart job in PBS_JOBDIR */
 			pwdp = getpwnam(get_jattr_str(pjob, JOB_ATR_euser));
 			if (pwdp != NULL) {
+<<<<<<< HEAD
+				if (chdir(jobdirname(pjob->ji_qs.ji_jobid, pwdp->pw_dir)) == -1) 
+					log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));					
+=======
 				if (chdir(jobdirname(pjob->ji_qs.ji_jobid, pwdp->pw_dir)) == -1) {
 					log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));					
 				}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 			}
 		} else {
 			pwdp = getpwnam(get_jattr_str(pjob, JOB_ATR_euser));
 			if (pwdp != NULL)
+<<<<<<< HEAD
+				if (chdir(pwdp->pw_dir) == -1) 
+					log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));
+=======
 				if (chdir(pwdp->pw_dir) == -1) {
 				log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));
 					
 				}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 		}
 	}
 #endif
@@ -3603,9 +3638,14 @@ mom_checkpoint_job(job *pjob, int abort)
 	/* Checkpoint successful */
 	/* return to MOM's rightful lair */
 	if (cwdname) {
+<<<<<<< HEAD
+		if (chdir(cwdname) == -1) 
+			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));		
+=======
 		if (chdir(cwdname) == -1) {
 			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));		
 		}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 		free(cwdname);
 	}
 
@@ -3655,9 +3695,14 @@ errout:
 
 	/* return to MOM's rightful lair */
 	if (cwdname) {
+<<<<<<< HEAD
+		if (chdir(cwdname) == -1) 
+			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));		
+=======
 		if (chdir(cwdname) == -1) {
 			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));		
 		}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 		free(cwdname);
 	}
 
@@ -4115,17 +4160,27 @@ mom_restart_job(job *pjob)
 			pwdp = getpwnam(get_jattr_str(pjob, JOB_ATR_euser));
 			if (pwdp != NULL) {
 				if (chdir(jobdirname(pjob->ji_qs.ji_jobid,
+<<<<<<< HEAD
+					save_actual_homedir(pwdp, pjob))) == -1) 
+					log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));				
+=======
 					save_actual_homedir(pwdp, pjob))) == -1) {
 					log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));				
 				}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 			}
 		} else {
 			pwdp = getpwnam(get_jattr_str(pjob, JOB_ATR_euser));
 			if (pwdp != NULL)
+<<<<<<< HEAD
+				if (chdir(save_actual_homedir(pwdp, pjob)) == -1) 
+					log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));
+=======
 				if (chdir(save_actual_homedir(pwdp, pjob)) == -1) {
 					log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));
 				
 			}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 		}
 	}
 #else
@@ -4135,9 +4190,14 @@ mom_restart_job(job *pjob)
 			/* "sandbox=PRIVATE" mode is enabled, so restart job in PBS_JOBDIR */
 			pwdp = getpwnam(get_jattr_str(pjob, JOB_ATR_euser));
 			if (pwdp != NULL)
+<<<<<<< HEAD
+				if (chdir(jobdirname(pjob->ji_qs.ji_jobid, pwdp->pw_dir)) == -1) 
+					log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));		
+=======
 				if (chdir(jobdirname(pjob->ji_qs.ji_jobid, pwdp->pw_dir)) == -1) {
 					log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));		
 			}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 		} else {
 			pwdp = getpwnam(get_jattr_str(pjob, JOB_ATR_euser));
 			if (pwdp != NULL)
@@ -4235,9 +4295,14 @@ done:
 
 	/* return to MOM's rightful lair */
 	if (cwdname) {
+<<<<<<< HEAD
+		if (chdir(cwdname) == -1) 
+			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));		
+=======
 		if (chdir(cwdname) == -1) {
 			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));		
 		}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 		free(cwdname);
 	}
 	return rserr;

--- a/src/resmom/requests.c
+++ b/src/resmom/requests.c
@@ -346,7 +346,9 @@ fork_to_user(struct batch_request *preq, job *pjob)
 		/* used the good stuff cached in the job structure */
 		useruid = pjob->ji_qs.ji_un.ji_momt.ji_exuid;
 		usergid = pjob->ji_qs.ji_un.ji_momt.ji_exgid;
-		(void) chdir(pjob->ji_grpcache->gc_homedir);
+		if (chdir(pjob->ji_grpcache->gc_homedir) == -1) {
+			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));		
+		}
 		user_rgid = pjob->ji_grpcache->gc_rgid;
 		/* Account ID used to be set her for Cray via acctid(). */
 	} else {
@@ -363,7 +365,9 @@ fork_to_user(struct batch_request *preq, job *pjob)
 				frk_err(PBSE_BADUSER, preq); /* no return */
 			usergid = grpp->gr_gid;
 		}
-		(void) chdir(pwdp->pw_dir); /* change to user`s home directory */
+		if (chdir(pwdp->pw_dir) == -1) { /* change to user`s home directory */
+			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));
+		}
 	}
 
 #if defined(PBS_SECURITY) && (PBS_SECURITY == KRB5)
@@ -2178,7 +2182,9 @@ del_files(struct rq_cpyfile *rqcpf, job *pjob, char **pbadfile)
 			pbs_jobdir = jobdirname(rqcpf->rq_jobid, pjob->ji_grpcache->gc_homedir);
 		else
 			pbs_jobdir = jobdirname(rqcpf->rq_jobid, NULL);
-		chdir(pbs_jobdir);
+		if (chdir(pbs_jobdir) == -1) {
+			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));		
+		}
 	}
 
 	pair = (struct rqfpair *) GET_NEXT(rqcpf->rq_pair);
@@ -3174,7 +3180,9 @@ req_cpyfile(struct batch_request *preq)
 
 	/* chdir to job pbs_jobdir directory if "sandbox=PRIVATE" mode is requested */
 	if (stage_inout.sandbox_private) {
-		chdir(pbs_jobdir);
+		if (chdir(pbs_jobdir) == -1) {
+			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));			
+		}
 	}
 
 #if defined(PBS_SECURITY) && (PBS_SECURITY == KRB5)
@@ -3229,7 +3237,9 @@ req_cpyfile(struct batch_request *preq)
 	if ((dir == STAGE_DIR_IN) && stage_inout.sandbox_private && stage_inout.bad_files) {
 		/* cd to user's home to be out of   */
 		/* the sandbox so it can be deleted */
-		chdir(pwdp->pw_dir);
+		if (chdir(pwdp->pw_dir) == -1) {
+			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));			
+		}
 		rmjobdir(rqcpf->rq_jobid, pbs_jobdir, useruid, usergid, 0);
 	}
 
@@ -3540,12 +3550,17 @@ mom_checkpoint_job(job *pjob, int abort)
 			/* "sandbox=PRIVATE" mode is enabled, so restart job in PBS_JOBDIR */
 			pwdp = getpwnam(get_jattr_str(pjob, JOB_ATR_euser));
 			if (pwdp != NULL) {
-				(void) chdir(jobdirname(pjob->ji_qs.ji_jobid, pwdp->pw_dir));
+				if (chdir(jobdirname(pjob->ji_qs.ji_jobid, pwdp->pw_dir)) == -1) {
+					log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));					
+				}
 			}
 		} else {
 			pwdp = getpwnam(get_jattr_str(pjob, JOB_ATR_euser));
 			if (pwdp != NULL)
-				chdir(pwdp->pw_dir);
+				if (chdir(pwdp->pw_dir) == -1) {
+				log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));
+					
+				}
 		}
 	}
 #endif
@@ -3588,7 +3603,9 @@ mom_checkpoint_job(job *pjob, int abort)
 	/* Checkpoint successful */
 	/* return to MOM's rightful lair */
 	if (cwdname) {
-		chdir(cwdname);
+		if (chdir(cwdname) == -1) {
+			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));		
+		}
 		free(cwdname);
 	}
 
@@ -3638,7 +3655,9 @@ errout:
 
 	/* return to MOM's rightful lair */
 	if (cwdname) {
-		chdir(cwdname);
+		if (chdir(cwdname) == -1) {
+			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));		
+		}
 		free(cwdname);
 	}
 
@@ -4095,13 +4114,18 @@ mom_restart_job(job *pjob)
 			/* "sandbox=PRIVATE" mode is enabled, so restart job in PBS_JOBDIR */
 			pwdp = getpwnam(get_jattr_str(pjob, JOB_ATR_euser));
 			if (pwdp != NULL) {
-				(void) chdir(jobdirname(pjob->ji_qs.ji_jobid,
-							save_actual_homedir(pwdp, pjob)));
+				if (chdir(jobdirname(pjob->ji_qs.ji_jobid,
+					save_actual_homedir(pwdp, pjob))) == -1) {
+					log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));				
+				}
 			}
 		} else {
 			pwdp = getpwnam(get_jattr_str(pjob, JOB_ATR_euser));
 			if (pwdp != NULL)
-				chdir(save_actual_homedir(pwdp, pjob));
+				if (chdir(save_actual_homedir(pwdp, pjob)) == -1) {
+					log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));
+				
+			}
 		}
 	}
 #else
@@ -4111,11 +4135,15 @@ mom_restart_job(job *pjob)
 			/* "sandbox=PRIVATE" mode is enabled, so restart job in PBS_JOBDIR */
 			pwdp = getpwnam(get_jattr_str(pjob, JOB_ATR_euser));
 			if (pwdp != NULL)
-				(void) chdir(jobdirname(pjob->ji_qs.ji_jobid, pwdp->pw_dir));
+				if (chdir(jobdirname(pjob->ji_qs.ji_jobid, pwdp->pw_dir)) == -1) {
+					log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));		
+			}
 		} else {
 			pwdp = getpwnam(get_jattr_str(pjob, JOB_ATR_euser));
 			if (pwdp != NULL)
-				chdir(pwdp->pw_dir);
+				if (chdir(pwdp->pw_dir) == -1) {
+					log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));			
+			}
 		}
 	}
 #endif
@@ -4207,7 +4235,9 @@ done:
 
 	/* return to MOM's rightful lair */
 	if (cwdname) {
-		chdir(cwdname);
+		if (chdir(cwdname) == -1) {
+			log_errf(-1, __func__, "chdir failed. ERR : %s", strerror(errno));		
+		}
 		free(cwdname);
 	}
 	return rserr;

--- a/src/resmom/start_exec.c
+++ b/src/resmom/start_exec.c
@@ -575,6 +575,13 @@ open_pty(job *pjob)
 
 		FDMOVE(pts);
 
+<<<<<<< HEAD
+		if (fchmod(pts, 0620) == -1) 
+			log_errf(-1, __func__, "fchmod failed. ERR : %s",strerror(errno));				
+		if (fchown(pts, pjob->ji_qs.ji_un.ji_momt.ji_exuid,
+			      pjob->ji_qs.ji_un.ji_momt.ji_exgid) == -1) 
+			log_errf(-1, __func__, "fchown failed. ERR : %s",strerror(errno));		
+=======
 		if (fchmod(pts, 0620) == -1) {
 			log_errf(-1, __func__, "fchmod failed. ERR : %s",strerror(errno));				
 		}
@@ -582,6 +589,7 @@ open_pty(job *pjob)
 			      pjob->ji_qs.ji_un.ji_momt.ji_exgid) == -1) {
 			log_errf(-1, __func__, "fchown failed. ERR : %s",strerror(errno));		
 				  }
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 #if defined(__osf__)
 		(void) ioctl(pts, TIOCSCTTY, 0); /* make controlling */
 #endif
@@ -670,25 +678,40 @@ open_std_out_err(job *pjob)
 		sprintf(log_buffer,
 			"Direct write is requested for job: %s, but the destination is not usecp-able from %s\n",
 			pjob->ji_qs.ji_jobid, pjob->ji_hosts[pjob->ji_nodeid].hn_host);
+<<<<<<< HEAD
+		if (write(file_err, log_buffer, strlen(log_buffer)) == -1) 
+			log_errf(-1, __func__, "write failed. ERR : %s",strerror(errno));			
+=======
 		if (write(file_err, log_buffer, strlen(log_buffer)) == -1) {
 			log_errf(-1, __func__, "write failed. ERR : %s",strerror(errno));			
 		}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 	}
 
 	FDMOVE(file_out); /* make sure descriptor > 2       */
 	FDMOVE(file_err); /* so don't clobber stdin/out/err */
 	if (file_out != 1) {
 		(void) close(1);
+<<<<<<< HEAD
+		if (dup(file_out) == -1) 
+			log_errf(-1, __func__, "dup failed. ERR : %s",strerror(errno));		
+=======
 		if (dup(file_out) == -1) {
 			log_errf(-1, __func__, "dup failed. ERR : %s",strerror(errno));		
 		}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 		(void) close(file_out);
 	}
 	if (file_err != 2) {
 		(void) close(2);
+<<<<<<< HEAD
+		if (dup(file_err) == -1) 
+			log_errf(-1, __func__, "dup failed. ERR : %s",strerror(errno));		
+=======
 		if (dup(file_err) == -1) {
 			log_errf(-1, __func__, "dup failed. ERR : %s",strerror(errno));		
 		}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 		(void) close(file_err);
 	}
 	return 0;
@@ -922,9 +945,14 @@ impersonate_user(uid_t uid, gid_t gid)
 	/* most systems */
 	if ((setegid(gid) == -1) ||
 	    (seteuid(uid) == -1)) {
+<<<<<<< HEAD
+		if (setegid(pbsgroup) == -1) 
+			log_errf(-1, __func__, "setegid to pbs group failed. ERR : %s",strerror(errno));		
+=======
 		if (setegid(pbsgroup) == -1) {
 			log_errf(-1, __func__, "setegid to pbs group failed. ERR : %s",strerror(errno));		
 		}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 		return -1;
 	}
 #elif defined(HAVE_SETRESUID) && defined(HAVE_SETRESGID)
@@ -944,9 +972,14 @@ revert_from_user(void)
 {
 #if defined(HAVE_SETEUID)
 	/* most systems */
+<<<<<<< HEAD
+	if (seteuid(0) == -1) 
+		log_errf(-1, __func__, "seteuid failed. ERR : %s",strerror(errno));	
+=======
 	if (seteuid(0) == -1) {
 		log_errf(-1, __func__, "seteuid failed. ERR : %s",strerror(errno));	
 	}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 #elif defined(HAVE_SETRESUID)
 	(void) setresuid(-1, 0, -1);
 #else
@@ -956,9 +989,14 @@ revert_from_user(void)
 	(void) initgroups("root", pbsgroup);
 #endif
 #if defined(HAVE_SETEGID)
+<<<<<<< HEAD
+	if (setegid(pbsgroup) == -1) 
+		log_errf(-1, __func__, "setegid to pbs group failed. ERR : %s",strerror(errno));		
+=======
 	if (setegid(pbsgroup) == -1) {
 		log_errf(-1, __func__, "setegid to pbs group failed. ERR : %s",strerror(errno));		
 	}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 #elif defined(HAVE_SETRESGID)
 	(void) setresgid(-1, pbsgroup, -1);
 #else
@@ -3274,9 +3312,14 @@ finish_exec(job *pjob)
 			sprintf(buf, "%s%s%s", path_jobs,
 				pjob->ji_qs.ji_jobid, JOB_SCRIPT_SUFFIX);
 		if (chown(buf, pjob->ji_qs.ji_un.ji_momt.ji_exuid,
+<<<<<<< HEAD
+			     pjob->ji_qs.ji_un.ji_momt.ji_exgid) == -1) 
+				log_errf(-1, __func__, "chown failed. ERR : %s",strerror(errno));				
+=======
 			     pjob->ji_qs.ji_un.ji_momt.ji_exgid) == -1) {
 				log_errf(-1, __func__, "chown failed. ERR : %s",strerror(errno));				
 			 }
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 
 		/* add escape in front of brackets */
 		for (s = buf, d = holdbuf; *s && ((d - holdbuf) < sizeof(holdbuf)); s++, d++) {
@@ -3953,24 +3996,38 @@ finish_exec(job *pjob)
 
 				/* change pty back to available after */
 				/* job is done */
+<<<<<<< HEAD
+				if (chmod(pts_name, 0666) == -1) 
+					log_errf(-1, __func__, "chmod failed. ERR : %s",strerror(errno));			
+				if (chown(pts_name, 0, 0) == -1) 
+					log_errf(-1, __func__, "chown failed. ERR : %s",strerror(errno));		
+=======
 				if (chmod(pts_name, 0666) == -1) {
 					log_errf(-1, __func__, "chmod failed. ERR : %s",strerror(errno));			
 				}
 				if (chown(pts_name, 0, 0) == -1) {
 					log_errf(-1, __func__, "chown failed. ERR : %s",strerror(errno));		
 				}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 				exit(0);
 			}
 		} else { /* error */
 			log_err(errno, __func__, "cannot fork nanny");
 
 			/* change pty back to available */
+<<<<<<< HEAD
+			if (chmod(pts_name, 0666) == -1) 
+				log_errf(-1, __func__, "chmod failed. ERR : %s",strerror(errno));		
+			if (chown(pts_name, 0, 0) == -1) 
+				log_errf(-1, __func__, "chown failed. ERR : %s",strerror(errno));			
+=======
 			if (chmod(pts_name, 0666) == -1) {
 				log_errf(-1, __func__, "chmod failed. ERR : %s",strerror(errno));		
 			}
 			if (chown(pts_name, 0, 0) == -1) {
 				log_errf(-1, __func__, "chown failed. ERR : %s",strerror(errno));			
 			}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 
 			starter_return(upfds, downfds, JOB_EXEC_RETRY, &sjr);
 		}
@@ -4021,9 +4078,14 @@ finish_exec(job *pjob)
 			FDMOVE(script_in); /* make sure descriptor > 2       */
 			if (script_in != 0) {
 				close(0);
+<<<<<<< HEAD
+				if (dup(script_in) == -1) 
+					log_errf(-1, __func__, "dup failed. ERR : %s",strerror(errno));			
+=======
 				if (dup(script_in) == -1) {
 					log_errf(-1, __func__, "dup failed. ERR : %s",strerror(errno));			
 				}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 				close(script_in);
 			}
 		}
@@ -5044,6 +5106,13 @@ start_process(task *ptask, char **argv, char **envp, bool nodemux)
 				(void) close(fd);
 
 			if (write(1, get_jattr_str(pjob, JOB_ATR_Cookie),
+<<<<<<< HEAD
+			      strlen(get_jattr_str(pjob, JOB_ATR_Cookie))) == -1) 
+				log_errf(-1, __func__, "write failed. ERR : %s",strerror(errno));			
+			if ( write(2, get_jattr_str(pjob, JOB_ATR_Cookie),
+			      strlen(get_jattr_str(pjob, JOB_ATR_Cookie))) == -1) 
+				log_errf(-1, __func__, "write failed. ERR : %s",strerror(errno));			
+=======
 			      strlen(get_jattr_str(pjob, JOB_ATR_Cookie))) == -1) {
 				log_errf(-1, __func__, "write failed. ERR : %s",strerror(errno));			
 				  }
@@ -5051,6 +5120,7 @@ start_process(task *ptask, char **argv, char **envp, bool nodemux)
 			      strlen(get_jattr_str(pjob, JOB_ATR_Cookie))) == -1) {
 				log_errf(-1, __func__, "write failed. ERR : %s",strerror(errno));			
 				  }
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 		}
 	} else if (is_jattr_set(pjob, JOB_ATR_interactive) && get_jattr_long(pjob, JOB_ATR_interactive) > 0) {
 		/* interactive job, single node, write to pty */

--- a/src/resmom/start_exec.c
+++ b/src/resmom/start_exec.c
@@ -575,21 +575,11 @@ open_pty(job *pjob)
 
 		FDMOVE(pts);
 
-<<<<<<< HEAD
 		if (fchmod(pts, 0620) == -1) 
 			log_errf(-1, __func__, "fchmod failed. ERR : %s",strerror(errno));				
 		if (fchown(pts, pjob->ji_qs.ji_un.ji_momt.ji_exuid,
 			      pjob->ji_qs.ji_un.ji_momt.ji_exgid) == -1) 
 			log_errf(-1, __func__, "fchown failed. ERR : %s",strerror(errno));		
-=======
-		if (fchmod(pts, 0620) == -1) {
-			log_errf(-1, __func__, "fchmod failed. ERR : %s",strerror(errno));				
-		}
-		if (fchown(pts, pjob->ji_qs.ji_un.ji_momt.ji_exuid,
-			      pjob->ji_qs.ji_un.ji_momt.ji_exgid) == -1) {
-			log_errf(-1, __func__, "fchown failed. ERR : %s",strerror(errno));		
-				  }
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 #if defined(__osf__)
 		(void) ioctl(pts, TIOCSCTTY, 0); /* make controlling */
 #endif
@@ -678,40 +668,22 @@ open_std_out_err(job *pjob)
 		sprintf(log_buffer,
 			"Direct write is requested for job: %s, but the destination is not usecp-able from %s\n",
 			pjob->ji_qs.ji_jobid, pjob->ji_hosts[pjob->ji_nodeid].hn_host);
-<<<<<<< HEAD
 		if (write(file_err, log_buffer, strlen(log_buffer)) == -1) 
 			log_errf(-1, __func__, "write failed. ERR : %s",strerror(errno));			
-=======
-		if (write(file_err, log_buffer, strlen(log_buffer)) == -1) {
-			log_errf(-1, __func__, "write failed. ERR : %s",strerror(errno));			
-		}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 	}
 
 	FDMOVE(file_out); /* make sure descriptor > 2       */
 	FDMOVE(file_err); /* so don't clobber stdin/out/err */
 	if (file_out != 1) {
 		(void) close(1);
-<<<<<<< HEAD
 		if (dup(file_out) == -1) 
 			log_errf(-1, __func__, "dup failed. ERR : %s",strerror(errno));		
-=======
-		if (dup(file_out) == -1) {
-			log_errf(-1, __func__, "dup failed. ERR : %s",strerror(errno));		
-		}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 		(void) close(file_out);
 	}
 	if (file_err != 2) {
 		(void) close(2);
-<<<<<<< HEAD
 		if (dup(file_err) == -1) 
 			log_errf(-1, __func__, "dup failed. ERR : %s",strerror(errno));		
-=======
-		if (dup(file_err) == -1) {
-			log_errf(-1, __func__, "dup failed. ERR : %s",strerror(errno));		
-		}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 		(void) close(file_err);
 	}
 	return 0;
@@ -945,14 +917,8 @@ impersonate_user(uid_t uid, gid_t gid)
 	/* most systems */
 	if ((setegid(gid) == -1) ||
 	    (seteuid(uid) == -1)) {
-<<<<<<< HEAD
 		if (setegid(pbsgroup) == -1) 
 			log_errf(-1, __func__, "setegid to pbs group failed. ERR : %s",strerror(errno));		
-=======
-		if (setegid(pbsgroup) == -1) {
-			log_errf(-1, __func__, "setegid to pbs group failed. ERR : %s",strerror(errno));		
-		}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 		return -1;
 	}
 #elif defined(HAVE_SETRESUID) && defined(HAVE_SETRESGID)
@@ -972,14 +938,8 @@ revert_from_user(void)
 {
 #if defined(HAVE_SETEUID)
 	/* most systems */
-<<<<<<< HEAD
 	if (seteuid(0) == -1) 
 		log_errf(-1, __func__, "seteuid failed. ERR : %s",strerror(errno));	
-=======
-	if (seteuid(0) == -1) {
-		log_errf(-1, __func__, "seteuid failed. ERR : %s",strerror(errno));	
-	}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 #elif defined(HAVE_SETRESUID)
 	(void) setresuid(-1, 0, -1);
 #else
@@ -989,14 +949,8 @@ revert_from_user(void)
 	(void) initgroups("root", pbsgroup);
 #endif
 #if defined(HAVE_SETEGID)
-<<<<<<< HEAD
 	if (setegid(pbsgroup) == -1) 
 		log_errf(-1, __func__, "setegid to pbs group failed. ERR : %s",strerror(errno));		
-=======
-	if (setegid(pbsgroup) == -1) {
-		log_errf(-1, __func__, "setegid to pbs group failed. ERR : %s",strerror(errno));		
-	}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 #elif defined(HAVE_SETRESGID)
 	(void) setresgid(-1, pbsgroup, -1);
 #else
@@ -3312,14 +3266,8 @@ finish_exec(job *pjob)
 			sprintf(buf, "%s%s%s", path_jobs,
 				pjob->ji_qs.ji_jobid, JOB_SCRIPT_SUFFIX);
 		if (chown(buf, pjob->ji_qs.ji_un.ji_momt.ji_exuid,
-<<<<<<< HEAD
 			     pjob->ji_qs.ji_un.ji_momt.ji_exgid) == -1) 
 				log_errf(-1, __func__, "chown failed. ERR : %s",strerror(errno));				
-=======
-			     pjob->ji_qs.ji_un.ji_momt.ji_exgid) == -1) {
-				log_errf(-1, __func__, "chown failed. ERR : %s",strerror(errno));				
-			 }
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 
 		/* add escape in front of brackets */
 		for (s = buf, d = holdbuf; *s && ((d - holdbuf) < sizeof(holdbuf)); s++, d++) {
@@ -3996,38 +3944,20 @@ finish_exec(job *pjob)
 
 				/* change pty back to available after */
 				/* job is done */
-<<<<<<< HEAD
 				if (chmod(pts_name, 0666) == -1) 
 					log_errf(-1, __func__, "chmod failed. ERR : %s",strerror(errno));			
 				if (chown(pts_name, 0, 0) == -1) 
 					log_errf(-1, __func__, "chown failed. ERR : %s",strerror(errno));		
-=======
-				if (chmod(pts_name, 0666) == -1) {
-					log_errf(-1, __func__, "chmod failed. ERR : %s",strerror(errno));			
-				}
-				if (chown(pts_name, 0, 0) == -1) {
-					log_errf(-1, __func__, "chown failed. ERR : %s",strerror(errno));		
-				}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 				exit(0);
 			}
 		} else { /* error */
 			log_err(errno, __func__, "cannot fork nanny");
 
 			/* change pty back to available */
-<<<<<<< HEAD
 			if (chmod(pts_name, 0666) == -1) 
 				log_errf(-1, __func__, "chmod failed. ERR : %s",strerror(errno));		
 			if (chown(pts_name, 0, 0) == -1) 
 				log_errf(-1, __func__, "chown failed. ERR : %s",strerror(errno));			
-=======
-			if (chmod(pts_name, 0666) == -1) {
-				log_errf(-1, __func__, "chmod failed. ERR : %s",strerror(errno));		
-			}
-			if (chown(pts_name, 0, 0) == -1) {
-				log_errf(-1, __func__, "chown failed. ERR : %s",strerror(errno));			
-			}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 
 			starter_return(upfds, downfds, JOB_EXEC_RETRY, &sjr);
 		}
@@ -4078,14 +4008,8 @@ finish_exec(job *pjob)
 			FDMOVE(script_in); /* make sure descriptor > 2       */
 			if (script_in != 0) {
 				close(0);
-<<<<<<< HEAD
 				if (dup(script_in) == -1) 
 					log_errf(-1, __func__, "dup failed. ERR : %s",strerror(errno));			
-=======
-				if (dup(script_in) == -1) {
-					log_errf(-1, __func__, "dup failed. ERR : %s",strerror(errno));			
-				}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 				close(script_in);
 			}
 		}
@@ -5106,21 +5030,11 @@ start_process(task *ptask, char **argv, char **envp, bool nodemux)
 				(void) close(fd);
 
 			if (write(1, get_jattr_str(pjob, JOB_ATR_Cookie),
-<<<<<<< HEAD
 			      strlen(get_jattr_str(pjob, JOB_ATR_Cookie))) == -1) 
 				log_errf(-1, __func__, "write failed. ERR : %s",strerror(errno));			
 			if ( write(2, get_jattr_str(pjob, JOB_ATR_Cookie),
 			      strlen(get_jattr_str(pjob, JOB_ATR_Cookie))) == -1) 
 				log_errf(-1, __func__, "write failed. ERR : %s",strerror(errno));			
-=======
-			      strlen(get_jattr_str(pjob, JOB_ATR_Cookie))) == -1) {
-				log_errf(-1, __func__, "write failed. ERR : %s",strerror(errno));			
-				  }
-			if ( write(2, get_jattr_str(pjob, JOB_ATR_Cookie),
-			      strlen(get_jattr_str(pjob, JOB_ATR_Cookie))) == -1) {
-				log_errf(-1, __func__, "write failed. ERR : %s",strerror(errno));			
-				  }
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 		}
 	} else if (is_jattr_set(pjob, JOB_ATR_interactive) && get_jattr_long(pjob, JOB_ATR_interactive) > 0) {
 		/* interactive job, single node, write to pty */

--- a/src/scheduler/fifo.cpp
+++ b/src/scheduler/fifo.cpp
@@ -2476,6 +2476,13 @@ parse_sched_obj(int connector, struct batch_status *status)
 						priv_dir_update_fail = 1;
 					} else {
 						/* write schedulers pid into lockfile */
+<<<<<<< HEAD
+						if (ftruncate(lockfds, (off_t) 0) == -1) 
+							log_errf(-1, __func__, "ftruncate failed. ERR : %s",strerror(errno));
+						(void) sprintf(log_buffer, "%d\n", getpid());
+						if (write(lockfds, log_buffer, strlen(log_buffer)) == -1) 
+							log_errf(-1, __func__, "fwrite failed. ERR : %s",strerror(errno));
+=======
 						if(ftruncate(lockfds, (off_t) 0) == -1) {
 							log_errf(-1, __func__, "ftruncate failed. ERR : %s",strerror(errno));
 						}
@@ -2483,6 +2490,7 @@ parse_sched_obj(int connector, struct batch_status *status)
 						if(write(lockfds, log_buffer, strlen(log_buffer)) == -1) {
 							log_errf(-1, __func__, "fwrite failed. ERR : %s",strerror(errno));
 						}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 						close(lockfds);
 						log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_SCHED, LOG_DEBUG, "reconfigure",
 							   "scheduler priv directory has changed to %s", tmp_priv_dir);

--- a/src/scheduler/fifo.cpp
+++ b/src/scheduler/fifo.cpp
@@ -2476,9 +2476,13 @@ parse_sched_obj(int connector, struct batch_status *status)
 						priv_dir_update_fail = 1;
 					} else {
 						/* write schedulers pid into lockfile */
-						(void) ftruncate(lockfds, (off_t) 0);
+						if(ftruncate(lockfds, (off_t) 0) == -1) {
+							log_errf(-1, __func__, "ftruncate failed. ERR : %s",strerror(errno));
+						}
 						(void) sprintf(log_buffer, "%d\n", getpid());
-						(void) write(lockfds, log_buffer, strlen(log_buffer));
+						if(write(lockfds, log_buffer, strlen(log_buffer)) == -1) {
+							log_errf(-1, __func__, "fwrite failed. ERR : %s",strerror(errno));
+						}
 						close(lockfds);
 						log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_SCHED, LOG_DEBUG, "reconfigure",
 							   "scheduler priv directory has changed to %s", tmp_priv_dir);

--- a/src/scheduler/fifo.cpp
+++ b/src/scheduler/fifo.cpp
@@ -2476,21 +2476,11 @@ parse_sched_obj(int connector, struct batch_status *status)
 						priv_dir_update_fail = 1;
 					} else {
 						/* write schedulers pid into lockfile */
-<<<<<<< HEAD
 						if (ftruncate(lockfds, (off_t) 0) == -1) 
 							log_errf(-1, __func__, "ftruncate failed. ERR : %s",strerror(errno));
 						(void) sprintf(log_buffer, "%d\n", getpid());
 						if (write(lockfds, log_buffer, strlen(log_buffer)) == -1) 
 							log_errf(-1, __func__, "fwrite failed. ERR : %s",strerror(errno));
-=======
-						if(ftruncate(lockfds, (off_t) 0) == -1) {
-							log_errf(-1, __func__, "ftruncate failed. ERR : %s",strerror(errno));
-						}
-						(void) sprintf(log_buffer, "%d\n", getpid());
-						if(write(lockfds, log_buffer, strlen(log_buffer)) == -1) {
-							log_errf(-1, __func__, "fwrite failed. ERR : %s",strerror(errno));
-						}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 						close(lockfds);
 						log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_SCHED, LOG_DEBUG, "reconfigure",
 							   "scheduler priv directory has changed to %s", tmp_priv_dir);

--- a/src/scheduler/pbs_sched_utils.cpp
+++ b/src/scheduler/pbs_sched_utils.cpp
@@ -1039,9 +1039,14 @@ sched_main(int argc, char *argv[], schedule_func sched_ptr)
 		}
 	}
 	lock_out(lockfds, F_WRLCK);
+<<<<<<< HEAD
+	if (freopen(dbfile, "a", stdout) == NULL) 
+		log_errf(-1, __func__, "freopen failed. ERR : %s",strerror(errno));
+=======
 	if (freopen(dbfile, "a", stdout) == NULL) {
 		log_errf(-1, __func__, "freopen failed. ERR : %s",strerror(errno));
 	}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 	setvbuf(stdout, NULL, _IOLBF, 0);
 	dup2(fileno(stdout), fileno(stderr));
 #else
@@ -1056,6 +1061,17 @@ sched_main(int argc, char *argv[], schedule_func sched_ptr)
 #endif
 	pid = getpid();
 	daemon_protect(0, PBS_DAEMON_PROTECT_ON);
+<<<<<<< HEAD
+	if (freopen("/dev/null", "r", stdin) == NULL) 
+		log_errf(-1, __func__, "freopen failed. ERR : %s",strerror(errno));
+
+	/* write schedulers pid into lockfile */
+	if (ftruncate(lockfds, (off_t) 0) == -1) 
+		log_errf(-1, __func__, "ftruncate failed. ERR : %s",strerror(errno));
+	(void) sprintf(log_buffer, "%ld\n", (long) pid);
+	if (write(lockfds, log_buffer, strlen(log_buffer)) == -1) 
+		log_errf(-1, __func__, "write failed. ERR : %s",strerror(errno));
+=======
 	if (freopen("/dev/null", "r", stdin) == NULL) {
 		log_errf(-1, __func__, "freopen failed. ERR : %s",strerror(errno));
 	}
@@ -1068,6 +1084,7 @@ sched_main(int argc, char *argv[], schedule_func sched_ptr)
 	if (write(lockfds, log_buffer, strlen(log_buffer)) == -1) {
 		log_errf(-1, __func__, "write failed. ERR : %s",strerror(errno));
 	}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 
 #ifdef _POSIX_MEMLOCK
 	if (do_mlockall == 1) {

--- a/src/scheduler/pbs_sched_utils.cpp
+++ b/src/scheduler/pbs_sched_utils.cpp
@@ -1039,14 +1039,8 @@ sched_main(int argc, char *argv[], schedule_func sched_ptr)
 		}
 	}
 	lock_out(lockfds, F_WRLCK);
-<<<<<<< HEAD
 	if (freopen(dbfile, "a", stdout) == NULL) 
 		log_errf(-1, __func__, "freopen failed. ERR : %s",strerror(errno));
-=======
-	if (freopen(dbfile, "a", stdout) == NULL) {
-		log_errf(-1, __func__, "freopen failed. ERR : %s",strerror(errno));
-	}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 	setvbuf(stdout, NULL, _IOLBF, 0);
 	dup2(fileno(stdout), fileno(stderr));
 #else
@@ -1061,7 +1055,6 @@ sched_main(int argc, char *argv[], schedule_func sched_ptr)
 #endif
 	pid = getpid();
 	daemon_protect(0, PBS_DAEMON_PROTECT_ON);
-<<<<<<< HEAD
 	if (freopen("/dev/null", "r", stdin) == NULL) 
 		log_errf(-1, __func__, "freopen failed. ERR : %s",strerror(errno));
 
@@ -1071,20 +1064,6 @@ sched_main(int argc, char *argv[], schedule_func sched_ptr)
 	(void) sprintf(log_buffer, "%ld\n", (long) pid);
 	if (write(lockfds, log_buffer, strlen(log_buffer)) == -1) 
 		log_errf(-1, __func__, "write failed. ERR : %s",strerror(errno));
-=======
-	if (freopen("/dev/null", "r", stdin) == NULL) {
-		log_errf(-1, __func__, "freopen failed. ERR : %s",strerror(errno));
-	}
-
-	/* write schedulers pid into lockfile */
-	if (ftruncate(lockfds, (off_t) 0) == -1) {
-		log_errf(-1, __func__, "ftruncate failed. ERR : %s",strerror(errno));
-	}
-	(void) sprintf(log_buffer, "%ld\n", (long) pid);
-	if (write(lockfds, log_buffer, strlen(log_buffer)) == -1) {
-		log_errf(-1, __func__, "write failed. ERR : %s",strerror(errno));
-	}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 
 #ifdef _POSIX_MEMLOCK
 	if (do_mlockall == 1) {

--- a/src/scheduler/server_info.cpp
+++ b/src/scheduler/server_info.cpp
@@ -3216,9 +3216,14 @@ read_formula(void)
 	form[0] = '\0';
 
 	/* first line is a comment */
+<<<<<<< HEAD
+	if (fgets(buf, RF_BUFSIZE, fp) == NULL) 
+		log_errf(-1, __func__, "fgets failed.");
+=======
 	if (fgets(buf, RF_BUFSIZE, fp) == NULL) {
 		log_errf(-1, __func__, "fgets failed.");
 	}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 
 	while (fgets(buf, RF_BUFSIZE, fp) != NULL) {
 		auto len = strlen(form) + strlen(buf);

--- a/src/scheduler/server_info.cpp
+++ b/src/scheduler/server_info.cpp
@@ -3216,14 +3216,8 @@ read_formula(void)
 	form[0] = '\0';
 
 	/* first line is a comment */
-<<<<<<< HEAD
 	if (fgets(buf, RF_BUFSIZE, fp) == NULL) 
 		log_errf(-1, __func__, "fgets failed.");
-=======
-	if (fgets(buf, RF_BUFSIZE, fp) == NULL) {
-		log_errf(-1, __func__, "fgets failed.");
-	}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 
 	while (fgets(buf, RF_BUFSIZE, fp) != NULL) {
 		auto len = strlen(form) + strlen(buf);

--- a/src/scheduler/server_info.cpp
+++ b/src/scheduler/server_info.cpp
@@ -3216,7 +3216,9 @@ read_formula(void)
 	form[0] = '\0';
 
 	/* first line is a comment */
-	fgets(buf, RF_BUFSIZE, fp);
+	if (fgets(buf, RF_BUFSIZE, fp) == NULL) {
+		log_errf(-1, __func__, "fgets failed.");
+	}
 
 	while (fgets(buf, RF_BUFSIZE, fp) != NULL) {
 		auto len = strlen(form) + strlen(buf);

--- a/src/server/pbs_comm.c
+++ b/src/server/pbs_comm.c
@@ -234,9 +234,13 @@ lock_out(int fds, int op)
 		if (fcntl(fds, F_SETLK, &flock) != -1) {
 			if (op == F_WRLCK) {
 				/* if write-lock, record pid in file */
-				(void) ftruncate(fds, (off_t) 0);
+				if (ftruncate(fds, (off_t) 0) == -1) {
+					log_errf(-1, __func__, "ftruncate failed. ERR : %s",strerror(errno));
+				}
 				(void) sprintf(buf, "%d\n", getpid());
-				(void) write(fds, buf, strlen(buf));
+				if(write(fds, buf, strlen(buf)) == -1) {
+					log_errf(-1, __func__, "write failed. ERR : %s",strerror(errno));
+				}
 			}
 			return;
 		}
@@ -264,10 +268,15 @@ pbs_close_stdfiles(void)
 		(void) fclose(stdout);
 		(void) fclose(stderr);
 
-		fopen(NULL_DEVICE, "r");
-
-		fopen(NULL_DEVICE, "w");
-		fopen(NULL_DEVICE, "w");
+		if (fopen(NULL_DEVICE, "r") == NULL) {
+			log_errf(-1, __func__, "fopen of null device failed. ERR : %s",strerror(errno));
+		}
+		if (fopen(NULL_DEVICE, "w") == NULL) {
+			log_errf(-1, __func__, "fopen of null device failed. ERR : %s",strerror(errno));
+		}
+		if (fopen(NULL_DEVICE, "w") == NULL) {
+			log_errf(-1, __func__, "fopen of null device failed. ERR : %s",strerror(errno));
+		}
 		already_done = 1;
 	}
 }

--- a/src/server/pbs_comm.c
+++ b/src/server/pbs_comm.c
@@ -234,6 +234,13 @@ lock_out(int fds, int op)
 		if (fcntl(fds, F_SETLK, &flock) != -1) {
 			if (op == F_WRLCK) {
 				/* if write-lock, record pid in file */
+<<<<<<< HEAD
+				if (ftruncate(fds, (off_t) 0) == -1) 
+					log_errf(-1, __func__, "ftruncate failed. ERR : %s",strerror(errno));
+				(void) sprintf(buf, "%d\n", getpid());
+				if(write(fds, buf, strlen(buf)) == -1) 
+					log_errf(-1, __func__, "write failed. ERR : %s",strerror(errno));
+=======
 				if (ftruncate(fds, (off_t) 0) == -1) {
 					log_errf(-1, __func__, "ftruncate failed. ERR : %s",strerror(errno));
 				}
@@ -241,6 +248,7 @@ lock_out(int fds, int op)
 				if(write(fds, buf, strlen(buf)) == -1) {
 					log_errf(-1, __func__, "write failed. ERR : %s",strerror(errno));
 				}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 			}
 			return;
 		}
@@ -268,6 +276,14 @@ pbs_close_stdfiles(void)
 		(void) fclose(stdout);
 		(void) fclose(stderr);
 
+<<<<<<< HEAD
+		if (fopen(NULL_DEVICE, "r") == NULL) 
+			log_errf(-1, __func__, "fopen of null device failed. ERR : %s",strerror(errno));
+		if (fopen(NULL_DEVICE, "w") == NULL) 
+			log_errf(-1, __func__, "fopen of null device failed. ERR : %s",strerror(errno));
+		if (fopen(NULL_DEVICE, "w") == NULL) 
+			log_errf(-1, __func__, "fopen of null device failed. ERR : %s",strerror(errno));
+=======
 		if (fopen(NULL_DEVICE, "r") == NULL) {
 			log_errf(-1, __func__, "fopen of null device failed. ERR : %s",strerror(errno));
 		}
@@ -277,6 +293,7 @@ pbs_close_stdfiles(void)
 		if (fopen(NULL_DEVICE, "w") == NULL) {
 			log_errf(-1, __func__, "fopen of null device failed. ERR : %s",strerror(errno));
 		}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 		already_done = 1;
 	}
 }

--- a/src/server/pbs_comm.c
+++ b/src/server/pbs_comm.c
@@ -234,21 +234,11 @@ lock_out(int fds, int op)
 		if (fcntl(fds, F_SETLK, &flock) != -1) {
 			if (op == F_WRLCK) {
 				/* if write-lock, record pid in file */
-<<<<<<< HEAD
 				if (ftruncate(fds, (off_t) 0) == -1) 
 					log_errf(-1, __func__, "ftruncate failed. ERR : %s",strerror(errno));
 				(void) sprintf(buf, "%d\n", getpid());
 				if(write(fds, buf, strlen(buf)) == -1) 
 					log_errf(-1, __func__, "write failed. ERR : %s",strerror(errno));
-=======
-				if (ftruncate(fds, (off_t) 0) == -1) {
-					log_errf(-1, __func__, "ftruncate failed. ERR : %s",strerror(errno));
-				}
-				(void) sprintf(buf, "%d\n", getpid());
-				if(write(fds, buf, strlen(buf)) == -1) {
-					log_errf(-1, __func__, "write failed. ERR : %s",strerror(errno));
-				}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 			}
 			return;
 		}
@@ -276,24 +266,12 @@ pbs_close_stdfiles(void)
 		(void) fclose(stdout);
 		(void) fclose(stderr);
 
-<<<<<<< HEAD
 		if (fopen(NULL_DEVICE, "r") == NULL) 
 			log_errf(-1, __func__, "fopen of null device failed. ERR : %s",strerror(errno));
 		if (fopen(NULL_DEVICE, "w") == NULL) 
 			log_errf(-1, __func__, "fopen of null device failed. ERR : %s",strerror(errno));
 		if (fopen(NULL_DEVICE, "w") == NULL) 
 			log_errf(-1, __func__, "fopen of null device failed. ERR : %s",strerror(errno));
-=======
-		if (fopen(NULL_DEVICE, "r") == NULL) {
-			log_errf(-1, __func__, "fopen of null device failed. ERR : %s",strerror(errno));
-		}
-		if (fopen(NULL_DEVICE, "w") == NULL) {
-			log_errf(-1, __func__, "fopen of null device failed. ERR : %s",strerror(errno));
-		}
-		if (fopen(NULL_DEVICE, "w") == NULL) {
-			log_errf(-1, __func__, "fopen of null device failed. ERR : %s",strerror(errno));
-		}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 		already_done = 1;
 	}
 }

--- a/src/server/pbsd_init.c
+++ b/src/server/pbsd_init.c
@@ -1919,14 +1919,8 @@ call_log_license(struct work_task *ptask)
 	/* write current info to file */
 	fd = open(path_usedlicenses, O_WRONLY | O_CREAT | O_TRUNC, 0600);
 	if (fd != -1) {
-<<<<<<< HEAD
-		if (write(fd, &license_counts.licenses_high_use, sizeof(license_counts.licenses_high_use)) == -1) 
+		if (write(fd, &license_counts.licenses_high_use, sizeof(license_counts.licenses_high_use)) == -1)
 			log_errf(-1, __func__, "write failed. ERR : %s",strerror(errno));
-=======
-		if (write(fd, &license_counts.licenses_high_use, sizeof(license_counts.licenses_high_use)) == -1) {
-			log_errf(-1, __func__, "write failed. ERR : %s",strerror(errno));
-		}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 		close(fd);
 	}
 

--- a/src/server/pbsd_init.c
+++ b/src/server/pbsd_init.c
@@ -1919,9 +1919,14 @@ call_log_license(struct work_task *ptask)
 	/* write current info to file */
 	fd = open(path_usedlicenses, O_WRONLY | O_CREAT | O_TRUNC, 0600);
 	if (fd != -1) {
+<<<<<<< HEAD
+		if (write(fd, &license_counts.licenses_high_use, sizeof(license_counts.licenses_high_use)) == -1) 
+			log_errf(-1, __func__, "write failed. ERR : %s",strerror(errno));
+=======
 		if (write(fd, &license_counts.licenses_high_use, sizeof(license_counts.licenses_high_use)) == -1) {
 			log_errf(-1, __func__, "write failed. ERR : %s",strerror(errno));
 		}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 		close(fd);
 	}
 

--- a/src/server/pbsd_init.c
+++ b/src/server/pbsd_init.c
@@ -1919,7 +1919,9 @@ call_log_license(struct work_task *ptask)
 	/* write current info to file */
 	fd = open(path_usedlicenses, O_WRONLY | O_CREAT | O_TRUNC, 0600);
 	if (fd != -1) {
-		(void) write(fd, &license_counts.licenses_high_use, sizeof(license_counts.licenses_high_use));
+		if (write(fd, &license_counts.licenses_high_use, sizeof(license_counts.licenses_high_use)) == -1) {
+			log_errf(-1, __func__, "write failed. ERR : %s",strerror(errno));
+		}
 		close(fd);
 	}
 

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -1220,14 +1220,8 @@ main(int argc, char **argv)
 
 				snprintf(schedcmd, sizeof(schedcmd), "%s/sbin/pbs_sched &", pbs_conf.pbs_exec_path);
 				snprintf(log_buffer, sizeof(log_buffer), "starting scheduler: %s", schedcmd);
-<<<<<<< HEAD
 				if (system(schedcmd) == -1) 
 					log_errf(-1, __func__, "system(%s) failed. ERR : %s",schedcmd, strerror(errno));
-=======
-				if (system(schedcmd) == -1) {
-					log_errf(-1, __func__, "system(%s) failed. ERR : %s",schedcmd, strerror(errno));
-				}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 
 				log_event(PBSEVENT_SYSTEM | PBSEVENT_FORCE,
 					  PBS_EVENTCLASS_SERVER, LOG_CRIT,
@@ -1680,23 +1674,12 @@ lock_out(int fds, int op)
 		if (fcntl(fds, F_SETLK, &flock) != -1) {
 			if (op == F_WRLCK) {
 				/* if write-lock, record pid in file */
-<<<<<<< HEAD
-				if (ftruncate(fds, (off_t) 0) == -1) 
+				if (ftruncate(fds, (off_t) 0) == -1)
 					log_errf(-1, __func__, "ftruncate failed. ERR : %s",strerror(errno));
 
 				(void) sprintf(buf, "%d\n", getpid());
 				if (write(fds, buf, strlen(buf)) == -1) 
 					log_errf(-1, __func__, "write failed. ERR : %s",strerror(errno));
-=======
-				if (ftruncate(fds, (off_t) 0) == -1) {
-					log_errf(-1, __func__, "ftruncate failed. ERR : %s",strerror(errno));
-				}
-
-				(void) sprintf(buf, "%d\n", getpid());
-				if (write(fds, buf, strlen(buf)) == -1) {
-					log_errf(-1, __func__, "write failed. ERR : %s",strerror(errno));
-				}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 			}
 			return;
 		}

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -1220,7 +1220,9 @@ main(int argc, char **argv)
 
 				snprintf(schedcmd, sizeof(schedcmd), "%s/sbin/pbs_sched &", pbs_conf.pbs_exec_path);
 				snprintf(log_buffer, sizeof(log_buffer), "starting scheduler: %s", schedcmd);
-				(void) system(schedcmd);
+				if (system(schedcmd) == -1) {
+					log_errf(-1, __func__, "system(%s) failed. ERR : %s",schedcmd, strerror(errno));
+				}
 
 				log_event(PBSEVENT_SYSTEM | PBSEVENT_FORCE,
 					  PBS_EVENTCLASS_SERVER, LOG_CRIT,
@@ -1673,9 +1675,14 @@ lock_out(int fds, int op)
 		if (fcntl(fds, F_SETLK, &flock) != -1) {
 			if (op == F_WRLCK) {
 				/* if write-lock, record pid in file */
-				(void) ftruncate(fds, (off_t) 0);
+				if (ftruncate(fds, (off_t) 0) == -1) {
+					log_errf(-1, __func__, "ftruncate failed. ERR : %s",strerror(errno));
+				}
+
 				(void) sprintf(buf, "%d\n", getpid());
-				(void) write(fds, buf, strlen(buf));
+				if (write(fds, buf, strlen(buf)) == -1) {
+					log_errf(-1, __func__, "write failed. ERR : %s",strerror(errno));
+				}
 			}
 			return;
 		}

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -1220,9 +1220,14 @@ main(int argc, char **argv)
 
 				snprintf(schedcmd, sizeof(schedcmd), "%s/sbin/pbs_sched &", pbs_conf.pbs_exec_path);
 				snprintf(log_buffer, sizeof(log_buffer), "starting scheduler: %s", schedcmd);
+<<<<<<< HEAD
+				if (system(schedcmd) == -1) 
+					log_errf(-1, __func__, "system(%s) failed. ERR : %s",schedcmd, strerror(errno));
+=======
 				if (system(schedcmd) == -1) {
 					log_errf(-1, __func__, "system(%s) failed. ERR : %s",schedcmd, strerror(errno));
 				}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 
 				log_event(PBSEVENT_SYSTEM | PBSEVENT_FORCE,
 					  PBS_EVENTCLASS_SERVER, LOG_CRIT,
@@ -1675,6 +1680,14 @@ lock_out(int fds, int op)
 		if (fcntl(fds, F_SETLK, &flock) != -1) {
 			if (op == F_WRLCK) {
 				/* if write-lock, record pid in file */
+<<<<<<< HEAD
+				if (ftruncate(fds, (off_t) 0) == -1) 
+					log_errf(-1, __func__, "ftruncate failed. ERR : %s",strerror(errno));
+
+				(void) sprintf(buf, "%d\n", getpid());
+				if (write(fds, buf, strlen(buf)) == -1) 
+					log_errf(-1, __func__, "write failed. ERR : %s",strerror(errno));
+=======
 				if (ftruncate(fds, (off_t) 0) == -1) {
 					log_errf(-1, __func__, "ftruncate failed. ERR : %s",strerror(errno));
 				}
@@ -1683,6 +1696,7 @@ lock_out(int fds, int op)
 				if (write(fds, buf, strlen(buf)) == -1) {
 					log_errf(-1, __func__, "write failed. ERR : %s",strerror(errno));
 				}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 			}
 			return;
 		}

--- a/src/server/req_track.c
+++ b/src/server/req_track.c
@@ -217,14 +217,8 @@ track_save(struct work_task *pwt)
 		return;
 	}
 
-<<<<<<< HEAD
 	if (write(fd, (char *) server.sv_track, server.sv_tracksize * sizeof(struct tracking)) == -1) 
 		log_errf(-1, __func__, "write failed. ERR : %s",strerror(errno));
-=======
-	if (write(fd, (char *) server.sv_track, server.sv_tracksize * sizeof(struct tracking)) == -1) {
-		log_errf(-1, __func__, "write failed. ERR : %s",strerror(errno));
-		}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 	(void) close(fd);
 	server.sv_trackmodifed = 0;
 	return;

--- a/src/server/req_track.c
+++ b/src/server/req_track.c
@@ -217,9 +217,14 @@ track_save(struct work_task *pwt)
 		return;
 	}
 
+<<<<<<< HEAD
+	if (write(fd, (char *) server.sv_track, server.sv_tracksize * sizeof(struct tracking)) == -1) 
+		log_errf(-1, __func__, "write failed. ERR : %s",strerror(errno));
+=======
 	if (write(fd, (char *) server.sv_track, server.sv_tracksize * sizeof(struct tracking)) == -1) {
 		log_errf(-1, __func__, "write failed. ERR : %s",strerror(errno));
 		}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 	(void) close(fd);
 	server.sv_trackmodifed = 0;
 	return;

--- a/src/server/req_track.c
+++ b/src/server/req_track.c
@@ -217,7 +217,9 @@ track_save(struct work_task *pwt)
 		return;
 	}
 
-	(void) write(fd, (char *) server.sv_track, server.sv_tracksize * sizeof(struct tracking));
+	if (write(fd, (char *) server.sv_track, server.sv_tracksize * sizeof(struct tracking)) == -1) {
+		log_errf(-1, __func__, "write failed. ERR : %s",strerror(errno));
+		}
 	(void) close(fd);
 	server.sv_trackmodifed = 0;
 	return;

--- a/src/server/svr_func.c
+++ b/src/server/svr_func.c
@@ -5981,9 +5981,14 @@ start_vnode_provisioning(struct prov_vnode_info *prov_vnode_info)
 			exit(13);
 
 		/* Redirect standard files to /dev/null */
+<<<<<<< HEAD
+		if (freopen("/dev/null", "r", stdin) == NULL) 
+			log_errf(-1, __func__, "freopen of null device failed. ERR : %s",strerror(errno));
+=======
 		if (freopen("/dev/null", "r", stdin) == NULL) {
 			log_errf(-1, __func__, "freopen of null device failed. ERR : %s",strerror(errno));
 		}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 
 
 		/* Unprotect child from being killed by system */

--- a/src/server/svr_func.c
+++ b/src/server/svr_func.c
@@ -5981,7 +5981,10 @@ start_vnode_provisioning(struct prov_vnode_info *prov_vnode_info)
 			exit(13);
 
 		/* Redirect standard files to /dev/null */
-		freopen("/dev/null", "r", stdin);
+		if (freopen("/dev/null", "r", stdin) == NULL) {
+			log_errf(-1, __func__, "freopen of null device failed. ERR : %s",strerror(errno));
+		}
+
 
 		/* Unprotect child from being killed by system */
 		daemon_protect(0, PBS_DAEMON_PROTECT_OFF);

--- a/src/server/svr_func.c
+++ b/src/server/svr_func.c
@@ -5981,14 +5981,8 @@ start_vnode_provisioning(struct prov_vnode_info *prov_vnode_info)
 			exit(13);
 
 		/* Redirect standard files to /dev/null */
-<<<<<<< HEAD
 		if (freopen("/dev/null", "r", stdin) == NULL) 
 			log_errf(-1, __func__, "freopen of null device failed. ERR : %s",strerror(errno));
-=======
-		if (freopen("/dev/null", "r", stdin) == NULL) {
-			log_errf(-1, __func__, "freopen of null device failed. ERR : %s",strerror(errno));
-		}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 
 
 		/* Unprotect child from being killed by system */

--- a/src/tools/pbs_ds_monitor.c
+++ b/src/tools/pbs_ds_monitor.c
@@ -151,9 +151,14 @@ get_pid()
 		return 0;
 
 	memset(buf, 0, TEMP_BUF_SIZE + 1);
+<<<<<<< HEAD
+	if (fgets(buf, TEMP_BUF_SIZE, fp) == NULL) 
+		fprintf(stderr, "%s fgets failed. \n", __func__);
+=======
 	if (fgets(buf, TEMP_BUF_SIZE, fp) == NULL) {
 		fprintf(stderr, "%s fgets failed. \n", __func__);
 	}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 	buf[TEMP_BUF_SIZE] = '\0';
 
 	fclose(fp);
@@ -204,6 +209,13 @@ lock_out(int fds, int op)
 	if (fcntl(fds, F_SETLK, &flock) != -1) {
 		if (op == F_WRLCK) {
 			/* if write-lock, record hostname and pid in file */
+<<<<<<< HEAD
+			if (ftruncate(fds, (off_t) 0) == -1) 
+				fprintf(stderr, "ftruncate failed, ERR = %s\n", strerror(errno));
+			(void) sprintf(buf, "%s:%d\n", thishost, getpid());
+			if (write(fds, buf, strlen(buf)) == -1) 
+				fprintf(stderr, "write failed, ERR = %s\n", strerror(errno));
+=======
 			if (ftruncate(fds, (off_t) 0) == -1) {
 				fprintf(stderr, "ftruncate failed, ERR = %s\n", strerror(errno));
 			}
@@ -211,6 +223,7 @@ lock_out(int fds, int op)
 			if (write(fds, buf, strlen(buf)) == -1) {
 				fprintf(stderr, "write failed, ERR = %s\n", strerror(errno));
 			}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 		}
 		return 0;
 	}
@@ -420,9 +433,14 @@ unix_db_monitor(char *mode)
 			return 1;
 
 		if (res != 0) {
+<<<<<<< HEAD
+			if (read(pipefd[0], &reason, sizeof(reason)) == -1) 
+				fprintf(stderr, "read failed, ERR = %s\n", strerror(errno));
+=======
 			if (read(pipefd[0], &reason, sizeof(reason)) == -1) {
 				fprintf(stderr, "read failed, ERR = %s\n", strerror(errno));
 			}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 			fprintf(stderr, "Failed to acquire lock on %s. %s\n", lockfile, reason);
 		}
 
@@ -448,19 +466,31 @@ unix_db_monitor(char *mode)
 		if (is_lock_local && strcmp(mode, "check") == 0) {
 			/* write success to parent since lock is already held by the localhost */
 			res = 0;
+<<<<<<< HEAD
+			if (write(pipefd[1], &res, sizeof(int)) == -1) 
+				fprintf(stderr, "write failed, ERR = %s\n", strerror(errno));
+=======
 			if (write(pipefd[1], &res, sizeof(int)) == -1) {
 				fprintf(stderr, "write failed, ERR = %s\n", strerror(errno));
 			}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 			close(pipefd[1]);
 			return 0;
 		}
 		res = 1;
+<<<<<<< HEAD
+		if (write(pipefd[1], &res, sizeof(int)) == -1) 
+			fprintf(stderr, "write failed, ERR = %s\n", strerror(errno));
+		if (write(pipefd[1], reason, sizeof(reason)) == -1) 
+			fprintf(stderr, "write failed, ERR = %s\n", strerror(errno));
+=======
 		if (write(pipefd[1], &res, sizeof(int)) == -1) {
 			fprintf(stderr, "write failed, ERR = %s\n", strerror(errno));
 		}
 		if (write(pipefd[1], reason, sizeof(reason)) == -1) {
 			fprintf(stderr, "write failed, ERR = %s\n", strerror(errno));
 		}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 		close(pipefd[1]);
 		return 1;
 	}
@@ -474,9 +504,14 @@ unix_db_monitor(char *mode)
 
 	/* write success to parent since we acquired the lock */
 	res = 0;
+<<<<<<< HEAD
+	if (write(pipefd[1], &res, sizeof(int)) == -1) 
+		fprintf(stderr, "%s : write failed, ERR = %s\n", __func__ , strerror(errno));
+=======
 	if (write(pipefd[1], &res, sizeof(int)) == -1) {
 		fprintf(stderr, "%s : write failed, ERR = %s\n", __func__ , strerror(errno));
 	}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 	close(pipefd[1]);
 
 	if (strcmp(mode, "check") == 0)

--- a/src/tools/pbs_ds_monitor.c
+++ b/src/tools/pbs_ds_monitor.c
@@ -151,14 +151,8 @@ get_pid()
 		return 0;
 
 	memset(buf, 0, TEMP_BUF_SIZE + 1);
-<<<<<<< HEAD
 	if (fgets(buf, TEMP_BUF_SIZE, fp) == NULL) 
 		fprintf(stderr, "%s fgets failed. \n", __func__);
-=======
-	if (fgets(buf, TEMP_BUF_SIZE, fp) == NULL) {
-		fprintf(stderr, "%s fgets failed. \n", __func__);
-	}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 	buf[TEMP_BUF_SIZE] = '\0';
 
 	fclose(fp);
@@ -209,21 +203,11 @@ lock_out(int fds, int op)
 	if (fcntl(fds, F_SETLK, &flock) != -1) {
 		if (op == F_WRLCK) {
 			/* if write-lock, record hostname and pid in file */
-<<<<<<< HEAD
 			if (ftruncate(fds, (off_t) 0) == -1) 
 				fprintf(stderr, "ftruncate failed, ERR = %s\n", strerror(errno));
 			(void) sprintf(buf, "%s:%d\n", thishost, getpid());
 			if (write(fds, buf, strlen(buf)) == -1) 
 				fprintf(stderr, "write failed, ERR = %s\n", strerror(errno));
-=======
-			if (ftruncate(fds, (off_t) 0) == -1) {
-				fprintf(stderr, "ftruncate failed, ERR = %s\n", strerror(errno));
-			}
-			(void) sprintf(buf, "%s:%d\n", thishost, getpid());
-			if (write(fds, buf, strlen(buf)) == -1) {
-				fprintf(stderr, "write failed, ERR = %s\n", strerror(errno));
-			}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 		}
 		return 0;
 	}
@@ -433,14 +417,8 @@ unix_db_monitor(char *mode)
 			return 1;
 
 		if (res != 0) {
-<<<<<<< HEAD
 			if (read(pipefd[0], &reason, sizeof(reason)) == -1) 
 				fprintf(stderr, "read failed, ERR = %s\n", strerror(errno));
-=======
-			if (read(pipefd[0], &reason, sizeof(reason)) == -1) {
-				fprintf(stderr, "read failed, ERR = %s\n", strerror(errno));
-			}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 			fprintf(stderr, "Failed to acquire lock on %s. %s\n", lockfile, reason);
 		}
 
@@ -466,31 +444,16 @@ unix_db_monitor(char *mode)
 		if (is_lock_local && strcmp(mode, "check") == 0) {
 			/* write success to parent since lock is already held by the localhost */
 			res = 0;
-<<<<<<< HEAD
 			if (write(pipefd[1], &res, sizeof(int)) == -1) 
 				fprintf(stderr, "write failed, ERR = %s\n", strerror(errno));
-=======
-			if (write(pipefd[1], &res, sizeof(int)) == -1) {
-				fprintf(stderr, "write failed, ERR = %s\n", strerror(errno));
-			}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 			close(pipefd[1]);
 			return 0;
 		}
 		res = 1;
-<<<<<<< HEAD
 		if (write(pipefd[1], &res, sizeof(int)) == -1) 
 			fprintf(stderr, "write failed, ERR = %s\n", strerror(errno));
 		if (write(pipefd[1], reason, sizeof(reason)) == -1) 
 			fprintf(stderr, "write failed, ERR = %s\n", strerror(errno));
-=======
-		if (write(pipefd[1], &res, sizeof(int)) == -1) {
-			fprintf(stderr, "write failed, ERR = %s\n", strerror(errno));
-		}
-		if (write(pipefd[1], reason, sizeof(reason)) == -1) {
-			fprintf(stderr, "write failed, ERR = %s\n", strerror(errno));
-		}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 		close(pipefd[1]);
 		return 1;
 	}
@@ -504,14 +467,8 @@ unix_db_monitor(char *mode)
 
 	/* write success to parent since we acquired the lock */
 	res = 0;
-<<<<<<< HEAD
 	if (write(pipefd[1], &res, sizeof(int)) == -1) 
 		fprintf(stderr, "%s : write failed, ERR = %s\n", __func__ , strerror(errno));
-=======
-	if (write(pipefd[1], &res, sizeof(int)) == -1) {
-		fprintf(stderr, "%s : write failed, ERR = %s\n", __func__ , strerror(errno));
-	}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 	close(pipefd[1]);
 
 	if (strcmp(mode, "check") == 0)

--- a/src/tools/printjob.c
+++ b/src/tools/printjob.c
@@ -557,7 +557,9 @@ main(int argc, char *argv[])
 						(void) close(fp);
 						return 1;
 					}
-					read(fp, (char *) ajtrk + sizeof(xs), xs - sizeof(xs));
+					if (read(fp, (char *) ajtrk + sizeof(xs), xs - sizeof(xs)) == -1) {
+						fprintf(stderr, "read failed, ERR = %s\n", strerror(errno));
+					}
 					free(ajtrk);
 				}
 			}

--- a/src/tools/printjob.c
+++ b/src/tools/printjob.c
@@ -557,14 +557,8 @@ main(int argc, char *argv[])
 						(void) close(fp);
 						return 1;
 					}
-<<<<<<< HEAD
 					if (read(fp, (char *) ajtrk + sizeof(xs), xs - sizeof(xs)) == -1) 
 						fprintf(stderr, "read failed, ERR = %s\n", strerror(errno));
-=======
-					if (read(fp, (char *) ajtrk + sizeof(xs), xs - sizeof(xs)) == -1) {
-						fprintf(stderr, "read failed, ERR = %s\n", strerror(errno));
-					}
->>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 					free(ajtrk);
 				}
 			}

--- a/src/tools/printjob.c
+++ b/src/tools/printjob.c
@@ -557,9 +557,14 @@ main(int argc, char *argv[])
 						(void) close(fp);
 						return 1;
 					}
+<<<<<<< HEAD
+					if (read(fp, (char *) ajtrk + sizeof(xs), xs - sizeof(xs)) == -1) 
+						fprintf(stderr, "read failed, ERR = %s\n", strerror(errno));
+=======
 					if (read(fp, (char *) ajtrk + sizeof(xs), xs - sizeof(xs)) == -1) {
 						fprintf(stderr, "read failed, ERR = %s\n", strerror(errno));
 					}
+>>>>>>> 1f914485208460cd8231cd853664f3a839138d7f
 					free(ajtrk);
 				}
 			}

--- a/test/fw/ptl/lib/ptl_batchutils.py
+++ b/test/fw/ptl/lib/ptl_batchutils.py
@@ -472,7 +472,7 @@ class BatchUtils(object):
         :type name: str
         :param fmt: Optional formatting string, uses %n for
                     object name, %a for attributes, for example
-                    a format of r'%nE{\}nE{\}t%aE{\}n' will display
+                    a format of r'%nE{}nE{}t%aE{}n' will display
                     objects with their name starting on the first
                     column, a new line, and attributes indented by
                     a tab followed by a new line at the end.
@@ -1528,8 +1528,8 @@ class BatchUtils(object):
         """
         Parse an ``FGC`` limit entry, of the form:
 
-        ``<limtype>[.<resource>]=\[<entity_type>:<entity_name>
-        =<entity_value>\]``
+        ``<limtype>[.<resource>]=[<entity_type>:<entity_name>
+        =<entity_value>]``
 
         :param limstr: FGC limit string
         :type limstr: str or None

--- a/test/fw/ptl/lib/ptl_sched.py
+++ b/test/fw/ptl/lib/ptl_sched.py
@@ -634,7 +634,7 @@ class Scheduler(PBSService):
                             for val in v:
                                 fd.write(k + ": " + str(val).strip() + "\n")
                         else:
-                                fd.write(k + ": " + str(v).strip() + "\n")
+                            fd.write(k + ": " + str(v).strip() + "\n")
 
                 if 'PTL_SCHED_CONFIG_TAIL' in self._sched_config_comments:
                     fd.write("\n".join(

--- a/test/fw/ptl/lib/ptl_types.py
+++ b/test/fw/ptl/lib/ptl_types.py
@@ -863,8 +863,8 @@ class PbsTypeFGCLimit(object):
     """
     FGC limit entry, of the form:
 
-    ``<limtype>[.<resource>]=\[<entity_type>:<entity_name>=
-    <entity_value>\]``
+    ``<limtype>[.<resource>]=[<entity_type>:<entity_name>=
+    <entity_value>]``
 
     :param attr: FGC limit attribute
     :type attr: str

--- a/test/fw/ptl/utils/pbs_anonutils.py
+++ b/test/fw/ptl/utils/pbs_anonutils.py
@@ -1053,7 +1053,7 @@ class PBSAnonymizer(object):
 
                 # Anonymize IP addresses
                 pattern = re.compile(
-                    "\b*\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b*")
+                    r"\b*\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b*")
                 match_obj = re.search(pattern, line)
                 if match_obj:
                     ip = match_obj.group(0)

--- a/test/fw/ptl/utils/pbs_cliutils.py
+++ b/test/fw/ptl/utils/pbs_cliutils.py
@@ -126,11 +126,11 @@ class CliUtils(object):
         """
         from ptl.utils.pbs_dshutils import DshUtils
 
-        netstat_tag = re.compile("tcp[\s]+[\d]+[\s]+[\d]+[\s]+"
-                                 "(?P<srchost>[\w\*\.]+):(?P<srcport>[\d]+)"
-                                 "[\s]+(?P<desthost>[\.\w\*:]+):"
-                                 "(?P<destport>[\d]+)"
-                                 "[\s]+(?P<state>[\w]+).*")
+        netstat_tag = re.compile(r"tcp[\s]+[\d]+[\s]+[\d]+[\s]+"
+                                 r"(?P<srchost>[\w\*\.]+):(?P<srcport>[\d]+)"
+                                 r"[\s]+(?P<desthost>[\.\w\*:]+):"
+                                 r"(?P<destport>[\d]+)"
+                                 r"[\s]+(?P<state>[\w]+).*")
         du = DshUtils()
         ret = du.run_cmd(hostname, ['netstat', '-at', '--numeric-ports'])
         if ret['rc'] != 0:

--- a/test/fw/ptl/utils/pbs_logutils.py
+++ b/test/fw/ptl/utils/pbs_logutils.py
@@ -1290,7 +1290,7 @@ class PBSSchedulerLog(PBSLogAnalyzer):
                     self.cycle.calendarduration[jid] = \
                         (tm - self.cycle.consider[jid])
                 elif '[' in jid:
-                    arrjid = re.sub("(\[\d+\])", '[]', jid)
+                    arrjid = re.sub(r"(\[\d+\])", '[]', jid)
                     if arrjid in self.cycle.consider:
                         self.cycle.consider[jid] = self.cycle.consider[arrjid]
                         self.cycle.calendarduration[jid] = \

--- a/test/tests/functional/pbs_accumulate_resc_used.py
+++ b/test/tests/functional/pbs_accumulate_resc_used.py
@@ -317,7 +317,7 @@ else:
         self.server.accounting_match("E;%s;.*%s.*" % (jid, acctlog_match),
                                      regexp=True, n=100, existence=False)
 
-        acctlog_match = 'resources_used.stra=\"glad\,elated\"\,\"happy\"'
+        acctlog_match = r'resources_used.stra=\"glad\,elated\"\,\"happy\"'
         self.server.accounting_match(
             "E;%s;.*%s.*" % (jid, acctlog_match), regexp=True, n=100)
 
@@ -488,7 +488,7 @@ else:
         self.server.accounting_match(
             "E;%s;.*%s.*" % (jid, acctlog_match), regexp=True, n=100)
 
-        acctlog_match = 'resources_used.stra=\"glad\,elated\"\,\"happy\"'
+        acctlog_match = r'resources_used.stra=\"glad\,elated\"\,\"happy\"'
         self.server.accounting_match(
             "E;%s;.*%s.*" % (jid, acctlog_match), regexp=True, n=100)
 
@@ -644,11 +644,11 @@ for jk in e.job_list.keys():
                 "E;%s;.*%s.*" % (jid, acctlog_match), regexp=True, n=100)
 
             acctlog_match = "resources_used.foo_str3='%s'" % (
-                foo_str3_dict_out_str.replace('.', '\.').
-                replace("#$%^&*@", "\#\$\%\^\&\*\@"))
+                foo_str3_dict_out_str.replace('.', r'\.').
+                replace("#$%^&*@", r"\#\$\%\^\&\*\@"))
             self.server.accounting_match(
                 "E;%s;.*%s.*" % (jid, acctlog_match), regexp=True, n=100)
-            acctlog_match = 'resources_used.stra=\"glad\,elated\"\,\"happy\"'
+            acctlog_match = r'resources_used.stra=\"glad\,elated\"\,\"happy\"'
             self.server.accounting_match(
                 "E;%s;.*%s.*" % (jid, acctlog_match), regexp=True, n=100)
 
@@ -1124,7 +1124,7 @@ else:
         #    "E;%s;.*%s.*" % (subjob1, acctlog_match), regexp=True, n=100)
         # self.assertTrue(s)
 
-        acctlog_match = 'resources_used.stra=\"glad\,elated\"\,\"happy\"'
+        acctlog_match = r'resources_used.stra=\"glad\,elated\"\,\"happy\"'
         # s = self.server.accounting_match(
         #    "E;%s;.*%s.*" % (subjob1, acctlog_match), regexp=True, n=100)
         # self.assertTrue(s)

--- a/test/tests/functional/pbs_cpuset.py
+++ b/test/tests/functional/pbs_cpuset.py
@@ -182,16 +182,17 @@ time.sleep(20)
 
         # values to use when matching accounting logs
         self.job1_exec_host_esc = self.job1_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         self.job1_exec_vnode_esc = self.job1_exec_vnode.replace(
-            "[", "\[").replace("]", "\]").replace("(", "\(").replace(
-            ")", "\)").replace("+", "\+")
+            "[", r"\[").replace("]", r"\]").replace("(", r"\(").replace(
+            ")", r"\)").replace("+", r"\+")
         self.job1_sel_esc = self.job1_select.replace(
-            "[", "\[").replace("]", "\]").replace("(", "\(").replace(
-            ")", "\)").replace("+", "\+")
+            "[", r"\[").replace("]", r"\]").replace("(", r"\(").replace(
+            ")", r"\)").replace("+", r"\+")
         self.job1_new_exec_vnode_esc = self.job1_new_exec_vnode.replace(
-            "[", "\[").replace("]", "\]").replace("(", "\(").replace(
-            ")", "\)").replace("+", "\+")
+            "[", r"\[").replace("]", r"\]").replace("(", r"\(").replace(
+            ")", r"\)").replace("+", r"\+")
 
     def tearDown(self):
         for host in [self.h0, self.h1]:
@@ -317,7 +318,7 @@ time.sleep(20)
 
         # Check if sister mom updated its internal nodes table after release
         self.moms.values()[1].log_match('Job;%s;updated nodes info' % jid1,
-                                        starttime=before_release-1)
+                                        starttime=before_release - 1)
 
         # Check the cpuset for the job after releasing self.n3
         cset_after = self.du.cat(self.n1, cset_file)
@@ -434,20 +435,20 @@ return i\\n return fib(i-1) + fib(i-2)\\n\\nprint(fib(400))\\\")"'
         # Check account update ('u') record
         msg0 = ".*%s;%s.*exec_host=%s" % ('u', jid, self.job1_exec_host_esc)
         msg1 = ".*exec_vnode=%s" % self.job1_exec_vnode_esc
-        msg2 = ".*Resource_List\.mem=%s" % '3gb'
-        msg3 = ".*Resource_List\.ncpus=%d" % 9
-        msg4 = ".*Resource_List\.place=%s" % self.job1_place
-        msg5 = ".*Resource_List\.select=%s.*" % self.job1_sel_esc
+        msg2 = r".*Resource_List\.mem=%s" % '3gb'
+        msg3 = r".*Resource_List\.ncpus=%d" % 9
+        msg4 = r".*Resource_List\.place=%s" % self.job1_place
+        msg5 = r".*Resource_List\.select=%s.*" % self.job1_sel_esc
         msg = msg0 + msg1 + msg2 + msg3 + msg4 + msg5
         self.server.accounting_match(msg=msg, regexp=True, n="ALL",
                                      starttime=stime)
         # Check to make sure 'c' (next) record got generated
         msg0 = ".*%s;%s.*exec_host=%s" % ('c', jid, self.job1_new_exec_host)
         msg1 = ".*exec_vnode=%s" % self.job1_new_exec_vnode_esc
-        msg2 = ".*Resource_List\.mem=%s" % '1048576kb'
-        msg3 = ".*Resource_List\.ncpus=%d" % 1
-        msg4 = ".*Resource_List\.place=%s" % self.job1_place
-        msg5 = ".*Resource_List\.select=%s.*" % self.job1_newsel
+        msg2 = r".*Resource_List\.mem=%s" % '1048576kb'
+        msg3 = r".*Resource_List\.ncpus=%d" % 1
+        msg4 = r".*Resource_List\.place=%s" % self.job1_place
+        msg5 = r".*Resource_List\.select=%s.*" % self.job1_newsel
         msg = msg0 + msg1 + msg2 + msg3 + msg4 + msg5
         self.server.accounting_match(msg=msg, regexp=True, n="ALL",
                                      starttime=stime)

--- a/test/tests/functional/pbs_exceeded_resources_notification.py
+++ b/test/tests/functional/pbs_exceeded_resources_notification.py
@@ -142,7 +142,7 @@ class TestExceededResourcesNotification(TestFunctional):
         j.create_script(body=test)
 
         jid = self.server.submit(j)
-        j_comment = '.* and exceeded resource ncpus \(sum\)'
+        j_comment = r'.* and exceeded resource ncpus \(sum\)'
         self.server.expect(JOB, {ATTR_state: 'F',
                                  ATTR_comment: (MATCH_RE, j_comment),
                                  ATTR_exit_status: -25},
@@ -172,7 +172,7 @@ class TestExceededResourcesNotification(TestFunctional):
         j.create_script(body=test)
 
         jid = self.server.submit(j)
-        j_comment = '.* and exceeded resource ncpus \(burst\)'
+        j_comment = r'.* and exceeded resource ncpus \(burst\)'
         self.server.expect(JOB, {ATTR_state: 'F',
                                  ATTR_comment: (MATCH_RE, j_comment),
                                  ATTR_exit_status: -24},

--- a/test/tests/functional/pbs_hook_perf_stat.py
+++ b/test/tests/functional/pbs_hook_perf_stat.py
@@ -88,12 +88,12 @@ pbs.logmsg(pbs.LOG_DEBUG, "mom data collected for %s" % s.name)
                               regexp=True)
 
         stat = "walltime=.* cputime=.*"
-        act = "action=populate:pbs\.event\(\)\.job\(.*\)"
+        act = r"action=populate:pbs\.event\(\)\.job\(.*\)"
         self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
                               regexp=True)
 
         lbl = "label=hook_func"
-        act = "action=populate:pbs.server\(\)"
+        act = r"action=populate:pbs.server\(\)"
         self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
                               regexp=True)
 
@@ -132,19 +132,19 @@ pbs.logmsg(pbs.LOG_DEBUG, "mom data collected for %s" % s.name)
                               regexp=True)
 
         stat = "walltime=.* cputime=.*"
-        act = "action=populate:pbs\.event\(\)\.job\(.*\)"
+        act = r"action=populate:pbs\.event\(\)\.job\(.*\)"
         self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
                               regexp=True)
 
-        act = "action=populate:pbs.server\(\).job\(.*\)"
+        act = r"action=populate:pbs.server\(\).job\(.*\)"
         self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
                               regexp=True)
 
-        act = "action=populate:pbs.server\(\).queue\(.*\)"
+        act = r"action=populate:pbs.server\(\).queue\(.*\)"
         self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
                               regexp=True)
 
-        act = "action=populate:pbs.server\(\)"
+        act = r"action=populate:pbs.server\(\)"
         self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
                               regexp=True)
 
@@ -183,15 +183,15 @@ pbs.logmsg(pbs.LOG_DEBUG, "mom data collected for %s" % s.name)
                               regexp=True)
 
         stat = "walltime=.* cputime=.*"
-        act = "action=populate:pbs.server\(\).job\(.*\)"
+        act = r"action=populate:pbs.server\(\).job\(.*\)"
         self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
                               regexp=True)
 
-        act = "action=populate:pbs.server\(\).queue\(.*\)"
+        act = r"action=populate:pbs.server\(\).queue\(.*\)"
         self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
                               regexp=True)
 
-        act = "action=populate:pbs.server\(\)"
+        act = r"action=populate:pbs.server\(\)"
         self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
                               regexp=True)
 
@@ -229,15 +229,15 @@ pbs.logmsg(pbs.LOG_DEBUG, "mom data collected for %s" % s.name)
                               regexp=True)
 
         stat = "walltime=.* cputime=.*"
-        act = "action=populate:pbs.server\(\).job\(.*\)"
+        act = r"action=populate:pbs.server\(\).job\(.*\)"
         self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
                               regexp=True)
 
-        act = "action=populate:pbs.server\(\).queue\(.*\)"
+        act = r"action=populate:pbs.server\(\).queue\(.*\)"
         self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
                               regexp=True)
 
-        act = "action=populate:pbs.server\(\)"
+        act = r"action=populate:pbs.server\(\)"
         self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
                               regexp=True)
 
@@ -270,12 +270,12 @@ pbs.logmsg(pbs.LOG_DEBUG, "mom data collected for %s" % s.name)
                               regexp=True)
 
         stat = "walltime=.* cputime=.*"
-        act = "action=populate:pbs\.event\(\)\.resv\(.*\)"
+        act = r"action=populate:pbs\.event\(\)\.resv\(.*\)"
         self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
                               regexp=True)
 
         lbl = "label=hook_func"
-        act = "action=populate:pbs.server\(\)"
+        act = r"action=populate:pbs.server\(\)"
         self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
                               regexp=True)
 
@@ -311,16 +311,16 @@ pbs.logmsg(pbs.LOG_DEBUG, "mom data collected for %s" % s.name)
                               regexp=True)
 
         stat = "walltime=.* cputime=.*"
-        act = "action=populate:pbs\.event\(\)\.vnode_list"
+        act = r"action=populate:pbs\.event\(\)\.vnode_list"
         self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
                               regexp=True)
 
-        act = "action=populate:pbs\.event\(\)\.resv_list"
+        act = r"action=populate:pbs\.event\(\)\.resv_list"
         self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
                               regexp=True)
 
         lbl = "label=hook_func"
-        act = "action=populate:pbs.server\(\)"
+        act = r"action=populate:pbs.server\(\)"
         self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
                               regexp=True)
 
@@ -382,7 +382,7 @@ pbs.logmsg(pbs.LOG_DEBUG, "mom data collected for %s" % s.name)
             self.mom.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
                                regexp=True)
 
-            act = "action=populate:pbs\.event\(\)\.job\(.*\)"
+            act = r"action=populate:pbs\.event\(\)\.job\(.*\)"
             self.mom.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
                                regexp=True)
 
@@ -429,11 +429,11 @@ pbs.logmsg(pbs.LOG_DEBUG, "mom data collected for %s" % s.name)
         self.mom.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
                            regexp=True)
 
-        act = "action=populate:pbs\.event\(\)\.vnode_list"
+        act = r"action=populate:pbs\.event\(\)\.vnode_list"
         self.mom.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
                            regexp=True)
 
-        act = "action=populate:pbs\.event\(\)\.job_list"
+        act = r"action=populate:pbs\.event\(\)\.job_list"
         self.mom.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
                            regexp=True)
 

--- a/test/tests/functional/pbs_hook_set_jobenv.py
+++ b/test/tests/functional/pbs_hook_set_jobenv.py
@@ -47,7 +47,7 @@ class TestPbsHookSetJobEnv(TestFunctional):
     This test suite to make sure hooks properly
     handle environment variables with special characters,
     values, in particular newline (\n), commas (,), semicolons (;),
-    single quotes ('), double quotes ("), and backaslashes (\).
+    single quotes ('), double quotes ("), and backaslashes.
     PRE: Set up currently executing user's environment to have variables
          whose values have the special characters.
          Job A: Submit a job using the -V option (pass current environment)
@@ -177,9 +177,9 @@ class TestPbsHookSetJobEnv(TestFunctional):
         Validate the env variable output in daemon logs
         """
         logutils = PBSLogUtils()
-        logmsg = ["TEST_COMMA=1\,2\,3\,4",
+        logmsg = [r"TEST_COMMA=1\,2\,3\,4",
                   "TEST_SEMICOLON=;",
-                  "TEST_ENCLOSED=\\'\,\\'",
+                  r"TEST_ENCLOSED=\\'\,\\'",
                   "TEST_COLON=:",
                   "TEST_BACKSLASH=\\\\",
                   "TEST_DQUOTE=\\\"",
@@ -196,11 +196,11 @@ class TestPbsHookSetJobEnv(TestFunctional):
                   "TEST_SQUOTE6=loving\\'",
                   "TEST_SPECIAL={}[]()~@#$%^&*!",
                   "TEST_SPECIAL2=<dumb-test_text>",
-                  "TEST_RETURN=\\'3\,",
+                  r"TEST_RETURN=\\'3\,",
                   # Cannot add '\n' here because '\n' is not included in
                   # the items of the list returned by log_lines(), (though
                   # lines are split by '\n')
-                  "4\,",
+                  r"4\,",
                   "5\\',"]
 
         if (daemon == "mom"):
@@ -227,9 +227,9 @@ class TestPbsHookSetJobEnv(TestFunctional):
                 if match:
                     # Dont want the test to pass if there are
                     # unwanted matched for "4\," and "5\\'.
-                    if msg == "TEST_RETURN=\\'3\,":
+                    if msg == r"TEST_RETURN=\\'3\,":
                         ret_linenum = match[0]
-                    if (msg == "4\," and match[0] != (ret_linenum - 1)) or \
+                    if (msg == r"4\," and match[0] != (ret_linenum - 1)) or \
                        (msg == "5\\'" and match[0] != (ret_linenum - 2)):
                         pass
                     else:
@@ -709,7 +709,7 @@ pbs.logmsg(pbs.LOG_DEBUG, "Variable_List is %s" % (j.Variable_List,))
         no hook is present
         """
 
-        os.environ['BROL'] = 'hii\\\haha'
+        os.environ['BROL'] = r'hii\\\haha'
         os.environ['BROL1'] = """'hii
 haa'"""
 
@@ -845,7 +845,7 @@ haa'"""
         """
 
         self.interactive = True
-        os.environ['BROL'] = 'hii\\\haha'
+        os.environ['BROL'] = r'hii\\\haha'
         os.environ['BROL1'] = """'hii
 haa'"""
 

--- a/test/tests/functional/pbs_job_array_comment.py
+++ b/test/tests/functional/pbs_job_array_comment.py
@@ -62,7 +62,7 @@ class TestJobArrayComment(TestFunctional):
             "import re\n"
             "e = pbs.event()\n"
             "jid = str(e.job.id)\n"
-            "if re.match(r'[0-9]*\[[057]\]', jid):\n"
+            r"if re.match(r'[0-9]*\[[057]\]', jid):\n"
             "    e.job.delete()\n"
             "    e.reject()\n"
             "else:\n"

--- a/test/tests/functional/pbs_maintenance_reservations.py
+++ b/test/tests/functional/pbs_maintenance_reservations.py
@@ -447,12 +447,13 @@ class TestMaintenanceReservations(TestFunctional):
         if _mom.is_cpuset_mom():
             n = self.server.status(NODE)
             cpuset_nodes = [i['id'] for i in n if i['Mom'] == _mom.hostname]
-            reg_str = '\(%s\[0\]:ncpus=[0-9]+\)' % _host
+            reg_str = r'\(%s\[0\]:ncpus=[0-9]+\)' % _host
             if (len(cpuset_nodes) - 1) > 1:
-                for i in range(1, len(cpuset_nodes)-1):
-                    reg_str += '\+' + '\(%s\[%s\]:ncpus=[0-9]+\)' % (_host, i)
+                for i in range(1, len(cpuset_nodes) - 1):
+                    reg_str += r'\+' + \
+                        r'\(%s\[%s\]:ncpus=[0-9]+\)' % (_host, i)
         else:
-            reg_str = "\(%s:ncpus=[0-9]+\)" % _host
+            reg_str = r"\(%s:ncpus=[0-9]+\)" % _host
         return reg_str
 
     @requirements(num_moms=2)
@@ -479,14 +480,14 @@ class TestMaintenanceReservations(TestFunctional):
 
         rid = self.server.submit(r)
 
-        possibility1 = reg_expr_hostA + '\+' + reg_expr_hostB
-        possibility2 = reg_expr_hostB + '\+' + reg_expr_hostA
+        possibility1 = reg_expr_hostA + r'\+' + reg_expr_hostB
+        possibility2 = reg_expr_hostB + r'\+' + reg_expr_hostA
 
         resv_nodes_re = "%s|%s" % (possibility1, possibility2)
 
-        possibility1 = "host=%s:ncpus=[0-9]+\+host=%s:ncpus=[0-9]+" \
+        possibility1 = r"host=%s:ncpus=[0-9]+\+host=%s:ncpus=[0-9]+" \
                        % (self.momA.shortname, self.momB.shortname)
-        possibility2 = "host=%s:ncpus=[0-9]+\+host=%s:ncpus=[0-9]+" \
+        possibility2 = r"host=%s:ncpus=[0-9]+\+host=%s:ncpus=[0-9]+" \
                        % (self.momB.shortname, self.momA.shortname)
         select_re = "%s|%s" % (possibility1, possibility2)
 

--- a/test/tests/functional/pbs_node_rampdown.py
+++ b/test/tests/functional/pbs_node_rampdown.py
@@ -197,28 +197,28 @@ class TestPbsNodeRampDown(TestFunctional):
             regexp=True, n="ALL", starttime=self.stime)
 
         self.server.accounting_match(
-            msg=".*%s;%s.*Resource_List\.mem=%s.*" % (atype, jid, mem),
+            msg=r".*%s;%s.*Resource_List\.mem=%s.*" % (atype, jid, mem),
             regexp=True, n="ALL", starttime=self.stime)
 
         self.server.accounting_match(
-            msg=".*%s;%s.*Resource_List\.ncpus=%d.*" % (atype, jid, ncpus),
+            msg=r".*%s;%s.*Resource_List\.ncpus=%d.*" % (atype, jid, ncpus),
             regexp=True, n="ALL", starttime=self.stime)
 
         self.server.accounting_match(
-            msg=".*%s;%s.*Resource_List\.nodect=%d.*" % (atype, jid, nodect),
+            msg=r".*%s;%s.*Resource_List\.nodect=%d.*" % (atype, jid, nodect),
             regexp=True, n="ALL", starttime=self.stime)
 
         self.server.accounting_match(
-            msg=".*%s;%s.*Resource_List\.place=%s.*" % (atype, jid, place),
+            msg=r".*%s;%s.*Resource_List\.place=%s.*" % (atype, jid, place),
             regexp=True, n="ALL", starttime=self.stime)
 
         self.server.accounting_match(
-            msg=".*%s;%s.*Resource_List\.select=%s.*" % (atype, jid, select),
+            msg=r".*%s;%s.*Resource_List\.select=%s.*" % (atype, jid, select),
             regexp=True, n="ALL", starttime=self.stime)
 
         if atype != 'c':
             self.server.accounting_match(
-                msg=".*%s;%s.*resources_used\..*" % (atype, jid),
+                msg=r".*%s;%s.*resources_used\..*" % (atype, jid),
                 regexp=True, n="ALL", starttime=self.stime)
 
     def match_vnode_status(self, vnode_list, state, jobs=None, ncpus=None,
@@ -388,20 +388,21 @@ return i\\n return fib(i-1) + fib(i-2)\\n\\nprint(fib(400))\\\")"'
             "%s:ncpus=1)+" % (self.n6,) + \
             "(%s:ncpus=2:mem=2097152kb)" % (self.n7,)
 
-        self.job1_sel_esc = self.job1_select.replace("+", "\+")
+        self.job1_sel_esc = self.job1_select.replace("+", r"\+")
         self.job1_exec_host_esc = self.job1_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+            "+", r"\+")
         self.job1_exec_vnode_esc = self.job1_exec_vnode.replace(
-            "[", "\[").replace("]", "\]").replace("(", "\(").replace(
-            ")", "\)").replace("+", "\+")
+            "[", r"\[").replace("]", r"\]").replace("(", r"\(").replace(
+            ")", r"\)").replace("+", r"\+")
         self.job1_newsel = self.transform_select(self.job1_select.split(
             '+')[0])
         self.job1_new_exec_host = self.job1_exec_host.split('+')[0]
         self.job1_new_exec_vnode = self.job1_exec_vnode.split(')')[0] + ')'
         self.job1_new_exec_vnode_esc = \
-            self.job1_new_exec_vnode.replace("[", "\[").replace(
-                "]", "\]").replace("(", "\(").replace(")", "\)").replace(
-                "+", "\+")
+            self.job1_new_exec_vnode.replace("[", r"\[").replace(
+                "]", r"\]").replace("(", r"\(").replace(")", r"\)").replace(
+                "+", r"\+")
 
         self.script['job1'] = \
             "#PBS -S /bin/bash\n" \
@@ -545,13 +546,13 @@ return i\\n return fib(i-1) + fib(i-2)\\n\\nprint(fib(400))\\\")"'
             "%s:ncpus=1)+" % (self.n6,) + \
             "(%s:ncpus=1:mem=1048576kb)" % (self.n7,)
         self.job11x_exec_vnode_match = \
-            "\(.+:mem=1048576kb:ncpus=1\+" + \
-            ".+:mem=1048576kb:ncpus=1\+" + \
-            ".+:ncpus=1\)\+" + \
-            "\(.+:mem=1048576kb:ncpus=1\+" + \
-            ".+:mem=1048576kb:ncpus=1\+" + \
-            ".+:ncpus=1\)\+" + \
-            "\(.+:ncpus=1:mem=1048576kb\)"
+            r"\(.+:mem=1048576kb:ncpus=1\+" + \
+            r".+:mem=1048576kb:ncpus=1\+" + \
+            r".+:ncpus=1\)\+" + \
+            r"\(.+:mem=1048576kb:ncpus=1\+" + \
+            r".+:mem=1048576kb:ncpus=1\+" + \
+            r".+:ncpus=1\)\+" + \
+            r"\(.+:ncpus=1:mem=1048576kb\)"
         self.script['job11x'] = \
             "#PBS -S /bin/bash\n" \
             "#PBS -l select=" + self.job11x_select + "\n" + \
@@ -691,26 +692,29 @@ return i\\n return fib(i-1) + fib(i-2)\\n\\nprint(fib(400))\\\")"'
 
         # Verify remaining job resources.
 
-        sel_esc = self.job1_select.replace("+", "\+")
+        sel_esc = self.job1_select.replace("+", r"\+")
         exec_host_esc = self.job1_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
-        exec_vnode_esc = self.job1_exec_vnode.replace("[", "\[").replace(
-            "]", "\]").replace("(", "\(").replace(")", "\)").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
+        exec_vnode_esc = self.job1_exec_vnode.replace("[", r"\[").replace(
+            "]", r"\]").replace("(", r"\(").replace(")", r"\)").replace(
+                    "+", r"\+")
         newsel = "1:mem=2097152kb:ncpus=3+1:mem=1048576kb:ncpus=1"
-        newsel_esc = newsel.replace("+", "\+")
+        newsel_esc = newsel.replace("+", r"\+")
         new_exec_host = self.job1_exec_host.replace(
             "+%s/0*2" % (self.n7,), "")
         new_exec_host_esc = new_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         new_exec_vnode = self.job1_exec_vnode.replace(
             "+%s:mem=1048576kb:ncpus=1" % (self.n5,), "")
         new_exec_vnode = new_exec_vnode.replace(
             "+%s:ncpus=1" % (self.n6,), "")
         new_exec_vnode = new_exec_vnode.replace(
             "+(%s:ncpus=2:mem=2097152kb)" % (self.n7,), "")
-        new_exec_vnode_esc = new_exec_vnode.replace("[", "\[").replace(
-            "]", "\]").replace(
-            "(", "\(").replace(")", "\)").replace("+", "\+")
+        new_exec_vnode_esc = new_exec_vnode.replace("[", r"\[").replace(
+            "]", r"\]").replace(
+            "(", r"\(").replace(")", r"\)").replace("+", r"\+")
         self.server.expect(JOB, {'job_state': 'R',
                                  'Resource_List.mem': '3gb',
                                  'Resource_List.ncpus': 4,
@@ -2433,15 +2437,16 @@ pbs.event().job.release_nodes_on_stageout=False
         # Verify remaining job resources.
         newsel = "1:mem=2097152kb:ncpus=3+1:mem=1048576kb:ncpus=2+" + \
                  "1:ncpus=2:mem=2097152kb"
-        newsel_esc = newsel.replace("+", "\+")
+        newsel_esc = newsel.replace("+", r"\+")
         new_exec_host = self.job1_exec_host
         new_exec_host_esc = self.job1_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         new_exec_vnode = self.job1_exec_vnode.replace(
             "%s:mem=1048576kb:ncpus=1+" % (self.n4,), "")
         new_exec_vnode_esc = new_exec_vnode.replace(
-            "[", "\[").replace("]", "\]").replace(
-            "(", "\(").replace(")", "\)").replace("+", "\+")
+            "[", r"\[").replace("]", r"\]").replace(
+            "(", r"\(").replace(")", r"\)").replace("+", r"\+")
         self.server.expect(JOB, {'job_state': 'R',
                                  'Resource_List.mem': '5gb',
                                  'Resource_List.ncpus': 7,
@@ -2563,15 +2568,16 @@ pbs.event().job.release_nodes_on_stageout=False
         # Verify remaining job resources.
         newsel = "1:mem=2097152kb:ncpus=3+1:mem=1048576kb:ncpus=2+" + \
                  "1:ncpus=2:mem=2097152kb"
-        newsel_esc = newsel.replace("+", "\+")
+        newsel_esc = newsel.replace("+", r"\+")
         new_exec_host = self.job1_exec_host
         new_exec_host_esc = self.job1_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         new_exec_vnode = self.job1_exec_vnode.replace(
             "%s:mem=1048576kb:ncpus=1+" % (self.n4,), "")
         new_exec_vnode_esc = new_exec_vnode.replace(
-            "[", "\[").replace("]", "\]").replace(
-            "(", "\(").replace(")", "\)").replace("+", "\+")
+            "[", r"\[").replace("]", r"\]").replace(
+            "(", r"\(").replace(")", r"\)").replace("+", r"\+")
         self.server.expect(JOB, {'job_state': 'R',
                                  'Resource_List.mem': '5gb',
                                  'Resource_List.ncpus': 7,
@@ -2715,27 +2721,29 @@ pbs.event().job.release_nodes_on_stageout=False
                             existence=False, max_attempts=5, interval=1)
 
         # Verify remaining job resources.
-        sel_esc = self.job1_extra_res_select.replace("+", "\+")
+        sel_esc = self.job1_extra_res_select.replace("+", r"\+")
         exec_host_esc = self.job1_extra_res_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+            "+", r"\+")
         exec_vnode_esc = \
             self.job1_extra_res_exec_vnode.replace(
-                "[", "\[").replace(
-                "]", "\]").replace("(", "\(").replace(")", "\)").replace(
-                "+", "\+")
+                "[", r"\[").replace(
+                "]", r"\]").replace("(", r"\(").replace(")", r"\)").replace(
+                "+", r"\+")
 
         newsel = "1:mem=2097152kb:ncpus=3:mpiprocs=3:ompthreads=2+" + \
             "1:mem=1048576kb:ncpus=2:mpiprocs=3:ompthreads=3+" + \
             "1:ncpus=2:mem=2097152kb:mpiprocs=2:ompthreads=2"
-        newsel_esc = newsel.replace("+", "\+")
+        newsel_esc = newsel.replace("+", r"\+")
         new_exec_host = self.job1_extra_res_exec_host
         new_exec_host_esc = self.job1_extra_res_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+            "+", r"\+")
         new_exec_vnode = self.job1_extra_res_exec_vnode.replace(
             "%s:mem=1048576kb:ncpus=1+" % (self.n4,), "")
-        new_exec_vnode_esc = new_exec_vnode.replace("[", "\[").replace(
-            "]", "\]").replace(
-            "(", "\(").replace(")", "\)").replace("+", "\+")
+        new_exec_vnode_esc = new_exec_vnode.replace("[", r"\[").replace(
+            "]", r"\]").replace(
+            "(", r"\(").replace(")", r"\)").replace("+", r"\+")
         self.server.expect(JOB,
                            {'job_state': 'R',
                             'Resource_List.mem': '5gb',
@@ -2884,20 +2892,23 @@ pbs.event().job.release_nodes_on_stageout=False
 
         # Verify remaining job resources.
         exec_host_esc = self.job1_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
-        exec_vnode_esc = self.job1_exec_vnode.replace("[", "\[").replace(
-            "]", "\]").replace("(", "\(").replace(")", "\)").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+            "+", r"\+")
+        exec_vnode_esc = self.job1_exec_vnode.replace("[", r"\[").replace(
+            "]", r"\]").replace("(", r"\(").replace(")", r"\)").replace(
+            "+", r"\+")
         newsel = "1:mem=2097152kb:ncpus=3+1:mem=1048576kb:ncpus=2+" + \
                  "1:ncpus=2:mem=2097152kb"
-        newsel_esc = newsel.replace("+", "\+")
+        newsel_esc = newsel.replace("+", r"\+")
         new_exec_host = self.job1_exec_host
         new_exec_host_esc = self.job1_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+            "+", r"\+")
         new_exec_vnode = self.job1_exec_vnode.replace(
             "%s:mem=1048576kb:ncpus=1+" % (self.n5,), "")
         new_exec_vnode_esc = new_exec_vnode.replace(
-            "[", "\[").replace("]", "\]").replace(
-            "(", "\(").replace(")", "\)").replace("+", "\+")
+            "[", r"\[").replace("]", r"\]").replace(
+            "(", r"\(").replace(")", r"\)").replace("+", r"\+")
         self.server.expect(JOB, {'job_state': 'R',
                                  'Resource_List.mem': '5gb',
                                  'Resource_List.ncpus': 7,
@@ -3041,25 +3052,27 @@ pbs.event().job.release_nodes_on_stageout=False
                             existence=False, max_attempts=5, interval=1)
 
         # Verify remaining job resources.
-        sel_esc = self.job1_extra_res_select.replace("+", "\+")
+        sel_esc = self.job1_extra_res_select.replace("+", r"\+")
         exec_host_esc = self.job1_extra_res_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+            "+", r"\+")
         exec_vnode_esc = self.job1_extra_res_exec_vnode.replace(
-            "[", "\[").replace("]", "\]").replace(
-            "(", "\(").replace(")", "\)").replace("+", "\+")
+            "[", r"\[").replace("]", r"\]").replace(
+            "(", r"\(").replace(")", r"\)").replace("+", r"\+")
         newsel = "1:mem=2097152kb:ncpus=3:mpiprocs=3:ompthreads=2+" + \
                  "1:mem=1048576kb:ncpus=2:mpiprocs=3:ompthreads=3+" + \
                  "1:ncpus=2:mem=2097152kb:mpiprocs=2:ompthreads=2"
 
-        newsel_esc = newsel.replace("+", "\+")
+        newsel_esc = newsel.replace("+", r"\+")
         new_exec_host = self.job1_extra_res_exec_host
         new_exec_host_esc = self.job1_extra_res_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         new_exec_vnode = self.job1_extra_res_exec_vnode.replace(
             "%s:mem=1048576kb:ncpus=1+" % (self.n5,), "")
         new_exec_vnode_esc = new_exec_vnode.replace(
-            "[", "\[").replace("]", "\]").replace(
-            "(", "\(").replace(")", "\)").replace("+", "\+")
+            "[", r"\[").replace("]", r"\]").replace(
+            "(", r"\(").replace(")", r"\)").replace("+", r"\+")
         self.server.expect(JOB,
                            {'job_state': 'R',
                             'Resource_List.mem': '5gb',
@@ -3208,22 +3221,24 @@ pbs.event().job.release_nodes_on_stageout=False
 
         # Verify remaining job resources.
         exec_host_esc = self.job1_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
-        exec_vnode_esc = self.job1_exec_vnode.replace("[", "\[").replace(
-            "]", "\]").replace("(", "\(").replace(")", "\)").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+            "+", r"\+")
+        exec_vnode_esc = self.job1_exec_vnode.replace("[", r"\[").replace(
+            "]", r"\]").replace("(", r"\(").replace(")", r"\)").replace(
+                    "+", r"\+")
 
         newsel = "1:mem=2097152kb:ncpus=3+1:mem=2097152kb:ncpus=2+" + \
                  "1:ncpus=2:mem=2097152kb"
-        newsel_esc = newsel.replace("+", "\+")
+        newsel_esc = newsel.replace("+", r"\+")
         new_exec_host = self.job1_exec_host
         new_exec_host_esc = self.job1_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace(
-            "+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+            "+", r"\+")
         new_exec_vnode = self.job1_exec_vnode.replace(
             "+%s:ncpus=1" % (self.n6,), "")
-        new_exec_vnode_esc = new_exec_vnode.replace("[", "\[").replace(
-            "]", "\]").replace(
-            "(", "\(").replace(")", "\)").replace("+", "\+")
+        new_exec_vnode_esc = new_exec_vnode.replace("[", r"\[").replace(
+            "]", r"\]").replace(
+            "(", r"\(").replace(")", r"\)").replace("+", r"\+")
         self.server.expect(JOB, {'job_state': 'R',
                                  'Resource_List.mem': '6gb',
                                  'Resource_List.ncpus': 7,
@@ -3369,25 +3384,28 @@ pbs.event().job.release_nodes_on_stageout=False
                             existence=False, max_attempts=5, interval=1)
 
         # Verify remaining job resources.
-        sel_esc = self.job1_extra_res_select.replace("+", "\+")
+        sel_esc = self.job1_extra_res_select.replace("+", r"\+")
         exec_host_esc = self.job1_extra_res_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         exec_vnode_esc = self.job1_extra_res_exec_vnode.replace(
-            "[", "\[").replace(
-            "]", "\]").replace("(", "\(").replace(")", "\)").replace("+", "\+")
+            "[", r"\[").replace(
+            "]", r"\]").replace("(", r"\(").replace(")", r"\)").replace(
+                    "+", r"\+")
 
         newsel = "1:mem=2097152kb:ncpus=3:mpiprocs=3:ompthreads=2+" + \
                  "1:mem=2097152kb:ncpus=2:mpiprocs=3:ompthreads=3+" + \
                  "1:ncpus=2:mem=2097152kb:mpiprocs=2:ompthreads=2"
-        newsel_esc = newsel.replace("+", "\+")
+        newsel_esc = newsel.replace("+", r"\+")
         new_exec_host = self.job1_extra_res_exec_host
         new_exec_host_esc = self.job1_extra_res_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+            "+", r"\+")
         new_exec_vnode = self.job1_extra_res_exec_vnode.replace(
             "+%s:ncpus=1" % (self.n6,), "")
         new_exec_vnode_esc = new_exec_vnode.replace(
-            "[", "\[").replace("]", "\]").replace(
-            "(", "\(").replace(")", "\)").replace("+", "\+")
+            "[", r"\[").replace("]", r"\]").replace(
+            "(", r"\(").replace(")", r"\)").replace("+", r"\+")
         self.server.expect(JOB,
                            {'job_state': 'R',
                             'Resource_List.mem': '6gb',
@@ -3539,18 +3557,21 @@ pbs.event().job.release_nodes_on_stageout=False
         self.assertEqual(len(self.server.pu.processes), 0)
 
         # Verify remaining job resources.
-        sel_esc = self.job1_select.replace("+", "\+")
+        sel_esc = self.job1_select.replace("+", r"\+")
         exec_host_esc = self.job1_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
-        exec_vnode_esc = self.job1_exec_vnode.replace("[", "\[").replace(
-            "]", "\]").replace("(", "\(").replace(")", "\)").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
+        exec_vnode_esc = self.job1_exec_vnode.replace("[", r"\[").replace(
+            "]", r"\]").replace("(", r"\(").replace(")", r"\)").replace(
+                    "+", r"\+")
 
         newsel = "1:mem=2097152kb:ncpus=3+1:ncpus=1"
-        newsel_esc = newsel.replace("+", "\+")
+        newsel_esc = newsel.replace("+", r"\+")
         new_exec_host = self.job1_exec_host.replace(
             "+%s/0*2" % (self.n7,), "")
         new_exec_host_esc = new_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         new_exec_vnode = self.job1_exec_vnode.replace(
             "%s:mem=1048576kb:ncpus=1+" % (self.n4,), "")
         new_exec_vnode = new_exec_vnode.replace(
@@ -3558,8 +3579,8 @@ pbs.event().job.release_nodes_on_stageout=False
         new_exec_vnode = new_exec_vnode.replace(
             "+(%s:ncpus=2:mem=2097152kb)" % (self.n7,), "")
         new_exec_vnode_esc = new_exec_vnode.replace(
-            "[", "\[").replace("]", "\]").replace(
-            "(", "\(").replace(")", "\)").replace("+", "\+")
+            "[", r"\[").replace("]", r"\]").replace(
+            "(", r"\(").replace(")", r"\)").replace("+", r"\+")
         self.server.expect(JOB, {'job_state': 'R',
                                  'Resource_List.mem': '2gb',
                                  'Resource_List.ncpus': 4,
@@ -3712,29 +3733,32 @@ pbs.event().job.release_nodes_on_stageout=False
         self.assertEqual(len(self.server.pu.processes), 0)
 
         # Verify remaining job resources.
-        sel_esc = self.job1_extra_res_select.replace("+", "\+")
+        sel_esc = self.job1_extra_res_select.replace("+", r"\+")
         exec_host_esc = self.job1_extra_res_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         exec_vnode_esc = self.job1_extra_res_exec_vnode.replace(
-            "[", "\[").replace(
-            "]", "\]").replace("(", "\(").replace(")", "\)").replace("+", "\+")
+            "[", r"\[").replace(
+            "]", r"\]").replace("(", r"\(").replace(")", r"\)").replace(
+                    "+", r"\+")
 
         newsel = "1:mem=2097152kb:ncpus=3:mpiprocs=3:ompthreads=2+" + \
                  "1:ncpus=1:mpiprocs=3:ompthreads=3"
-        newsel_esc = newsel.replace("+", "\+")
+        newsel_esc = newsel.replace("+", r"\+")
         new_exec_host = self.job1_extra_res_exec_host.replace(
             "+%s/0*2" % (self.n7,), "")
         new_exec_host_esc = new_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         new_exec_vnode = self.job1_extra_res_exec_vnode.replace(
             "%s:mem=1048576kb:ncpus=1+" % (self.n4,), "")
         new_exec_vnode = new_exec_vnode.replace(
             "%s:mem=1048576kb:ncpus=1+" % (self.n5,), "")
         new_exec_vnode = new_exec_vnode.replace(
             "+(%s:ncpus=2:mem=2097152kb)" % (self.n7,), "")
-        new_exec_vnode_esc = new_exec_vnode.replace("[", "\[").replace(
-            "]", "\]").replace(
-            "(", "\(").replace(")", "\)").replace("+", "\+")
+        new_exec_vnode_esc = new_exec_vnode.replace("[", r"\[").replace(
+            "]", r"\]").replace(
+            "(", r"\(").replace(")", r"\)").replace("+", r"\+")
         self.server.expect(JOB, {'job_state': 'R',
                                  'Resource_List.mem': '2gb',
                                  'Resource_List.ncpus': 4,
@@ -3889,18 +3913,21 @@ pbs.event().job.release_nodes_on_stageout=False
         self.assertEqual(len(self.server.pu.processes), 0)
 
         # Verify remaining job resources.
-        sel_esc = self.job1_select.replace("+", "\+")
+        sel_esc = self.job1_select.replace("+", r"\+")
         exec_host_esc = self.job1_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
-        exec_vnode_esc = self.job1_exec_vnode.replace("[", "\[").replace(
-            "]", "\]").replace("(", "\(").replace(")", "\)").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
+        exec_vnode_esc = self.job1_exec_vnode.replace("[", r"\[").replace(
+            "]", r"\]").replace("(", r"\(").replace(")", r"\)").replace(
+                    "+", r"\+")
         newsel = "1:mem=2097152kb:ncpus=3+1:mem=1048576kb:ncpus=1"
 
-        newsel_esc = newsel.replace("+", "\+")
+        newsel_esc = newsel.replace("+", r"\+")
         new_exec_host = self.job1_exec_host.replace(
             "+%s/0*2" % (self.n7,), "")
         new_exec_host_esc = new_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         new_exec_vnode = self.job1_exec_vnode.replace(
             "+%s:mem=1048576kb:ncpus=1" % (self.n5,), "")
         new_exec_vnode = new_exec_vnode.replace(
@@ -3908,8 +3935,8 @@ pbs.event().job.release_nodes_on_stageout=False
         new_exec_vnode = new_exec_vnode.replace(
             "+(%s:ncpus=2:mem=2097152kb)" % (self.n7,), "")
         new_exec_vnode_esc = \
-            new_exec_vnode.replace("[", "\[").replace("]", "\]").replace(
-                "(", "\(").replace(")", "\)").replace("+", "\+")
+            new_exec_vnode.replace("[", r"\[").replace("]", r"\]").replace(
+                "(", r"\(").replace(")", r"\)").replace("+", r"\+")
         self.server.expect(JOB, {'job_state': 'R',
                                  'Resource_List.mem': '3gb',
                                  'Resource_List.ncpus': 4,
@@ -4066,22 +4093,24 @@ pbs.event().job.release_nodes_on_stageout=False
         self.assertEqual(len(self.server.pu.processes), 0)
 
         # Verify remaining job resources.
-        sel_esc = self.job1_extra_res_select.replace("+", "\+")
+        sel_esc = self.job1_extra_res_select.replace("+", r"\+")
         exec_host_esc = self.job1_extra_res_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         exec_vnode_esc = \
-            self.job1_extra_res_exec_vnode.replace("[", "\[").replace(
-                "]", "\]").replace("(", "\(").replace(")", "\)").replace(
-                "+", "\+")
+            self.job1_extra_res_exec_vnode.replace("[", r"\[").replace(
+                "]", r"\]").replace("(", r"\(").replace(")", r"\)").replace(
+                "+", r"\+")
         newsel = \
             "1:mem=2097152kb:ncpus=3:mpiprocs=3:ompthreads=2+" + \
             "1:mem=1048576kb:ncpus=1:mpiprocs=3:ompthreads=3"
 
-        newsel_esc = newsel.replace("+", "\+")
+        newsel_esc = newsel.replace("+", r"\+")
         new_exec_host = self.job1_extra_res_exec_host.replace(
             "+%s/0*2" % (self.n7,), "")
         new_exec_host_esc = new_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         new_exec_vnode = self.job1_extra_res_exec_vnode.replace(
             "+%s:mem=1048576kb:ncpus=1" % (self.n5,), "")
         new_exec_vnode = new_exec_vnode.replace(
@@ -4089,8 +4118,8 @@ pbs.event().job.release_nodes_on_stageout=False
         new_exec_vnode = new_exec_vnode.replace(
             "+(%s:ncpus=2:mem=2097152kb)" % (self.n7,), "")
         new_exec_vnode_esc = \
-            new_exec_vnode.replace("[", "\[").replace("]", "\]").replace(
-                "(", "\(").replace(")", "\)").replace("+", "\+")
+            new_exec_vnode.replace("[", r"\[").replace("]", r"\]").replace(
+                "(", r"\(").replace(")", r"\)").replace("+", r"\+")
         self.server.expect(JOB, {'job_state': 'R',
                                  'Resource_List.mem': '3gb',
                                  'Resource_List.ncpus': 4,
@@ -4378,20 +4407,22 @@ pbs.event().job.release_nodes_on_stageout=False
         self.assertEqual(len(self.server.pu.processes), 0)
 
         # Verify remaining job resources.
-        sel_esc = self.job1_extra_res_select.replace("+", "\+")
+        sel_esc = self.job1_extra_res_select.replace("+", r"\+")
         exec_host_esc = self.job1_extra_res_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         exec_vnode_esc = \
-            self.job1_extra_res_exec_vnode.replace("[", "\[").replace(
-                "]", "\]").replace(
-                "(", "\(").replace(")", "\)").replace("+", "\+")
+            self.job1_extra_res_exec_vnode.replace("[", r"\[").replace(
+                "]", r"\]").replace(
+                "(", r"\(").replace(")", r"\)").replace("+", r"\+")
         newsel = "1:mem=2097152kb:ncpus=3:mpiprocs=3:ompthreads=2"
-        newsel_esc = newsel.replace("+", "\+")
+        newsel_esc = newsel.replace("+", r"\+")
         new_exec_host = self.job1_extra_res_exec_host.replace(
             "+%s/0*2" % (self.n7,), "")
         new_exec_host = new_exec_host.replace("+%s/0*0" % (self.n4,), "")
         new_exec_host_esc = new_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         new_exec_vnode = self.job1_extra_res_exec_vnode.replace(
             "+%s:mem=1048576kb:ncpus=1" % (self.n5,), "")
         new_exec_vnode = new_exec_vnode.replace(
@@ -4401,8 +4432,8 @@ pbs.event().job.release_nodes_on_stageout=False
         new_exec_vnode = new_exec_vnode.replace(
             "+(%s:ncpus=2:mem=2097152kb)" % (self.n7,), "")
         new_exec_vnode_esc = \
-            new_exec_vnode.replace("[", "\[").replace("]", "\]").replace(
-                "(", "\(").replace(")", "\)").replace("+", "\+")
+            new_exec_vnode.replace("[", r"\[").replace("]", r"\]").replace(
+                "(", r"\(").replace(")", r"\)").replace("+", r"\+")
         self.server.expect(JOB,
                            {'job_state': 'R',
                             'Resource_List.mem': '2gb',
@@ -4555,22 +4586,25 @@ pbs.event().job.release_nodes_on_stageout=False
 
         # Verify remaining job resources.
 
-        sel_esc = self.job1_select.replace("+", "\+")
+        sel_esc = self.job1_select.replace("+", r"\+")
         exec_host_esc = self.job1_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
-        exec_vnode_esc = self.job1_exec_vnode.replace("[", "\[").replace(
-            "]", "\]").replace("(", "\(").replace(")", "\)").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
+        exec_vnode_esc = self.job1_exec_vnode.replace("[", r"\[").replace(
+            "]", r"\]").replace("(", r"\(").replace(")", r"\)").replace(
+                    "+", r"\+")
 
         newsel = "1:mem=2097152kb:ncpus=3+1:mem=2097152kb:ncpus=3"
-        newsel_esc = newsel.replace("+", "\+")
+        newsel_esc = newsel.replace("+", r"\+")
         new_exec_host = "%s/0*0+%s/0*0" % (self.n0, self.hostB)
         new_exec_host_esc = new_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         new_exec_vnode = self.job1_exec_vnode.replace(
             "+(%s:ncpus=2:mem=2097152kb)" % (self.n7,), "")
         new_exec_vnode_esc = new_exec_vnode.replace(
-            "[", "\[").replace("]", "\]").replace(
-            "(", "\(").replace(")", "\)").replace("+", "\+")
+            "[", r"\[").replace("]", r"\]").replace(
+            "(", r"\(").replace(")", r"\)").replace("+", r"\+")
         self.server.expect(JOB, {'job_state': 'R',
                                  'Resource_List.mem': '4194304kb',
                                  'Resource_List.ncpus': 6,
@@ -4619,21 +4653,24 @@ pbs.event().job.release_nodes_on_stageout=False
 
         # Verify remaining job resources.
 
-        sel_esc = self.job1_select.replace("+", "\+")
+        sel_esc = self.job1_select.replace("+", r"\+")
         exec_host_esc = self.job1_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
-        exec_vnode_esc = self.job1_exec_vnode.replace("[", "\[").replace(
-            "]", "\]").replace("(", "\(").replace(")", "\)").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
+        exec_vnode_esc = self.job1_exec_vnode.replace("[", r"\[").replace(
+            "]", r"\]").replace("(", r"\(").replace(")", r"\)").replace(
+                    "+", r"\+")
         newsel = self.transform_select(self.job1_select.split('+')[0])
-        newsel_esc = newsel.replace("+", "\+")
+        newsel_esc = newsel.replace("+", r"\+")
 
         new_exec_host = self.job1_exec_host.split('+')[0]
         new_exec_host_esc = new_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         new_exec_vnode = self.job1_exec_vnode.split(')')[0] + ')'
-        new_exec_vnode_esc = new_exec_vnode.replace("[", "\[").replace(
-            "]", "\]").replace("(", "\(").replace(")", "\)").replace(
-            "+", "\+")
+        new_exec_vnode_esc = new_exec_vnode.replace("[", r"\[").replace(
+            "]", r"\]").replace("(", r"\(").replace(")", r"\)").replace(
+            "+", r"\+")
         self.server.expect(JOB, {'job_state': 'E',
                                  'Resource_List.mem': '2gb',
                                  'Resource_List.ncpus': 3,
@@ -4778,24 +4815,27 @@ pbs.event().job.release_nodes_on_stageout=False
 
         # Verify remaining job resources.
 
-        sel_esc = self.job1_select.replace("+", "\+")
+        sel_esc = self.job1_select.replace("+", r"\+")
         exec_host_esc = self.job1_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
-        exec_vnode_esc = self.job1_exec_vnode.replace("[", "\[").replace(
-            "]", "\]").replace("(", "\(").replace(")", "\)").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
+        exec_vnode_esc = self.job1_exec_vnode.replace("[", r"\[").replace(
+            "]", r"\]").replace("(", r"\(").replace(")", r"\)").replace(
+                    "+", r"\+")
 
         newsel = "1:mem=2097152kb:ncpus=3+1:mem=1048576kb:ncpus=2+" + \
                  "1:ncpus=2:mem=2097152kb"
-        newsel_esc = newsel.replace("+", "\+")
+        newsel_esc = newsel.replace("+", r"\+")
         new_exec_host = self.job1_exec_host
         new_exec_host_esc = self.job1_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         new_exec_vnode = self.job1_exec_vnode.replace(
             "%s:mem=1048576kb:ncpus=1+" % (self.n4,), "")
         new_exec_vnode_esc = \
-            new_exec_vnode.replace("[", "\[").replace(
-                "]", "\]").replace("(", "\(").replace(
-                ")", "\)").replace("+", "\+")
+            new_exec_vnode.replace("[", r"\[").replace(
+                "]", r"\]").replace("(", r"\(").replace(
+                ")", r"\)").replace("+", r"\+")
         self.server.expect(JOB, {'job_state': 'R',
                                  'Resource_List.mem': '5gb',
                                  'Resource_List.ncpus': 7,
@@ -4873,11 +4913,12 @@ pbs.event().job.release_nodes_on_stageout=False
 
         # Verify remaining job resources.
         newsel = "1:mem=2097152kb:ncpus=3"
-        newsel_esc = newsel.replace("+", "\+")
+        newsel_esc = newsel.replace("+", r"\+")
         new_exec_host = new_exec_host.replace("+%s/0*2" % (self.n7,), "")
         new_exec_host = new_exec_host.replace("+%s/0*0" % (self.n4,), "")
         new_exec_host_esc = new_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         new_exec_vnode = new_exec_vnode.replace(
             "+(%s:mem=1048576kb:ncpus=1" % (self.n5,), "")
         new_exec_vnode = new_exec_vnode.replace(
@@ -4885,8 +4926,8 @@ pbs.event().job.release_nodes_on_stageout=False
         new_exec_vnode = new_exec_vnode.replace(
             "+(%s:ncpus=2:mem=2097152kb)" % (self.n7,), "")
         new_exec_vnode_esc = new_exec_vnode.replace(
-            "[", "\[").replace("]", "\]").replace(
-            "(", "\(").replace(")", "\)").replace("+", "\+")
+            "[", r"\[").replace("]", r"\]").replace(
+            "(", r"\(").replace(")", r"\)").replace("+", r"\+")
         self.server.expect(JOB, {'job_state': 'R',
                                  'Resource_List.mem': '2gb',
                                  'Resource_List.ncpus': 3,
@@ -5226,26 +5267,29 @@ pbs.logjobmsg(pbs.event().job.id, "epilogue hook executed")
 
         # Verify remaining job resources.
 
-        sel_esc = self.job11x_select.replace("+", "\+")
+        sel_esc = self.job11x_select.replace("+", r"\+")
         exec_host_esc = self.job11x_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
-        exec_vnode_esc = self.job11x_exec_vnode.replace("[", "\[").replace(
-            "]", "\]").replace("(", "\(").replace(")", "\)").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
+        exec_vnode_esc = self.job11x_exec_vnode.replace("[", r"\[").replace(
+            "]", r"\]").replace("(", r"\(").replace(")", r"\)").replace(
+                    "+", r"\+")
         newsel = "1:mem=2097152kb:ncpus=3+1:ncpus=1"
-        newsel_esc = newsel.replace("+", "\+")
+        newsel_esc = newsel.replace("+", r"\+")
         new_exec_host = self.job11x_exec_host.replace(
             "+%s/0" % (self.n7,), "")
         new_exec_host_esc = new_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         new_exec_vnode = self.job11x_exec_vnode.replace(
             "%s:mem=1048576kb:ncpus=1+" % (self.n4,), "")
         new_exec_vnode = new_exec_vnode.replace(
             "%s:mem=1048576kb:ncpus=1+" % (self.n5), "")
         new_exec_vnode = new_exec_vnode.replace(
             "+(%s:ncpus=1:mem=1048576kb)" % (self.n7,), "")
-        new_exec_vnode_esc = new_exec_vnode.replace("[", "\[").replace(
-            "]", "\]").replace(
-            "(", "\(").replace(")", "\)").replace("+", "\+")
+        new_exec_vnode_esc = new_exec_vnode.replace("[", r"\[").replace(
+            "]", r"\]").replace(
+            "(", r"\(").replace(")", r"\)").replace("+", r"\+")
         self.server.expect(JOB, {'job_state': 'R',
                                  'Resource_List.mem': '2gb',
                                  'Resource_List.ncpus': 4,
@@ -5483,26 +5527,29 @@ pbs.logjobmsg(pbs.event().job.id, "epilogue hook executed")
 
         # Verify remaining job resources.
 
-        sel_esc = self.job11x_select.replace("+", "\+")
+        sel_esc = self.job11x_select.replace("+", r"\+")
         exec_host_esc = self.job11x_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
-        exec_vnode_esc = self.job11x_exec_vnode.replace("[", "\[").replace(
-            "]", "\]").replace("(", "\(").replace(")", "\)").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
+        exec_vnode_esc = self.job11x_exec_vnode.replace("[", r"\[").replace(
+            "]", r"\]").replace("(", r"\(").replace(")", r"\)").replace(
+                    "+", r"\+")
         newsel = "1:mem=2097152kb:ncpus=3+1:ncpus=1"
-        newsel_esc = newsel.replace("+", "\+")
+        newsel_esc = newsel.replace("+", r"\+")
         new_exec_host = self.job11x_exec_host.replace(
             "+%s/0" % (self.n7,), "")
         new_exec_host_esc = new_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         new_exec_vnode = self.job11x_exec_vnode.replace(
             "%s:mem=1048576kb:ncpus=1+" % (self.n4,), "")
         new_exec_vnode = new_exec_vnode.replace(
             "%s:mem=1048576kb:ncpus=1+" % (self.n5), "")
         new_exec_vnode = new_exec_vnode.replace(
             "+(%s:ncpus=1:mem=1048576kb)" % (self.n7,), "")
-        new_exec_vnode_esc = new_exec_vnode.replace("[", "\[").replace(
-            "]", "\]").replace(
-            "(", "\(").replace(")", "\)").replace("+", "\+")
+        new_exec_vnode_esc = new_exec_vnode.replace("[", r"\[").replace(
+            "]", r"\]").replace(
+            "(", r"\(").replace(")", r"\)").replace("+", r"\+")
         self.server.expect(JOB, {'job_state': 'R',
                                  'Resource_List.mem': '2gb',
                                  'Resource_List.ncpus': 4,
@@ -5680,26 +5727,29 @@ pbs.logjobmsg(pbs.event().job.id, "epilogue hook executed")
 
         # Verify remaining job resources.
 
-        sel_esc = self.job11x_select.replace("+", "\+")
+        sel_esc = self.job11x_select.replace("+", r"\+")
         exec_host_esc = self.job11x_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
-        exec_vnode_esc = self.job11x_exec_vnode.replace("[", "\[").replace(
-            "]", "\]").replace("(", "\(").replace(")", "\)").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
+        exec_vnode_esc = self.job11x_exec_vnode.replace("[", r"\[").replace(
+            "]", r"\]").replace("(", r"\(").replace(")", r"\)").replace(
+                    "+", r"\+")
         newsel = "1:mem=2097152kb:ncpus=3+1:ncpus=1"
-        newsel_esc = newsel.replace("+", "\+")
+        newsel_esc = newsel.replace("+", r"\+")
         new_exec_host = self.job11x_exec_host.replace(
             "+%s/0" % (self.n7,), "")
         new_exec_host_esc = new_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         new_exec_vnode = self.job11x_exec_vnode.replace(
             "%s:mem=1048576kb:ncpus=1+" % (self.n4,), "")
         new_exec_vnode = new_exec_vnode.replace(
             "%s:mem=1048576kb:ncpus=1+" % (self.n5), "")
         new_exec_vnode = new_exec_vnode.replace(
             "+(%s:ncpus=1:mem=1048576kb)" % (self.n7,), "")
-        new_exec_vnode_esc = new_exec_vnode.replace("[", "\[").replace(
-            "]", "\]").replace(
-            "(", "\(").replace(")", "\)").replace("+", "\+")
+        new_exec_vnode_esc = new_exec_vnode.replace("[", r"\[").replace(
+            "]", r"\]").replace(
+            "(", r"\(").replace(")", r"\)").replace("+", r"\+")
         self.server.expect(JOB, {'job_state': 'R',
                                  'Resource_List.mem': '2gb',
                                  'Resource_List.ncpus': 4,
@@ -5847,26 +5897,29 @@ pbs.logjobmsg(pbs.event().job.id, "epilogue hook executed")
                             existence=False, max_attempts=5, interval=1)
 
         # Verify remaining job resources.
-        sel_esc = self.job11_select.replace("+", "\+")
+        sel_esc = self.job11_select.replace("+", r"\+")
         exec_host_esc = self.job11_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
-        exec_vnode_esc = self.job11_exec_vnode.replace("[", "\[").replace(
-            "]", "\]").replace("(", "\(").replace(")", "\)").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
+        exec_vnode_esc = self.job11_exec_vnode.replace("[", r"\[").replace(
+            "]", r"\]").replace("(", r"\(").replace(")", r"\)").replace(
+                    "+", r"\+")
         newsel = "1:mem=2097152kb:ncpus=3+1:ncpus=1"
-        newsel_esc = newsel.replace("+", "\+")
+        newsel_esc = newsel.replace("+", r"\+")
         new_exec_host = self.job11_exec_host.replace(
             "+%s/0" % (self.n7,), "")
         new_exec_host_esc = new_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         new_exec_vnode = self.job11_exec_vnode.replace(
             "%s:mem=1048576kb:ncpus=1+" % (self.n4,), "")
         new_exec_vnode = new_exec_vnode.replace(
             "%s:mem=1048576kb:ncpus=1+" % (self.n5,), "")
         new_exec_vnode = new_exec_vnode.replace(
             "+(%s:ncpus=1:mem=1048576kb)" % (self.n7,), "")
-        new_exec_vnode_esc = new_exec_vnode.replace("[", "\[").replace(
-            "]", "\]").replace(
-            "(", "\(").replace(")", "\)").replace("+", "\+")
+        new_exec_vnode_esc = new_exec_vnode.replace("[", r"\[").replace(
+            "]", r"\]").replace(
+            "(", r"\(").replace(")", r"\)").replace("+", r"\+")
         self.server.expect(JOB, {'job_state': 'R',
                                  'Resource_List.mem': '2gb',
                                  'Resource_List.ncpus': 4,
@@ -6024,17 +6077,20 @@ pbs.logjobmsg(pbs.event().job.id, "epilogue hook executed")
                             existence=False, max_attempts=5, interval=1)
 
         # Verify remaining job resources.
-        sel_esc = self.job11_select.replace("+", "\+")
+        sel_esc = self.job11_select.replace("+", r"\+")
         exec_host_esc = self.job11_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
-        exec_vnode_esc = self.job11_exec_vnode.replace("[", "\[").replace(
-            "]", "\]").replace("(", "\(").replace(")", "\)").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
+        exec_vnode_esc = self.job11_exec_vnode.replace("[", r"\[").replace(
+            "]", r"\]").replace("(", r"\(").replace(")", r"\)").replace(
+                    "+", r"\+")
         newsel = "1:mem=2097152kb:ncpus=3+1:ncpus=1"
-        newsel_esc = newsel.replace("+", "\+")
+        newsel_esc = newsel.replace("+", r"\+")
         new_exec_host = self.job11_exec_host.replace(
             "+%s/0" % (self.n7,), "")
         new_exec_host_esc = new_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         new_exec_vnode = self.job11_exec_vnode.replace(
             "%s:mem=1048576kb:ncpus=1+" % (self.n4,), "")
         new_exec_vnode = new_exec_vnode.replace(
@@ -6042,8 +6098,8 @@ pbs.logjobmsg(pbs.event().job.id, "epilogue hook executed")
         new_exec_vnode = new_exec_vnode.replace(
             "+(%s:ncpus=1:mem=1048576kb)" % (self.n7,), "")
         new_exec_vnode_esc = new_exec_vnode.replace(
-            "[", "\[").replace("]", "\]").replace(
-            "(", "\(").replace(")", "\)").replace("+", "\+")
+            "[", r"\[").replace("]", r"\]").replace(
+            "(", r"\(").replace(")", r"\)").replace("+", r"\+")
         # job's substate is 41 (PRERUN) since MS mom is stopped
         self.server.expect(JOB, {'job_state': 'R',
                                  'Resource_List.mem': '2gb',
@@ -6186,18 +6242,21 @@ pbs.logjobmsg(pbs.event().job.id, "epilogue hook executed")
                             max_attempts=5, existence=False, interval=1)
 
         # Verify remaining job resources.
-        sel_esc = self.job1_select.replace("+", "\+")
+        sel_esc = self.job1_select.replace("+", r"\+")
         exec_host_esc = self.job1_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
-        exec_vnode_esc = self.job1_exec_vnode.replace("[", "\[").replace(
-            "]", "\]").replace("(", "\(").replace(")", "\)").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
+        exec_vnode_esc = self.job1_exec_vnode.replace("[", r"\[").replace(
+            "]", r"\]").replace("(", r"\(").replace(")", r"\)").replace(
+                    "+", r"\+")
         newsel = "1:mem=2097152kb:ncpus=3+1:mem=1048576kb:ncpus=1"
 
-        newsel_esc = newsel.replace("+", "\+")
+        newsel_esc = newsel.replace("+", r"\+")
         new_exec_host = self.job1_exec_host.replace(
             "+%s/0*2" % (self.n7,), "")
         new_exec_host_esc = new_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         new_exec_vnode = self.job1_exec_vnode.replace(
             "+%s:mem=1048576kb:ncpus=1" % (self.n5,), "")
         new_exec_vnode = new_exec_vnode.replace(
@@ -6205,8 +6264,8 @@ pbs.logjobmsg(pbs.event().job.id, "epilogue hook executed")
         new_exec_vnode = new_exec_vnode.replace(
             "+(%s:ncpus=2:mem=2097152kb)" % (self.n7,), "")
         new_exec_vnode_esc = \
-            new_exec_vnode.replace("[", "\[").replace("]", "\]").replace(
-                "(", "\(").replace(")", "\)").replace("+", "\+")
+            new_exec_vnode.replace("[", r"\[").replace("]", r"\]").replace(
+                "(", r"\(").replace(")", r"\)").replace("+", r"\+")
         self.server.expect(JOB,
                            {'job_state': 'R',
                             'Resource_List.mem': '3gb',
@@ -6355,7 +6414,7 @@ pbs.logjobmsg(pbs.event().job.id, "epilogue hook executed")
         # Verify remaining job resources.
         newsel = "1:mem=2097152kb:ncpus=3+1:mem=1048576kb:ncpus=2+" + \
                  "1:ncpus=2:mem=2097152kb"
-        newsel_esc = newsel.replace("+", "\+")
+        newsel_esc = newsel.replace("+", r"\+")
         new_exec_host = self.job1_exec_host
 
         # Below variable is being used for the accounting log match
@@ -6366,8 +6425,8 @@ pbs.logjobmsg(pbs.event().job.id, "epilogue hook executed")
         new_exec_vnode = self.job1_exec_vnode.replace(
             "%s:mem=1048576kb:ncpus=1+" % (self.n4,), "")
         new_exec_vnode_esc = new_exec_vnode.replace(
-            "[", "\[").replace("]", "\]").replace(
-            "(", "\(").replace(")", "\)").replace("+", "\+")
+            "[", r"\[").replace("]", r"\]").replace(
+            "(", r"\(").replace(")", r"\)").replace("+", r"\+")
         self.server.expect(JOB, {'job_state': 'R',
                                  'Resource_List.mem': '5gb',
                                  'Resource_List.ncpus': 7,
@@ -6737,12 +6796,12 @@ pbs.logjobmsg(pbs.event().job.id, "epilogue hook executed")
         # Verify remaining job resources
         newsel = "1:mem=2097152kb:ncpus=3+1:mem=1048576kb:ncpus=2+" + \
                  "1:ncpus=2:mem=2097152kb"
-        newsel_esc = newsel.replace("+", "\+")
+        newsel_esc = newsel.replace("+", r"\+")
         new_exec_vnode = self.job1_exec_vnode.replace(
             "%s:mem=1048576kb:ncpus=1+" % (self.n4,), "")
         new_exec_vnode_esc = new_exec_vnode.replace(
-            "[", "\[").replace("]", "\]").replace(
-            "(", "\(").replace(")", "\)").replace("+", "\+")
+            "[", r"\[").replace("]", r"\]").replace(
+            "(", r"\(").replace(")", r"\)").replace("+", r"\+")
         self.server.expect(JOB, {'job_state': 'R',
                                  'Resource_List.mem': '5gb',
                                  'Resource_List.ncpus': 7,

--- a/test/tests/functional/pbs_nonprint_characters.py
+++ b/test/tests/functional/pbs_nonprint_characters.py
@@ -866,7 +866,7 @@ sleep 5
         execjob_launch when qsub -V is passed through command line.
         """
         # variable to check if with escaped nonprinting character
-        chk_var = 'NONPRINT_VAR=X\,%s\,%s\,Y' % (self.bold_esc, self.red_esc)
+        chk_var = r'NONPRINT_VAR=X\,%s\,%s\,Y' % (self.bold_esc, self.red_esc)
         var = "X,%s,%s,Y" % (self.bold, self.red)
         env_vals = {"NONPRINT_VAR": var}
         a = {'Resource_List.select': '1:ncpus=1',

--- a/test/tests/functional/pbs_provisioning_enhancement.py
+++ b/test/tests/functional/pbs_provisioning_enhancement.py
@@ -459,7 +459,7 @@ e.reject()
         self.server.expect(JOB, {'job_state': 'R',
                                  'substate': 71}, attrop=PTL_AND, id=jid)
         exp_msg = "Provisioning vnode " + self.momA.shortname
-        exp_msg += "\[[0-3]\] with AOE osimage1 started"
+        exp_msg += r"\[[0-3]\] with AOE osimage1 started"
         logs = self.server.log_match(msg=exp_msg, regexp=True, allmatch=True)
 
         # since max_concurrent_provision is 1, there should be only one

--- a/test/tests/functional/pbs_qstat_formats.py
+++ b/test/tests/functional/pbs_qstat_formats.py
@@ -576,13 +576,13 @@ class TestQstatFormats(TestFunctional):
         os.environ["MYVAR3"] = """\\\\'"""
         os.environ["MYVAR4"] = """\\\\\\'"""
         os.environ["MYVAR5"] = """\\\\\\\\\\'"""
-        os.environ["MYVAR6"] = """\,"""
+        os.environ["MYVAR6"] = r"""\,"""
         os.environ["MYVAR7"] = """\\,"""
-        os.environ["MYVAR8"] = """\\\,"""
+        os.environ["MYVAR8"] = r"""\\\,"""
         os.environ["MYVAR9"] = """\\\\,"""
         os.environ["MYVAR10"] = """\\\\\\,"""
         os.environ["MYVAR11"] = """\\\\\\\\\\,"""
-        os.environ["MYVAR12"] = """apple\,delight"""
+        os.environ["MYVAR12"] = r"""apple\,delight"""
 
         self.server.manager(MGR_CMD_SET, SERVER,
                             {'default_qsub_arguments': '-V'})

--- a/test/tests/functional/pbs_reliable_job_startup.py
+++ b/test/tests/functional/pbs_reliable_job_startup.py
@@ -156,36 +156,36 @@ class TestPbsReliableJobStartup(TestFunctional):
                                starttime=self.stime)
 
         self.server.accounting_match(
-            msg=".*%s;%s.*exec_host=%s" % (atype, jid, exec_host),
+            msg=r".*%s;%s.*exec_host=%s" % (atype, jid, exec_host),
             regexp=True, n="ALL", max_attempts=3, starttime=self.stime)
 
         self.server.accounting_match(
-            msg=".*%s;%s.*exec_vnode=%s" % (atype, jid, exec_vnode),
+            msg=r".*%s;%s.*exec_vnode=%s" % (atype, jid, exec_vnode),
             regexp=True, n="ALL", max_attempts=3, starttime=self.stime)
 
         self.server.accounting_match(
-            msg=".*%s;%s.*Resource_List\.mem=%s" % (atype, jid,  mem),
+            msg=r".*%s;%s.*Resource_List\.mem=%s" % (atype, jid,  mem),
             regexp=True, n="ALL", max_attempts=3, starttime=self.stime)
 
         self.server.accounting_match(
-            msg=".*%s;%s.*Resource_List\.ncpus=%d" % (atype, jid, ncpus),
+            msg=r".*%s;%s.*Resource_List\.ncpus=%d" % (atype, jid, ncpus),
             regexp=True, n="ALL", max_attempts=3, starttime=self.stime)
 
         self.server.accounting_match(
-            msg=".*%s;%s.*Resource_List\.nodect=%d" % (atype, jid, nodect),
+            msg=r".*%s;%s.*Resource_List\.nodect=%d" % (atype, jid, nodect),
             regexp=True, n="ALL", max_attempts=3, starttime=self.stime)
 
         self.server.accounting_match(
-            msg=".*%s;%s.*Resource_List\.place=%s" % (atype, jid, place),
+            msg=r".*%s;%s.*Resource_List\.place=%s" % (atype, jid, place),
             regexp=True, n="ALL", max_attempts=3, starttime=self.stime)
 
         self.server.accounting_match(
-            msg=".*%s;%s.*Resource_List\.select=%s" % (atype, jid, select),
+            msg=r".*%s;%s.*Resource_List\.select=%s" % (atype, jid, select),
             regexp=True, n="ALL", max_attempts=3, starttime=self.stime)
 
         if (atype != 'c') and (atype != 'S') and (atype != 's'):
             self.server.accounting_match(
-                msg=".*%s;%s.*resources_used\." % (atype, jid),
+                msg=r".*%s;%s.*resources_used\." % (atype, jid),
                 regexp=True, n="ALL", max_attempts=3, starttime=self.stime)
 
     def match_vnode_status(self, vnode_list, state, jobs=None, ncpus=None,
@@ -380,18 +380,19 @@ return i\\n return fib(i-1) + fib(i-2)\\n\\nprint(fib(40))\\\")"'
             "(%s:ncpus=2:mem=2097152kb)+" % (self.nC,) + \
             "(%s:mem=1048576kb:ncpus=1+" % (self.nE,) + \
             "%s:mem=1048576kb:ncpus=1)" % (self.nEv0,)
-        self.job1_isel_esc = self.job1_iselect.replace("+", "\+")
+        self.job1_isel_esc = self.job1_iselect.replace(r"+", r"\+")
         self.job1_iexec_host_esc = self.job1_iexec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            r"*", r"\*").replace(r"[", r"\[").replace(r"]", r"\]").replace(
+                    r"+", r"\+")
         self.job1_iexec_vnode_esc = self.job1_iexec_vnode.replace(
-            "[", "\[").replace("]", "\]").replace("(", "\(").replace(
-            ")", "\)").replace("+", "\+")
+            r"[", r"\[").replace(r"]", r"\]").replace(r"(", r"\(").replace(
+            r")", r"\)").replace(r"+", r"\+")
 
         # expected values version 1 upon successful job launch
         self.job1_select = \
             "1:ncpus=3:mem=2gb+1:ncpus=3:mem=2gb+1:ncpus=2:mem=2gb"
         self.job1_schedselect = self.job1_select
-        self.job1_exec_host = "%s/0*0+%s/0*3+%s/0*0" % (
+        self.job1_exec_host = r"%s/0*0+%s/0*3+%s/0*0" % (
             self.nA, self.nD, self.nE)
         self.job1_exec_vnode = \
             "(%s:mem=1048576kb:ncpus=1+" % (self.nAv0,) + \
@@ -401,18 +402,19 @@ return i\\n return fib(i-1) + fib(i-2)\\n\\nprint(fib(40))\\\")"'
             "(%s:mem=1048576kb:ncpus=1+" % (self.nE,) + \
             "%s:mem=1048576kb:ncpus=1)" % (self.nEv0,)
 
-        self.job1_sel_esc = self.job1_select.replace("+", "\+")
+        self.job1_sel_esc = self.job1_select.replace(r"+", r"\+")
         self.job1_exec_host_esc = self.job1_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            r"*", r"\*").replace(r"[", r"\[").replace(r"]", r"\]").replace(
+                    r"+", r"\+")
         self.job1_exec_vnode_esc = self.job1_exec_vnode.replace(
-            "[", "\[").replace("]", "\]").replace("(", "\(").replace(
-            ")", "\)").replace("+", "\+")
+            r"[", r"\[").replace(r"]", r"\]").replace(r"(", r"\(").replace(
+            r")", r"\)").replace(r"+", r"\+")
 
         # expected values version 2 upon successful job launch
         self.job1v2_select = \
-            "1:ncpus=3:mem=2gb+1:ncpus=3:mem=2gb+1:ncpus=2:mem=2gb"
+            r"1:ncpus=3:mem=2gb+1:ncpus=3:mem=2gb+1:ncpus=2:mem=2gb"
         self.job1v2_schedselect = self.job1v2_select
-        self.job1v2_exec_host = "%s/0*0+%s/0*3+%s/0*2" % (
+        self.job1v2_exec_host = r"%s/0*0+%s/0*3+%s/0*2" % (
             self.nA, self.nD, self.nC)
         self.job1v2_exec_vnode = \
             "(%s:mem=1048576kb:ncpus=1+" % (self.nAv0,) + \
@@ -421,12 +423,13 @@ return i\\n return fib(i-1) + fib(i-2)\\n\\nprint(fib(40))\\\")"'
             "(%s:ncpus=3:mem=2097152kb)+" % (self.nD,) + \
             "(%s:ncpus=2:mem=2097152kb)" % (self.nC,)
 
-        self.job1v2_sel_esc = self.job1v2_select.replace("+", "\+")
+        self.job1v2_sel_esc = self.job1v2_select.replace(r"+", r"\+")
         self.job1v2_exec_host_esc = self.job1v2_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            r"*", r"\*").replace(r"[", r"\[").replace(r"]", r"\]").replace(
+                    r"+", r"\+")
         self.job1v2_exec_vnode_esc = self.job1v2_exec_vnode.replace(
-            "[", "\[").replace("]", "\]").replace("(", "\(").replace(
-            ")", "\)").replace("+", "\+")
+            r"[", r"\[").replace(r"]", r"\]").replace(r"(", r"\(").replace(
+            r")", r"\)").replace(r"+", r"\+")
 
         # expected values version 3 upon successful job launch
         self.job1v3_select = \
@@ -444,12 +447,13 @@ return i\\n return fib(i-1) + fib(i-2)\\n\\nprint(fib(40))\\\")"'
             "(%s:mem=1048576kb:ncpus=1+" % (self.nE,) + \
             "%s:mem=1048576kb:ncpus=1)" % (self.nEv0,)
 
-        self.job1v3_sel_esc = self.job1v3_select.replace("+", "\+")
+        self.job1v3_sel_esc = self.job1v3_select.replace("+", r"\+")
         self.job1v3_exec_host_esc = self.job1v3_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         self.job1v3_exec_vnode_esc = self.job1v3_exec_vnode.replace(
-            "[", "\[").replace("]", "\]").replace("(", "\(").replace(
-            ")", "\)").replace("+", "\+")
+            "[", r"\[").replace("]", r"\]").replace("(", r"\(").replace(
+            ")", r"\)").replace("+", r"\+")
 
         # expected values version 4 upon successful job launch
         self.job1v4_select = \
@@ -466,12 +470,13 @@ return i\\n return fib(i-1) + fib(i-2)\\n\\nprint(fib(40))\\\")"'
             "%s:ncpus=1)+" % (self.nBv1,) + \
             "(%s:ncpus=2:mem=2097152kb)" % (self.nD,)
 
-        self.job1v4_sel_esc = self.job1v4_select.replace("+", "\+")
+        self.job1v4_sel_esc = self.job1v4_select.replace("+", r"\+")
         self.job1v4_exec_host_esc = self.job1v4_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         self.job1v4_exec_vnode_esc = self.job1v4_exec_vnode.replace(
-            "[", "\[").replace("]", "\]").replace("(", "\(").replace(
-            ")", "\)").replace("+", "\+")
+            "[", r"\[").replace("]", r"\]").replace("(", r"\(").replace(
+            ")", r"\)").replace("+", r"\+")
 
         # expected values version 5 upon successful job launch
         self.job1v5_select = \
@@ -488,12 +493,13 @@ return i\\n return fib(i-1) + fib(i-2)\\n\\nprint(fib(40))\\\")"'
             "%s:ncpus=1)+" % (self.nBv1,) + \
             "(%s:ncpus=2:mem=2097152kb)" % (self.nC,)
 
-        self.job1v5_sel_esc = self.job1v5_select.replace("+", "\+")
+        self.job1v5_sel_esc = self.job1v5_select.replace("+", r"\+")
         self.job1v5_exec_host_esc = self.job1v5_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         self.job1v5_exec_vnode_esc = self.job1v5_exec_vnode.replace(
-            "[", "\[").replace("]", "\]").replace("(", "\(").replace(
-            ")", "\)").replace("+", "\+")
+            "[", r"\[").replace("]", r"\]").replace("(", r"\(").replace(
+            ")", r"\)").replace("+", r"\+")
 
         # expected values version 6 upon successful job launch
         self.job1v6_select = \
@@ -512,12 +518,13 @@ return i\\n return fib(i-1) + fib(i-2)\\n\\nprint(fib(40))\\\")"'
             "(%s:ncpus=2:mem=2097152kb)+" % (self.nC,) + \
             "(%s:mem=1048576kb:ncpus=1)" % (self.nE,)
 
-        self.job1v6_sel_esc = self.job1v6_select.replace("+", "\+")
+        self.job1v6_sel_esc = self.job1v6_select.replace("+", r"\+")
         self.job1v6_exec_host_esc = self.job1v6_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         self.job1v6_exec_vnode_esc = self.job1v6_exec_vnode.replace(
-            "[", "\[").replace("]", "\]").replace("(", "\(").replace(
-            ")", "\)").replace("+", "\+")
+            "[", r"\[").replace("]", r"\]").replace("(", r"\(").replace(
+            ")", r"\)").replace("+", r"\+")
 
         self.script['job1'] = """
 #PBS -l select=%s
@@ -580,22 +587,25 @@ done
             "(%s:ncpus=1:mem=1048576kb)+" % (self.nC,) + \
             "(%s:ncpus=1:mem=1048576kb)+" % (self.nD,) + \
             "(%s:ncpus=1:mem=1048576kb)" % (self.nE,)
-        self.jobA_isel_esc = self.jobA_iselect.replace("+", "\+")
+        self.jobA_isel_esc = self.jobA_iselect.replace("+", r"\+")
         self.jobA_iexec_host1_esc = self.jobA_iexec_host1.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         self.jobA_iexec_host2_esc = self.jobA_iexec_host2.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         self.jobA_iexec_host3_esc = self.jobA_iexec_host3.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         self.jobA_iexec_vnode1_esc = self.jobA_iexec_vnode1.replace(
-            "[", "\[").replace("]", "\]").replace("(", "\(").replace(
-            ")", "\)").replace("+", "\+")
+            "[", r"\[").replace("]", r"\]").replace("(", r"\(").replace(
+            ")", r"\)").replace("+", r"\+")
         self.jobA_iexec_vnode2_esc = self.jobA_iexec_vnode2.replace(
-            "[", "\[").replace("]", "\]").replace("(", "\(").replace(
-            ")", "\)").replace("+", "\+")
+            "[", r"\[").replace("]", r"\]").replace("(", r"\(").replace(
+            ")", r"\)").replace("+", r"\+")
         self.jobA_iexec_vnode3_esc = self.jobA_iexec_vnode3.replace(
-            "[", "\[").replace("]", "\]").replace("(", "\(").replace(
-            ")", "\)").replace("+", "\+")
+            "[", r"\[").replace("]", r"\]").replace("(", r"\(").replace(
+            ")", r"\)").replace("+", r"\+")
 
         # expected values version 1 upon successful job launch
         self.jobA_select = \
@@ -620,22 +630,25 @@ done
             "(%s:ncpus=1:mem=1048576kb)+" % (self.nBv1,) + \
             "(%s:ncpus=1:mem=1048576kb)" % (self.nD,)
 
-        self.jobA_sel_esc = self.jobA_select.replace("+", "\+")
+        self.jobA_sel_esc = self.jobA_select.replace("+", r"\+")
         self.jobA_exec_host1_esc = self.jobA_exec_host1.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         self.jobA_exec_host2_esc = self.jobA_exec_host2.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         self.jobA_exec_host3_esc = self.jobA_exec_host3.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         self.jobA_exec_vnode1_esc = self.jobA_exec_vnode1.replace(
-            "[", "\[").replace("]", "\]").replace("(", "\(").replace(
-            ")", "\)").replace("+", "\+")
+            "[", r"\[").replace("]", r"\]").replace("(", r"\(").replace(
+            ")", r"\)").replace("+", r"\+")
         self.jobA_exec_vnode2_esc = self.jobA_exec_vnode2.replace(
-            "[", "\[").replace("]", "\]").replace("(", "\(").replace(
-            ")", "\)").replace("+", "\+")
+            "[", r"\[").replace("]", r"\]").replace("(", r"\(").replace(
+            ")", r"\)").replace("+", r"\+")
         self.jobA_exec_vnode3_esc = self.jobA_exec_vnode3.replace(
-            "[", "\[").replace("]", "\]").replace("(", "\(").replace(
-            ")", "\)").replace("+", "\+")
+            "[", r"\[").replace("]", r"\]").replace("(", r"\(").replace(
+            ")", r"\)").replace("+", r"\+")
         self.script['jobA'] = """
 #PBS -J 1-3
 #PBS -l select=%s
@@ -762,12 +775,13 @@ done
             "(%s:ncpus=0:mem=2097152kb)+" % (self.nC,) + \
             "(%s:mem=1048576kb:ncpus=0+" % (self.nE,) + \
             "%s:mem=1048576kb)" % (self.nEv0,)
-        self.job2_isel_esc = self.job2_iselect.replace("+", "\+")
+        self.job2_isel_esc = self.job2_iselect.replace("+", r"\+")
         self.job2_iexec_host_esc = self.job2_iexec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         self.job2_iexec_vnode_esc = self.job2_iexec_vnode.replace(
-            "[", "\[").replace("]", "\]").replace("(", "\(").replace(
-            ")", "\)").replace("+", "\+")
+            "[", r"\[").replace("]", r"\]").replace("(", r"\(").replace(
+            ")", r"\)").replace("+", r"\+")
 
         # expected values version upon successful job launch
         self.job2_select = \
@@ -788,12 +802,13 @@ done
             "(%s:mem=1048576kb+" % (self.nE,) + \
             "%s:mem=1048576kb)" % (self.nEv0,)
 
-        self.job2_sel_esc = self.job2_select.replace("+", "\+")
+        self.job2_sel_esc = self.job2_select.replace("+", r"\+")
         self.job2_exec_host_esc = self.job2_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         self.job2_exec_vnode_esc = self.job2_exec_vnode.replace(
-            "[", "\[").replace("]", "\]").replace("(", "\(").replace(
-            ")", "\)").replace("+", "\+")
+            "[", r"\[").replace("]", r"\]").replace("(", r"\(").replace(
+            ")", r"\)").replace("+", r"\+")
 
         self.script['job2'] = \
             "#PBS -l select=" + self.job2_oselect + "\n" + \
@@ -844,19 +859,21 @@ done
             "(%s:mem=1048576kb:ncpus=1+" % (self.nE,) + \
             "%s:mem=1048576kb:ncpus=1)" % (self.nEv0,)
 
-        self.job3_sel_esc = self.job3_select.replace("+", "\+")
+        self.job3_sel_esc = self.job3_select.replace("+", r"\+")
         self.job3_exec_host_esc = self.job3_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         self.job3_exec_vnode_esc = self.job3_exec_vnode.replace(
-            "[", "\[").replace("]", "\]").replace("(", "\(").replace(
-            ")", "\)").replace("+", "\+")
+            "[", r"\[").replace("]", r"\]").replace("(", r"\(").replace(
+            ")", r"\)").replace("+", r"\+")
 
-        self.job3_isel_esc = self.job3_iselect.replace("+", "\+")
+        self.job3_isel_esc = self.job3_iselect.replace("+", r"\+")
         self.job3_iexec_host_esc = self.job3_iexec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         self.job3_iexec_vnode_esc = self.job3_iexec_vnode.replace(
-            "[", "\[").replace("]", "\]").replace("(", "\(").replace(
-            ")", "\)").replace("+", "\+")
+            "[", r"\[").replace("]", r"\]").replace("(", r"\(").replace(
+            ")", r"\)").replace("+", r"\+")
 
         self.script['job3'] = \
             "#PBS -l select=" + self.job3_oselect + "\n" + \
@@ -905,19 +922,21 @@ done
             "#PBS -l place=" + self.job4_place + "\n" + \
             SLEEP_CMD + " 300\n"
 
-        self.job4_sel_esc = self.job4_select.replace("+", "\+")
+        self.job4_sel_esc = self.job4_select.replace("+", r"\+")
         self.job4_exec_host_esc = self.job4_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         self.job4_exec_vnode_esc = self.job4_exec_vnode.replace(
-            "[", "\[").replace("]", "\]").replace("(", "\(").replace(
-            ")", "\)").replace("+", "\+")
+            "[", r"\[").replace("]", r"\]").replace("(", r"\(").replace(
+            ")", r"\)").replace("+", r"\+")
 
-        self.job4_isel_esc = self.job4_iselect.replace("+", "\+")
+        self.job4_isel_esc = self.job4_iselect.replace("+", r"\+")
         self.job4_iexec_host_esc = self.job4_iexec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         self.job4_iexec_vnode_esc = self.job4_iexec_vnode.replace(
-            "[", "\[").replace("]", "\]").replace("(", "\(").replace(
-            ")", "\)").replace("+", "\+")
+            "[", r"\[").replace("]", r"\]").replace("(", r"\(").replace(
+            ")", r"\)").replace("+", r"\+")
 
         self.job5_oselect = "ncpus=3:mem=2gb+ncpus=3:mem=2gb+ncpus=2:mem=2gb"
         self.job5_place = "free"
@@ -961,19 +980,21 @@ done
             "#PBS -l place=" + self.job5_place + "\n" + \
             SLEEP_CMD + " 300\n"
 
-        self.job5_sel_esc = self.job5_select.replace("+", "\+")
+        self.job5_sel_esc = self.job5_select.replace("+", r"\+")
         self.job5_exec_host_esc = self.job5_exec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         self.job5_exec_vnode_esc = self.job5_exec_vnode.replace(
-            "[", "\[").replace("]", "\]").replace("(", "\(").replace(
-            ")", "\)").replace("+", "\+")
+            "[", r"\[").replace("]", r"\]").replace("(", r"\(").replace(
+            ")", r"\)").replace("+", r"\+")
 
-        self.job5_isel_esc = self.job5_iselect.replace("+", "\+")
+        self.job5_isel_esc = self.job5_iselect.replace("+", r"\+")
         self.job5_iexec_host_esc = self.job5_iexec_host.replace(
-            "*", "\*").replace("[", "\[").replace("]", "\]").replace("+", "\+")
+            "*", r"\*").replace("[", r"\[").replace("]", r"\]").replace(
+                    "+", r"\+")
         self.job5_iexec_vnode_esc = self.job5_iexec_vnode.replace(
-            "[", "\[").replace("]", "\]").replace("(", "\(").replace(
-            ")", "\)").replace("+", "\+")
+            "[", r"\[").replace("]", r"\]").replace("(", r"\(").replace(
+            ")", r"\)").replace("+", r"\+")
 
         # queuejob hooks used throughout the test
         self.qjob_hook_body = """
@@ -5421,8 +5442,8 @@ pbs_tmrsh %s hostname
             sjid = sub_jobs[idx]
             # Verify mom_logs
             sjid_esc = sjid.replace(
-                "[", "\[").replace("]", "\]").replace("(", "\(").replace(
-                ")", "\)").replace("+", "\+")
+                "[", r"\[").replace("]", r"\]").replace("(", r"\(").replace(
+                ")", r"\)").replace("+", r"\+")
             self.momA.log_match(
                 "Job;%s;job_start_error.+from node %s.+could not JOIN_JOB" % (
                     sjid_esc, self.hostC), n=10, regexp=True)

--- a/test/tests/functional/pbs_resc_used_single_node.py
+++ b/test/tests/functional/pbs_resc_used_single_node.py
@@ -227,7 +227,7 @@ e.job.resources_used["stra"] = '"glad,elated","happy"'
         s = self.server.accounting_match(
             "E;%s;.*%s'{.*}'.*" % (jid, acctlog_match), regexp=True, n=100)
         self.assertTrue(s)
-        acctlog_match = 'resources_used.stra=\"glad\,elated\"\,\"happy\"'
+        acctlog_match = r'resources_used.stra=\"glad\,elated\"\,\"happy\"'
         s = self.server.accounting_match(
             "E;%s;.*%s.*" % (jid, acctlog_match), regexp=True, n=100)
         self.assertTrue(s)

--- a/test/tests/functional/pbs_server_periodic_hook.py
+++ b/test/tests/functional/pbs_server_periodic_hook.py
@@ -112,10 +112,10 @@ pbs.logmsg(pbs.LOG_DEBUG, "periodic hook ended at %%d" %% time.time())
                                             starttime=search_after)
                 time_logged = self.get_timestamp(msg[1])
                 if alarm != 0:
-                        self.assertLessEqual(time_logged - time_expected,
-                                             alarm - hook_run_time)
+                    self.assertLessEqual(time_logged - time_expected,
+                                         alarm - hook_run_time)
                 else:
-                        self.assertLessEqual(time_logged - time_expected, 1)
+                    self.assertLessEqual(time_logged - time_expected, 1)
 
                 if hook_run_time <= freq:
                     intr = freq - hook_run_time


### PR DESCRIPTION
#### Describe Bug or Feature
There are two types of warnings in compilation 
>> In Ubuntu 20 and 22
1. daemon_protect.c:98:3: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result] 
>> Only in Ubuntu 22
2. qsub.c:2169:33: note: destination object of size 0 allocated by ‘malloc’
>> Warning found only in CI
3. ../../../src/mom_rcp/rcp.c:777:7 - error: suggest explicit braces to avoid ambiguous ‘else’ [-Werror=dangling-else]
4. added "tpp_unlock(&mbox->mbox_mutex);" to tpp_em.c before returning, as it would otherwise create a deadlock.
5. runcheck failed saying ubuntu 18.04 is deprecated. So changed to 20.04. This caused several pep8 errors. All of them were fixed. Autopep8 did not work for most of the problems, so had to fix them manually.

#### Describe Your Change
fixed all warnings by checking the error and logging in case of error. No functional changes has been introduced.

#### Link to Design Doc
Not Applicable

#### Attach Test and Valgrind Logs/Output
attaching logs before and after fix.

Before Fix
[warnings_Ubuntu_20.txt](https://github.com/openpbs/openpbs/files/11070909/warnings_Ubuntu_20.txt)
[warnings_Ubuntu_22.txt](https://github.com/openpbs/openpbs/files/11070911/warnings_Ubuntu_22.txt)

After Fix
[warnings_after_fix.txt](https://github.com/openpbs/openpbs/files/11070914/warnings_after_fix.txt)

