### PR TITLE
Ubuntu 22.04 Jammy Support

### DIFF
--- a/ci/etc/build-pbs-packages.sh
+++ b/ci/etc/build-pbs-packages.sh
@@ -67,7 +67,7 @@ fi
 cp -r $pbsdir /tmp/pbs
 cd /tmp/pbs
 ./autogen.sh
-mkdir target
+mkdir -p target
 cd target
 ../configure --prefix=/opt/pbs --enable-ptl ${swig_opt}
 make dist

--- a/ci/etc/install-system-packages
+++ b/ci/etc/install-system-packages
@@ -160,7 +160,7 @@ elif [ "x${ID}" == "xubuntu" ]; then
     expect cpanminus locales-all dnsutils tzdata vim bc file \
     systemd systemd-sysv sysvinit-utils libcap2-bin rsyslog libpam-dev \
     openssh-server openssh-client valgrind llvm gdb rsync wget ccache \
-    python python-pip
+    python3 python3-pip cpanminus
   if [ "x${ID}" == "xubuntu" -a "x${VERSION_ID}" == "x16.04" ]; then
     wget -qO - https://package.perforce.com/perforce.pubkey | apt-key add - &&
       echo 'deb http://package.perforce.com/apt/ubuntu/ xenial release' >/etc/apt/sources.list.d/perforce.list

--- a/configure.ac
+++ b/configure.ac
@@ -43,7 +43,7 @@ AC_PREREQ([2.63])
 # Use PBS_VERSION to override the version statically defined here. For example:
 # ./configure PBS_VERSION=20.0.0 --prefix=/opt/pbs
 AC_INIT([OpenPBS],
-  [20.0.0],
+  [22.05.11],
   [pbssupport@altair.com],
   [openpbs],
   [http://www.openpbs.org/])

--- a/openpbs.spec
+++ b/openpbs.spec
@@ -44,7 +44,7 @@
 %endif
 
 %if !%{defined pbs_version}
-%define pbs_version 20.0.0
+%define pbs_version 22.05.11
 %endif
 
 %if !%{defined pbs_release}
@@ -466,7 +466,7 @@ ${RPM_INSTALL_PREFIX:=%{pbs_prefix}}/libexec/pbs_posttrans \
 %{pbs_prefix}/*
 %attr(4755, root, root) %{pbs_prefix}/sbin/pbs_rcp
 %attr(4755, root, root) %{pbs_prefix}/sbin/pbs_iff
-%attr(644, root, root) %{pbs_prefix}/lib*/libpbs.la
+#%attr(644, root, root) %{pbs_prefix}/lib*/libpbs.la
 %{_sysconfdir}/profile.d/pbs.csh
 %{_sysconfdir}/profile.d/pbs.sh
 %config(noreplace) %{_sysconfdir}/profile.d/pbs.*
@@ -479,8 +479,8 @@ ${RPM_INSTALL_PREFIX:=%{pbs_prefix}}/libexec/pbs_posttrans \
 %exclude %{_unitdir}/pbs.service
 %exclude %{pbs_prefix}/libexec/pbs_reload
 %endif
-%exclude %{pbs_prefix}/unsupported/*.pyc
-%exclude %{pbs_prefix}/unsupported/*.pyo
+#%exclude %{pbs_prefix}/unsupported/*.pyc
+#%exclude %{pbs_prefix}/unsupported/*.pyo
 %exclude %{pbs_prefix}/lib*/*.a
 %exclude %{pbs_prefix}/include/*
 %doc README.md
@@ -492,7 +492,7 @@ ${RPM_INSTALL_PREFIX:=%{pbs_prefix}}/libexec/pbs_posttrans \
 %{pbs_prefix}/*
 %attr(4755, root, root) %{pbs_prefix}/sbin/pbs_rcp
 %attr(4755, root, root) %{pbs_prefix}/sbin/pbs_iff
-%attr(644, root, root) %{pbs_prefix}/lib*/libpbs.la
+#%attr(644, root, root) %{pbs_prefix}/lib*/libpbs.la
 %{_sysconfdir}/profile.d/pbs.csh
 %{_sysconfdir}/profile.d/pbs.sh
 %config(noreplace) %{_sysconfdir}/profile.d/pbs.*
@@ -521,8 +521,8 @@ ${RPM_INSTALL_PREFIX:=%{pbs_prefix}}/libexec/pbs_posttrans \
 %exclude %{pbs_prefix}/sbin/pbs_server
 %exclude %{pbs_prefix}/sbin/pbs_server.bin
 %exclude %{pbs_prefix}/sbin/pbsfs
-%exclude %{pbs_prefix}/unsupported/*.pyc
-%exclude %{pbs_prefix}/unsupported/*.pyo
+#%exclude %{pbs_prefix}/unsupported/*.pyc
+#%exclude %{pbs_prefix}/unsupported/*.pyo
 %exclude %{pbs_prefix}/lib*/*.a
 %exclude %{pbs_prefix}/include/*
 %doc README.md
@@ -533,7 +533,7 @@ ${RPM_INSTALL_PREFIX:=%{pbs_prefix}}/libexec/pbs_posttrans \
 %dir %{pbs_prefix}
 %{pbs_prefix}/*
 %attr(4755, root, root) %{pbs_prefix}/sbin/pbs_iff
-%attr(644, root, root) %{pbs_prefix}/lib*/libpbs.la
+#%attr(644, root, root) %{pbs_prefix}/lib*/libpbs.la
 %{_sysconfdir}/profile.d/pbs.csh
 %{_sysconfdir}/profile.d/pbs.sh
 %config(noreplace) %{_sysconfdir}/profile.d/pbs.*
@@ -570,8 +570,8 @@ ${RPM_INSTALL_PREFIX:=%{pbs_prefix}}/libexec/pbs_posttrans \
 %exclude %{pbs_prefix}/sbin/pbs_server.bin
 %exclude %{pbs_prefix}/sbin/pbs_upgrade_job
 %exclude %{pbs_prefix}/sbin/pbsfs
-%exclude %{pbs_prefix}/unsupported/*.pyc
-%exclude %{pbs_prefix}/unsupported/*.pyo
+#%exclude %{pbs_prefix}/unsupported/*.pyc
+#%exclude %{pbs_prefix}/unsupported/*.pyo
 %exclude %{_unitdir}/pbs.service
 %exclude %{pbs_prefix}/lib*/*.a
 %exclude %{pbs_prefix}/include/*

--- a/openpbs.spec.in
+++ b/openpbs.spec.in
@@ -466,7 +466,7 @@ ${RPM_INSTALL_PREFIX:=%{pbs_prefix}}/libexec/pbs_posttrans \
 %{pbs_prefix}/*
 %attr(4755, root, root) %{pbs_prefix}/sbin/pbs_rcp
 %attr(4755, root, root) %{pbs_prefix}/sbin/pbs_iff
-%attr(644, root, root) %{pbs_prefix}/lib*/libpbs.la
+#%attr(644, root, root) %{pbs_prefix}/lib*/libpbs.la
 %{_sysconfdir}/profile.d/pbs.csh
 %{_sysconfdir}/profile.d/pbs.sh
 %config(noreplace) %{_sysconfdir}/profile.d/pbs.*
@@ -479,8 +479,8 @@ ${RPM_INSTALL_PREFIX:=%{pbs_prefix}}/libexec/pbs_posttrans \
 %exclude %{_unitdir}/pbs.service
 %exclude %{pbs_prefix}/libexec/pbs_reload
 %endif
-%exclude %{pbs_prefix}/unsupported/*.pyc
-%exclude %{pbs_prefix}/unsupported/*.pyo
+#%exclude %{pbs_prefix}/unsupported/*.pyc
+#%exclude %{pbs_prefix}/unsupported/*.pyo
 %exclude %{pbs_prefix}/lib*/*.a
 %exclude %{pbs_prefix}/include/*
 %doc README.md
@@ -492,7 +492,7 @@ ${RPM_INSTALL_PREFIX:=%{pbs_prefix}}/libexec/pbs_posttrans \
 %{pbs_prefix}/*
 %attr(4755, root, root) %{pbs_prefix}/sbin/pbs_rcp
 %attr(4755, root, root) %{pbs_prefix}/sbin/pbs_iff
-%attr(644, root, root) %{pbs_prefix}/lib*/libpbs.la
+#%attr(644, root, root) %{pbs_prefix}/lib*/libpbs.la
 %{_sysconfdir}/profile.d/pbs.csh
 %{_sysconfdir}/profile.d/pbs.sh
 %config(noreplace) %{_sysconfdir}/profile.d/pbs.*
@@ -521,8 +521,8 @@ ${RPM_INSTALL_PREFIX:=%{pbs_prefix}}/libexec/pbs_posttrans \
 %exclude %{pbs_prefix}/sbin/pbs_server
 %exclude %{pbs_prefix}/sbin/pbs_server.bin
 %exclude %{pbs_prefix}/sbin/pbsfs
-%exclude %{pbs_prefix}/unsupported/*.pyc
-%exclude %{pbs_prefix}/unsupported/*.pyo
+#%exclude %{pbs_prefix}/unsupported/*.pyc
+#%exclude %{pbs_prefix}/unsupported/*.pyo
 %exclude %{pbs_prefix}/lib*/*.a
 %exclude %{pbs_prefix}/include/*
 %doc README.md
@@ -533,7 +533,7 @@ ${RPM_INSTALL_PREFIX:=%{pbs_prefix}}/libexec/pbs_posttrans \
 %dir %{pbs_prefix}
 %{pbs_prefix}/*
 %attr(4755, root, root) %{pbs_prefix}/sbin/pbs_iff
-%attr(644, root, root) %{pbs_prefix}/lib*/libpbs.la
+#%attr(644, root, root) %{pbs_prefix}/lib*/libpbs.la
 %{_sysconfdir}/profile.d/pbs.csh
 %{_sysconfdir}/profile.d/pbs.sh
 %config(noreplace) %{_sysconfdir}/profile.d/pbs.*
@@ -570,8 +570,8 @@ ${RPM_INSTALL_PREFIX:=%{pbs_prefix}}/libexec/pbs_posttrans \
 %exclude %{pbs_prefix}/sbin/pbs_server.bin
 %exclude %{pbs_prefix}/sbin/pbs_upgrade_job
 %exclude %{pbs_prefix}/sbin/pbsfs
-%exclude %{pbs_prefix}/unsupported/*.pyc
-%exclude %{pbs_prefix}/unsupported/*.pyo
+#%exclude %{pbs_prefix}/unsupported/*.pyc
+#%exclude %{pbs_prefix}/unsupported/*.pyo
 %exclude %{_unitdir}/pbs.service
 %exclude %{pbs_prefix}/lib*/*.a
 %exclude %{pbs_prefix}/include/*


### PR DESCRIPTION
The following code will produce .deb packages for Ubuntu 22.04 with the ci command:

```
cd ci
./ci --params 'os=ubuntu:jammy' -b
```

This started life as #2562 but should have been a branch to merge instead of off `master`.
