### PR TITLE
fix clearing of exit status on job start

### DIFF
--- a/src/server/req_jobobit.c
+++ b/src/server/req_jobobit.c
@@ -1483,7 +1483,7 @@ job_obit(ruu *pruu, int stream)
 		local_exitstatus = get_jattr_long(pjob, JOB_ATR_exit_status);
 
 	if ((local_exitstatus == JOB_EXEC_HOOK_RERUN || local_exitstatus == JOB_EXEC_HOOK_DELETE) &&
-	    exitstatus != JOB_EXEC_FAILHOOK_RERUN && exitstatus != JOB_EXEC_FAILHOOK_DELETE)
+	    exitstatus != JOB_EXEC_FAILHOOK_RERUN && exitstatus != JOB_EXEC_FAILHOOK_DELETE && exitstatus < 0)
 		exitstatus = local_exitstatus;
 	else
 		set_jattr_l_slim(pjob, JOB_ATR_exit_status, exitstatus, SET);

--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -933,9 +933,10 @@ svr_startjob(job *pjob, struct batch_request *preq)
 
 	if (!(is_jattr_set(pjob, JOB_ATR_hashname)))
 		if (set_jattr_str_slim(pjob, JOB_ATR_hashname, pjob->ji_qs.ji_jobid, NULL))
+			return (PBSE_SYSTEM);
 
-			/* clear Exit_status which may have been set in a hook and requeued */
-			clear_attr(get_jattr(pjob, JOB_ATR_exit_status), &job_attr_def[(int) JOB_ATR_exit_status]);
+	/* clear Exit_status which may have been set in a hook and requeued */
+	clear_attr(get_jattr(pjob, JOB_ATR_exit_status), &job_attr_def[(int) JOB_ATR_exit_status]);
 
 	/* if exec_vnode already set and either (hotstart or checkpoint) */
 	/* then reuseuse the host(s) listed in the current exec_vnode	 */


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
This bug was introduced in #2016 . It removed a line of code: `return (PBSE_SYSTEM);`. It happened obviously by accident on refactoring.

See the detail of the change in #2016:
![image](https://github.com/openpbs/openpbs/assets/16756616/0d2edb6a-ede0-403c-8125-6b090440f6f6)

The bug introduced an error when the old exit status is not cleared on job start. This is e.g. a problem with the exit code -18 (JOB_EXEC_HOOK_RERUN). I manually tested the job having exit code -18 on the **first run** and exit code 0 on all **subsequent runs**. It runs repeatedly also due to the condition for JOB_EXEC_HOOK_RERUN in job_obit(). This condition should be also improved. It runs until it reaches run_count=21 and gets hold no matter the last 20 runs exited 0.

#### Describe Your Change

1. Return the line: `return (PBSE_SYSTEM);`
2. I suggest improving the condition in job_obit() in order to prefer exit code >= 0 over negative exit codes. If a job had some RERUN exit code before and in the current run the job finishes OK, it does not make sense to remember the old exit code instead of the current one.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
