### PR TITLE
allow manually unsetting encrypt method

### DIFF
--- a/src/include/libutil.h
+++ b/src/include/libutil.h
@@ -289,6 +289,11 @@ char **dup_string_arr(char **strarr);
 void free_string_array(char **arr);
 
 /*
+ * ensure_string_not_null - if string is NULL, allocate an empty string
+ */
+void ensure_string_not_null(char **str);
+
+/*
  * convert_string_to_lowercase - convert string to lower case
  */
 char *convert_string_to_lowercase(char *str);

--- a/src/lib/Libifl/pbs_loadconf.c
+++ b/src/lib/Libifl/pbs_loadconf.c
@@ -906,7 +906,12 @@ __pbs_loadconf(int reload)
 		free(value);
 	}
 	if ((gvalue = getenv(PBS_CONF_ENCRYPT_METHOD)) != NULL) {
-		char *value = convert_string_to_lowercase(gvalue);
+		char *value;
+		if (gvalue != NULL && gvalue[0] == '\0') { // allow unsetting the encrypt method
+			value = strdup("");
+		} else {
+			value = convert_string_to_lowercase(gvalue);
+		}
 		if (value == NULL)
 			goto err;
 		memset(pbs_conf.encrypt_method, '\0', sizeof(pbs_conf.encrypt_method));

--- a/src/lib/Libifl/pbs_loadconf.c
+++ b/src/lib/Libifl/pbs_loadconf.c
@@ -906,12 +906,8 @@ __pbs_loadconf(int reload)
 		free(value);
 	}
 	if ((gvalue = getenv(PBS_CONF_ENCRYPT_METHOD)) != NULL) {
-		char *value;
-		if (gvalue != NULL && gvalue[0] == '\0') { // allow unsetting the encrypt method
-			value = strdup("");
-		} else {
-			value = convert_string_to_lowercase(gvalue);
-		}
+		char *value = convert_string_to_lowercase(gvalue);
+		ensure_string_not_null(&value); // allow unsetting
 		if (value == NULL)
 			goto err;
 		memset(pbs_conf.encrypt_method, '\0', sizeof(pbs_conf.encrypt_method));

--- a/src/lib/Libutil/misc_utils.c
+++ b/src/lib/Libutil/misc_utils.c
@@ -1351,6 +1351,22 @@ free_string_array(char **arr)
 
 /**
  * @brief
+ *	ensure_string_not_null - if string is NULL, allocate an empty string
+ *
+ * @param[in]	str - pointer to pointer to string (or to NULL)
+ *
+ * @return	nothing
+ *
+ */
+void
+ensure_string_not_null(char **str)
+{
+	if (*str == NULL)
+		*str = strdup("");
+}
+
+/**
+ * @brief
  *	convert_string_to_lowercase - Convert string to lowercase
  *
  * @param[in]	str - string to be converted


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Having GSS enabled by default in `/etc/pbs.conf`, it is not possible to manually unset the variable PBS_AUTH_METHOD. Assuming the file  `/etc/pbs.conf` includes:
```
PBS_SUPPORTED_AUTH_METHODS=GSS,resvport
PBS_ENCRYPT_METHOD=GSS
PBS_AUTH_METHOD=GSS
```
it is not possible to call PBS commands without GSS. We can change the auth method to `resvport` but PBS  will still use GSS as encrypt method.

Not having a valid Kerberos ticket, the PBS commands fail using  `resvport`  like this:
```
$ PBS_AUTH_METHOD=resvport pbsnodes -a
pbs_gss_establish_context: GSS - gss_acquire_cred :  No credentials were supplied, or the credentials were unavailable or inaccessible.
pbs_gss_establish_context: GSS - gss_acquire_cred : unknown mech-code 0 for mech unknown
auth: error returned: 15010
auth: auth_process_handshake_data failure
Permission denied
pbsnodes: cannot connect to server torque4.grid.cesnet.cz, error=15010
```

Trying to unset the auth method, we get `Invalid argument`:
```
$ PBS_ENCRYPT_METHOD= PBS_AUTH_METHOD=resvport pbsnodes -a
Invalid argument
pbsnodes: cannot connect to server , error=0
```

#### Describe Your Change
I suggest allowing the manually unset of the PBS_ENCRYPT_METHOD. It can be useful (for admins) to control the PBS without a Kerberos ticket. E.g.: for the initial configuration of PBS ignoring Kerberos makes things easier. (You need to edit the `/etc/pbs.conf` file now.)

The change allows the unsettling of the environmental variable PBS_ENCRYPT_METHOD by setting it to an empty string and not considering it to be an invalid argument.

This change preserves the theoretical possibility use different encrypt method and auth method.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
Manual test without a valid Kerberos ticket, variable is unset:
```
$ PBS_ENCRYPT_METHOD= PBS_AUTH_METHOD=resvport pbsnodes -a
torque4
     Mom = torque4.grid.cesnet.cz
     ntype = PBS
     state = free
     pcpus = 2
     resources_available.arch = linux
     resources_available.host = torque4
     resources_available.mem = 2030240kb
     resources_available.ncpus = 2
     resources_available.vnode = torque4
     resources_assigned.accelerator_memory = 0kb
     resources_assigned.hbmem = 0kb
     resources_assigned.mem = 0kb
     resources_assigned.naccelerators = 0
     resources_assigned.ncpus = 0
     resources_assigned.vmem = 0kb
     resv_enable = True
     sharing = default_shared
     license = l
     last_state_change_time = Tue Jun 20 07:29:01 2023
     last_used_time = Tue Jun 20 07:23:17 2023
```

Manual test without a valid Kerberos ticket. Setting the env variable still works (requires GSS):
```
$ PBS_ENCRYPT_METHOD=GSS PBS_AUTH_METHOD=resvport pbsnodes -a
pbs_gss_establish_context: GSS - gss_acquire_cred :  No credentials were supplied, or the credentials were unavailable or inaccessible.
pbs_gss_establish_context: GSS - gss_acquire_cred : unknown mech-code 0 for mech unknown
auth: error returned: 15010
auth: auth_process_handshake_data failure
Permission denied
pbsnodes: cannot connect to server torque4.grid.cesnet.cz, error=15010
```

Manual test with a valid Kerberos ticket, variable is set:
```
$ PBS_ENCRYPT_METHOD=GSS PBS_AUTH_METHOD=resvport pbsnodes -a
torque4
     Mom = torque4.grid.cesnet.cz
     ntype = PBS
     state = free
     pcpus = 2
     resources_available.arch = linux
     resources_available.host = torque4
     resources_available.mem = 2030240kb
     resources_available.ncpus = 2
     resources_available.vnode = torque4
     resources_assigned.accelerator_memory = 0kb
     resources_assigned.hbmem = 0kb
     resources_assigned.mem = 0kb
     resources_assigned.naccelerators = 0
     resources_assigned.ncpus = 0
     resources_assigned.vmem = 0kb
     resv_enable = True
     sharing = default_shared
     license = l
     last_state_change_time = Tue Jun 20 07:29:01 2023
     last_used_time = Tue Jun 20 07:23:17 2023
```



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
