### PR TITLE
fix useless chown of *.SC files of interactive jobs

### DIFF
--- a/src/resmom/start_exec.c
+++ b/src/resmom/start_exec.c
@@ -3130,7 +3130,6 @@ finish_exec(job *pjob)
 	cpid = fork_me(-1);
 	if (cpid > 0) {
 		conn_t *conn = NULL;
-		char *s, *d, holdbuf[(2 * MAXPATHLEN) + 5];
 
 		/* the parent side, still the main man, uhh that is MOM */
 
@@ -3259,28 +3258,34 @@ finish_exec(job *pjob)
 			(void) close(ptc);
 			ptc = -1;
 		}
-		if (*pjob->ji_qs.ji_fileprefix != '\0')
-			sprintf(buf, "%s%s%s", path_jobs,
-				pjob->ji_qs.ji_fileprefix, JOB_SCRIPT_SUFFIX);
-		else
-			sprintf(buf, "%s%s%s", path_jobs,
-				pjob->ji_qs.ji_jobid, JOB_SCRIPT_SUFFIX);
-		if (chown(buf, pjob->ji_qs.ji_un.ji_momt.ji_exuid,
-			     pjob->ji_qs.ji_un.ji_momt.ji_exgid) == -1) 
-				log_errf(-1, __func__, "chown failed. ERR : %s",strerror(errno));				
 
-		/* add escape in front of brackets */
-		for (s = buf, d = holdbuf; *s && ((d - holdbuf) < sizeof(holdbuf)); s++, d++) {
-			if (*s == '[' || *s == ']')
-				*d++ = '\\';
-			*d = *s;
-		}
-		*d = '\0';
-		snprintf(buf, sizeof(buf), "%s", holdbuf);
-		DBPRT(("shell: %s\n", buf))
 #if SHELL_INVOKE == 1
 		if (is_interactive == 0) {
+			char *s;
+			char *d;
+			char holdbuf[(2 * MAXPATHLEN) + 5];
 			int k;
+
+			if (*pjob->ji_qs.ji_fileprefix != '\0')
+				sprintf(buf, "%s%s%s", path_jobs,
+					pjob->ji_qs.ji_fileprefix, JOB_SCRIPT_SUFFIX);
+			else
+				sprintf(buf, "%s%s%s", path_jobs,
+					pjob->ji_qs.ji_jobid, JOB_SCRIPT_SUFFIX);
+
+			if (chown(buf, pjob->ji_qs.ji_un.ji_momt.ji_exuid,
+					pjob->ji_qs.ji_un.ji_momt.ji_exgid) == -1)
+					log_errf(-1, __func__, "chown failed. ERR : %s",strerror(errno));
+
+			/* add escape in front of brackets */
+			for (s = buf, d = holdbuf; *s && ((d - holdbuf) < sizeof(holdbuf)); s++, d++) {
+				if (*s == '[' || *s == ']')
+					*d++ = '\\';
+				*d = *s;
+			}
+			*d = '\0';
+			snprintf(buf, sizeof(buf), "%s", holdbuf);
+			DBPRT(("shell: %s\n", buf))
 
 			/* pass name of shell script on pipe	*/
 			/* will be stdin of shell 		*/


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->

Pbs mom tries to chown *.SC files of interactive jobs. This bug is present since the init commit and it does not do real harm.

Interactive jobs do not use script files but mom tries to chown the files. This bug has no negative impact except for logging the error in the mom log. The logging was introduced in #2577 and the useless error line looks like this (while starting the **interactive** job):
```
06/20/2023 09:41:14;0001;pbs_mom;Svr;pbs_mom;finish_exec, chown failed. ERR : No such file or directory
```


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

The *.SC file strings are concated and the chown is done only for non-interactive jobs.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

Test the interactive job:
```
torque4.grid.cesnet.cz$ qsub -I
qsub: waiting for job 114.torque4.grid.cesnet.cz to start
qsub: job 114.torque4.grid.cesnet.cz ready

torque4.grid.cesnet.cz$ exit
logout

qsub: job 114.torque4.grid.cesnet.cz completed
torque4.grid.cesnet.cz$ 
```

Test the non-interactive job and chowing of the *.SC file:
```
torque4.grid.cesnet.cz$ echo "sleep 100" | qsub
115.torque4.grid.cesnet.cz
torque4.grid.cesnet.cz$ 
```

```
(BULLSEYE)root@torque4:~# ls -l /var/spool/pbs/mom_priv/jobs/
total 16
-rw------- 1 root   root 5142 Jun 20 10:25 115.torque4.grid.cesnet.cz.JB
-rwx------ 1 vchlum meta   10 Jun 20 10:25 115.torque4.grid.cesnet.cz.SC
drwx------ 2 root   root 4096 Jun 20 10:25 115.torque4.grid.cesnet.cz.TK
```

No useless chown error line is logged anymore.

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
