### PR TITLE
revert useless tpp error logging

### DIFF
--- a/src/lib/Libtpp/tpp_em.c
+++ b/src/lib/Libtpp/tpp_em.c
@@ -1090,11 +1090,8 @@ tpp_mbox_read(tpp_mbox_t *mbox, unsigned int *tfd, int *cmdval, void **data)
 	if (cmd == NULL) {
 		mbox->mbox_size = 0;
 #ifdef HAVE_SYS_EVENTFD_H
-		if (read(mbox->mbox_eventfd, &u, sizeof(uint64_t)) == -1) {
-			tpp_log(LOG_CRIT, __func__, "Unable to read from msg box");
-			tpp_unlock(&mbox->mbox_mutex);
-			return -1;
-		}
+		if (read(mbox->mbox_eventfd, &u, sizeof(uint64_t)) == -1)
+			;
 #else
 		while (tpp_pipe_read(mbox->mbox_pipe[0], &b, sizeof(char)) == sizeof(char))
 			;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
There is a useless error logging in tpp. The bunch of lines look like this:
```
06/21/2023 08:55:13;0c06;pbs_mom;TPP;pbs_mom(Thread 0);tpp_mbox_read;Unable to read from msg box
```
```
06/21/2023 09:06:44;0c06;Comm@torque4;TPP;Comm@torque4(Thread 1);tpp_mbox_read;Unable to read from msg box
```
```
06/21/2023 09:07:16;0c06;Server@torque4;TPP;Server@torque4(Thread 0);tpp_mbox_read;Unable to read from msg box
```

This logging was added in #2577 to fix the compiler warning because the read() was not tested to return.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
The read() here is just to clear the notification if the cmd is NULL. If there is nothing to read, it is not an error to log. It is just there is no notification to be cleared. 

I suggest using empty 'if' to silence the compiler and revert the change from #2577.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

After the change no more `Unable to read from msg box` errors.


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
