### PR TITLE
remove python-xml from build requirements for suse version >= 15.5

### DIFF
--- a/openpbs.spec
+++ b/openpbs.spec
@@ -129,7 +129,9 @@ BuildRequires: libXext-devel
 BuildRequires: libXft-devel
 BuildRequires: fontconfig
 BuildRequires: timezone
+%if ( ( !%{defined sle_version} ) || ( 0%{?sle_version} < 150500 ) )
 BuildRequires: python-xml
+%endif
 %else
 BuildRequires: expat-devel
 BuildRequires: openssl-devel

--- a/openpbs.spec.in
+++ b/openpbs.spec.in
@@ -129,7 +129,9 @@ BuildRequires: libXext-devel
 BuildRequires: libXft-devel
 BuildRequires: fontconfig
 BuildRequires: timezone
+%if ( ( !%{defined sle_version} ) || ( 0%{?sle_version} < 150500 ) )
 BuildRequires: python-xml
+%endif
 %else
 BuildRequires: expat-devel
 BuildRequires: openssl-devel


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
CI fails on Opensuse leap 15.5


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Since Opensuse leap 15.5, the python-xml was removed. [See](https://software.opensuse.org/package/python-xml):
```
A Python XML Interface

The expat module is a Python interface to the expat XML parser. Since Python2.x, it is part of the core Python distribution.

There is no official package available for openSUSE Leap 15.5
```

This patch checks for the [opensuse leap version](https://en.opensuse.org/openSUSE:Build_Service_cross_distribution_howto). The python-xml is added into requirements only for opensuse < 15.5

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
