### PR TITLE
terminate the afslog process if a job's task fails to start

### DIFF
--- a/src/resmom/start_exec.c
+++ b/src/resmom/start_exec.c
@@ -1768,6 +1768,9 @@ record_finish_exec(int sd)
 		if (sjr.sj_reservation == -1)
 			call_hup = HUP_INIT;
 #endif
+#if defined(PBS_SECURITY) && (PBS_SECURITY == KRB5)
+		AFSLOG_TERM(ptask);
+#endif
 		(void) sprintf(log_buffer, "job not started, %s %d",
 			       (sjr.sj_code == JOB_EXEC_RETRY) ? "Retry" : "Failure", sjr.sj_code);
 		exec_bail(pjob, sjr.sj_code, log_buffer);
@@ -4671,6 +4674,9 @@ start_process(task *ptask, char **argv, char **envp, bool nodemux)
 		 */
 		set_globid(pjob, &sjr);
 		if (sjr.sj_code < 0) {
+#if defined(PBS_SECURITY) && (PBS_SECURITY == KRB5)
+			AFSLOG_TERM(ptask);
+#endif
 			(void) sprintf(log_buffer, "task not started, %s %s %d",
 				       (sjr.sj_code == JOB_EXEC_RETRY) ? "Retry" : "Failure",
 				       argv[0],


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Using Kerberos and OpenAFS, AFS requires setting the PAG (process authentication group) and logging into AFS after each Kerberos ticket renew. **The AFS log must be done in the child of the original process who set the PAG.** That is why the separate process 'afslog' is run along with each job task.

If the job's task fails to start (e.g.: home is unavailable or the launch hook rejects) the Kerberos credentials are destroyed but the afslog process is not terminated:

```
06/23/2023 09:57:33;0001;pbs_mom;Job;160.torque4.grid.cesnet.cz;job not started, Failure -17
06/23/2023 09:57:33;0080;pbs_mom;Job;160.torque4.grid.cesnet.cz;credential destroy for FILE:/tmp/krb5cc_pbsjob_160.torque4.grid.cesnet.cz succeeded

```
The afslog process keeps running indefinitely. See the failed task's afslog process:

```
(BULLSEYE)root@torque4:~# ps faxu | grep mom
root     4124921  0.0  0.0   9400   712 pts/1    S+   10:00   0:00  |       \_ grep mom
root     3905078  0.0  0.6 103380 12760 ?        Ssl  Jun22   0:01 /usr/sbin/pbs_mom
vchlum   4124875  0.0  0.1 102988  3708 ?        Ss   09:57   0:00 /usr/sbin/pbs_mom # <- this is afslog process
```

See the process:
```
(BULLSEYE)root@torque4:~# gdb -p 4124875
...
..
.
..
...
Attaching to process 4124875
0x000014a8421231a1 in __GI___clock_nanosleep (clock_id=clock_id@entry=0, flags=flags@entry=0, 
    req=req@entry=0x7fff457e5ab0, rem=rem@entry=0x7fff457e5ab0) at ../sysdeps/unix/sysv/linux/clock_nanosleep.c:48
48	../sysdeps/unix/sysv/linux/clock_nanosleep.c: No such file or directory.
(gdb) bt
#0  0x000014a8421231a1 in __GI___clock_nanosleep (clock_id=clock_id@entry=0, flags=flags@entry=0, 
    req=req@entry=0x7fff457e5ab0, rem=rem@entry=0x7fff457e5ab0) at ../sysdeps/unix/sysv/linux/clock_nanosleep.c:48
#1  0x000014a842128983 in __GI___nanosleep (requested_time=requested_time@entry=0x7fff457e5ab0, 
    remaining=remaining@entry=0x7fff457e5ab0) at nanosleep.c:27
#2  0x000014a8421288ba in __sleep (seconds=0) at ../sysdeps/posix/sleep.c:55
#3  0x0000558f49a51c0c in wait_afslog () at renew_creds.c:1304
#4  0x0000558f49a522cd in start_afslog (ptask=0x558f4b7a8c50, ticket=0x558f4b72d4f0, fd1=15, fd2=16)
    at renew_creds.c:1474
#5  0x0000558f49a471cb in finish_exec (pjob=0x558f4b7cf3e0) at start_exec.c:3455
#6  0x0000558f49a4e91b in start_exec (pjob=0x558f4b7cf3e0) at start_exec.c:6247
#7  0x0000558f499f147f in req_commit_now (preq=0x558f4b7c1ee0, pj=0x558f4b7cf3e0)
    at ../../src/server/req_quejob.c:1744
#8  0x0000558f499f14dd in req_commit (preq=0x558f4b7c1ee0) at ../../src/server/req_quejob.c:1895
#9  0x0000558f499edd0b in dispatch_request (sfds=1, request=0x558f4b7c1ee0)
    at ../../src/server/process_request.c:870
#10 0x0000558f499ee24c in process_IS_CMD (stream=1) at ../../src/server/process_request.c:1228
#11 0x0000558f49a32945 in is_request (stream=1, version=4) at mom_server.c:909
#12 0x0000558f49a26866 in do_tpp (stream=1) at mom_main.c:5123
#13 0x0000558f49a268c7 in tpp_request (fd=10) at mom_main.c:5160
#14 0x0000558f49a6166a in process_socket (sock=10) at net_server.c:510
#15 0x0000558f49a6199c in wait_request (waittime=2, priority_context=0x0) at net_server.c:623
#16 0x0000558f49a1deee in finish_loop (waittime=2) at linux/mom_func.c:142
#17 0x0000558f49a2d50c in main (argc=1, argv=0x7fff457f1418) at mom_main.c:8356

```

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

This patch sends TERM signal to afslog process if the starter_return() sends the negative error code to the mom process - meaning the job task failed to start.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

Having this hook enabled:
```
import pbs
e = pbs.event()
if e.type == pbs.EXECJOB_LAUNCH:
    if pbs.get_local_nodename() == "torque5":
        e.reject("this is intended fail")
```


TEST 1:
Running single node job on node torque5, the afslog is terminated:
```
06/23/2023 10:24:13;0100;pbs_mom;Hook;fail_hook_launch;execjob_launch request rejected by 'fail_hook_launch'
06/23/2023 10:24:13;0008;pbs_mom;Job;161.torque4.grid.cesnet.cz;this is intended fail
06/23/2023 10:24:13;0080;pbs_mom;Job;161.torque4.grid.cesnet.cz;afslog for task 00000001, signal 15 sent to pid 3629890
06/23/2023 10:24:13;0001;pbs_mom;Job;161.torque4.grid.cesnet.cz;job not started, Failure -17
06/23/2023 10:24:13;0080;pbs_mom;Job;161.torque4.grid.cesnet.cz;credential destroy for FILE:/tmp/krb5cc_pbsjob_161.torque4.grid.cesnet.cz succeeded

```
And no residual mom process:
```
(BULLSEYE)root@torque5:~# ps faxu | grep mom
root     3631258  0.0  0.0   9400   708 pts/3    S+   10:28   0:00          \_ grep mom
root     3612128  0.0  0.6 103388 13368 ?        Ssl  07:57   0:00 /usr/sbin/pbs_mom

```

TEST 2:
Running multinode job (-l select=vnode=torque4+vnode=torque5):
```
qsub: waiting for job 162.torque4.grid.cesnet.cz to start
qsub: job 162.torque4.grid.cesnet.cz ready

torque4.grid.cesnet.cz$ pbsdsh hostname
torque4.grid.cesnet.cz
error 15010 on spawn
torque4.grid.cesnet.cz$ 
```
The afslog is terminated along with failed task on node torque5:
```
06/23/2023 10:32:24;0100;pbs_mom;Hook;fail_hook_launch;execjob_launch request rejected by 'fail_hook_launch'
06/23/2023 10:32:24;0008;pbs_mom;Job;162.torque4.grid.cesnet.cz;this is intended fail
06/23/2023 10:32:24;0080;pbs_mom;Job;162.torque4.grid.cesnet.cz;afslog for task 40000001, signal 15 sent to pid 3631278
06/23/2023 10:32:24;0001;pbs_mom;Job;162.torque4.grid.cesnet.cz;task not started, Failure hostname -17

```
No residual mom process:
```
(BULLSEYE)root@torque5:~# ps faxu | grep mom
root     3631284  0.0  0.0   9400   716 pts/3    S+   10:33   0:00          \_ grep mom
root     3612128  0.0  0.6 103388 13376 ?        Ssl  07:57   0:00 /usr/sbin/pbs_mom

```


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
