### PR TITLE
fix environmental variables with qsub parameter -V

### DIFF
--- a/src/cmds/qsub.c
+++ b/src/cmds/qsub.c
@@ -2169,8 +2169,6 @@ env_array_to_varlist(char **envp)
 	if ((len > 0) && ((job_env = (char *) malloc(len)) == NULL)) {
 			fprintf(stderr, "env_array_to_varlist: malloc failure errno=%d", errno);
 			return NULL;
-	} else {
-		return NULL;
 	}
 
 	*job_env = '\0';

--- a/src/resmom/start_exec.c
+++ b/src/resmom/start_exec.c
@@ -3469,8 +3469,14 @@ finish_exec(job *pjob)
 	/* Second, the variables passed with the job.  They may */
 	/* be overwritten with new correct values for this job	*/
 
-	for (j = 0; j < vstrs->as_usedptr; ++j)
+	for (j = 0; j < vstrs->as_usedptr; ++j) {
+#if defined(PBS_SECURITY) && (PBS_SECURITY == KRB5)
+			/* never set KRB5CCNAME; it would rewrite the correct value */
+			if (strncmp(vstrs->as_string[j], "KRB5CCNAME", strlen("KRB5CCNAME")) == 0)
+				continue;
+#endif
 		bld_env_variables(&(pjob->ji_env), vstrs->as_string[j], NULL);
+	}
 
 	/* .. Next the critical variables: home, path, logname, ... */
 	/* these may replace some passed in with the job	    */
@@ -4751,8 +4757,14 @@ start_process(task *ptask, char **argv, char **envp, bool nodemux)
 	/* Next, the variables passed with the job.  They may   */
 	/* be overwritten with new correct values for this job	*/
 
-	for (j = 0; j < vstrs->as_usedptr; ++j)
+	for (j = 0; j < vstrs->as_usedptr; ++j) {
+#if defined(PBS_SECURITY) && (PBS_SECURITY == KRB5)
+			/* never set KRB5CCNAME; it would rewrite the correct value */
+			if (strncmp(vstrs->as_string[j], "KRB5CCNAME", strlen("KRB5CCNAME")) == 0)
+				continue;
+#endif
 		bld_env_variables(&(pjob->ji_env), vstrs->as_string[j], NULL);
+	}
 
 	/* HOME */
 	bld_env_variables(&(pjob->ji_env), variables_else[0],


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
There are two issues with the -V parameter to qsub:

1. The environmental variables are not passed to the job at all. See the failing ptl Test_passing_environment_variable_via_qsub.test_option_V_cmdline:
[ptl_output_-V_failed.txt](https://github.com/openpbs/openpbs/files/11891142/ptl_output_-V_failed.txt)

2. if the env variables were passed, the env variables would rewrite KRB5CCNAME while using Kerberos. See the bug (after fixing  1). The env KRB5CCNAME is passed to the job and rewrites the correct value: `FILE:/tmp/krb5cc_pbsjob_221.torque4.grid.cesnet.cz`:
```
torque4.grid.cesnet.cz$ klist
Credentials cache: FILE:/tmp/krb5cc_13167_id7YiS
        Principal: vchlum@META

  Issued                Expires               Principal
Jun 28 06:51:38 2023  Jun 28 16:51:29 2023  krbtgt/META@META
Jun 28 06:51:38 2023  Jun 28 16:51:29 2023  krbtgt/EINFRA-SERVICES@META
Jun 28 06:51:38 2023  Jun 28 16:51:29 2023  nfs/storage-vestec1.elixir-czech.cz@EINFRA-SERVICES
Jun 28 06:51:38 2023  Jun 28 16:51:29 2023  afs/ics.muni.cz@META
Jun 28 06:51:38 2023  Jun 28 16:51:29 2023  krbtgt/ZCU.CZ@META
Jun 28 06:51:38 2023  Jun 28 16:51:29 2023  afs/zcu.cz@ZCU.CZ
Jun 28 06:52:00 2023  Jun 28 16:51:29 2023  host/torque4.grid.cesnet.cz@EINFRA-SERVICES
torque4.grid.cesnet.cz$ qsub -V -I -l select=2 -l place=scatter
qsub: waiting for job 221.torque4.grid.cesnet.cz to start
qsub: job 221.torque4.grid.cesnet.cz ready

torque4.grid.cesnet.cz$ pbsdsh klist
Credentials cache: FILE:/tmp/krb5cc_13167_id7YiS
        Principal: vchlum@META

  Issued                Expires               Principal
Jun 28 06:51:38 2023  Jun 28 16:51:29 2023  krbtgt/META@META
Jun 28 06:51:38 2023  Jun 28 16:51:29 2023  krbtgt/EINFRA-SERVICES@META
Jun 28 06:51:38 2023  Jun 28 16:51:29 2023  nfs/storage-vestec1.elixir-czech.cz@EINFRA-SERVICES
Jun 28 06:51:38 2023  Jun 28 16:51:29 2023  afs/ics.muni.cz@META
Jun 28 06:51:38 2023  Jun 28 16:51:29 2023  krbtgt/ZCU.CZ@META
Jun 28 06:51:38 2023  Jun 28 16:51:29 2023  afs/zcu.cz@ZCU.CZ
Jun 28 06:52:00 2023  Jun 28 16:51:29 2023  host/torque4.grid.cesnet.cz@EINFRA-SERVICES
klist: No ticket file: /tmp/krb5cc_13167_id7YiS
pbsdsh: task 0x00000001 exit status 1
torque4.grid.cesnet.cz$ 
```




#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

1. This bug was introduced in #2577 by accident. The 'else' part I have removed is unwanted. It obviously should be removed because `if whatever then return NULL else return NULL` will never return the correct environmental variable list
2. If Kerberos is enabled, ignore KRB5CCNAME environmental variables while building the env of job.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
1. see the succeeded tests of pbs_passing_environment_variable.py: [ptl_output-V_fixed.txt](https://github.com/openpbs/openpbs/files/11891351/ptl_output-V_fixed.txt)
2. see the manual test:
```
torque4.grid.cesnet.cz$ qsub -V -I -l select=2 -l place=scatter
qsub: waiting for job 223.torque4.grid.cesnet.cz to start
qsub: job 223.torque4.grid.cesnet.cz ready

torque4.grid.cesnet.cz$ pbsdsh klist
Credentials cache: FILE:/tmp/krb5cc_pbsjob_223.torque4.grid.cesnet.cz
        Principal: vchlum@META

  Issued                Expires               Principal
Jun 28 08:49:39 2023  Jun 29 08:49:38 2023  krbtgt/META@META
Jun 28 08:50:01 2023  Jun 29 08:49:38 2023  afs/ics.muni.cz@META
Jun 28 08:50:01 2023  Jun 29 08:49:38 2023  krbtgt/ZCU.CZ@META
Jun 28 08:50:01 2023  Jun 29 00:50:01 2023  afs/zcu.cz@ZCU.CZ
Credentials cache: FILE:/tmp/krb5cc_pbsjob_223.torque4.grid.cesnet.cz
        Principal: vchlum@META

  Issued                Expires               Principal
Jun 28 08:49:39 2023  Jun 29 08:49:38 2023  krbtgt/META@META
Jun 28 08:50:05 2023  Jun 29 08:49:38 2023  afs/ics.muni.cz@META
Jun 28 08:50:05 2023  Jun 29 08:49:38 2023  krbtgt/ZCU.CZ@META
Jun 28 08:50:05 2023  Jun 29 00:50:05 2023  afs/zcu.cz@ZCU.CZ
torque4.grid.cesnet.cz$ pbs_tmrsh torque5.grid.cesnet.cz klist
Credentials cache: FILE:/tmp/krb5cc_pbsjob_223.torque4.grid.cesnet.cz
        Principal: vchlum@META

  Issued                Expires               Principal
Jun 28 08:49:39 2023  Jun 29 08:49:38 2023  krbtgt/META@META
Jun 28 08:50:05 2023  Jun 29 08:49:38 2023  afs/ics.muni.cz@META
Jun 28 08:50:05 2023  Jun 29 08:49:38 2023  krbtgt/ZCU.CZ@META
Jun 28 08:50:05 2023  Jun 29 00:50:05 2023  afs/zcu.cz@ZCU.CZ
torque4.grid.cesnet.cz$ 
```


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
