### PR TITLE
switch CI to Rocky Linux 9 and related changes

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -3,6 +3,12 @@
 
 How to install PBS using the configure script.
 
+0. Disable SELinux.
+
+  OpenPBS does not support SELinux. With SELinux enabled, initial start fails
+    with datastore permission error. You can also define proper policy but it is
+    out of scope of this guide.
+
 1. Install the prerequisite packages for building PBS.
 
   For CentOS-8 systems you should configure and enable powertools
@@ -64,7 +70,7 @@ How to install PBS using the configure script.
   For CentOS systems you should run the following command as root:
 
     yum install -y expat libedit postgresql-server postgresql-contrib python3 \
-      sendmail sudo tcl tk libical
+      sendmail sudo tcl tk libical chkconfig
 
   For openSUSE systems you should run the following command as root:
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,15 +23,15 @@ jobs:
            PKG_INSTALL_CMD: "apt-get -y update ; apt-get -y upgrade ; apt-get install -y python3"
            DOCKER_EXTRA_ARG: "-e DEBIAN_FRONTEND=noninteractive -e LANGUAGE=C.UTF-8 -e LANG=C.UTF-8 -e LC_ALL=C.UTF-8"
            CI_CMD: "./ci --local"
-        "CentOS 7 Sanitize":
-           OS_TYPE: "centos:7"
+        "Rocky Linux 9 Sanitize":
+           OS_TYPE: "rockylinux/rockylinux:9.2"
            PKG_INSTALL_CMD: "yum -y install python3"
-           DOCKER_EXTRA_ARG: "-e BUILD_MODE=sanitize -e LC_ALL=en_US.utf-8 -e LANG=en_US.utf-8"
+           DOCKER_EXTRA_ARG: "-e BUILD_MODE=sanitize"
            CI_CMD: "./ci --local='sanitize'"
-        "CentOS 7 Kerberos":
-           OS_TYPE: "centos:7"
+        "Rocky Linux 9 Kerberos":
+           OS_TYPE: "rockylinux/rockylinux:9.2"
            PKG_INSTALL_CMD: "yum -y install python3"
-           DOCKER_EXTRA_ARG: "-e BUILD_MODE=kerberos -e LC_ALL=en_US.utf-8 -e LANG=en_US.utf-8"
+           DOCKER_EXTRA_ARG: "-e BUILD_MODE=kerberos"
            CI_CMD: "./ci --local"
     steps:
     - script: |

--- a/ci/etc/do.sh
+++ b/ci/etc/do.sh
@@ -95,6 +95,22 @@ if [ "x${IS_CI_BUILD}" != "x1" ] || [ "x${FIRST_TIME_BUILD}" == "x1" -a "x${IS_C
     if [ "x${BUILD_MODE}" == "xkerberos" ]; then
       dnf -y install krb5-libs krb5-devel libcom_err libcom_err-devel
     fi
+  elif [ "x${ID}" == "xrocky" -a "x${VERSION_ID}" == "x9.2" ]; then
+    export LANG="C.utf8"
+    dnf -y clean all
+    yum -y install yum-utils
+    dnf -y install 'dnf-command(config-manager)'
+    dnf config-manager --set-enabled crb
+    dnf -y install epel-release
+    dnf -y install python3-pip sudo which net-tools man-db time.x86_64 procps \
+      expat libedit postgresql-server postgresql-contrib python3 \
+      sendmail sudo tcl tk libical libasan llvm git chkconfig
+    dnf -y builddep ${SPEC_FILE}
+    dnf -y install $(rpmspec --requires -q ${SPEC_FILE} | awk '{print $1}' | sort -u | grep -vE '^(/bin/)?(ba)?sh$')
+    pip3 install --trusted-host pypi.org --trusted-host files.pythonhosted.org -r ${REQ_FILE}
+    if [ "x${BUILD_MODE}" == "xkerberos" ]; then
+      dnf -y install krb5-libs krb5-devel libcom_err libcom_err-devel
+    fi
   elif [ "x${ID}" == "xopensuse" -o "x${ID}" == "xopensuse-leap" ]; then
     zypper -n ref
     zypper -n install rpmdevtools python3-pip sudo which net-tools man time.x86_64 git

--- a/openpbs.spec
+++ b/openpbs.spec
@@ -166,6 +166,9 @@ Conflicts: pbspro-server-ohpc
 Conflicts: pbs
 Conflicts: pbs-mom
 Conflicts: pbs-cmds
+%if %{defined rhel}
+Requires: chkconfig
+%endif
 Requires: bash
 Requires: expat
 Requires: libedit
@@ -217,6 +220,9 @@ Conflicts: pbspro-server-ohpc
 Conflicts: pbs
 Conflicts: pbs-mom
 Conflicts: pbs-cmds
+%if %{defined rhel}
+Requires: chkconfig
+%endif
 Requires: bash
 Requires: expat
 Requires: python3 >= 3.5

--- a/openpbs.spec.in
+++ b/openpbs.spec.in
@@ -166,6 +166,9 @@ Conflicts: pbspro-server-ohpc
 Conflicts: pbs
 Conflicts: pbs-mom
 Conflicts: pbs-cmds
+%if %{defined rhel}
+Requires: chkconfig
+%endif
 Requires: bash
 Requires: expat
 Requires: libedit
@@ -217,6 +220,9 @@ Conflicts: pbspro-server-ohpc
 Conflicts: pbs
 Conflicts: pbs-mom
 Conflicts: pbs-cmds
+%if %{defined rhel}
+Requires: chkconfig
+%endif
 Requires: bash
 Requires: expat
 Requires: python3 >= 3.5

--- a/src/cmds/pbs_rstat.c
+++ b/src/cmds/pbs_rstat.c
@@ -366,6 +366,7 @@ handle_resv(char *resv_id, char *server, int how)
 	}
 
 	display(bstat, how);
+	pbs_statfree(bstat);
 }
 
 /*

--- a/src/cmds/pbsnodes.c
+++ b/src/cmds/pbsnodes.c
@@ -1174,6 +1174,8 @@ main(int argc, char *argv[])
 						rc = ret;
 				}
 			}
+			pbs_statfree(bstat_head);
+
 			break;
 
 		case CLEAR:
@@ -1253,6 +1255,8 @@ main(int argc, char *argv[])
 					       get_nstate(bstat), show_nonprint_chars(get_comment(bstat)));
 				}
 			}
+			pbs_statfree(bstat_head);
+
 			break;
 
 		case LISTSP:
@@ -1283,6 +1287,7 @@ main(int argc, char *argv[])
 					} else {
 						prt_node(bstat);
 					}
+					pbs_statfree(bstat);
 				}
 			}
 			if (output_format == FORMAT_JSON) {
@@ -1292,6 +1297,9 @@ main(int argc, char *argv[])
 				}
 				generate_json(stdout);
 				free_json_node_list();
+			}
+			if (do_vnodes) {
+				pbs_statfree(bstat_head);
 			}
 
 			break;

--- a/src/iff/iff2.c
+++ b/src/iff/iff2.c
@@ -163,6 +163,17 @@ main(int argc, char *argv[], char *envp[])
 	if ((servport = atoi(argv[++optind])) <= 0)
 		return (1);
 
+	/* set single threaded mode */
+	pbs_client_thread_set_single_threaded_mode();
+	/* disable attribute verification */
+	set_no_attribute_verification();
+
+	/* initialize the thread context */
+	if (pbs_client_thread_init_thread_context() != 0) {
+		fprintf(stderr, "pbs_iff: thread initialization failed\n");
+		return (1);
+	}
+
 	for (i = 0; i < PBS_IFF_MAX_CONN_RETRIES; i++) {
 		sock = client_to_svr_extend(hostaddr, (unsigned int) servport, 1, cln_hostaddr);
 		if (sock != PBS_NET_RC_RETRY)
@@ -176,16 +187,6 @@ main(int argc, char *argv[], char *envp[])
 		return (4);
 	}
 
-	/* set single threaded mode */
-	pbs_client_thread_set_single_threaded_mode();
-	/* disable attribute verification */
-	set_no_attribute_verification();
-
-	/* initialize the thread context */
-	if (pbs_client_thread_init_thread_context() != 0) {
-		fprintf(stderr, "pbs_iff: thread initialization failed\n");
-		return (1);
-	}
 	DIS_tcp_funcs();
 
 	/* setup connection level thread context */

--- a/src/include/reservation.h
+++ b/src/include/reservation.h
@@ -220,7 +220,7 @@ struct resc_resv {
 		time_t ri_duration;			   /* reservation duration */
 		time_t ri_tactive;			   /* time reservation became active */
 		int ri_svrflags;			   /* server flags */
-		char ri_resvID[PBS_MAXSVRRESVID + 1];	   /* reservation identifier */
+		char ri_resvID[PBS_MAXSVRRESVID];	   /* reservation identifier */
 		char ri_fileprefix[PBS_RESVBASE + 1];	   /* reservation file prefix */
 		char ri_queue[PBS_MAXQRESVNAME + 1];	   /* queue used by reservation */
 	} ri_qs;

--- a/src/lib/Libecl/pbs_client_thread.c
+++ b/src/lib/Libecl/pbs_client_thread.c
@@ -264,6 +264,8 @@ __pbs_client_thread_init_thread_context_single_threaded(void)
 	ptr->th_pbs_tcp_interrupt = 0;
 	ptr->th_pbs_tcp_errno = 0;
 
+	ptr->th_pbs_errno = 0;
+
 	dis_init_tables();
 
 	single_threaded_init_done = 1;
@@ -493,6 +495,8 @@ __pbs_client_thread_init_thread_context(void)
 	ptr->th_pbs_tcp_timeout = PBS_DIS_TCP_TIMEOUT_SHORT;
 	ptr->th_pbs_tcp_interrupt = 0;
 	ptr->th_pbs_tcp_errno = 0;
+
+	ptr->th_pbs_errno = 0;
 
 	/* initialize any elements of the ptr */
 	ptr->th_dis_buffer = calloc(1, dis_buffsize); /* defined in tcp_dis.c */

--- a/src/lib/Libifl/pbsD_stathost.c
+++ b/src/lib/Libifl/pbsD_stathost.c
@@ -960,6 +960,8 @@ __pbs_stathost(int con, const char *hid, struct attrl *attrib, const char *exten
 	}
 
 	pbs_statfree(bstatus); /* free info returned by pbs_statvnodes() */
+	for (i = 0; i < consumable_size; ++i)
+		free((consum + i)->cons_resource);
 	free(consum);
 	consum = NULL;
 	consumable_size = 0;

--- a/src/resmom/Makefile.am
+++ b/src/resmom/Makefile.am
@@ -53,10 +53,10 @@ pbs_mom_CPPFLAGS = \
 	@KRB5_CFLAGS@
 
 pbs_mom_LDADD = \
+	$(top_builddir)/src/lib/Libpbs/libpbs.la \
 	$(top_builddir)/src/lib/Libattr/libattr.a \
 	$(top_builddir)/src/lib/Liblog/liblog.a \
 	$(top_builddir)/src/lib/Libnet/libnet.a \
-	$(top_builddir)/src/lib/Libpbs/libpbs.la \
 	$(top_builddir)/src/lib/Libsec/libsec.a \
 	$(top_builddir)/src/lib/Libsite/libsite.a \
 	$(top_builddir)/src/lib/Libtpp/libtpp.a \

--- a/src/resmom/mom_hook_func.c
+++ b/src/resmom/mom_hook_func.c
@@ -1289,7 +1289,22 @@ run_hook(hook *phook, unsigned int event_type, mom_hook_input_t *hook_input,
 			}
 		}
 
+#ifdef __SANITIZE_ADDRESS__
+		/*
+		 * Ignore ASAN link order for pbs_python because Python bin
+		 * is not compiled with ASAN. There are also some leaks in the Python
+		 * library so ignore them by setting exitcode to 0.
+		 */
+		char *env_asan[] =
+		{
+				"ASAN_OPTIONS=verify_asan_link_order=0",
+				"LSAN_OPTIONS=exitcode=0",
+				NULL
+		};
+		execve(pypath, arg, env_asan);
+#else
 		execve(pypath, arg, environ);
+#endif
 	run_hook_exit:
 		if (fp != NULL) {
 			fclose(fp);

--- a/src/resmom/renew_creds.c
+++ b/src/resmom/renew_creds.c
@@ -65,6 +65,7 @@
 #include "attribute.h"
 #include "resource.h"
 #include "resmon.h"
+#include "libutil.h"
 
 #include "tpp.h"
 #include "pbs_error.h"
@@ -263,7 +264,7 @@ static int
 init_ticket(struct krb_holder *ticket, job *pjob, int cred_action)
 {
 	int ret;
-	char buf[LOG_BUF_SIZE];
+	char buf[LOG_BUF_SIZE * 2];
 
 	if ((ret = krb5_init_context(&ticket->context)) != 0) {
 		log_err(ret, __func__, "Failed to initialize context.");
@@ -273,8 +274,8 @@ init_ticket(struct krb_holder *ticket, job *pjob, int cred_action)
 	switch (cred_action) {
 		case CRED_SINGLESHOT:
 		case CRED_RENEWAL:
-			if ((ret = get_renewed_creds(ticket, buf, LOG_BUF_SIZE)) != 0) {
-				char buf2[LOG_BUF_SIZE * 2];
+			if ((ret = get_renewed_creds(ticket, buf, sizeof(buf))) != 0) {
+				char buf2[LOG_BUF_SIZE * 3];
 
 				krb5_free_context(ticket->context);
 				snprintf(buf2, sizeof(buf2), "get_renewed_creds returned %d, %s", ret, buf);
@@ -765,7 +766,7 @@ get_job_info_from_principal(const char *principal, const char *jobid, eexec_job_
 		return PBS_KRB5_ERR_INTERNAL;
 
 	char login[PBS_MAXUSER + 1];
-	strncpy(login, principal, PBS_MAXUSER + 1);
+	pbs_strncpy(login, principal, PBS_MAXUSER + 1);
 	char *c = strchr(login, '@');
 	if (c != NULL)
 		*c = '\0';

--- a/src/scheduler/Makefile.am
+++ b/src/scheduler/Makefile.am
@@ -52,11 +52,11 @@ common_cflags = \
 common_libs = \
 	$(builddir)/libpbs_sched.a \
 	$(builddir)/libschedharness.a \
+	$(top_builddir)/src/lib/Libpbs/libpbs.la \
 	$(top_builddir)/src/lib/Libutil/libutil.a \
 	$(top_builddir)/src/lib/Liblog/liblog.a \
 	$(top_builddir)/src/lib/Libnet/libnet.a \
 	$(top_builddir)/src/lib/Libsec/libsec.a \
-	$(top_builddir)/src/lib/Libpbs/libpbs.la \
 	@PYTHON_LDFLAGS@ \
 	@PYTHON_LIBS@ \
 	@libz_lib@ \

--- a/src/scheduler/multi_threading.cpp
+++ b/src/scheduler/multi_threading.cpp
@@ -171,6 +171,7 @@ init_multi_threading(int nthreads)
 
 	if (num_threads <= 1) {
 		num_threads = 1;
+		pthread_once(&key_once, create_id_key);
 		return 1; /* main thread will act as the only worker thread */
 	}
 

--- a/src/server/Makefile.am
+++ b/src/server/Makefile.am
@@ -51,6 +51,7 @@ pbs_server_bin_CPPFLAGS = \
 	@KRB5_CFLAGS@
 
 pbs_server_bin_LDADD = \
+	$(top_builddir)/src/lib/Libpbs/libpbs.la \
 	$(top_builddir)/src/lib/Libtpp/libtpp.a \
 	$(top_builddir)/src/lib/Libattr/libattr.a \
 	$(top_builddir)/src/lib/Libutil/libutil.a \
@@ -60,7 +61,6 @@ pbs_server_bin_LDADD = \
 	$(top_builddir)/src/lib/Libsite/libsite.a \
 	$(top_builddir)/src/lib/Libpython/libpbspython_svr.a \
 	$(top_builddir)/src/lib/Libdb/libpbsdb.la \
-	$(top_builddir)/src/lib/Libpbs/libpbs.la \
 	$(top_builddir)/src/lib/Liblicensing/liblicensing.la \
 	@expat_lib@ \
 	@libz_lib@ \
@@ -147,10 +147,10 @@ pbs_comm_CPPFLAGS = \
 	@KRB5_CFLAGS@
 
 pbs_comm_LDADD = \
+	$(top_builddir)/src/lib/Libpbs/libpbs.la \
 	$(top_builddir)/src/lib/Libtpp/libtpp.a \
 	$(top_builddir)/src/lib/Liblog/liblog.a \
 	$(top_builddir)/src/lib/Libutil/libutil.a \
-	$(top_builddir)/src/lib/Libpbs/libpbs.la \
 	-lpthread \
 	@libz_lib@ \
 	@socket_lib@ \

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -115,12 +115,18 @@ pbs_python_CPPFLAGS =  \
 	@PYTHON_INCLUDES@
 
 pbs_python_LDADD = \
-	$(top_builddir)/src/lib/Libpython/libpbspython.a \
+	$(top_builddir)/src/lib/Libpbs/libpbs.la \
 	$(top_builddir)/src/lib/Liblog/liblog.a \
 	$(top_builddir)/src/lib/Libattr/libattr.a \
-	${common_libs} \
+	$(top_builddir)/src/lib/Libutil/libutil.a \
+	$(top_builddir)/src/lib/Libnet/libnet.a \
+	$(top_builddir)/src/lib/Libsec/libsec.a \
+	$(top_builddir)/src/lib/Libpython/libpbspython.a \
 	@PYTHON_LDFLAGS@ \
 	@PYTHON_LIBS@
+	-lpthread \
+	@socket_lib@ \
+	@KRB5_LIBS@
 
 pbs_python_SOURCES = \
 	$(top_srcdir)/src/server/resc_attr.c \

--- a/src/tools/pbs_idled.c
+++ b/src/tools/pbs_idled.c
@@ -119,6 +119,9 @@ main(int argc, char *argv[], char *envp[])
 	int fd;
 	int c;
 
+	cur_xy.x = -1;
+	cur_xy.y = -1;
+
 	/*the real deal or output pbs_version and exit?*/
 	PRINT_VERSION_AND_EXIT(argc, argv);
 

--- a/src/tools/pbs_python.c
+++ b/src/tools/pbs_python.c
@@ -1570,7 +1570,7 @@ main(int argc, char *argv[], char *envp[])
 					pc2 = in_data + 2;
 					while (isspace(*pc2))
 						pc2++;
-					memccpy(dirname, pc2, '\0', MAXPATHLEN);
+					pbs_strncpy(dirname, pc2, MAXPATHLEN);
 					if ((pc = strrchr(dirname, ';')))
 						*pc = '\0';
 					if (chdir(dirname) == -1) {

--- a/src/tools/printjob.c
+++ b/src/tools/printjob.c
@@ -367,6 +367,7 @@ print_db_job(char *id, int no_attributes)
 		printf("\n");
 	}
 
+	free_attrlist(&dbjob.db_attr_list.attrs);
 	return 0;
 }
 #endif
@@ -522,7 +523,7 @@ main(int argc, char *argv[])
 
 		/* If not asked for displaying of script, execute below code */
 		if (!display_script) {
-			svrattrl *pal, *pali;
+			svrattrl *pal, *pali, *ppal;
 			char *state = "";
 			char *substate = "";
 			char *errbuf = malloc(1024);
@@ -580,10 +581,15 @@ main(int argc, char *argv[])
 				pali = GET_NEXT(pal->al_link);
 				while (pali != NULL) {
 					print_attr(pali);
-					if (pali->al_link.ll_next == NULL)
+					if (pali->al_link.ll_next == NULL) {
+						free(pali);
 						break;
+					}
+					ppal = pali;
 					pali = GET_NEXT(pali->al_link);
+					free(ppal);
 				}
+				free(pal);
 			}
 
 			(void) close(fp);
@@ -642,6 +648,7 @@ main(int argc, char *argv[])
 			if (job_id)
 				free(job_id);
 			closedir(dirp);
+			free(errbuf);
 		}
 		/* if asked for displaying of script, execute below code  (for mom-side) */
 		else {

--- a/src/unsupported/Makefile.am
+++ b/src/unsupported/Makefile.am
@@ -74,10 +74,10 @@ pbs_rmget_CPPFLAGS = \
 	@KRB5_CFLAGS@
 
 pbs_rmget_LDADD = \
+	$(top_builddir)/src/lib/Libpbs/libpbs.la \
 	$(top_builddir)/src/lib/Libtpp/libtpp.a \
 	$(top_builddir)/src/lib/Liblog/liblog.a \
 	$(top_builddir)/src/lib/Libnet/libnet.a \
-	$(top_builddir)/src/lib/Libpbs/libpbs.la \
 	$(top_builddir)/src/lib/Libutil/libutil.a \
 	-lpthread \
 	@libz_lib@ \


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
I would like to suggest switching CI from Centos 7 to Rocky Linux 9. Centos repository is deprecated on the docker hub, hence switch to Rocky Linux. It means using newer gcc and address sanitizer, which means new errors and leaks are recognized. A comprehensive list of problems resolved by this PR is listed in this file: [gcc11_and_new_sanitizer-error_list.txt](https://github.com/openpbs/openpbs/files/12376180/gcc11_and_new_sanitizer-error_list.txt)


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
- Centos 7 was changed to Rocky Linux 9.2 in CI.
- As a first thing to resolve issues, I moved libpbs.so  in makefiles to the top place in all occurrences. The reason for this is the 'one definition rule'. The linker reads symbols from left to right and it reads only what it really needs. Miscellaneous occurrences of symbols are needed in the libpbs.so by **the compiled program** and also by **the libpbs.so itself**. Having other *.a lib before libpbs.so sometimes caused reading symbols from the *.a lib and then it was read also from libpbs.so because it was used inside of libpbs.so itself. Moving libpbs.so to the top, the linker reads the symbols from libpbs.so and not reading them from subsequent *.a libs. It resolves the odr-violations.
- Miscellaneous memory leaks were fixed. Usually, the leaks were on bin exiting and did no real harm except for the leak sanitizer complaining, and the executed binary exited with a positive exit code, which resulted in PTL error.
- There are also some threads issues connected to thread initialization. Like pthread_getspecific() was called before pthread_key_create().
- While compiling with Kerberos, compiler warnings were resolved.
- Leak sanitizer was disabled in mom in a forked process that becomes user process. Sanitizer was not able to connect to the process after using setuid()/setgid().
- Python-related staff in PBS are compiled with libpython. Libpython is not compiled with sanitizer, which resulted in the error that ASAN is not the first liked library, hance this check is ignored in appropriate places.
- As SELinux is enabled by default in some modern Linux systems, I also suggest informing the admins that PBS has issues handling SELinux in the installation guide. This is because postgres requires certain context. Not having the context on the datastore results in initdb permission error while PBS is installed.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

Working CI is the proof of testing.

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
