### PR TITLE
Node creation and attribute setting unbearably slow on large clusters.

### DIFF
--- a/src/include/pbs_nodes.h
+++ b/src/include/pbs_nodes.h
@@ -252,6 +252,7 @@ struct pbsnode {
 	int nd_added_to_unlicensed_list; /* To record if the node is added to the list of unlicensed node */
 	pbs_list_link un_lic_link;	 /*Link to unlicense list */
 	int nd_svrflags;		 /* server flags */
+	int nd_modified;
 	attribute nd_attr[ND_ATR_LAST];
 };
 typedef struct pbsnode pbs_node;

--- a/src/scheduler/misc.cpp
+++ b/src/scheduler/misc.cpp
@@ -99,7 +99,7 @@ string_dup(const char *str)
 
 /**
  * @brief
- * 		add a string to a string to a string array only if it is unique
+ * 		add a string to a string array only if it is unique
  *
  * @param[in,out]	str_arr	-	array of strings of unique values
  * @param[in]	str	-	string to add

--- a/src/server/hook_func.c
+++ b/src/server/hook_func.c
@@ -6876,6 +6876,7 @@ get_server_hook_results(char *input_file, int *accept_flag, int *reject_flag, ch
 					} else {
 						mgr_log_attr(msg_man_set, plist,
 							     PBS_EVENTCLASS_NODE, pnode->nd_name, NULL);
+						pnode->nd_modified = 1;
 					}
 				}
 				free_svrattrl(plist);

--- a/src/server/nattr_get_set.c
+++ b/src/server/nattr_get_set.c
@@ -169,6 +169,7 @@ set_nattr_generic(struct pbsnode *pnode, int attr_idx, char *val, char *rscn, en
 	if (pnode == NULL || val == NULL)
 		return 1;
 
+	pnode->nd_modified = 1;
 	return set_attr_generic(get_nattr(pnode, attr_idx), &node_attr_def[attr_idx], val, rscn, op);
 }
 
@@ -190,6 +191,7 @@ set_nattr_str_slim(struct pbsnode *pnode, int attr_idx, char *val, char *rscn)
 	if (pnode == NULL || val == NULL)
 		return 1;
 
+	pnode->nd_modified = 1;
 	return set_attr_generic(get_nattr(pnode, attr_idx), &node_attr_def[attr_idx], val, rscn, INTERNAL);
 }
 
@@ -211,6 +213,12 @@ set_nattr_l_slim(struct pbsnode *pnode, int attr_idx, long val, enum batch_op op
 	if (pnode == NULL)
 		return 1;
 
+	if ((attr_idx != ND_ATR_last_state_change_time) && 
+		(attr_idx != ND_ATR_state || 
+		 (val == INUSE_OFFLINE || val == INUSE_OFFLINE_BY_MOM ||
+		  val == INUSE_MAINTENANCE ||val == INUSE_SLEEP ||
+		  val == INUSE_PROV || val == INUSE_WAIT_PROV)))
+		pnode->nd_modified = 1;
 	set_attr_l(get_nattr(pnode, attr_idx), val, op);
 
 	return 0;
@@ -234,6 +242,7 @@ set_nattr_b_slim(struct pbsnode *pnode, int attr_idx, long val, enum batch_op op
 	if (pnode == NULL)
 		return 1;
 
+	pnode->nd_modified = 1;
 	set_attr_b(get_nattr(pnode, attr_idx), val, op);
 
 	return 0;
@@ -257,6 +266,7 @@ set_nattr_c_slim(struct pbsnode *pnode, int attr_idx, char val, enum batch_op op
 	if (pnode == NULL)
 		return 1;
 
+	pnode->nd_modified = 1;
 	set_attr_c(get_nattr(pnode, attr_idx), val, op);
 
 	return 0;
@@ -280,6 +290,7 @@ set_nattr_short_slim(struct pbsnode *pnode, int attr_idx, short val, enum batch_
 	if (pnode == NULL)
 		return 1;
 
+	pnode->nd_modified = 1;
 	set_attr_short(get_nattr(pnode, attr_idx), val, op);
 
 	return 0;
@@ -345,6 +356,7 @@ clear_nattr(struct pbsnode *pnode, int attr_idx)
 void
 set_nattr_jinfo(struct pbsnode *pnode, int attr_idx, struct pbsnode *val)
 {
+	pnode->nd_modified = 1;
 	attribute *attr = get_nattr(pnode, attr_idx);
 	attr->at_val.at_jinfo = val;
 	attr->at_flags = ATR_SET_MOD_MCACHE;

--- a/src/server/node_func.c
+++ b/src/server/node_func.c
@@ -298,6 +298,7 @@ initialize_pbsnode(struct pbsnode *pnode, char *pname, int ntype)
 	pnode->nd_nummoms = 0;
 	pnode->nd_svrflags |= NODE_NEWOBJ;
 	pnode->nd_lic_info = NULL;
+	pnode->nd_modified = 0;
 	pnode->nd_moms = (mominfo_t **) calloc(1, sizeof(mominfo_t *));
 	if (pnode->nd_moms == NULL)
 		return (PBSE_SYSTEM);
@@ -387,7 +388,7 @@ subnode_delete(struct pbssubn *psubn)
  * @brief
  * 		Remove the vnode from the list of vnodes of a mom.
  * @see
- * 		effective_node_delete and effective_node_delete
+ * 		effective_node_delete
  *
  * @param[in]	pnode	- Vnode structure
  *
@@ -718,9 +719,12 @@ save_nodes_db_mom(mominfo_t *pmom)
 			continue;
 		}
 
-		if (node_save_db(np) != 0) {
-			log_event(PBSEVENT_ADMIN, PBS_EVENTCLASS_SERVER, LOG_WARNING, "nodes", nodeerrtxt);
-			return (-1);
+		if (np->nd_modified) {
+			if (node_save_db(np) != 0) {
+				log_event(PBSEVENT_ADMIN, PBS_EVENTCLASS_SERVER, LOG_WARNING, "nodes", nodeerrtxt);
+				return (-1);
+			}
+			np->nd_modified = 0;
 		}
 	}
 

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -1184,9 +1184,8 @@ set_vnode_state(struct pbsnode *pnode, unsigned long state_bits, enum vnode_stat
 	time_now = time(NULL);
 	time_int_val = time_now;
 
-	if (pnode == NULL) {
+	if (pnode == NULL)
 		return;
-	}
 
 	/*
 	 * Allocate space for the modifyvnode hook event params
@@ -1238,17 +1237,18 @@ set_vnode_state(struct pbsnode *pnode, unsigned long state_bits, enum vnode_stat
 	if (pnode->nd_state != get_nattr_long(pnode, ND_ATR_state))
 		set_nattr_l_slim(pnode, ND_ATR_state, pnode->nd_state, SET);
 
-	if (vnode_o->nd_state != pnode->nd_state)
+	if (vnode_o->nd_state != pnode->nd_state) {
 		set_nattr_l_slim(pnode, ND_ATR_last_state_change_time, time_int_val, SET);
 
-	/* Write the vnode state change event to server log */
-	last_time_int = (int) vnode_o->nd_attr[(int) ND_ATR_last_state_change_time].at_val.at_long;
-	log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_NODE, LOG_INFO, pnode->nd_name,
-		   "set_vnode_state;vnode.state=0x%lx vnode_o.state=0x%lx "
-		   "vnode.last_state_change_time=%d vnode_o.last_state_change_time=%d "
-		   "state_bits=0x%lx state_bit_op_type_str=%s state_bit_op_type_enum=%d",
-		   pnode->nd_state, vnode_o->nd_state, time_int_val, last_time_int,
-		   state_bits, get_vnode_state_op(type), type);
+		/* Write the vnode state change event to server log */
+		last_time_int = (int) vnode_o->nd_attr[(int) ND_ATR_last_state_change_time].at_val.at_long;
+		log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_NODE, LOG_INFO, pnode->nd_name,
+		   	"set_vnode_state;vnode.state=0x%lx vnode_o.state=0x%lx "
+		   	"vnode.last_state_change_time=%d vnode_o.last_state_change_time=%d "
+		   	"state_bits=0x%lx state_bit_op_type_str=%s state_bit_op_type_enum=%d",
+		   	pnode->nd_state, vnode_o->nd_state, time_int_val, last_time_int,
+		   	state_bits, get_vnode_state_op(type), type);
+	}
 
 	if (pnode->nd_state & INUSE_PROV) {
 		if (!(pnode->nd_state & VNODE_UNAVAILABLE) ||
@@ -1281,6 +1281,17 @@ set_vnode_state(struct pbsnode *pnode, unsigned long state_bits, enum vnode_stat
 		 */
 		goto fn_fire_event;
 	}
+
+	unsigned long bits;
+	if (type == Nd_State_And)
+		bits = ~state_bits;
+	else
+		bits = state_bits;
+
+	if (bits & INUSE_OFFLINE || bits & INUSE_OFFLINE_BY_MOM ||
+		bits & INUSE_MAINTENANCE || bits & INUSE_SLEEP ||
+		bits & INUSE_PROV || bits & INUSE_WAIT_PROV)
+		pnode->nd_modified = 1;
 
 	DBPRT(("%s(%5s): state transition 0x%lx --> 0x%lx\n", __func__, pnode->nd_name,
 	       vnode_o->nd_state, pnode->nd_state))
@@ -3483,9 +3494,8 @@ update2_to_vnode(vnal_t *pvnal, int new, mominfo_t *pmom, int *madenew, int from
 		 * current vnode's parent mom be the incoming node,
 		 * which is what cross_link_mom_node() does.
 		 */
-		if ((i = cross_link_mom_vnode(pnode, pmom)) != 0) {
+		if ((i = cross_link_mom_vnode(pnode, pmom)) != 0)
 			return (i);
-		}
 	}
 
 	/*
@@ -3888,6 +3898,7 @@ update2_to_vnode(vnal_t *pvnal, int new, mominfo_t *pmom, int *madenew, int from
 		set_vnode_state(pnode,
 				~states_to_clear,
 				Nd_State_And);
+		pnode->nd_modified = 1;
 		return 0;
 	} else {
 		snprintf(log_buffer, sizeof(log_buffer),
@@ -4700,14 +4711,14 @@ found:
 
 					if (is_nattr_set(np, ND_ATR_version) == 0 || strcmp(psvrmom->msr_pbs_ver, get_nattr_str(np, ND_ATR_version)) != 0) {
 						free_nattr(np, ND_ATR_version);
-						set_nattr_str_slim(np, ND_ATR_version, psvrmom->msr_pbs_ver, NULL);
+						if (!set_nattr_str_slim(np, ND_ATR_version, psvrmom->msr_pbs_ver, NULL))
+							np->nd_modified = 1;
 					}
 				}
 			}
 
-			if (made_new_vnodes || cr_node) {
+			if (made_new_vnodes || cr_node)
 				save_nodes_db(1, pmom); /* update the node database */
-			}
 
 			if (command_orig == IS_REGISTERMOM) {
 				/* Mom is acknowledging the info sent by the Server */

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -1285,9 +1285,9 @@ set_vnode_state(struct pbsnode *pnode, unsigned long state_bits, enum vnode_stat
 	unsigned long bits;
 	bits = vnode_o->nd_state ^ pnode->nd_state;
 
-	if (bits & INUSE_OFFLINE || bits & INUSE_OFFLINE_BY_MOM ||
-		bits & INUSE_MAINTENANCE || bits & INUSE_SLEEP ||
-		bits & INUSE_PROV || bits & INUSE_WAIT_PROV)
+	if (bits & (INUSE_OFFLINE | INUSE_OFFLINE_BY_MOM |
+		    INUSE_MAINTENANCE | INUSE_SLEEP |
+		    INUSE_PROV | INUSE_WAIT_PROV))
 		pnode->nd_modified = 1;
 
 	DBPRT(("%s(%5s): state transition 0x%lx --> 0x%lx\n", __func__, pnode->nd_name,

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -1283,10 +1283,7 @@ set_vnode_state(struct pbsnode *pnode, unsigned long state_bits, enum vnode_stat
 	}
 
 	unsigned long bits;
-	if (type == Nd_State_And)
-		bits = ~state_bits;
-	else
-		bits = state_bits;
+	bits = vnode_o->nd_state ^ pnode->nd_state;
 
 	if (bits & INUSE_OFFLINE || bits & INUSE_OFFLINE_BY_MOM ||
 		bits & INUSE_MAINTENANCE || bits & INUSE_SLEEP ||

--- a/src/server/node_recov_db.c
+++ b/src/server/node_recov_db.c
@@ -404,10 +404,18 @@ recov_node_cb(pbs_db_obj_info_t *dbobj, int *refreshed)
 	struct pbsnode *pnode = NULL;
 	pbs_db_node_info_t *dbnode = dbobj->pbs_db_un.pbs_db_node;
 	int load_type = 0;
+	extern time_t time_now;
 
 	*refreshed = 0;
-	if ((pnode = pbsd_init_node(dbnode, load_type)) != NULL)
+	if ((pnode = pbsd_init_node(dbnode, load_type)) != NULL) {
 		*refreshed = 1;
+		pnode->nd_state = dbnode->nd_state;
+		if (pnode->nd_state != get_nattr_long(pnode, ND_ATR_state)) {
+			set_nattr_l_slim(pnode, ND_ATR_state, pnode->nd_state, SET);
+			set_nattr_l_slim(pnode, ND_ATR_last_state_change_time, time_now, SET);
+		}
+		pnode->nd_modified = 0;
+	}
 
 	free_db_attr_list(&dbnode->db_attr_list);
 	if (pnode == NULL)

--- a/src/server/req_signal.c
+++ b/src/server/req_signal.c
@@ -649,6 +649,7 @@ set_admin_suspend(job *pjob, int set_remove_nstate)
 						set_vnode_state(pnode, ~INUSE_MAINTENANCE, Nd_State_And);
 				}
 			}
+			pnode->nd_modified = 1;
 		}
 		chunk = parse_plus_spec_r(last, &last, &hasprn);
 	}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
PBS saves all nodes to DB even when a single node's attribute is changed. The same happens even when a node is created.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Save only those nodes that are modified.
Also, save the states that are set by the admin OR cannot be determined on the fly.

Testing logs
[openpbs testing.txt](https://github.com/openpbs/openpbs/files/12495961/openpbs.testing.txt)