### PR TITLE
Updated logging to aid in debugging.

### DIFF
--- a/src/lib/Libtpp/tpp_transport.c
+++ b/src/lib/Libtpp/tpp_transport.c
@@ -1621,6 +1621,7 @@ work(void *v)
 
 			conn = alloc_conn(newfd);
 			if (!conn) {
+				tpp_log(LOG_CRIT, __func__, "Allocating socket connection failed.");
 				tpp_sock_close(newfd);
 				return NULL;
 			}

--- a/src/server/hook_func.c
+++ b/src/server/hook_func.c
@@ -962,8 +962,17 @@ mgr_hook_delete(struct batch_request *preq)
 
 	phook = find_hook(hookname);
 
-	if ((phook == NULL) || phook->pending_delete) {
+	if (phook == NULL) {
 		snprintf(hook_msg, sizeof(hook_msg), "%s does not exist!",
+			 hookname);
+		log_event(PBSEVENT_ADMIN, PBS_EVENTCLASS_HOOK, LOG_INFO,
+			  hookname, hook_msg);
+		reply_text(preq, PBSE_HOOKERROR, hook_msg);
+		return;
+	}
+
+	if (phook->pending_delete) {
+		snprintf(hook_msg, sizeof(hook_msg), "%s is pending delete!",
 			 hookname);
 		log_event(PBSEVENT_ADMIN, PBS_EVENTCLASS_HOOK, LOG_INFO,
 			  hookname, hook_msg);


### PR DESCRIPTION
tpp_transport.c: added log due to when running out of file descriptors
	causes a return with no message.
hook_func.c: split the hook doesn't exist from pending delete messages.
	This is a problem when trying to delete a mom hook with a mom down.
node_manager.c: Raising the log level of node state changes from
	DEBUG2 -> DEBUG3.
node_manager.c: added detail reason for connection reject.  This was found
	when debugging an unauthorized mom connect.