### PR TITLE
only manual states of nodes should be recovered from db

### DIFF
--- a/src/include/pbs_nodes.h
+++ b/src/include/pbs_nodes.h
@@ -307,6 +307,9 @@ enum part_flags { PART_refig,
 #define VNODE_UNAVAILABLE (INUSE_STALE | INUSE_OFFLINE | INUSE_DOWN | \
 			   INUSE_DELETED | INUSE_UNKNOWN | INUSE_UNRESOLVABLE | INUSE_OFFLINE_BY_MOM | INUSE_MAINTENANCE | INUSE_SLEEP)
 
+/* states that are set by the admin OR cannot be determined on the fly */
+#define INUSE_NOAUTO_MASK (INUSE_OFFLINE | INUSE_OFFLINE_BY_MOM | INUSE_MAINTENANCE | INUSE_SLEEP | INUSE_PROV | INUSE_WAIT_PROV)
+
 /* the following are used in Mom's internal state			*/
 #define MOM_STATE_DOWN INUSE_DOWN
 #define MOM_STATE_BUSY INUSE_BUSY

--- a/src/server/nattr_get_set.c
+++ b/src/server/nattr_get_set.c
@@ -214,10 +214,7 @@ set_nattr_l_slim(struct pbsnode *pnode, int attr_idx, long val, enum batch_op op
 		return 1;
 
 	if ((attr_idx != ND_ATR_last_state_change_time) && 
-		(attr_idx != ND_ATR_state || 
-		 (val == INUSE_OFFLINE || val == INUSE_OFFLINE_BY_MOM ||
-		  val == INUSE_MAINTENANCE ||val == INUSE_SLEEP ||
-		  val == INUSE_PROV || val == INUSE_WAIT_PROV)))
+		(attr_idx != ND_ATR_state || (val & INUSE_NOAUTO_MASK)))
 		pnode->nd_modified = 1;
 	set_attr_l(get_nattr(pnode, attr_idx), val, op);
 

--- a/src/server/node_recov_db.c
+++ b/src/server/node_recov_db.c
@@ -409,7 +409,7 @@ recov_node_cb(pbs_db_obj_info_t *dbobj, int *refreshed)
 	*refreshed = 0;
 	if ((pnode = pbsd_init_node(dbnode, load_type)) != NULL) {
 		*refreshed = 1;
-		pnode->nd_state = dbnode->nd_state;
+		pnode->nd_state |= (dbnode->nd_state & INUSE_NOAUTO_MASK);
 		if (pnode->nd_state != get_nattr_long(pnode, ND_ATR_state)) {
 			set_nattr_l_slim(pnode, ND_ATR_state, pnode->nd_state, SET);
 			set_nattr_l_slim(pnode, ND_ATR_last_state_change_time, time_now, SET);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->

PBS saves the set of node's states into db only if a manual state is put into the set of states (introduced in #2607). It can happen that the auto-determined state is no longer valid at the time of the set of states recovering ...but it is recovered anyway.  The auto-determined states could already be set and recovering rewrites the correct state with the old state. 

We can get an invalid node like this, see this error:

1) run a single job that utilizes all ncpus, the node is `job-busy` as expected.
```
torque4.grid.cesnet.cz$ qsub -I -l select=ncpus=2
qsub: waiting for job 5002.torque4.grid.cesnet.cz to start
qsub: job 5002.torque4.grid.cesnet.cz ready

torque5.grid.cesnet.cz$ 

torque4.grid.cesnet.cz$ pbsnodes -a
torque5
     Mom = torque5.grid.cesnet.cz
     ntype = PBS
     state = job-busy
     pcpus = 2
     jobs = 5000.torque4.grid.cesnet.cz/0, 5000.torque4.grid.cesnet.cz/1
     resources_available.arch = linux
     resources_available.host = torque5
     resources_available.mem = 2029568kb
     resources_available.ncpus = 2
     resources_available.vmem = 2029568kb
     resources_available.vnode = torque5
     resources_assigned.accelerator_memory = 0kb
     resources_assigned.hbmem = 0kb
     resources_assigned.mem = 0kb
     resources_assigned.naccelerators = 0
     resources_assigned.ncpus = 2
     resources_assigned.vmem = 0kb
     resv_enable = True
     sharing = default_shared
     license = l
     last_state_change_time = Sat Oct  7 10:45:52 2023

torque4.grid.cesnet.cz$ 
```
2) exit job - the node is free

3) restart pbs server

4) the node is `job-busy` without any job on it:
```
torque4.grid.cesnet.cz$ pbsnodes -a
torque5
     Mom = torque5.grid.cesnet.cz
     ntype = PBS
     state = job-busy
     pcpus = 2
     resources_available.arch = linux
     resources_available.host = torque5
     resources_available.mem = 2029568kb
     resources_available.ncpus = 2
     resources_available.vmem = 2029568kb
     resources_available.vnode = torque5
     resources_assigned.accelerator_memory = 0kb
     resources_assigned.hbmem = 0kb
     resources_assigned.mem = 0kb
     resources_assigned.naccelerators = 0
     resources_assigned.ncpus = 0
     resources_assigned.vmem = 0kb
     resv_enable = True
     sharing = default_shared
     license = l
     last_state_change_time = Sat Oct  7 10:47:43 2023
     last_used_time = Sat Oct  7 10:47:24 2023

torque4.grid.cesnet.cz$ 
```



#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

If we save node states only at the time the manual state is set, we should also ignore the auto-determined states while recovering node states.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->

[openpbs.testing_node_state_recovery.txt](https://github.com/openpbs/openpbs/files/12837347/openpbs.testing_node_state_recovery.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
