### PR TITLE
fix race condition in environment with gss/krb on server init

### DIFF
--- a/src/server/pbsd_init.c
+++ b/src/server/pbsd_init.c
@@ -360,9 +360,6 @@ pbsd_init(int type)
 
 	/* The following is code to reduce security risks                */
 
-	if (setup_env(pbs_conf.pbs_environment) == -1)
-		return (-1);
-
 	log_supported_auth_methods(pbs_conf.supported_auth_methods);
 
 	i = getgid();

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -1164,6 +1164,12 @@ main(int argc, char **argv)
 		return (1);
 	}
 
+	if (setup_env(pbs_conf.pbs_environment) == -1) {
+		fprintf(stderr, "%s\n", "Setup environment failed");
+		stop_db();
+		return (3);
+	}
+
 	/* set tpp config */
 	rc = set_tpp_config(&pbs_conf, &tpp_conf, nodename, pbs_server_port_dis, pbs_conf.pbs_leaf_routers);
 	free(nodename);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->

There is a race condition in the environment settings of pbs server on server initialization.

Using gss and kerberos, the function `pbs_gss_establish_context()` calling `init_pbs_client_ccache_from_keytab()` sets the KRB5CCNAME env and it needs the value few lines later in order to success of `gss_acquire_cred()`. This is the other thread...

PBS initializes the environment in the first thread using function `setup_env()` and the environment is set to null here. It can happen the env is set to null between `init_pbs_client_ccache_from_keytab()` and `gss_acquire_cred()`, which results in error:
```
10/07/2023 11:54:33;0001;Server@torque4;Svr;;GSS - gss_acquire_cred :  No credentials were supplied, or the credentials were unavailable or inaccessible.
10/07/2023 11:54:33;0001;Server@torque4;Svr;;GSS - gss_acquire_cred : unknown mech-code 0 for mech unknown
10/07/2023 11:54:33;0080;Server@torque4;Svr;;Refreshing server credentials at 1696672473
10/07/2023 11:54:33;0080;Server@torque4;Svr;;Server credentials renewed with indefinite lifetime, using 7200.
```
And the server connection is not established.

The problem showing removal of KRB5CCNAME while we are between the two function in gdb here:
```
(gdb) r
The program being debugged has been started already.
Start it from the beginning? (y or n) y
Starting program: /usr/sbin/pbs_server.bin -N
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
[Detaching after vfork from child process 4053891]
[Detaching after vfork from child process 4053900]
[Detaching after vfork from child process 4053903]
[Detaching after vfork from child process 4053914]
[Detaching after vfork from child process 4053928]
[Detaching after vfork from child process 4053937]
Connecting to PBS dataservice....connected to PBS dataservice@torque4.grid.cesnet.cz
[New Thread 0x7ffff4365700 (LWP 4053947)]

Thread 1 "pbs_server.bin" hit Breakpoint 1, setup_env (filen=0x555555718cd0 "/var/spool/pbs/pbs_environment")
    at setup_env.c:82
82		int questionable = 0;
(gdb) n
84		int nstr = 0;
(gdb) 
86		char *pval = NULL;
(gdb) 
89		if (environ == envp) {
(gdb) 
95		environ = nulenv;
(gdb) print (char*)getenv("KRB5CCNAME")
$1 = 0x7fffec00145b "FILE:/tmp/krb5cc_pbs_client"
(gdb) n
96		if ((filen == NULL) || (*filen == '\0'))
(gdb) print (char*)getenv("KRB5CCNAME")
$2 = 0x0
(gdb) info threads 
  Id   Target Id                                            Frame 
* 1    Thread 0x7ffff4783e00 (LWP 4053890) "pbs_server.bin" setup_env (
    filen=0x555555718cd0 "/var/spool/pbs/pbs_environment") at setup_env.c:96
  2    Thread 0x7ffff4365700 (LWP 4053947) "pbs_server.bin" 0x00007ffff73b296f in __GI___poll (
    fds=fds@entry=0x7ffff43622b8, nfds=nfds@entry=1, timeout=1000, 
    timeout@entry=<error reading variable: That operation is not available on integers of more than 8 bytes.>)
    at ../sysdeps/unix/sysv/linux/poll.c:29
(gdb) thread 2
[Switching to thread 2 (Thread 0x7ffff4365700 (LWP 4053947))]
#0  0x00007ffff73b296f in __GI___poll (fds=fds@entry=0x7ffff43622b8, nfds=nfds@entry=1, timeout=1000, 
    timeout@entry=<error reading variable: That operation is not available on integers of more than 8 bytes.>)
    at ../sysdeps/unix/sysv/linux/poll.c:29
29	../sysdeps/unix/sysv/linux/poll.c: No such file or directory.
(gdb) bt
#0  0x00007ffff73b296f in __GI___poll (fds=fds@entry=0x7ffff43622b8, nfds=nfds@entry=1, timeout=1000, 
    timeout@entry=<error reading variable: That operation is not available on integers of more than 8 bytes.>)
    at ../sysdeps/unix/sysv/linux/poll.c:29
#1  0x00007ffff4dc5260 in send_dg (statp=0x7ffff4362c40, buf=<optimized out>, buflen=<optimized out>, 
    buf2=0x7ffff4362280 "p/!e", buflen2=<optimized out>, ansp=<optimized out>, anssizp=<optimized out>, 
    terrno=<optimized out>, ns=<optimized out>, v_circuit=<optimized out>, gotsomewhere=<optimized out>, 
    anscp=<optimized out>, ansp2=<optimized out>, anssizp2=<optimized out>, resplen2=<optimized out>, 
    ansp2_malloced=<optimized out>) at res_send.c:1151
#2  0x00007ffff4dc5f89 in __res_context_send (ctx=ctx@entry=0x7fffec001f00, 
    buf=buf@entry=0x7ffff4362500 "9\276\001", buflen=50, buf2=buf2@entry=0x0, buflen2=buflen2@entry=0, 
    ans=<optimized out>, ans@entry=0x7fffec006b80 "2o\201\200", anssiz=<optimized out>, ansp=<optimized out>, 
    ansp2=<optimized out>, nansp2=<optimized out>, resplen2=<optimized out>, ansp2_malloced=<optimized out>)
    at res_send.c:530
#3  0x00007ffff4dc2d4a in __GI___res_context_query (ctx=ctx@entry=0x7fffec001f00, 
    name=name@entry=0x7ffff4363300 "_kerberos.torque4.grid.cesnet.cz.", class=class@entry=1, type=type@entry=16, 
    answer=answer@entry=0x7fffec006b80 "2o\201\200", anslen=anslen@entry=24000, answerp=0x0, answerp2=0x0, 
    nanswerp2=0x0, resplen2=0x0, answerp2_malloced=0x0) at res_query.c:216
#4  0x00007ffff4dc39bf in __res_context_querydomain (answerp2_malloced=0x0, resplen2=0x0, nanswerp2=0x0, 
    answerp2=0x0, answerp=0x0, anslen=24000, answer=0x7fffec006b80 "2o\201\200", type=16, class=1, domain=0x0, 
    name=0x7ffff4363300 "_kerberos.torque4.grid.cesnet.cz.", ctx=0x7fffec001f00) at res_query.c:601
#5  __GI___res_context_search (ctx=ctx@entry=0x7fffec001f00, 
    name=name@entry=0x7ffff4363300 "_kerberos.torque4.grid.cesnet.cz.", class=class@entry=1, type=type@entry=16, 
    answer=answer@entry=0x7fffec006b80 "2o\201\200", anslen=anslen@entry=24000, answerp=<optimized out>, 
    answerp2=<optimized out>, nanswerp2=<optimized out>, resplen2=<optimized out>, 
    answerp2_malloced=<optimized out>) at res_query.c:370
#6  0x00007ffff4dc405f in context_search_common (anslen=24000, answer=0x7fffec006b80 "2o\201\200", type=16, 
    class=1, name=0x7ffff4363300 "_kerberos.torque4.grid.cesnet.cz.", ctx=0x7fffec001f00) at res_query.c:539
#7  __res_nsearch (statp=<optimized out>, name=0x7ffff4363300 "_kerberos.torque4.grid.cesnet.cz.", class=1, 
    type=16, answer=0x7fffec006b80 "2o\201\200", anslen=24000) at res_query.c:552
#8  0x00007ffff43b7165 in ?? () from /lib/x86_64-linux-gnu/libroken.so.18
#9  0x00007ffff470293a in ?? () from /lib/x86_64-linux-gnu/libkrb5.so.26
#10 0x00007ffff4702ccc in _krb5_get_host_realm_int () from /lib/x86_64-linux-gnu/libkrb5.so.26
#11 0x00007ffff4702dda in krb5_get_host_realm () from /lib/x86_64-linux-gnu/libkrb5.so.26
#12 0x00007ffff46fb203 in krb5_expand_hostname_realms () from /lib/x86_64-linux-gnu/libkrb5.so.26
#13 0x00007ffff471be08 in ?? () from /lib/x86_64-linux-gnu/libkrb5.so.26
#14 0x00007ffff471d0e7 in krb5_sname_to_principal () from /lib/x86_64-linux-gnu/libkrb5.so.26
#15 0x00007ffff7fc41ab in init_pbs_client_ccache_from_keytab (err_buf=0x7ffff7fca260 <gss_log_buffer> "", 
    err_buf_size=4352) at pbs_gss.c:537
#16 0x00007ffff7fc4a9c in pbs_gss_establish_context (gss_extra=0x7fffec001280, data_in=0x0, len_in=0, 
    data_out=0x7ffff4364af0, len_out=0x7ffff4364ae8) at pbs_gss.c:724
#17 0x00007ffff7fc6035 in pbs_auth_process_handshake_data (ctx=0x7fffec001280, data_in=0x0, len_in=0, 
    data_out=0x7ffff4364af0, len_out=0x7ffff4364ae8, is_handshake_done=0x7ffff4364ae4) at pbs_gss.c:1063
#18 0x0000555555629b04 in tpp_handle_auth_handshake (tfd=13, conn_fd=13, authdata=0x7fffec001220, for_encrypt=1, 
    data_in=0x0, len_in=0) at tpp_util.c:600
#19 0x00005555556212cc in leaf_post_connect_handler (tfd=13, data=0x0, c=0x5555556f90b0, extra=0x0)
    at tpp_client.c:482
#20 0x0000555555627adf in work (v=0x55555572f8b0) at tpp_transport.c:1594
#21 0x00007ffff78d6ea7 in start_thread (arg=<optimized out>) at pthread_create.c:477
#22 0x00007ffff73bea2f in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
(gdb) 
```




#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Move the `setup_env()` before starting the thread with tpp.

I considered not using the KRB5CCNAME in this case but I do not think it is possible with the gss/krb5 function gss_acquire_cred(). 

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

With this fix, the connection is established and no gss eror message:
```
(BULLSEYE)root@torque4:~# systemctl restart pbs
(BULLSEYE)root@torque4:~# pbsnodes -a
torque5
     Mom = torque5.grid.cesnet.cz
     Port = 15002
     pbs_version = 23.06.06
     ntype = PBS
     state = free
     pcpus = 2
     resources_available.arch = linux
     resources_available.host = torque5
     resources_available.mem = 2029568kb
     resources_available.ncpus = 2
     resources_available.vmem = 2029568kb
     resources_available.vnode = torque5
     resources_assigned.accelerator_memory = 0kb
     resources_assigned.hbmem = 0kb
     resources_assigned.mem = 0kb
     resources_assigned.naccelerators = 0
     resources_assigned.ncpus = 0
     resources_assigned.vmem = 0kb
     resv_enable = True
     sharing = default_shared
     license = l
     last_state_change_time = Sat Oct  7 12:25:08 2023
     last_used_time = Sat Oct  7 11:15:04 2023

(BULLSEYE)root@torque4:~# 
```




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
