### PR TITLE
Some fixes for FreeBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -128,7 +128,6 @@ AC_CHECK_HEADERS([ \
 # Checks for required header files.
 AC_CHECK_HEADERS([ \
 	stdio.h \
-	alloca.h \
 	arpa/inet.h \
 	assert.h \
 	ctype.h \
@@ -147,7 +146,6 @@ AC_CHECK_HEADERS([ \
 	netdb.h \
 	netinet/in.h \
 	netinet/in_systm.h \
-	netinet/ip.h \
 	netinet/tcp.h \
 	openssl/aes.h \
 	openssl/bio.h \
@@ -175,7 +173,6 @@ AC_CHECK_HEADERS([ \
 	sys/mount.h \
 	sys/param.h \
 	sys/poll.h \
-	sys/quota.h \
 	sys/resource.h \
 	sys/select.h \
 	sys/signal.h \

--- a/m4/with_tcl.m4
+++ b/m4/with_tcl.m4
@@ -50,9 +50,18 @@ AC_DEFUN([PBS_AC_WITH_TCL],
     tcl_dir=["$with_tcl"],
     tcl_dir=["/usr"]
   )
+  AC_ARG_WITH([tk],
+    AS_HELP_STRING([--with-tk=DIR],
+      [Specify the directory where Tk is installed.]
+    )
+  )
+  AS_IF([test "x$with_tk" != "x"],
+    tk_dir=["$with_tk"],
+    tk_dir=["/usr"]
+  )
   AC_MSG_CHECKING([for Tcl])
-  AS_IF([test -r "$tcl_dir/lib64/tclConfig.sh"],
-    [. "$tcl_dir/lib64/tclConfig.sh"],
+  AS_IF([test -r "$tcl_dir/tclConfig.sh"],
+    [. "$tcl_dir/tclConfig.sh"],
     AS_IF([test -r "$tcl_dir/lib/tclConfig.sh"],
       [. "$tcl_dir/lib/tclConfig.sh"],
       AS_IF([test -r "$tcl_dir/lib/x86_64-linux-gnu/tclConfig.sh"],
@@ -66,8 +75,8 @@ AC_DEFUN([PBS_AC_WITH_TCL],
   [tcl_version="$TCL_VERSION"]
   AC_SUBST(tcl_version)
   AC_MSG_CHECKING([for Tk])
-  AS_IF([test -r "$tcl_dir/lib64/tkConfig.sh"],
-    [. "$tcl_dir/lib64/tkConfig.sh"],
+  AS_IF([test -r "$tk_dir/tkConfig.sh"],
+    [. "$tk_dir/tkConfig.sh"],
     AS_IF([test -r "$tcl_dir/lib/tkConfig.sh"],
       [. "$tcl_dir/lib/tkConfig.sh"],
       AS_IF([test -r "$tcl_dir/lib/x86_64-linux-gnu/tkConfig.sh"],

--- a/src/cmds/qstat.c
+++ b/src/cmds/qstat.c
@@ -62,6 +62,7 @@
 #include <stdlib.h>
 #include "pbs_internal.h"
 #include "libutil.h"
+#include <sys/socket.h>
 #include <arpa/inet.h>
 #include "pbs_json.h"
 

--- a/src/cmds/scripts/pbs_init.d.in
+++ b/src/cmds/scripts/pbs_init.d.in
@@ -645,6 +645,10 @@ conf=${PBS_CONF_FILE:-@PBS_CONF_FILE@}
 # re-apply saved env variables
 . "${env_save}"
 
+# get PATH
+. "${PBS_HOME}/pbs_environment"
+export PATH
+
 rm -f "${env_save}"
 
 if [ -z "${PBS_EXEC}" ]; then

--- a/src/lib/Libdb/pgsql/db_common.c
+++ b/src/lib/Libdb/pgsql/db_common.c
@@ -451,6 +451,7 @@ pbs_dataservice_control(char *cmd, char *pbs_ds_host, int pbs_ds_port)
 		 * try protect self from Linux OOM killer
 		 * but don't fail if can't update OOM score
 		 */
+#ifndef __FreeBSD__
 		if (access(oom_score_adj, F_OK) != -1) {
 			strcpy(oom_file, oom_score_adj);
 			oom_val = strdup("-1000");
@@ -467,6 +468,7 @@ pbs_dataservice_control(char *cmd, char *pbs_ds_host, int pbs_ds_port)
 				ret = PBS_DB_OOM_ERR;
 			free(oom_val);
 		}
+#endif
 		sprintf(errfile, "%s/spool/pbs_ds_monitor_errfile", pbs_conf.pbs_home_path);
 		/* launch monitoring program which will fork to background */
 		sprintf(dbcmd, "%s/sbin/pbs_ds_monitor monitor > %s 2>&1", pbs_conf.pbs_exec_path, errfile);
@@ -605,8 +607,10 @@ pbs_dataservice_control(char *cmd, char *pbs_ds_host, int pbs_ds_port)
 		}
 	} else if (rc == 0 && !(strcmp(cmd, PBS_DB_CONTROL_START))) {
 		/* launch systemd setup script */
+#ifndef __FreeBSD__
 		sprintf(dbcmd, "%s/sbin/pbs_ds_systemd", pbs_conf.pbs_exec_path);
 		rc = system(dbcmd);
+#endif
 		if (WIFEXITED(rc))
 			rc = WEXITSTATUS(rc);
 		if (rc != 0) {

--- a/src/lib/Libtpp/tpp_platform.c
+++ b/src/lib/Libtpp/tpp_platform.c
@@ -62,6 +62,8 @@
 #include <signal.h>
 #include "tpp_internal.h"
 
+#define INVALID_THREAD_ID ((pthread_t)-1)
+
 #ifdef WIN32
 
 /**
@@ -890,7 +892,7 @@ tpp_invalidate_thrd_handle(pthread_t *thrd)
 	thrd->thHandle = INVALID_HANDLE_VALUE;
 	thrd->thId = -1;
 #else
-	*thrd = -1; /* initialize to -1 */
+	*thrd = INVALID_THREAD_ID; /* initialize to an invalid value */
 #endif
 }
 
@@ -914,7 +916,7 @@ int
 tpp_is_valid_thrd(pthread_t thrd)
 {
 #ifndef WIN32
-	if (thrd != -1)
+	if (thrd != INVALID_THREAD_ID)
 		return 1;
 #else
 	if (thrd.thHandle != INVALID_HANDLE_VALUE)

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -169,6 +169,7 @@ pbs_upgrade_job_SOURCES = pbs_upgrade_job.c
 pbs_wish_CPPFLAGS = \
 	${common_cflags} \
 	@libz_inc@ \
+	@tcl_inc@ \
 	@tk_inc@
 
 pbs_wish_LDADD = \


### PR DESCRIPTION
OpenPBS does not compile "out of the box" on FreeBSD, and some files have to be patched:

- some headers are not available and configure fails;
- with_tcl and with_tk must be honored to detect TCL/TK;
- <sys/socket.h> must be included for qstat;
- the default PATH must include /usr/local/bin;
- systemd does not exist;
- recent clang fail on src/lib/Libtpp/tpp_platform.c.