### PR TITLE
being a job in prerun substate, prevent job discard on server init

### DIFF
--- a/src/server/pbsd_init.c
+++ b/src/server/pbsd_init.c
@@ -1362,8 +1362,12 @@ pbsd_init_job(job *pjob, int type)
 			case JOB_SUBSTATE_SYNCHOLD:
 			case JOB_SUBSTATE_DEPNHOLD:
 			case JOB_SUBSTATE_WAITING:
-			case JOB_SUBSTATE_PRERUN:
 				if (pbsd_init_reque(pjob, CHANGE_STATE) == -1)
+					return -1;
+				break;
+
+			case JOB_SUBSTATE_PRERUN:
+				if (pbsd_init_reque(pjob, KEEP_STATE) == -1)
 					return -1;
 				break;
 
@@ -1592,8 +1596,6 @@ pbsd_init_reque(job *pjob, int change_state)
 	int newsubstate;
 	int rc;
 
-	sprintf(logbuf, msg_init_substate, get_job_substate(pjob));
-
 	/* re-enqueue the job into the queue it was in */
 
 	if (change_state) {
@@ -1610,6 +1612,7 @@ pbsd_init_reque(job *pjob, int change_state)
 	post_attr_set(get_jattr(pjob, JOB_ATR_substate));
 
 	if ((rc = svr_enquejob(pjob, NULL)) == 0) {
+		sprintf(logbuf, msg_init_substate, get_job_substate(pjob));
 		(void) strcat(logbuf, msg_init_queued);
 		(void) strcat(logbuf, pjob->ji_qs.ji_queue);
 		log_event(PBSEVENT_SYSTEM | PBSEVENT_ADMIN | PBSEVENT_DEBUG,


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->

Hitting qterm in the sort period while a job is in PRERUN substate, the server's next initialization needlessly sets the recovered job state form R/PRERUN to Q/QUEUED and the running job is discarded on the next calling of `mom_running_jobs()`. The reason for discarding is a state mismatch. The job is successfully running on mom but the server considers the job QUEUED.

We can consistently reproduce this bug by setting a breakpoint in gdb on `svr_setjobstate` and once the job is set to R/PRERUN we hit the `qterm` command. Once the `qterm` command is waiting, we let the server process `continue` in gdb. Once the server is terminated, we start the `pbs_server` again. See the breakpoint:

```
Thread 1 "pbs_server.bin" hit Breakpoint 1, svr_setjobstate (pjob=0x5555557ec4c0, newstate=82 'R', newsubstate=41) at svr_jobfunc.c:525
525		pbs_queue *pque = pjob->ji_qhdr;
(gdb) bt
#0  svr_setjobstate (pjob=0x5555557ec4c0, newstate=82 'R', newsubstate=41) at svr_jobfunc.c:525
#1  0x00005555555e2f20 in svr_strtjob2 (pjob=0x5555557ec4c0, preq=0x55555571b8c0) at req_runjob.c:1053
#2  0x00005555555e2e34 in svr_startjob (pjob=0x5555557ec4c0, preq=0x55555571b8c0) at req_runjob.c:1013
#3  0x00005555555e25eb in req_runjob2 (preq=0x55555571b8c0, pjob=0x5555557ec4c0) at req_runjob.c:698
#4  0x00005555555e1a1b in req_runjob (preq=0x55555571b8c0) at req_runjob.c:473
#5  0x00005555555b9a96 in dispatch_request (sfds=17, request=0x55555571b8c0) at process_request.c:979
#6  0x00005555555b955a in process_request (sfds=17) at process_request.c:720
#7  0x000055555562efee in process_socket (sock=17) at net_server.c:510
#8  0x000055555562f182 in wait_request (waittime=2, priority_context=0x5555556febe0) at net_server.c:591
#9  0x00005555555b7a0a in main (argc=2, argv=0x7fffffffea38) at pbsd_main.c:1404
```

The log of this event follows:
```
(BULLSEYE)root@torque4:~# grep -E "Log|3.torque4.grid.cesnet.cz" /var/spool/pbs/server_logs/20240216
02/16/2024 08:35:48;0100;Server@torque4;Job;3.torque4.grid.cesnet.cz;enqueuing into default, state Q hop 1
02/16/2024 08:35:48;0008;Server@torque4;Job;3.torque4.grid.cesnet.cz;Job Queued at request of vchlum@META, owner = vchlum@META, job name = STDIN, queue = default
02/16/2024 08:35:48;0008;Server@torque4;Job;3.torque4.grid.cesnet.cz;Job Run at request of host/torque4.grid.cesnet.cz@EINFRA-SERVICES on exec_vnode (torque4:ncpus=1:mem=409600kb)
02/16/2024 08:36:15;0100;Server@torque4;Job;3.torque4.grid.cesnet.cz;sending credential to mom succeed
02/16/2024 08:36:18;0002;Server@torque4;Svr;Log;Log closed
02/16/2024 08:36:21;0002;Server@torque4;Svr;Log;Log opened
02/16/2024 08:36:36;0100;Server@torque4;Job;3.torque4.grid.cesnet.cz;enqueuing into default, state Q hop 1
02/16/2024 08:36:36;0086;Server@torque4;Job;3.torque4.grid.cesnet.cz;Requeueing job, substate: 41 Requeued in queue: default
02/16/2024 08:36:36;0008;Server@torque4;Job;3.torque4.grid.cesnet.cz;Discard running job, state mismatch 
02/16/2024 08:36:36;0008;Server@torque4;Job;3.torque4.grid.cesnet.cz;Job Run at request of host/torque4.grid.cesnet.cz@EINFRA-SERVICES on exec_vnode (torque4:ncpus=1:mem=409600kb)
02/16/2024 08:36:39;0100;Server@torque4;Job;3.torque4.grid.cesnet.cz;sending credential to mom succeed
02/16/2024 08:36:40;0080;Server@torque4;Job;3.torque4.grid.cesnet.cz;Obit received momhop:2 serverhop:2 state:R substate:41
02/16/2024 08:36:40;0080;Server@torque4;Job;3.torque4.grid.cesnet.cz;express end of job
02/16/2024 08:36:40;0010;Server@torque4;Job;3.torque4.grid.cesnet.cz;Exit_status=-1 resources_used.walltime=00:00:00
02/16/2024 08:36:40;0100;Server@torque4;Job;3.torque4.grid.cesnet.cz;dequeuing from default, state E
```

Examining the log leads to discovering one more confusing issue: The log lines of `enqueuing` and `Requeueing` have reversed order. The `Requeueing` line is stored in the memory before calling `svr_evaljobstate()`. `svr_evaljobstate()` changes the job state and logs the `enqueuing` line. Afterward, the previously stored state is logged along with `Requeueing` line.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* keep the PRERUN state of a job on server initialization
* fix the order of logging in `pbsd_init_reque()`

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

To reproduce the error consistently, we need the gdb. So the manual test is attached.

The critical situation is invoked after the fix in this log:
```
(BULLSEYE)root@torque4:~# grep -E "Log|6.torque4.grid.cesnet.cz" /var/spool/pbs/server_logs/20240216
02/16/2024 08:50:27;0100;Server@torque4;Job;6.torque4.grid.cesnet.cz;enqueuing into default, state Q hop 1
02/16/2024 08:50:27;0008;Server@torque4;Job;6.torque4.grid.cesnet.cz;Job Queued at request of vchlum@META, owner = vchlum@META, job name = STDIN, queue = default
02/16/2024 08:50:27;0008;Server@torque4;Job;6.torque4.grid.cesnet.cz;Job Run at request of host/torque4.grid.cesnet.cz@EINFRA-SERVICES on exec_vnode (torque4:ncpus=1:mem=409600kb)
02/16/2024 08:50:33;0100;Server@torque4;Job;6.torque4.grid.cesnet.cz;sending credential to mom succeed
02/16/2024 08:50:36;0002;Server@torque4;Svr;Log;Log closed
02/16/2024 08:50:38;0002;Server@torque4;Svr;Log;Log opened
02/16/2024 08:50:49;0100;Server@torque4;Job;6.torque4.grid.cesnet.cz;enqueuing into default, state R hop 1
02/16/2024 08:50:49;0086;Server@torque4;Job;6.torque4.grid.cesnet.cz;Requeueing job, substate: 41 Requeued in queue: default
```
The job continues running without issues:
```
torque4.grid.cesnet.cz$ qstat    
Job id            Name             User              Time Use S Queue
----------------  ---------------- ----------------  -------- - -----
6.torque4         STDIN            vchlum            00:00:00 R default  
```
By manual testing, I wasn't able to discover an issue with a job preserving PRERUN state on the server restart.

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
