### PR TITLE
changes to server ACL and subnets support

### DIFF
--- a/src/include/attribute.h
+++ b/src/include/attribute.h
@@ -636,6 +636,7 @@ void free_attr(attribute_def *attr_def, attribute *pattr, int attr_idx);
 #define ACL_Host 1
 #define ACL_User 2
 #define ACL_Group 3
+#define ACL_Subnet 4
 
 #ifdef __cplusplus
 }

--- a/src/include/pbs_ifl.h
+++ b/src/include/pbs_ifl.h
@@ -486,6 +486,7 @@ enum mgr_obj {
 #define PBS_STDNG_RESV_ID_CHAR 'S'						     /* Character in front of a resv ID */
 #define PBS_MNTNC_RESV_ID_CHAR 'M'						     /* Character in front of a resv ID */
 #define PBS_AUTH_KEY_LEN (129)
+#define PBS_MAXIP 15
 
 /* the pair to this list is in module_pbs_v1.c and must be updated to reflect any changes */
 enum batch_op { SET,

--- a/src/include/pbs_ifl.h
+++ b/src/include/pbs_ifl.h
@@ -486,7 +486,7 @@ enum mgr_obj {
 #define PBS_STDNG_RESV_ID_CHAR 'S'						     /* Character in front of a resv ID */
 #define PBS_MNTNC_RESV_ID_CHAR 'M'						     /* Character in front of a resv ID */
 #define PBS_AUTH_KEY_LEN (129)
-#define PBS_MAXIP 15
+#define PBS_MAXIP_LEN 15							     /* max ip address length */
 
 /* the pair to this list is in module_pbs_v1.c and must be updated to reflect any changes */
 enum batch_op { SET,

--- a/src/include/pbs_internal.h
+++ b/src/include/pbs_internal.h
@@ -313,7 +313,7 @@ extern struct pbs_config pbs_conf;
 #define PBS_CONF_SCHED_THREADS	"PBS_SCHED_THREADS"
 #define PBS_CONF_DAEMON_SERVICE_USER "PBS_DAEMON_SERVICE_USER"
 #define PBS_CONF_DAEMON_SERVICE_AUTH_USER "PBS_DAEMON_SERVICE_AUTH_USER"
-#define PBS_CONF_PRIVILEGED_AUTH_USER "PBS_PRIVILEGED_AUTH_USER" /* e.g.: used for gss/krb and krb principal is expected */
+#define PBS_CONF_PRIVILEGED_AUTH_USER "PBS_PRIVILEGED_AUTH_USER" /* e.g.: used for gss/krb and krb host principal (host/<fqdn>@<REALM>) is expected */
 #ifdef WIN32
 #define PBS_CONF_REMOTE_VIEWER "PBS_REMOTE_VIEWER"	/* Executable for remote viewer application alongwith its launch options, for PBS GUI jobs */
 #endif

--- a/src/include/pbs_internal.h
+++ b/src/include/pbs_internal.h
@@ -245,6 +245,7 @@ struct pbs_config
 	unsigned int pbs_sched_threads;	/* number of threads for scheduler */
 	char *pbs_daemon_service_user; /* user the scheduler runs as */
 	char *pbs_daemon_service_auth_user; /* auth user the scheduler runs as */
+	char *pbs_privileged_auth_user; /* auth user with admin access */
 	char current_user[PBS_MAXUSER+1]; /* current running user */
 #ifdef WIN32
 	char *pbs_conf_remote_viewer; /* Remote viewer client executable for PBS GUI jobs, along with launch options */
@@ -312,6 +313,7 @@ extern struct pbs_config pbs_conf;
 #define PBS_CONF_SCHED_THREADS	"PBS_SCHED_THREADS"
 #define PBS_CONF_DAEMON_SERVICE_USER "PBS_DAEMON_SERVICE_USER"
 #define PBS_CONF_DAEMON_SERVICE_AUTH_USER "PBS_DAEMON_SERVICE_AUTH_USER"
+#define PBS_CONF_PRIVILEGED_AUTH_USER "PBS_PRIVILEGED_AUTH_USER"
 #ifdef WIN32
 #define PBS_CONF_REMOTE_VIEWER "PBS_REMOTE_VIEWER"	/* Executable for remote viewer application alongwith its launch options, for PBS GUI jobs */
 #endif

--- a/src/include/pbs_internal.h
+++ b/src/include/pbs_internal.h
@@ -313,7 +313,7 @@ extern struct pbs_config pbs_conf;
 #define PBS_CONF_SCHED_THREADS	"PBS_SCHED_THREADS"
 #define PBS_CONF_DAEMON_SERVICE_USER "PBS_DAEMON_SERVICE_USER"
 #define PBS_CONF_DAEMON_SERVICE_AUTH_USER "PBS_DAEMON_SERVICE_AUTH_USER"
-#define PBS_CONF_PRIVILEGED_AUTH_USER "PBS_PRIVILEGED_AUTH_USER"
+#define PBS_CONF_PRIVILEGED_AUTH_USER "PBS_PRIVILEGED_AUTH_USER" /* e.g.: used for gss/krb and krb principal is expected */
 #ifdef WIN32
 #define PBS_CONF_REMOTE_VIEWER "PBS_REMOTE_VIEWER"	/* Executable for remote viewer application alongwith its launch options, for PBS GUI jobs */
 #endif

--- a/src/lib/Libattr/attr_fn_acl.c
+++ b/src/lib/Libattr/attr_fn_acl.c
@@ -749,7 +749,7 @@ sacl_match(const char *can, const char *master)
 	uint32_t ip;
 	uint32_t subnet;
 	uint32_t mask;
-	char tmpsubnet[PBS_MAXIP + 1];
+	char tmpsubnet[PBS_MAXIP_LEN + 1];
 	char *delimiter;
 	int len;
 	int short_mask;
@@ -767,7 +767,7 @@ sacl_match(const char *can, const char *master)
 		return 1;
 
 	len = delimiter - master;
-	if (len > PBS_MAXIP)
+	if (len > PBS_MAXIP_LEN)
 		return 1;
 
 	/* get subnet */
@@ -786,6 +786,8 @@ sacl_match(const char *can, const char *master)
 	} else {
 		/* short mask */
 		short_mask = atoi(delimiter + 1);
+		if (short_mask < 0 || short_mask > 32)
+			return 1;
 		mask = short_mask ? ~0 << (32 - short_mask) : 0;
 	}
 

--- a/src/lib/Libifl/pbs_loadconf.c
+++ b/src/lib/Libifl/pbs_loadconf.c
@@ -129,6 +129,7 @@ struct pbs_config pbs_conf = {
 	0,			    /* number of scheduler threads */
 	NULL,			    /* default scheduler user */
 	NULL,			    /* default scheduler auth user */
+	NULL,			    /* privileged auth user */
 	{'\0'}			    /* current running user */
 #ifdef WIN32
 	,
@@ -558,6 +559,9 @@ __pbs_loadconf(int reload)
 			} else if (!strcmp(conf_name, PBS_CONF_DAEMON_SERVICE_AUTH_USER)) {
 				free(pbs_conf.pbs_daemon_service_auth_user);
 				pbs_conf.pbs_daemon_service_auth_user = strdup(conf_value);
+			 }else if (!strcmp(conf_name, PBS_CONF_PRIVILEGED_AUTH_USER)) {
+				free(pbs_conf.pbs_privileged_auth_user);
+				pbs_conf.pbs_privileged_auth_user = strdup(conf_value);
 			}
 			/* iff_path is inferred from pbs_conf.pbs_exec_path - see below */
 		}
@@ -774,6 +778,11 @@ __pbs_loadconf(int reload)
 	if ((gvalue = getenv(PBS_CONF_DAEMON_SERVICE_AUTH_USER)) != NULL) {
 		free(pbs_conf.pbs_daemon_service_auth_user);
 		pbs_conf.pbs_daemon_service_auth_user = strdup(gvalue);
+	}
+
+	if ((gvalue = getenv(PBS_CONF_PRIVILEGED_AUTH_USER)) != NULL) {
+		free(pbs_conf.pbs_privileged_auth_user);
+		pbs_conf.pbs_privileged_auth_user = strdup(gvalue);
 	}
 
 #ifdef WIN32

--- a/src/server/process_request.c
+++ b/src/server/process_request.c
@@ -413,7 +413,6 @@ process_request(int sfds)
 	struct batch_request *request;
 	conn_t *conn;
 #ifndef PBS_MOM
-	int access_by_krb;
 	int access_allowed;
 #endif
 

--- a/src/server/process_request.c
+++ b/src/server/process_request.c
@@ -622,12 +622,16 @@ process_request(int sfds)
 
 		access_allowed = 0;
 
-		if (strcasecmp(server_host, request->rq_host)) {
+		if (strcasecmp(server_host, request->rq_host) == 0) {
 			/* always allow myself */
 			access_allowed = 1;
 		}
 
-		if (acl_check(get_sattr(SVR_ATR_acl_krb_realms), conn->cn_credid, ACL_Host)) {
+		if (get_sattr_long(SVR_ATR_acl_krb_realm_enable)) {
+			if (acl_check(get_sattr(SVR_ATR_acl_krb_realms), conn->cn_credid, ACL_Host)) {
+				access_allowed = 1;
+			}
+		} else {
 			access_allowed = 1;
 		}
 
@@ -645,6 +649,7 @@ process_request(int sfds)
 		if (access_allowed == 0) {
 			req_reject(PBSE_PERM, 0, request);
 			close_client(sfds);
+			return;
 		}
 	}
 #endif

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -201,6 +201,19 @@ char *host;
 		if (is_local != 0)
 			return (TRUE);
 	}
+#if defined(PBS_SECURITY) && (PBS_SECURITY == KRB5)
+	char *privil_auth_user = pbs_conf.pbs_privileged_auth_user ? pbs_conf.pbs_privileged_auth_user : NULL;
+	char uh[PBS_MAXUSER + PBS_MAXHOSTNAME + 2];
+	if (privil_auth_user) {
+		strcpy(uh, user);
+		strcat(uh, "@");
+		strcat(uh, host);
+
+		if (strcmp(uh, privil_auth_user) == 0) {
+			return (TRUE);
+		}
+	}
+#endif
 	return (FALSE);
 }
 

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -204,7 +204,8 @@ char *host;
 #if defined(PBS_SECURITY) && (PBS_SECURITY == KRB5)
 	char *privil_auth_user = pbs_conf.pbs_privileged_auth_user ? pbs_conf.pbs_privileged_auth_user : NULL;
 	char uh[PBS_MAXUSER + PBS_MAXHOSTNAME + 2];
-	if (privil_auth_user) {
+	if (privil_auth_user &&
+	    is_string_in_arr(pbs_conf.supported_auth_methods, AUTH_GSS_NAME)) {
 		strcpy(uh, user);
 		strcat(uh, "@");
 		strcat(uh, host);

--- a/src/server/svr_chk_owner.c
+++ b/src/server/svr_chk_owner.c
@@ -251,7 +251,8 @@ svr_get_privilege(char *user, char *host)
 
 #if defined(PBS_SECURITY) && (PBS_SECURITY == KRB5)
 	char *privil_auth_user = pbs_conf.pbs_privileged_auth_user ? pbs_conf.pbs_privileged_auth_user : NULL;
-	if (privil_auth_user) {
+	if (privil_auth_user &&
+	    is_string_in_arr(pbs_conf.supported_auth_methods, AUTH_GSS_NAME)) {
 		if (strcmp(uh, privil_auth_user) == 0) {
 			is_root = 1;
 		}

--- a/src/server/svr_chk_owner.c
+++ b/src/server/svr_chk_owner.c
@@ -249,6 +249,15 @@ svr_get_privilege(char *user, char *host)
 		}
 	}
 
+#if defined(PBS_SECURITY) && (PBS_SECURITY == KRB5)
+	char *privil_auth_user = pbs_conf.pbs_privileged_auth_user ? pbs_conf.pbs_privileged_auth_user : NULL;
+	if (privil_auth_user) {
+		if (strcmp(uh, privil_auth_user) == 0) {
+			is_root = 1;
+		}
+	}
+#endif
+
 #ifdef PBS_ROOT_ALWAYS_ADMIN
 	if (is_root)
 		return (priv | ATR_DFLAG_MGRD | ATR_DFLAG_MGWR | ATR_DFLAG_OPRD | ATR_DFLAG_OPWR);

--- a/test/tests/functional/pbs_acl_host_server.py
+++ b/test/tests/functional/pbs_acl_host_server.py
@@ -41,7 +41,7 @@
 from tests.functional import *
 
 
-class Test_acl_subnet(TestFunctional):
+class Test_acl_host_server(TestFunctional):
     """
     This test suite is for testing the subnets in server's
     attribute acl_hosts. This test requires remote client.

--- a/test/tests/functional/pbs_acl_subnets.py
+++ b/test/tests/functional/pbs_acl_subnets.py
@@ -1,0 +1,121 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2021 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of both the OpenPBS software ("OpenPBS")
+# and the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# OpenPBS is free software. You can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# OpenPBS is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# PBS Pro is commercially licensed software that shares a common core with
+# the OpenPBS software.  For a copy of the commercial license terms and
+# conditions, go to: (http://www.pbspro.com/agreement.html) or contact the
+# Altair Legal Department.
+#
+# Altair's dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of OpenPBS and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair's trademarks, including but not limited to "PBS™",
+# "OpenPBS®", "PBS Professional®", and "PBS Pro™" and Altair's logos is
+# subject to Altair's trademark licensing policies.
+
+
+from tests.functional import *
+
+
+class Test_acl_subnet(TestFunctional):
+    """
+    This test suite is for testing the subnets in server's
+    attribute acl_hosts. This test requires remote client.
+    """
+
+    def setUp(self):
+        """
+        Determine the server ip and remote host
+        """
+
+        TestFunctional.setUp(self)
+
+        usage_string = 'test requires a remote client as input,' + \
+                       ' use -p client=<client>'
+
+        self.serverip = socket.gethostbyname(self.server.hostname)
+
+        if not self.du.is_localhost(self.server.client):
+            self.remote_host = socket.getfqdn(self.server.client)
+        else:
+            self.skip_test(usage_string)
+
+        self.assertTrue(self.remote_host)
+
+        self.pbsnodes_cmd = os.path.join(self.server.pbs_conf[
+            'PBS_EXEC'], 'bin', 'pbsnodes') + ' -av' \
+            + ' -s ' + self.server.hostname
+
+    def test_acl_subnet_enable_allow(self):
+        """
+        Set acl_host_enable = True, subnet to server ip with the mask
+        255.255.0.0 or 16 and check whether or not the remote host
+        is able to run pbsnodes. It should allow.
+        """
+
+        a = {"acl_host_enable": True,
+             "acl_hosts": self.serverip + "/255.255.0.0"}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+
+        ret = self.du.run_cmd(self.remote_host, cmd=self.pbsnodes_cmd)
+        self.assertEqual(ret['rc'], 0)
+
+        a = {"acl_host_enable": True,
+             "acl_hosts": self.serverip + "/16"}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+
+        ret = self.du.run_cmd(self.remote_host, cmd=self.pbsnodes_cmd)
+        self.assertEqual(ret['rc'], 0)
+
+    def test_acl_subnet_enable_refuse(self):
+        """
+        Set acl_host_enable = True, subnet to server ip with the mask
+        255.255.255.255 or 32 and check whether or not the remote host
+        is able to run pbsnodes. It should refuse.
+        """
+
+        a = {"acl_host_enable": True,
+             "acl_hosts": self.serverip + "/255.255.255.255"}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+
+        ret = self.du.run_cmd(self.remote_host, cmd=self.pbsnodes_cmd)
+        self.assertNotEqual(ret['rc'], 0)
+
+        a = {"acl_host_enable": True,
+             "acl_hosts": self.serverip + "/32"}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+
+        ret = self.du.run_cmd(self.remote_host, cmd=self.pbsnodes_cmd)
+        self.assertNotEqual(ret['rc'], 0)
+
+    def tearDown(self):
+        """
+        Unset the acl attributes so tearDown can process on remote host.
+        """
+
+        a = ["acl_host_enable", "acl_hosts"]
+        self.server.manager(MGR_CMD_UNSET, SERVER, a)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->

1. I would like to introduce subnets to `acl_hosts` and forward hostname resolution for its evaluation. Currently, the implementation of acl hosts is not suitable as a firewall substitution. This new feature (due to the forward hostname resolution) makes it a bit safer and moves it a bit closer to it. This means e.g.: `acl_hosts = 192.168.0.0/255.255.0.0` or   `acl_hosts = 192.168.0.0/16` enables access to subnet 192.168.?.?.

2. Enabling `gss`/Kerberos and `acl_hosts`, the `acl_hosts` is evaluated for `PBS_BATCH_Connect` even if the connection is authenticated by `gss`.  Using gss,  `acl_hosts` is checked to hostname while the request is `PBS_BATCH_Connect` and for others requests the `acl_krb_realms` is used to check the principals. It means both acls are needlessly used for the same connection.

3. Currently admin access can be obtained only via `resvport` auth method. I would like to introduce a server env `PBS_PRIVILEGED_AUTH_USER`. This env can be used to get privileged access by other methods than `resvport`. The `gss` method in this case. This option opens a possibility to disable `resvport` and use only `gss` method for all interaction with OpenPBS in case of such a desire. 

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

1. Added support to subnets in `acl_hosts` checks IP address obtained by a forward resolution of a request's hostname to the provided `subnet/mask`. The `subnet/mask` is distinguished by `inet_pton` and requires `/` char. Hence it can be safely added to `acl_hosts`.

2.  The `acl_hosts` are not checked for the request `PBS_BATCH_Connect` now. The reason for this is that `PBS_BATCH_Authenticate` is sent after `PBS_BATCH_Connect` and at the time of `PBS_BATCH_Connect` we can not know which auth method will the connection use. Using the `gss` auth method, the `acl_hosts` were used for the `PBS_BATCH_Connect` even if the connection is authenticated in `PBS_BATCH_Authenticate` and can safely use the `acl_krb_realms`.  This change is safe because no other request can be read before `PBS_BATCH_Authenticate` except for simple `PBS_BATCH_Connect`. An attempt to send a different request before `PBS_BATCH_Authenticate` will result in `PBSE_BADCRED`.

3. A new server env `PBS_PRIVILEGED_AUTH_USER` is added. Privileged permission is checked against user and host in each request. Using `gss`/kerberos, the user and host contain (and together create) a principal. Using `gss`/Kerberos, the new env expects principal and is simply used as a way how to get privileged permissions. 

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

* PTL results are attached: [ptl_acl_subnets.txt](https://github.com/openpbs/openpbs/files/14370552/ptl_acl_subnets.txt)

Manual test of privileged access, using only gss:
```
(BULLSEYE)root@torque4:~# grep AUTH /etc/pbs.conf 
PBS_AUTH_METHOD=GSS
PBS_SUPPORTED_AUTH_METHODS=GSS
PBS_DAEMON_SERVICE_AUTH_USER=host/torque4.grid.cesnet.cz@EINFRA-SERVICES
PBS_PRIVILEGED_AUTH_USER=host/torque4.grid.cesnet.cz@EINFRA-SERVICES
```
the privileged access is granted to the selected principal:
```
(BULLSEYE)root@torque4:~# KRB5CCNAME=/tmp/krb5cc_pbs_client klist
Credentials cache: FILE:/tmp/krb5cc_pbs_client
        Principal: host/torque4.grid.cesnet.cz@EINFRA-SERVICES

  Issued                Expires               Principal
Feb 21 04:44:18 2024  Feb 22 04:44:18 2024  krbtgt/EINFRA-SERVICES@EINFRA-SERVICES
Feb 21 04:44:18 2024  Feb 22 04:44:18 2024  host/torque4.grid.cesnet.cz@EINFRA-SERVICES
(BULLSEYE)root@torque4:~# qmgr -c 'l h'
Hook test
    type = site
    enabled = true
    event = ""
    user = pbsadmin
    alarm = 30
    order = 1
    debug = false
    fail_action = none

(BULLSEYE)root@torque4:~#
```
and the access is rejected for others:
```
(BULLSEYE)root@torque5:~#  KRB5CCNAME=/tmp/krb5cc_pbs_client klist
Credentials cache: FILE:/tmp/krb5cc_pbs_client
        Principal: host/torque5.grid.cesnet.cz@EINFRA-SERVICES

  Issued                Expires               Principal
Feb 21 12:00:28 2024  Feb 22 12:00:28 2024  krbtgt/EINFRA-SERVICES@EINFRA-SERVICES
Feb 21 12:00:28 2024  Feb 22 12:00:28 2024  host/torque4.grid.cesnet.cz@EINFRA-SERVICES
(BULLSEYE)root@torque5:~# qmgr -c 'l h'
host/torque5.grid.cesnet.cz@EINFRA-SERVICES is unauthorized to access hooks data from server torque4.grid.cesnet.cz
(BULLSEYE)root@torque5:~# 

```
also  resvport is rejected:
```
(BULLSEYE)root@torque4:~# PBS_AUTH_METHOD=resvport PBS_ENCRYPT_METHOD= qmgr
auth: error returned: -1
auth: Unable to authenticate connection (torque4.grid.cesnet.cz:15001)
Invalid argument
qmgr: cannot connect to server 
(BULLSEYE)root@torque4:~# 

```

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
