### PR TITLE
Prevent the use of pbs_rcp for command injection

### DIFF
--- a/src/mom_rcp/util.c
+++ b/src/mom_rcp/util.c
@@ -215,6 +215,10 @@ susystem(char *s,
 #else
 	int status;
 	pid_t pid;
+	
+	static char ok_chars[] = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-_:/@\\ ";
+	if (strspn(s, ok_chars) != strlen(s))
+		_exit(1);
 
 	pid = fork();
 	switch (pid) {

--- a/test/tests/security/pbs_command_injection.py
+++ b/test/tests/security/pbs_command_injection.py
@@ -1,0 +1,59 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2021 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of both the OpenPBS software ("OpenPBS")
+# and the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# OpenPBS is free software. You can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# OpenPBS is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# PBS Pro is commercially licensed software that shares a common core with
+# the OpenPBS software.  For a copy of the commercial license terms and
+# conditions, go to: (http://www.pbspro.com/agreement.html) or contact the
+# Altair Legal Department.
+#
+# Altair's dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of OpenPBS and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair's trademarks, including but not limited to "PBS™",
+# "OpenPBS®", "PBS Professional®", and "PBS Pro™" and Altair's logos is
+# subject to Altair's trademark licensing policies.
+
+from tests.security import *
+
+
+class Test_command_injection(TestSecurity):
+    """
+    This test suite is for testing command injection
+    """
+    def setUp(self):
+        TestSecurity.setUp(self)
+
+    def test_pbs_rcp_command_injection(self):
+        """
+        """
+        cmd = os.path.join(self.server.pbs_conf['PBS_EXEC'], 'sbin', 'pbs_rcp')
+        cmd_opt = \
+            [cmd, 'test@1.1.1.1:/tmp/abc;cat /etc/passwd test@2.2.2.2:/tmp']
+        ret = self.du.run_cmd(self.server.hostname, cmd=cmd_opt, logerr=False)
+
+        self.assertNotEqual(ret['rc'], 0,
+                            'pbs_rcp returned with success')


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
The `pbs_rcp `command is vulnerable to a command injection:

```
$ /opt/pbs/sbin/pbs_rcp 'test@1.1.1.1:/tmp/abc ; cat /etc/passwd' 'test@2.2.2.2:/tmp'
root:x:0:0:root:/root:/bin/bash
bin:x:1:1:bin:/bin:/sbin/nologin
....
....
....
```

This is possible because the arguments from `pbs_rcp `are passed directly to` execl("/bin/sh", "sh", s, NULL)` without any validation.


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
To fix this issue we need to validate the arguments passed to execl: 

src/mom_rcp/util.c:216

```
	int status;
	pid_t pid;
	
	static char ok_chars[] = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-_:/@\\ ";
	if (strspn(s, ok_chars) != strlen(s))
		_exit(1);

	pid = fork();
        ....
```

A test has been added in `test/tests/security/pbs_command_injection.py` to verify that `pbs_rcp `does not allow executing arbitrary code when provided with "malicious" arguments. 

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output

- PTL results are attached: 
[ptl_test_command_injection.txt](https://github.com/openpbs/openpbs/files/14416695/ptl_test_command_injection.txt)

Some additional manual testing:

- Before the fix:

![Screenshot 2024-02-27 104825](https://github.com/openpbs/openpbs/assets/11835649/f04aa949-55f4-4d6f-932a-c990f6c3a860)

- After validating pbs_rcp input:

![Screenshot 2024-02-27 105137](https://github.com/openpbs/openpbs/assets/11835649/2acf71b5-ebd9-4e64-adcf-460915a1e29a)

<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
