### PR TITLE
Allow running jobs on overlapping maintenance reservations

### DIFF
--- a/src/scheduler/node_info.cpp
+++ b/src/scheduler/node_info.cpp
@@ -3001,10 +3001,16 @@ is_vnode_eligible(node_info *node, resource_resv *resresv,
 	if (node == NULL || resresv == NULL || pl == NULL || err == NULL)
 		return false;
 
+	bool job_in_maintenance_resv = false;
+	if (resresv->job && resresv->job->resv)
+		if (resresv->job->resv->name[0] == 'M')
+			job_in_maintenance_resv = true;
+
 	/* A node is invalid for an exclusive job if jobs/resvs are running on it
+	 * except if the job is a maintenance reservation
 	 * NOTE: this check must be the first check or exclhost may break
 	 */
-	if (is_excl(pl, node->sharing) &&
+	if (!job_in_maintenance_resv && is_excl(pl, node->sharing) &&
 	    (node->num_jobs > 0 || node->num_run_resv > 0)) {
 		set_schd_error_codes(err, NOT_RUN, NODE_NOT_EXCL);
 		set_schd_error_arg(err, ARG1, resresv->is_job ? "Job" : "Reservation");


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
The issue arises when a job is submitted to a maintenance reservation that overlaps with another prior maintenance reservation. Jobs submitted to both reservations should be allowed to run if the reservation resources are not allocated to other jobs. 

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
To fix this, a short-circuit condition was added in the scheduler's `node_info::is_vnode_eligible() `method, that does not exclude the vnode from running the request if the job is in a maintenance reservation. 

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
The new functionality can be verified with a simple bash script: 

```bash

#!/bin/bash

current_time_plus1=$(date -d "1 minute" +"%H%M")
duration="02:00"
hosts=$(hostname)

# query nodes status
echo -en "Node status before reservations: "
pbsnodes -avSj

# submit first advance reservation
resv_id_1=$(pbs_rsub -R $current_time_plus1 -D $duration --hosts $hosts)
resv_id_1=$(echo $resv_id_1 | cut -d'.' -f1)

# submit second advance reservation
resv_id_2=$(pbs_rsub -R $current_time_plus1 -D $duration --hosts $hosts)
resv_id_2=$(echo $resv_id_2 | cut -d'.' -f1)

# wait until reservations start
/bin/sleep 60

# query reservations
pbs_rstat 

# submit a job that takes all resources in second queue
job_id_2=$(qsub -q $resv_id_2 -lselect=1 -lplace=excl -o job2.txt -e job2.txt -- /bin/sleep 30)

# check job info
qstat -was1 $job_id_2

running_jobs=$(qselect -s R)

# normally you should see that job is running
if [[ $running_jobs == *"$job_id_2"* ]]; then
    echo "Jobs in overlapping maintenance reservations are running!"
else
    echo "Cannot run job in overlapping maintenance reservation."
fi


```

- The output of this script before the fix was: 

![Screenshot 2024-02-29 115058](https://github.com/openpbs/openpbs/assets/11835649/7ab57bf8-91c3-4a4c-a4f4-318ebbc5f4e8)

  You see that the job is in Q state, despite the host being free. 

- After allowing executing jobs on hosts allocated to overlapping maintenance reservations: 

![Screenshot 2024-02-29 114617](https://github.com/openpbs/openpbs/assets/11835649/4f0acae8-0fa6-4f6c-8418-ab851f873cfb)

  Same scenario, but now the job goes immediately in R state, since there is a free vnode to run it. 


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
