### PR TITLE
Fix scheduling bug when last select resource in select is 0

### DIFF
--- a/src/scheduler/check.cpp
+++ b/src/scheduler/check.cpp
@@ -1225,6 +1225,7 @@ check_avail_resources(schd_resource *reslist, resource_req *reqlist,
 		      enum sched_error_code fail_code, schd_error *perr)
 {
 	long long num_chunk = SCHD_INFINITY;
+	long long match_chunk = SCHD_INFINITY;
 
 	int any_fail = 0;
 	schd_error *prev_err = NULL;
@@ -1247,7 +1248,12 @@ check_avail_resources(schd_resource *reslist, resource_req *reqlist,
 			if (res == NULL)
 				continue;
 
-			num_chunk = match_resource(res, resreq, flags, fail_code, err);
+			match_chunk = match_resource(res, resreq, flags, fail_code, err);
+
+			if (num_chunk == SCHD_INFINITY)
+				num_chunk = match_chunk;
+			else if (match_chunk != SCHD_INFINITY && match_chunk < num_chunk)
+				num_chunk = match_chunk;
 
 			if (num_chunk == 0) {
 				any_fail = 1;
@@ -1286,6 +1292,7 @@ check_avail_resources(schd_resource *reslist, resource_req *reqlist,
 		      unsigned int flags, enum sched_error_code fail_code, schd_error *perr)
 {
 	long long num_chunk = SCHD_INFINITY;
+	long long match_chunk = SCHD_INFINITY;
 
 	int any_fail = 0;
 	schd_error *prev_err = NULL;
@@ -1305,7 +1312,12 @@ check_avail_resources(schd_resource *reslist, resource_req *reqlist,
 		if (res == NULL)
 			continue;
 
-		num_chunk = match_resource(res, resreq, flags, fail_code, err);
+		match_chunk = match_resource(res, resreq, flags, fail_code, err);
+
+		if (num_chunk == SCHD_INFINITY)
+			num_chunk = match_chunk;
+		else if (match_chunk != SCHD_INFINITY && match_chunk < num_chunk)
+			num_chunk = match_chunk;
 
 		if (num_chunk == 0) {
 			any_fail = 1;


### PR DESCRIPTION
* Fixes bug: job which conflicts with top jobs/reservations can be run bu the scheduler if the last resource in the select statement requests 0, pushing out the start time of top jobs.
* Adds two relevant ptl tests.

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->

The bug can be demonstrated by the following execution scenario with 5 vnodes, each with resources_available.ncpus=4.
 
```bash

root@u22:~# pbsnodes -av | grep ncpus
     resources_available.ncpus = 4
     resources_assigned.ncpus = 0
     resources_available.ncpus = 4
     resources_assigned.ncpus = 0
     resources_available.ncpus = 4
     resources_assigned.ncpus = 0
     resources_available.ncpus = 4
     resources_assigned.ncpus = 0
     resources_available.ncpus = 4
     resources_assigned.ncpus = 0

 

root@u22:~# grep -v ^# /var/spool/pbs/sched_priv/sched_config | sort | uniq

backfill_prime: false   ALL
by_queue: True          non_prime
by_queue: True          prime
dedicated_prefix: ded
fairshare_decay_factor: 0.5
fairshare_decay_time: 24:00:00
fairshare_entity: euser
fair_share: false       ALL
fairshare_usage_res: cput
job_sort_key: "job_priority HIGH"       ALL  <------------!
node_sort_key: "sort_priority HIGH"     ALL
nonprimetime_prefix: np_
preemptive_sched: true  ALL
prime_exempt_anytime_queues:    false
primetime_prefix: p_
provision_policy: "aggressive_provision"
resources: "ncpus, mem, arch, host, vnode, aoe, eoe, ngpus, zz"  <------------!
round_robin: False      all
smp_cluster_dist: pack
strict_ordering: true   ALL  <------------!

 
```

Job 1031 correctly does not run because it would delay the start time of job 1030, but job 1032, which is identical to 1031 EXCEPT that it requests ngpus=0 as the last item in the select statement IS run incorrectly.

 ```bash

user1@u22:~$ echo "sleep 1000000000" | qsub -lselect=2:ncpus=4 -lwalltime=1:00:00 -lplace=vscatter
1028.u22
user1@u22:~$ echo "sleep 1000000000" | qsub -lselect=2:ncpus=4 -lwalltime=1:00:00 -lplace=vscatter
1029.u22
user1@u22:~$ echo "sleep 1000000000" | qsub -lselect=5:ncpus=4 -lwalltime=1:00:00 -lplace=vscatter -P1000
1030.u22
user1@u22:~$ echo "sleep 1000000000" | qsub -lselect=1:ncpus=4 -lwalltime=24:00:01 -lplace=vscatter
1031.u22
user1@u22:~$ qstat -anst

u22:
                                                            Req'd  Req'd   Elap
Job ID          Username Queue    Jobname    SessID NDS TSK Memory Time  S Time
--------------- -------- -------- ---------- ------ — --- ------ ----- - -----
1028.u22        user1    workq    STDIN        3349   2   8    --  01:00 R 00:00
   u22/0*4+u22/1*4
   Job run at Tue Feb 06 at 20:20 on (u22:ncpus=4)+(node1:ncpus=4)
1029.u22        user1    workq    STDIN        3362   2   8    --  01:00 R 00:00
   u22/2*4+u22/3*4
   Job run at Tue Feb 06 at 20:20 on (node2:ncpus=4)+(node3:ncpus=4)
1030.u22        user1    workq    STDIN         –    5  20    --  01:00 Q   –
    –
   Not Running: Not enough free nodes available
1031.u22        user1    workq    STDIN         –    1   4    --  24:00 Q   –
    –
   Not Running: Job would conflict with reservation or top job
user1@u22:~$ echo "sleep 1000000000" | qsub -lselect=1:ncpus=4:ngpus=0 -lwalltime=24:00:01 -lplace=vscatter
1032.u22
user1@u22:~$ qstat -anst

u22:
                                                            Req'd  Req'd   Elap
Job ID          Username Queue    Jobname    SessID NDS TSK Memory Time  S Time
--------------- -------- -------- ---------- ------ — --- ------ ----- - -----
1028.u22        user1    workq    STDIN        3349   2   8    --  01:00 R 00:00
   u22/0*4+u22/1*4
   Job run at Tue Feb 06 at 20:20 on (u22:ncpus=4)+(node1:ncpus=4)
1029.u22        user1    workq    STDIN        3362   2   8    --  01:00 R 00:00
   u22/2*4+u22/3*4
   Job run at Tue Feb 06 at 20:20 on (node2:ncpus=4)+(node3:ncpus=4)
1030.u22        user1    workq    STDIN         –    5  20    --  01:00 Q   –
    –
   Not Running: Not enough free nodes available
1031.u22        user1    workq    STDIN         –    1   4    --  24:00 Q   –
    –
   Not Running: Job would conflict with reservation or top job
1032.u22        user1    workq    STDIN        3383   1   4    --  24:00 R 00:00
   u22/4*4
   Job run at Tue Feb 06 at 20:20 on (node4:ncpus=4:ngpus=0)
```

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
The problem was that in the loop inside both overloaded versions of `check.cpp:check_avail_resources()`, only the last value of `num_chunk` was kept. When the last resource check returned `SCHD_INFINITY` chunks, the job would be scheduled since the scheduler though that an infinite number of such jobs could be run. This has been fixed now, and `num_chunk `holds the minimum number of chunks found instead of the last value. 

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

Apart from the two added PTL tests (output attached), the following manual scenario was also tested: 

```bash
#!/bin/bash
# Colors
Black='\033[0;30m'        # Black
Red='\033[0;31m'          # Red
Green='\033[0;32m'        # Green'
NC='\033[0m'              # Text Reset

# verify correct settings
sudo grep -v ^# /var/spool/pbs/sched_priv/sched_config | sort | uniq \
    | grep -e job_sort_key -e resources -e strict_ordering

# submit job 1, 1hr takes 4/8 cores
jid_1=$(qsub  -lselect=1:ncpus=4 -lwalltime=1:00:00 -j oe -o job1.txt -N job1 -- /bin/sleep 10000)
sleep 1
# expect job to run
# submit job 2, 1hr high priority, 8/8 cores
jid_2=$(qsub  -p1000 -lselect=1:ncpus=8 -lwalltime=1:00:00 -j oe -o job2.txt -N job2 -- /bin/sleep 10000)
sleep 1
# expect job not to run due to resources
# submit job 3, 4hr normal priority, 4/8 cores
jid_3=$(qsub  -lselect=1:ncpus=4 -lwalltime=4:00:00 -j oe -o job3.txt -N job3 -- /bin/sleep 10000)
sleep 1
# expect job not to run, because it will delay top job
# submit job 4, 4hr normal priority, 4/8 cores, 0ngpus
jid_4=$(qsub  -lselect=1:ncpus=4:ngpus=0 -lwalltime=4:00:00 -j oe -o job4.txt -N job4 -- /bin/sleep 10000)
sleep 1
# expect job to incorrectly run (due to bug with 0 ngpus)

qstat -was1

running_jobs=$(qselect -s R)
queueing_jobs=$(qselect -s Q)

ret=0

# normally you should see that job is running
if [[ $running_jobs == *"$jid_1"* ]]; then
    echo -e "${Green}Job $jid_1 runs correctly"
else
    echo -e "${Red}Job $jid_1 not running"
    ret=1
fi

if [[ $queueing_jobs == *"$jid_2"* ]] && [[ $queueing_jobs == *"$jid_3"* ]]; then
    echo -e "${Green}Jobs $jid_2 and $jid_3 are correctly queued"
else
    echo -e "${Red}Jobs $jid_2 and $jid_3 should be queued"
    ret=1
fi

if [[ $queueing_jobs == *"$jid_4"* ]]; then
    echo -e "${Green}Job $jid_4 is correctly queued"
elif [[ $running_jobs == *"$jid_4"* ]]; then
    echo -e "${Red}Job $jid_4 is incorrectly running, it will delay top job"
    ret=1
fi

if [ $ret != 0 ]; then
    echo -e "${Red}There was an error in the execution scenario"
else
    echo -e "${Green}Everything run as expected"
fi

echo -e "${NC}Deleting jobs and output files"
qdel $jid_1 $jid_2 $jid_3 $jid_4
rm -f job?.txt
```

The faulty output before the fix: 

```bash

job_sort_key: "job_priority HIGH"       ALL
resources: "ncpus, mem, arch, host, vnode, aoe, eoe, ngpus, naccelerators"
strict_ordering: true   ALL

ubuntu22-vm1: 
                                                                                                   Req'd  Req'd   Elap
Job ID                         Username        Queue           Jobname         SessID   NDS  TSK   Memory Time  S Time
------------------------------ --------------- --------------- --------------- -------- ---- ----- ------ ----- - -----
2044.ubuntu22-vm1              pbsuser        workq           STDIN                --     1     4    --  01:00 R   --     Job was sent for execution at Fri Mar 01 at 16:09 on (ubuntu22-vm1:ncpus=4)
2045.ubuntu22-vm1              pbsuser        workq           STDIN                --     1     8    --  01:00 Q   --     Not Running: Insufficient amount of resource: ncpus (R: 8 A: 4 T: 8)
2046.ubuntu22-vm1              pbsuser        workq           STDIN                --     1     4    --  04:00 Q   --     Not Running: Job would conflict with reservation or top job
2047.ubuntu22-vm1              pbsuser        workq           STDIN                --     1     4    --  04:00 R   --     Job was sent for execution at Fri Mar 01 at 16:09 on (ubuntu22-vm1:ncpus=4:ngpus=0)
Job 2044.ubuntu22-vm1 runs correctly
Jobs 2045.ubuntu22-vm1 and 2046.ubuntu22-vm1 are correctly queued
Job 2047.ubuntu22-vm1 is incorrectly running, it will delay top job
There was an error in the execution scenario
Deleting jobs and output files
```

Notice that job 2046 is correctly put in Q because it conflicts with top priority 2045. However, job 2047 requests for ngpus=0, and is incorrectly run ahead of 2045, delaying its starting time. 

```bash

After fixing the issue: 

job_sort_key: "job_priority HIGH ALL"
resources: "ncpus, mem, arch, host, vnode, aoe, eoe, ngpus, zz"
strict_ordering: True ALL

ubuntu22-vm1: 
                                                                                                   Req'd  Req'd   Elap
Job ID                         Username        Queue           Jobname         SessID   NDS  TSK   Memory Time  S Time
------------------------------ --------------- --------------- --------------- -------- ---- ----- ------ ----- - -----
4015.ubuntu22-vm1              pbsuser        workq           job1               28697    1     4    --  01:00 R 00:00    Job run at Mon Mar 04 at 09:50 on (ubuntu22-vm1:ncpus=4)
4016.ubuntu22-vm1              pbsuser        workq           job2                 --     1     8    --  01:00 Q   --     Not Running: Insufficient amount of resource: ncpus (R: 8 A: 4 T: 8)
4017.ubuntu22-vm1              pbsuser        workq           job3                 --     1     4    --  04:00 Q   --     Not Running: Job would conflict with reservation or top job
4018.ubuntu22-vm1              pbsuser        workq           job4                 --     1     4    --  04:00 Q   --     Not Running: Job would conflict with reservation or top job
Job 4015.ubuntu22-vm1 runs correctly
Jobs 4016.ubuntu22-vm1 and 4017.ubuntu22-vm1 are correctly queued
Job 4018.ubuntu22-vm1 is correctly queued
Everything run as expected
Deleting jobs and output files

```

You can see that both jobs coming after top priority job 4016 are correctly put in Q state. 
[ptl_test.txt](https://github.com/openpbs/openpbs/files/14479735/ptl_test.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
