### PR TITLE
parse /proc/PID/stat file by cgroup hook properly

### DIFF
--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -3976,7 +3976,9 @@ class CgroupUtils(object):
         for filename in glob.glob(pattern):
             try:
                 with open(filename, 'r') as desc:
-                    entries = desc.readline().split(' ')
+                    line = desc.readline()
+                    # valid columns are \(.+\) or [^\s]+
+                    entries = re.split(r'\s+(\(.+\)|[^\s]+)\s+', line)
                     if int(entries[5]) != sid:
                         continue
                     if check_tasks:


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->

The cgroup hook does not parse `/proc/PID/stat` file correctly. It simply anticipates the space is always a delimiter.

The `man proc` states:
```
              (2) comm  %s
                     The filename of the executable, in parentheses.  Strings longer than TASK_COMM_LEN (16) char‐
                     acters (including the terminating null byte) are silently truncated.  This is visible whether
                     or not the executable is swapped out.
```

and having processes with space in the name:
```
==> /proc/3523/stat <==
3523 (UVM global queue) S 2 0 0 0 -1 2129984 0 0 0 0 0 0 0 0 20 0 1 0 3814 0 0 18446744073709551615 0 0 0 0 0 0 0 214 7483647 0 1 0 0 17 14 0 0 0 0 0 0 0 0 0 0 0 0 0

==> /proc/3524/stat <==
3524 (UVM deferred release queue) S 2 0 0 0 -1 2129984 0 0 0 0 0 0 0 0 20 0 1 0 3814 0 0 18446744073709551615 0 0 0 0 0 0 0 2147483647 0 1 0 0 17 16 0 0 0 0 0 0 0 0 0 0 0 0 0

==> /proc/3525/stat <==
3525 (UVM Tools Event Queue) S 2 0 0 0 -1 2129984 0 0 0 0 0 0 0 0 20 0 1 0 3814 0 0 18446744073709551615 0 0 0 0 0 0 0 2147483647 0 1 0 0 17 19 0 0 0 0 0 0 0 0 0 0 0 0 0
```

can cause errors like:
```
03/07/2024 06:21:31;0080;pbs_python;Hook;pbs_python;['Traceback (most recent call last):', '  File "<embedded code object>", line 6425, in main', '  File "<embedded code object>", line 1041, in invoke_handler', '  File "<embedded code object>", line 1240, in _execjob_launch_handler', '  File "<embedded code object>", line 4019, in add_pids', '  File "<embedded code object>", line 3980, in _get_pids_in_sid', "ValueError: invalid literal for int() with base 10: 'S'"]
```
The bug is also reported in #2628

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

The change splits the line from the stat file by a suitable regex. Valid columns are `\(.+\)` or `[^\s]+`, and splitting is done by spaces around these columns.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

* Manual parsing test in python interpreter - simple regex testing:

```
>>> import re
>>> line="3523 (UVM global queue) S 2 0 0 0 -1 2129984 0 0 0 0 0 0 0 0 20 0 1 0 3814 0 0 18446744073709551615 0 0 0 0 0 0 0 214 7483647 0 1 0 0 17 14 0 0 0 0 0 0 0 0 0 0 0 0 0"
>>> entries = re.split(r'\s+(\(.+\)|[^\s]+)\s+', line)
>>> print(entries)
['3523', '(UVM global queue)', 'S', '2', '0', '0', '0', '-1', '2129984', '0', '0', '0', '0', '0', '0', '0', '0', '20', '0', '1', '0', '3814', '0', '0', '18446744073709551615', '0', '0', '0', '0', '0', '0', '0', '214', '7483647', '0', '1', '0', '0', '17', '14', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0']
```

 * PTL - test cgroups hook: 
[ptl_cgroups_hook.txt](https://github.com/openpbs/openpbs/files/14538169/ptl_cgroups_hook.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
