### PR TITLE
Register primary scheduler with primary server and secondary scheduler with secondary server

### DIFF
--- a/src/scheduler/pbs_sched_utils.cpp
+++ b/src/scheduler/pbs_sched_utils.cpp
@@ -554,7 +554,7 @@ open_server_conns(void)
 				goto unmask_continue;
 		}
 		clust_secondary_sock = pbs_connect(NULL);
-		if (clust_secondary_sock < 0)
+		if (clust_secondary_sock < 0 || clust_primary_sock == clust_secondary_sock)
 			goto unmask_continue;
 
 		if (pbs_register_sched(sc_name, clust_primary_sock, clust_secondary_sock) != 0) {

--- a/src/server/process_request.c
+++ b/src/server/process_request.c
@@ -326,15 +326,13 @@ req_register_sched(conn_t *conn, struct batch_request *preq)
 				rc = PBSE_BADHOST;
 				goto rerr;
 			}
-		}
-		else if (are_primary == FAILOVER_SECONDARY) {
+		} else if (are_primary == FAILOVER_SECONDARY) {
 			addr = get_hostaddr(pbs_conf.pbs_secondary);
 			if (addr != conn->cn_addr) {
 				rc = PBSE_BADHOST;
 				goto rerr;
 			}
-		}
-		else {
+		} else {
 			rc = PBSE_BADHOST;
 			goto rerr;
 		}
@@ -593,10 +591,10 @@ process_request(int sfds)
 
 			addr = get_hostaddr(request->rq_host);
 			if (snprintf(ip, PBS_MAXIP_LEN + 1, "%ld.%ld.%ld.%ld",
-			    (addr & 0xff000000) >> 24,
-			    (addr & 0x00ff0000) >> 16,
-			    (addr & 0x0000ff00) >> 8,
-			    (addr & 0x000000ff)) <= 0) {
+				     (addr & 0xff000000) >> 24,
+				     (addr & 0x00ff0000) >> 16,
+				     (addr & 0x0000ff00) >> 8,
+				     (addr & 0x000000ff)) <= 0) {
 				addr = 0;
 			}
 

--- a/src/server/process_request.c
+++ b/src/server/process_request.c
@@ -274,6 +274,7 @@ req_register_sched(conn_t *conn, struct batch_request *preq)
 	pbs_sched *sched;
 	conn_t *pconn;
 	int rc;
+	int are_primary;
 	int preq_conn;
 	char *auth_user = pbs_conf.pbs_daemon_service_auth_user ? pbs_conf.pbs_daemon_service_auth_user : pbs_conf.pbs_daemon_service_user;
 	char *user = auth_user ? auth_user : pbs_current_user;
@@ -316,17 +317,24 @@ req_register_sched(conn_t *conn, struct batch_request *preq)
 		goto rerr;
 	}
 
-	if (sched->sc_conn_addr != conn->cn_addr) {
-		if (pbs_conf.pbs_primary != NULL && pbs_conf.pbs_secondary != NULL) {
-			pbs_net_t addr = get_hostaddr(pbs_conf.pbs_primary);
+	if (pbs_conf.pbs_primary != NULL && pbs_conf.pbs_secondary != NULL) {
+		are_primary = are_we_primary();
+		pbs_net_t addr;
+		if (are_primary == FAILOVER_PRIMARY) {
+			addr = get_hostaddr(pbs_conf.pbs_primary);
 			if (addr != conn->cn_addr) {
-				addr = get_hostaddr(pbs_conf.pbs_secondary);
-				if (addr != conn->cn_addr) {
-					rc = PBSE_BADHOST;
-					goto rerr;
-				}
+				rc = PBSE_BADHOST;
+				goto rerr;
 			}
-		} else {
+		}
+		else if (are_primary == FAILOVER_SECONDARY) {
+			addr = get_hostaddr(pbs_conf.pbs_secondary);
+			if (addr != conn->cn_addr) {
+				rc = PBSE_BADHOST;
+				goto rerr;
+			}
+		}
+		else {
 			rc = PBSE_BADHOST;
 			goto rerr;
 		}


### PR DESCRIPTION
#### Describe Bug or Feature
This PR fixes an issue that appears only when using a failover setup. 

After the primary server would go offiline, the secondary successfully takes over. When the primary server is back up again, it takes back the operation from the secondary. However, the communication with the scheduler is not properly established, therefore jobs cannot be scheduled on the available execution mom(s). 


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Solution Description:

* In `pbs_sched_utils.cpp:open_server_conns()` make sure that the value of` cluster_secondary_sock` & `cluster_primary_sock `values are different before registering.

* In `process_request.c:req_register_sched()`: Make sure that only primary scheduler registers with primary server and the secondary scheduler registers with secondary server.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

Two scenarios were tested. In both of them with begin with a properly configured primary-secondary server failover setup. The only difference between the two scenarios is that in the first one only the server daemon dies, while in the second scenario, both the server and scheduler daemons die. 

**Scenario 1:** 

* **The primary server daemon dies.** 
* The secondary takes over after a while.
* Jobs can be scheduled and execute with the secondary server in command.
* The primary becomes active again and takes back from the second. 
* Before the fix, jobs can be submitted but go in Q state indefinitely. After the fix, jobs run with no problems. 
* In the server logs we see the following message periodically: 03/08/2024 12:58:41;0002;Server@ub22-primary;Sched;default;scheduler disconnected


**Scenario 2:** 

* **The primary server and scheduler daemons die.** 
* The secondary takes over after a while.
* Jobs can be scheduled and execute with the secondary server in command.
* The primary server and scheduler become active again and the primary server takes back from the second. 
* Before the fix, jobs could be submitted but they would go in Q state indefinitely. After the fix, jobs run with no problems.
* In the server logs we see the following message periodically: 03/08/2024 12:58:41;0002;Server@ub22-primary;Sched;default;scheduler disconnected

Attached the logs from local testing in a setup with primary server, a secondary server, and a mom, all on separate hosts. 

[failover-before-fix.txt](https://github.com/openpbs/openpbs/files/14538570/failover-simple-before-fix.txt)
[failover-after-fix.txt](https://github.com/openpbs/openpbs/files/14538569/failover-simple.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
