### PR TITLE
fix systemd version recognizing in cgroup hook

### DIFF
--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -3881,7 +3881,7 @@ class CgroupUtils(object):
             # Note: some versions prepend "Version=", other versions
             # add a more precise version in parentheses after a space
             out_split = stringified_output(out).splitlines()
-            ver = int(re.sub(r'Version=\D*(\d+)', r'\1',
+            ver = int(re.sub(r'Version=\D*(\d+).*', r'\1',
                              out_split[0].split()[0]))
         except Exception:
             # Note we also get here if we can't decode an int version


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->

The systemd version in cgroup hook is not recognized on miscellaneous systems:

```
(BULLSEYE)root@torque4:~# grep "systemd version seems to be" /var/spool/pbs/mom_logs/20240312 
03/12/2024 09:54:39;0800;pbs_python;Hook;pbs_python;__init__: systemd version seems to be 0
03/12/2024 09:56:40;0800;pbs_python;Hook;pbs_python;__init__: systemd version seems to be 0
```

and the cgroups service `pbs_jobs.service` is not started on mom.

The command called to get the systemd version is `systemctl --system show --property=Version`.

See the result on miscellaneous systems:
```
(BULLSEYE)root@torque4:~# systemctl --system show --property=Version
Version=247.3-7+deb11u4
```
```
[root@almalinux ~]# systemctl --system show --property=Version
Version=252-18.el9
```

but the parsing regex `r'Version=\D*(\d+)'` lacks the string after major version number. The systemd version is not recognized in such cases.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Change the parsing regex to ignore any string after major version number.



#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Manual test:
After the fix and importing a new version of the hook, the version is recognized, and the service started:
```
(BULLSEYE)root@torque4:~# grep "systemd version seems to be" /var/spool/pbs/mom_logs/20240312 
03/12/2024 09:54:39;0800;pbs_python;Hook;pbs_python;__init__: systemd version seems to be 0
03/12/2024 09:56:40;0800;pbs_python;Hook;pbs_python;__init__: systemd version seems to be 0
03/12/2024 09:57:29;0800;pbs_python;Hook;pbs_python;__init__: systemd version seems to be 0
03/12/2024 09:57:30;0800;pbs_python;Hook;pbs_python;__init__: systemd version seems to be 0
03/12/2024 09:59:30;0800;pbs_python;Hook;pbs_python;__init__: systemd version seems to be 0
03/12/2024 10:01:32;0800;pbs_python;Hook;pbs_python;__init__: systemd version seems to be 0
03/12/2024 10:03:33;0800;pbs_python;Hook;pbs_python;__init__: systemd version seems to be 0
03/12/2024 10:05:34;0800;pbs_python;Hook;pbs_python;__init__: systemd version seems to be 0
03/12/2024 10:07:35;0800;pbs_python;Hook;pbs_python;__init__: systemd version seems to be 0
03/12/2024 10:09:37;0800;pbs_python;Hook;pbs_python;__init__: systemd version seems to be 0
03/12/2024 10:11:38;0800;pbs_python;Hook;pbs_python;__init__: systemd version seems to be 0
03/12/2024 10:13:39;0800;pbs_python;Hook;pbs_python;__init__: systemd version seems to be 247
03/12/2024 10:14:43;0800;pbs_python;Hook;pbs_python;__init__: systemd version seems to be 247
03/12/2024 10:14:43;0800;pbs_python;Hook;pbs_python;__init__: systemd version seems to be 247
```
```
(BULLSEYE)root@torque4:~# systemctl status  pbs_jobs.service 
● pbs_jobs.service - PBS Pro job parent service
     Loaded: loaded (/run/systemd/system/pbs_jobs.service; static)
     Active: active (running) since Tue 2024-03-12 10:14:43 CET; 17s ago
   Main PID: 2112267 (sleep)
      Tasks: 1
     CGroup: /pbs_jobs.service
             └─2112267 /bin/sleep infinity

Mar 12 10:14:43 torque4.grid.cesnet.cz systemd[1]: Started PBS Pro job parent service.
```



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
