### PR TITLE
Handle corrupt standing reservations

### DIFF
--- a/src/include/job.h
+++ b/src/include/job.h
@@ -1112,6 +1112,7 @@ extern int get_used_wall(job *);
 extern int get_used_cput(job *);
 extern int get_cput(job *);
 extern void remove_deleted_resvs(void);
+extern void degrade_corrupted_confirmed_resvs(void);
 extern int pbsd_init_job(job *pjob, int type);
 
 extern void del_job_related_file(job *pjob, char *fsuffix);

--- a/src/include/reservation.h
+++ b/src/include/reservation.h
@@ -295,6 +295,7 @@ extern void set_idle_delete_task(resc_resv *presv);
 extern int change_enableORstart(resc_resv *, int, char *);
 extern void unset_resv_retry(resc_resv *);
 extern void set_resv_retry(resc_resv *, long);
+extern void force_resv_retry(resc_resv *, long);
 extern void eval_resvState(resc_resv *, enum resvState_discrim, int, int *, int *);
 extern void free_resvNodes(resc_resv *);
 extern int act_resv_add_owner(attribute *, void *, int);
@@ -303,6 +304,7 @@ extern void resv_free(resc_resv *);
 extern void set_old_subUniverse(resc_resv *);
 extern int assign_resv_resc(resc_resv *, char *, int);
 extern void resv_exclusive_handler(resc_resv *);
+extern void resv_exclusive_handler_forced(resc_resv *);
 extern long determine_resv_retry(resc_resv *presv);
 
 extern resc_resv *resv_recov_db(char *resvid, resc_resv *presv);

--- a/src/include/server.h
+++ b/src/include/server.h
@@ -151,6 +151,9 @@ extern long resv_retry_time;
 #define SOFT_WALLTIME "soft_walltime"
 #define MCAST_WAIT_TM 2
 
+
+#define ESTIMATED_DELAY_NODES_UP 60 /* delay reservation reconf at boot until nodes expected up */
+
 /*
  * Server failover role
  */

--- a/src/scheduler/queue_info.cpp
+++ b/src/scheduler/queue_info.cpp
@@ -781,15 +781,17 @@ queue_info::queue_info(queue_info &oqinfo, server_info *nsinfo) : name(oqinfo.na
 
 	if (oqinfo.resv != NULL) {
 		resv = find_resource_resv_by_indrank(nsinfo->resvs, oqinfo.resv->resresv_ind, oqinfo.resv->rank);
-		if (!resv->resv->is_standing) {
-			/* just incase we we didn't set the reservation cross pointer */
-			resv->resv->resv_queue = this;
-		} else {
-			/* For standing reservations, we need to restore the resv_queue pointers for all occurrences */
-			int i;
-			for (i = 0; server->resvs[i] != NULL; i++) {
-				if (server->resvs[i]->name == resv->name)
-					server->resvs[i]->resv->resv_queue = this;
+		if (resv != NULL) {
+			if (!resv->resv->is_standing) {
+				/* just incase we we didn't set the reservation cross pointer */
+				resv->resv->resv_queue = this;
+			} else {
+				/* For standing reservations, we need to restore the resv_queue pointers for all occurrences */
+				int i;
+				for (i = 0; server->resvs[i] != NULL; i++) {
+					if (server->resvs[i]->name == resv->name)
+						server->resvs[i]->resv->resv_queue = this;
+				}
 			}
 		}
 	} else

--- a/src/scheduler/resv_info.cpp
+++ b/src/scheduler/resv_info.cpp
@@ -409,9 +409,9 @@ query_reservations(int pbs_sd, server_info *sinfo, struct batch_status *resvs)
 							execvnode_ptr[degraded_idx - 1], sinfo, resresv_ocr->select);
 					else {
 						resresv_ocr->resv->orig_nspec_arr = {};
-						log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_RESV,
-							   LOG_DEBUG, resresv->name,
-							   "%s: occurence %d has no execvnodes, using empty vector",
+						log_eventf(PBSEVENT_ERROR, PBS_EVENTCLASS_RESV,
+							   LOG_INFO, resresv->name,
+							   "%s: occurence %d has no execvnodes, proceeding without assigned resources",
 							   __func__, j + 1);
 					}
 
@@ -1086,9 +1086,9 @@ check_new_reservations(status *policy, int pbs_sd, resource_resv **resvs, server
 							parse_execvnode(occr_execvnodes_arr[j_adjusted], sinfo, nresv_copy->select);
 					} else {
 						nresv_copy->resv->orig_nspec_arr = {};
-						log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_RESV,
-							   LOG_DEBUG, nresv->name,
-							   "%s: occurence %d has no execvnodes, using empty vector",
+						log_eventf(PBSEVENT_ERROR, PBS_EVENTCLASS_RESV,
+							   LOG_INFO, nresv->name,
+							   "%s: occurence %d has no execvnodes, proceeding without assigned resources",
 							   __func__, j + 1);
 					}
 

--- a/src/scheduler/resv_info.cpp
+++ b/src/scheduler/resv_info.cpp
@@ -285,7 +285,6 @@ query_reservations(int pbs_sd, server_info *sinfo, struct batch_status *resvs)
 			 * Note that resv_idx starts at 1 on the first occurrence and not 0.
 			 */
 			occr_idx = resresv->resv->resv_idx;
-			/* string_dup returns NULL when input is NULL pointer */
 			execvnodes_seq = string_dup(resresv->resv->execvnodes_seq);
 			/* the error handling for the string duplication returning NULL is
 			 * combined with the following assignment, because get_execvnodes_count
@@ -295,8 +294,6 @@ query_reservations(int pbs_sd, server_info *sinfo, struct batch_status *resvs)
 			/* this should happen only if the execvnodes_seq are corrupted. In such
 			 * case, we ignore the reservation and move on to the next one
 			 */
-			/* -- modified, let's just process it with empty execvnode and degrade it
-			*/
 			if (occr_count == 0) {
 				log_event(PBSEVENT_SCHED, PBS_EVENTCLASS_RESV, LOG_DEBUG,
 					  resresv->name, "Error processing standing reservation, degrading it");
@@ -412,10 +409,10 @@ query_reservations(int pbs_sd, server_info *sinfo, struct batch_status *resvs)
 							execvnode_ptr[degraded_idx - 1], sinfo, resresv_ocr->select);
 					else {
 						resresv_ocr->resv->orig_nspec_arr = {};
-						log_eventf(PBSEVENT_ERROR, PBS_EVENTCLASS_RESV,
-						           LOG_INFO, resresv->name,
-						           "%s: occurence %d has no execvnodes, using empty vector",
-						           __func__, j + 1);
+						log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_RESV,
+							   LOG_DEBUG, resresv->name,
+							   "%s: occurence %d has no execvnodes, using empty vector",
+							   __func__, j + 1);
 					}
 
 					resresv_ocr->nspec_arr = combine_nspec_array(resresv_ocr->resv->orig_nspec_arr);
@@ -1089,10 +1086,10 @@ check_new_reservations(status *policy, int pbs_sd, resource_resv **resvs, server
 							parse_execvnode(occr_execvnodes_arr[j_adjusted], sinfo, nresv_copy->select);
 					} else {
 						nresv_copy->resv->orig_nspec_arr = {};
-						log_eventf(PBSEVENT_ERROR, PBS_EVENTCLASS_RESV,
-						           LOG_INFO, nresv->name,
-						           "%s: occurence %d has no execvnodes, using empty vector",
-						           __func__, j + 1);
+						log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_RESV,
+							   LOG_DEBUG, nresv->name,
+							   "%s: occurence %d has no execvnodes, using empty vector",
+							   __func__, j + 1);
 					}
 
 					nresv_copy->nspec_arr = combine_nspec_array(nresv_copy->resv->orig_nspec_arr);

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -8234,8 +8234,6 @@ static void
 set_resv_for_degrade(struct pbsnode *pnode, resc_resv *presv)
 {
 	long degraded_time;
-	char *execvnodes = NULL;
-	int occurrence = -1;
 
 	if ((degraded_time = get_rattr_long(presv, RESV_ATR_resv_standing)) == 0)
 		presv->ri_degraded_time = degraded_time;
@@ -8258,6 +8256,9 @@ set_resv_for_degrade(struct pbsnode *pnode, resc_resv *presv)
 		 * string for debugging purposes
 		 */
 		if (get_rattr_long(presv, RESV_ATR_resv_standing)) {
+			char *execvnodes = NULL;
+			int occurrence = -1;
+
 			if (is_rattr_set(presv, RESV_ATR_resv_execvnodes))
 				execvnodes = get_rattr_str(presv, RESV_ATR_resv_execvnodes);
 			if (execvnodes == NULL)

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -1343,6 +1343,8 @@ vnode_available(struct pbsnode *np)
 	resc_resv *presv;
 	struct resvinfo *rinfp;
 	struct resvinfo *rinfp_hd = NULL;
+	char *execvnodes = NULL;
+	int occurrence = -1;
 
 	if (np == NULL)
 		return;
@@ -1395,11 +1397,23 @@ vnode_available(struct pbsnode *np)
 			 */
 			/* If a standing reservation we print the execvnodes sequence
 			 * string for debugging purposes */
-			if (get_rattr_long(presv, RESV_ATR_resv_standing))
-				log_eventf(PBSEVENT_DEBUG, PBS_EVENTCLASS_RESV, LOG_DEBUG,
-					   presv->ri_qs.ri_resvID, "execvnodes sequence %s", get_rattr_str(presv, RESV_ATR_resv_execvnodes));
-			log_eventf(PBSEVENT_DEBUG, PBS_EVENTCLASS_RESV, LOG_DEBUG,
-				   presv->ri_qs.ri_resvID, "vnodes in occurrence: %d; ", presv->ri_vnodect);
+			if (get_rattr_long(presv, RESV_ATR_resv_standing)) {
+				if (is_rattr_set(presv, RESV_ATR_resv_execvnodes))
+					execvnodes = get_rattr_str(presv, RESV_ATR_resv_execvnodes);
+				if (execvnodes == NULL)
+					execvnodes = "";
+ 				log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_RESV, LOG_DEBUG,
+				           presv->ri_qs.ri_resvID, "execvnodes sequence: %s", execvnodes);
+				if (is_rattr_set(presv, RESV_ATR_resv_idx))
+					occurrence = get_rattr_long(presv, RESV_ATR_resv_idx);
+				log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_RESV, LOG_DEBUG,
+				           presv->ri_qs.ri_resvID, "vnodes in occurrence %d: %d; ",
+				           occurrence, presv->ri_vnodect);
+			} else {
+				log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_RESV, LOG_DEBUG,
+			           presv->ri_qs.ri_resvID, "vnodes in reservation: %d; ",
+			           presv->ri_vnodect);
+			}
 		}
 	}
 
@@ -1439,6 +1453,8 @@ vnode_unavailable(struct pbsnode *np, int account_vnode)
 	long degraded_time;
 	long resv_start_time;
 	long retry_time;
+	char *execvnodes = NULL;
+	int occurrence = -1;
 
 	if (np == NULL)
 		return;
@@ -1508,14 +1524,27 @@ vnode_unavailable(struct pbsnode *np, int account_vnode)
 			if (presv->ri_vnodes_down > presv->ri_vnodect) {
 				/* If a standing reservation we print the execvnodes sequence
 				 * string for debugging purposes */
-				if (get_rattr_arst(presv, RESV_ATR_resv_standing))
-					log_eventf(PBSEVENT_DEBUG, PBS_EVENTCLASS_RESV, LOG_DEBUG,
-						   presv->ri_qs.ri_resvID, " execvnodes sequence %s",
-						   get_rattr_str(presv, RESV_ATR_resv_execvnodes));
-				log_eventf(PBSEVENT_DEBUG, PBS_EVENTCLASS_RESV, LOG_DEBUG,
-					   presv->ri_qs.ri_resvID,
-					   "vnodes in occurrence: %d; unavailable vnodes in reservation: %d",
-					   presv->ri_vnodect, presv->ri_vnodes_down);
+				if (get_rattr_arst(presv, RESV_ATR_resv_standing)) {
+					if (is_rattr_set(presv, RESV_ATR_resv_execvnodes))
+						execvnodes = get_rattr_str(presv, RESV_ATR_resv_execvnodes);
+					if (execvnodes == NULL)
+						execvnodes = "";
+					log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_RESV, LOG_DEBUG,
+						   presv->ri_qs.ri_resvID, "execvnodes sequence: %s",
+						   execvnodes);
+					if (is_rattr_set(presv, RESV_ATR_resv_idx))
+						occurrence = get_rattr_long(presv, RESV_ATR_resv_idx);
+ 					log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_RESV, LOG_DEBUG,
+					           presv->ri_qs.ri_resvID,
+					           "vnodes in occurrence %d: %d;"
+					           " unavailable vnodes in reservation: %d",
+					           occurrence, presv->ri_vnodect, presv->ri_vnodes_down);
+				} else {
+					log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_RESV, LOG_DEBUG,
+ 					   presv->ri_qs.ri_resvID,
+					   "vnodes in reservation: %d; unavailable vnodes in reservation: %d",
+ 					   presv->ri_vnodect, presv->ri_vnodes_down);
+				}
 			}
 			presv->ri_vnodes_down++;
 		}
@@ -1553,6 +1582,7 @@ find_vnode_in_resvs(struct pbsnode *np, enum vnode_degraded_op degraded_op)
 	pbsnode_list_t *pl;
 	int match = 0;
 	int is_degraded = 0;
+	long retry_time;
 
 	if (np == NULL)
 		return NULL;
@@ -1607,12 +1637,41 @@ find_vnode_in_resvs(struct pbsnode *np, enum vnode_degraded_op degraded_op)
 			 * happen as the reservation should have been confirmed and the nodes
 			 * been assigned to it
 			 */
-			if (is_rattr_set(presv, RESV_ATR_resv_execvnodes) == 0) {
-				log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_RESV, LOG_NOTICE,
-					  presv->ri_qs.ri_resvID, "Reservation's execvnodes_seq are corrupted");
-				continue;
-			}
-			is_degraded = find_degraded_occurrence(presv, np, degraded_op);
+			if (!is_rattr_set(presv, RESV_ATR_resv_execvnodes)) {
+				is_degraded = 1;
+				log_eventf(PBSEVENT_DEBUG, PBS_EVENTCLASS_RESV, LOG_NOTICE,
+				           presv->ri_qs.ri_resvID,
+				           "%s: Reservation's execvnodes_seq are corrupted, degrading it",
+				           __func__);
+				if (presv->ri_qs.ri_substate != RESV_DEGRADED) {
+					if (presv->ri_qs.ri_state == RESV_RUNNING
+					    || presv->ri_qs.ri_state == RESV_DELETING_JOBS) {
+						/*
+						** leave it as is, rely on resv_vnodes to run jobs in it;
+						** once this occurrence finally finishes
+						** we will re-evaluate whether to reconfirm next occurrence.
+						** Still set substate to degraded now to alert site admins
+						*/
+						resv_setResvState(presv, presv->ri_qs.ri_state, RESV_DEGRADED);
+					} else {
+						resv_setResvState(presv, RESV_DEGRADED, RESV_DEGRADED);
+						retry_time = determine_resv_retry(presv);
+						/* if server just came up wait 'some time' for nodes to come up */
+						if (time_now + ESTIMATED_DELAY_NODES_UP < retry_time)
+							retry_time = time_now + ESTIMATED_DELAY_NODES_UP;
+						/* bogus value for degraded_time, but avoid skipping a reconfirmation */
+						presv->ri_degraded_time = get_rattr_long(presv, RESV_ATR_start);
+						log_eventf(PBSEVENT_ERROR, PBS_EVENTCLASS_RESV, LOG_NOTICE, presv->ri_qs.ri_resvID,
+						           "%s: Reservation with corrupted nodes, setting up reconfirmation",
+						           __func__);
+						force_resv_retry(presv, retry_time);
+					}
+				}
+				/* the reservation is degraded but we cannot associate it with the node */
+ 				continue;
+			} else {
+				is_degraded = find_degraded_occurrence(presv, np, degraded_op);
+ 			}
 
 			/* If no occurrence is degraded move on to the next reservation */
 			if (is_degraded == 0)
@@ -1677,7 +1736,7 @@ find_degraded_occurrence(resc_resv *presv, struct pbsnode *np,
 	char **tofree = NULL;
 	char *rrule;
 	char *tz;
-	char *execvnodes;
+	char *execvnodes = NULL;
 	long dtstart;
 	long occr_time;
 	long curr_degraded_time;
@@ -1697,9 +1756,9 @@ find_degraded_occurrence(resc_resv *presv, struct pbsnode *np,
 	rrule = get_rattr_str(presv, RESV_ATR_resv_rrule);
 	tz = get_rattr_str(presv, RESV_ATR_resv_timezone);
 	dtstart = get_rattr_long(presv, RESV_ATR_start);
-	execvnodes = get_rattr_str(presv, RESV_ATR_resv_execvnodes);
-
-	if ((short_execvnodes_seq = strdup(execvnodes)) == NULL)
+	if (is_rattr_set(presv, RESV_ATR_resv_execvnodes))
+		execvnodes = get_rattr_str(presv, RESV_ATR_resv_execvnodes);
+	if (execvnodes == NULL || (short_execvnodes_seq = strdup(execvnodes)) == NULL)
 		return -1;
 	execvnodes_seq = unroll_execvnode_seq(short_execvnodes_seq, &tofree);
 	/* If an error occurred during unrolling, this reservation is ignored */
@@ -1721,6 +1780,12 @@ find_degraded_occurrence(resc_resv *presv, struct pbsnode *np,
 
 	/* Search for a match for this node in each occurrence's execvnode */
 	for (i = ridx_adjusted - 1, j = 1; i < rcount_adjusted; i++, j++) {
+		if (i < 0) {
+			log_eventf(PBSEVENT_ERROR, PBS_EVENTCLASS_RESV, LOG_NOTICE, presv->ri_qs.ri_resvID,
+				       "%s: attempt to find vnodes for for occurence %d failed; skipping",
+		           __func__, j);
+			continue;
+		}
 		if (find_vnode_in_execvnode(execvnodes_seq[i], np->nd_name)) {
 			occr_found = 1;
 			if (degraded_op == Set_Degraded_Time) {
@@ -1801,7 +1866,7 @@ unset_resv_retry(resc_resv *presv)
 	if (presv == NULL)
 		return;
 
-	if (is_rattr_set(presv, RESV_ATR_retry) == 0)
+	if (!is_rattr_set(presv, RESV_ATR_retry))
 		return;
 
 	set_rattr_l_slim(presv, RESV_ATR_retry, 0, SET);
@@ -1820,16 +1885,19 @@ unset_resv_retry(resc_resv *presv)
  *
  * @param[in]	presv	-	The reservation to process
  * @param[in]	retry_time	-	The retry time to set
+ * @param[in]	forced  - determines which handler we call
+ * 
  *
  * @return	void
  *
  * @par MT-safe: No
  */
 void
-set_resv_retry(resc_resv *presv, long retry_time)
+set_resv_retry2(resc_resv *presv, long retry_time, int forced)
 {
 	struct work_task *pwt;
-	extern void resv_retry_handler(struct work_task * ptask);
+	extern void resv_retry_handler(struct work_task *ptask);
+	extern void resv_retry_handler_forced(struct work_task *ptask);
 	char *msg;
 	char *str_time;
 
@@ -1846,20 +1914,65 @@ set_resv_retry(resc_resv *presv, long retry_time)
 	presv->ri_resv_retry = retry_time;
 
 	str_time = ctime(&retry_time);
-	if (str_time != NULL) {
-		str_time[strlen(str_time) - 1] = '\0';
-		log_eventf(PBSEVENT_DEBUG2, PBS_EVENTCLASS_RESV, LOG_NOTICE, presv->ri_qs.ri_resvID, msg, str_time);
-	}
+	if (str_time == NULL)
+		str_time = "";
+	log_eventf(PBSEVENT_DEBUG2, PBS_EVENTCLASS_RESV, LOG_NOTICE, presv->ri_qs.ri_resvID, msg, str_time);
 
 	/* Set a work task to initiate a scheduling cycle when the time to check
 	 * for alternate nodes to assign the reservation comes
 	 */
-	if ((pwt = set_task(WORK_Timed, retry_time, resv_retry_handler, presv)) != NULL) {
+	if ((pwt = set_task(WORK_Timed, retry_time, forced ? resv_retry_handler_forced : resv_retry_handler, presv)) != NULL) {
 		/* set things so that the reservation going away will result in
 		 * any "yet to be processed" work tasks also going away
 		 */
 		append_link(&presv->ri_svrtask, &pwt->wt_linkobj, pwt);
 	}
+}
+
+/**
+ * @brief
+ * 		Set reservation retry attributes and variables.
+ * 		The reservation attribute RESV_ATR_retry is recovered upon a server
+ * 		restart. The field ri_resv_retry is not.
+ * 		If RESV_ATR_retry is set, we add that already existing time as the
+ * 		event time, otherwise we compute the event time
+ *
+ *      This one will only kick a reconfirmation if ri_vnodes_down is positive
+ *
+ * @param[in]	presv	-	The reservation to process
+ * @param[in]	retry_time	-	The retry time to set
+ *
+ * @return	void
+ *
+ * @par MT-safe: No
+ */
+void
+set_resv_retry(resc_resv *presv, long retry_time)
+{
+	set_resv_retry2(presv, retry_time, 0);
+}
+
+/**
+ * @brief
+ * 		Set reservation retry attributes and variables.
+ * 		The reservation attribute RESV_ATR_retry is recovered upon a server
+ * 		restart. The field ri_resv_retry is not.
+ * 		If RESV_ATR_retry is set, we add that already existing time as the
+ * 		event time, otherwise we compute the event time
+ *
+ *      This will always kick a reconfirmation
+ *
+ * @param[in]	presv	-	The reservation to process
+ * @param[in]	retry_time	-	The retry time to set
+ *
+ * @return	void
+ *
+ * @par MT-safe: No
+ */
+void
+force_resv_retry(resc_resv *presv, long retry_time)
+{
+	set_resv_retry2(presv, retry_time, 1);
 }
 
 /**
@@ -6312,7 +6425,7 @@ end:
 
 /**
  * @brief update node state based on the job sharing type
- * and node sharing type. For instance; 
+ * and node sharing type. For instance:
  * node-state is set to exclusive if either of them are exclusive.
  * 
  * @param[in,out] pnode - node for which state is updated
@@ -8121,6 +8234,8 @@ static void
 set_resv_for_degrade(struct pbsnode *pnode, resc_resv *presv)
 {
 	long degraded_time;
+	char *execvnodes = NULL;
+	int occurrence = -1;
 
 	if ((degraded_time = get_rattr_long(presv, RESV_ATR_resv_standing)) == 0)
 		presv->ri_degraded_time = degraded_time;
@@ -8142,14 +8257,26 @@ set_resv_for_degrade(struct pbsnode *pnode, resc_resv *presv)
 		/* If a standing reservation we print the execvnodes sequence
 		 * string for debugging purposes
 		 */
-		if (get_rattr_long(presv, RESV_ATR_resv_standing))
+		if (get_rattr_long(presv, RESV_ATR_resv_standing)) {
+			if (is_rattr_set(presv, RESV_ATR_resv_execvnodes))
+				execvnodes = get_rattr_str(presv, RESV_ATR_resv_execvnodes);
+			if (execvnodes == NULL)
+				execvnodes = "";
+ 			log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_RESV, LOG_DEBUG,
+			           presv->ri_qs.ri_resvID, "execvnodes sequence: %s",
+			           execvnodes);
+			if (is_rattr_set(presv, RESV_ATR_resv_idx))
+				occurrence = get_rattr_long(presv, RESV_ATR_resv_idx);
 			log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_RESV, LOG_DEBUG,
-				   presv->ri_qs.ri_resvID, " execvnodes sequence %s",
-				   get_rattr_str(presv, RESV_ATR_resv_execvnodes));
-
-		log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_RESV, LOG_DEBUG,
-			   presv->ri_qs.ri_resvID, "vnodes in occurrence: %d; unavailable vnodes in reservation: %d",
-			   presv->ri_vnodect, presv->ri_vnodes_down);
+			           presv->ri_qs.ri_resvID, "vnodes in occurrence %d: %d; "
+			           "unavailable vnodes in reservation: %d",
+			           occurrence, presv->ri_vnodect, presv->ri_vnodes_down);
+		} else {
+			log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_RESV, LOG_DEBUG,
+			           presv->ri_qs.ri_resvID, "vnodes in reservation: %d; "
+			           "unavailable vnodes in reservation: %d",
+			           presv->ri_vnodect, presv->ri_vnodes_down);
+		}
 	}
 	presv->ri_vnodes_down++;
 }

--- a/src/server/pbsd_init.c
+++ b/src/server/pbsd_init.c
@@ -734,6 +734,7 @@ pbsd_init(int type)
 	 */
 
 	remove_deleted_resvs();
+	degrade_corrupted_confirmed_resvs();
 	add_resv_beginEnd_tasks();
 
 	resv_timer_init();

--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -3961,17 +3961,16 @@ degrade_corrupted_confirmed_resvs(void)
 		/* if corrupted and already degraded we still need to set a retry time for the scheduler to be prodded again */
 		if (presv->ri_qs.ri_state == RESV_CONFIRMED || presv->ri_qs.ri_state == RESV_DEGRADED) {
 			if (get_rattr_long(presv, RESV_ATR_resv_standing))
-				if (!(is_rattr_set(presv, RESV_ATR_resv_execvnodes))
-				    || get_rattr_str(presv, RESV_ATR_resv_execvnodes) == NULL)
-                    is_degraded = 1;
-            if (!(is_rattr_set(presv, RESV_ATR_resv_nodes)) || get_rattr_str(presv, RESV_ATR_resv_nodes) == NULL)
-                is_degraded = 1;
+				if (!(is_rattr_set(presv, RESV_ATR_resv_execvnodes)) || get_rattr_str(presv, RESV_ATR_resv_execvnodes) == NULL)
+					is_degraded = 1;
+			if (!(is_rattr_set(presv, RESV_ATR_resv_nodes)) || get_rattr_str(presv, RESV_ATR_resv_nodes) == NULL)
+				is_degraded = 1;
 		} else if (presv->ri_qs.ri_state == RESV_FINISHED && get_rattr_long(presv, RESV_ATR_resv_standing))
-            if (get_rattr_long(presv, RESV_ATR_resv_idx) < get_rattr_long(presv, RESV_ATR_resv_count))
-                /* should never keep a standing reservation in RESV_FINISHED state for anything but the last occurrence */
-                /* if we don't degrade it then remove_deleted_resvs may create a task to nuke it */
-                is_degraded = 1;
-        if (is_degraded) {
+			if (get_rattr_long(presv, RESV_ATR_resv_idx) < get_rattr_long(presv, RESV_ATR_resv_count))
+				/* should never keep a standing reservation in RESV_FINISHED state for anything but the last occurrence */
+				/* if we don't degrade it then remove_deleted_resvs may create a task to nuke it */
+				is_degraded = 1;
+		if (is_degraded) {
 			resv_setResvState(presv, RESV_DEGRADED, RESV_DEGRADED);
 			/* there is no point in trying to reconfirm it immediately at server start,
 			 * since the nodes will not have reported as free yet.
@@ -3988,7 +3987,7 @@ degrade_corrupted_confirmed_resvs(void)
 			presv->ri_degraded_time = get_rattr_long(presv, RESV_ATR_start);
 			/* bogus value, but avoid skipping a reconfirmation */
 			log_eventf(PBSEVENT_ERROR, PBS_EVENTCLASS_RESV, LOG_NOTICE, presv->ri_qs.ri_resvID,
-			           "Reservation with corrupted nodes, degrading with retry time set to %s", str_time);
+				   "Reservation with corrupted nodes, degrading with retry time set to %s", str_time);
 			force_resv_retry(presv, retry_time);
 		}
 		presv = nxresv;


### PR DESCRIPTION
#### Describe Bug or Feature
Handles identified issues with standing reservations that are corrupted and then crash the server (and scheduler).
The Root cause is unknown (probable race condition including a reservation that is degraded and reconfirmed at an "awkward" moment).


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
These changes will:

- consistently use the reserve_execvnodes DB attribute (and corresponding internal attributes in server and scheduler) with N entries to mean these are for the last N occurrences.
- will do bounds checking when accessing elements in the unrolled array created from it (to handle a number of entries that is unexpectedly short -- reconfirmation can change the number of entries).
- will avoid exiting routines with a standing reservation in an inconsistent state, especially when partially changed but not written to the DB.
- will degrade a reservation that is either missing resv_vnodes or reserve_execvnodes or has a reserve_execvnodes that is too short for the current reserve_index and occurrence count.
- will modify the scheduler to not give up on such reservations when asked to reconfirm them, accepting the current reserve_vnode as detailed above (treating occurrences that have no entry as 'currently nodeless', with the scheduler free to assign any nodes it can find to them).
- when restarting the server, will create the timed tasks to move reservations in RESV_DELETING_JOBS to finished state (and beyond); the current code assumes the timed task will 'take care of things' but when we restart the server that task will be gone.
- The logging was also improved to make it more easy to see exactly what the server or scheduler did not like about a reservation, and in the case of a standing reservation, which occurrence it was having trouble with.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->


It's impossible to create a PTL test for these without the root cause, but I have successfully tested the changes against the following kind of standing reservation:
- reservation with the current index set to a finished reservation, start/end/duration consistent with the next occurrence, and a reserve_execvnode that is missing some entries wrt the reserve_index value

**A session that demonstrates the issue before fixing it:** 

```bash

All daemons in one node: ub22-single

08:26:12 root ub22-single  ~ 
→ ps -ef | grep pbs
root        2537       1  0 08:20 ?        00:00:00 /opt/pbs/sbin/pbs_comm
root        2547       1  0 08:20 ?        00:00:00 /opt/pbs/sbin/pbs_mom
root        2559       1  0 08:20 ?        00:00:00 /opt/pbs/sbin/pbs_sched
root        2605       1  0 08:20 ?        00:00:00 /opt/pbs/sbin/pbs_ds_monitor monitor
postgres    2627       1  0 08:20 ?        00:00:00 /usr/lib/postgresql/14/bin/postgres -D /var/spool/pbs/datastore -p 15007
postgres    2667    2627  0 08:20 ?        00:00:00 postgres: postgres pbs_datastore 172.18.1.10(38260) idle
root        2668       1  0 08:20 ?        00:00:00 /opt/pbs/sbin/pbs_server.bin
root        2920     152  0 08:35 pts/1    00:00:00 grep --color=auto pbs


Submit a standing reservation

08:37:31 pbsuser ub22-single  ~ 
→ pbs_rsub -lselect=1:ncpus=4 -R 0839 -D 2:00 -r "FREQ=HOURLY;COUNT=4"
S1.ub22-single UNCONFIRMED

The reservation is confirmed:

08:37:49 pbsuser ub22-single  ~ 
→ pbs_rstat
Resv ID    Queue    User     State             Start / Duration / End              
---------------------------------------------------------------------
S1.ub22-si S1       pbsuser@ CO  

08:38:43 pbsuser ub22-single  ~ 
→ sleep 60; pbs_rstat; sleep 120; pbs_rstat
Resv ID    Queue    User     State             Start / Duration / End              
---------------------------------------------------------------------
S1.ub22-si S1       pbsuser@ RN          Today 08:39 / 120 / Today 08:41      
Resv ID    Queue    User     State             Start / Duration / End              
---------------------------------------------------------------------
S1.ub22-si S1       pbsuser@ CO          Today 09:39 / 120 / Today 09:41

Stop PBS: 

08:35:24 root ub22-single  ~ 
→ /etc/init.d/pbs stop
Stopping PBS
Shutting server down with qterm.
PBS server - was pid: 2668
PBS mom - was pid: 2547
PBS sched - was pid: 2559
PBS comm - was pid: 2537
Waiting for shutdown to complete

Start the dataservice
09:00:18 root ub22-single  ~ 
→ /opt/pbs/sbin/pbs_dataservice start
Starting PBS Data Service..

09:01:15 root ub22-single  ~ 
→ ps -ef | grep pbs
root        2924     243  0 08:35 pts/2    00:00:00 su pbsuser
pbsuser     2926       1  0 08:35 ?        00:00:00 /lib/systemd/systemd --user
pbsuser     2927    2926  0 08:35 ?        00:00:00 (sd-pam)
pbsuser     2932    2924  0 08:35 pts/2    00:00:00 bash
root        3530       1  0 09:01 ?        00:00:00 /opt/pbs/sbin/pbs_ds_monitor monitor
postgres    3552       1  0 09:01 ?        00:00:00 /usr/lib/postgresql/14/bin/postgres -D /var/spool/pbs/datastore -p 15007
root        3577     152  0 09:01 pts/1    00:00:00 grep --color=auto pbs

Corrupt the reservation entry in the datastore.

state and substate set to RESV_FINISHED, 
reserve_index set to 1 but times corresponding to the second occurrence,
number of elements in reserve_execvnodes inconsistent (too short) with reserve_index.

09:16:25 root ub22-single  ~ 
→ cat corrupt_db_1.sql 
set search_path to pbs,public;
select * from resv;
update resv set ri_state = 6;
update resv set ri_substate = 6;
update resv set attributes = attributes || '"reserve_state"=>"11.6"';
update resv set attributes = attributes || '"reserve_substate"=>"11.6"';
update resv set attributes = attributes || '"reserve_index"=>"11.1"';
update resv set attributes = attributes || '"reserve_execvnodes"=>"11.2#(ub22-single:ncpus=4){0-1}"';
select * from resv;


09:22:19 root ub22-single  ~ 
→ /usr/lib/postgresql/14/bin/psql -A -t -p 15007 -U postgres -d pbs_datastore -f corrupt_db_1.sql
SET
S1.ub22-single|S1|6|6|1710322740|1710322860|120|1710319140|4097|2024-03-13 08:41:05.505724|2024-03-13 08:37:49.567258|"ctime"=>"11.1710319069", "euser"=>"11.pbsuser", "mtime"=>"11.1710319265", "queue"=>"11.S1", "egroup"=>"15.tstgrp00", "server"=>"11.ub22-single", "hop_count"=>"11.1", "partition"=>"11.pbs-default", "resv_nodes"=>"11.(ub22-single:ncpus=4)", "reserve_end"=>"11.1710322860", "schedselect"=>"15.1:ncpus=4", "Reserve_Name"=>"11.NULL", "Reserve_Owner"=>"11.pbsuser@ub22-single", "Variable_List"=>"11.PBS_O_LOGNAME=pbsuser,PBS_O_HOST=ub22-single,PBS_O_MAIL=/var/mail/pbsuser,PBS_TZID=UTC", "reserve_count"=>"11.4", "reserve_index"=>"11.2", "reserve_rrule"=>"11.FREQ=HOURLY;COUNT=4", "reserve_start"=>"11.1710322740", "reserve_state"=>"11.2", "Authorized_Users"=>"11.pbsuser@ub22-single", "reserve_duration"=>"11.120", "reserve_standing"=>"11.1", "reserve_substate"=>"11.2", "reserve_timezone"=>"11.UTC", "reserve_execvnodes"=>"11.4#(ub22-single:ncpus=4){0-3}", "Resource_List.ncpus"=>"15.4", "Resource_List.place"=>"11.free", "Resource_List.nodect"=>"15.1", "Resource_List.select"=>"9.1:ncpus=4", "Resource_List.walltime"=>"11.00:02:00"
UPDATE 1
UPDATE 1
UPDATE 1
UPDATE 1
UPDATE 1
UPDATE 1
S1.ub22-single|S1|6|6|1710322740|1710322860|120|1710319140|4097|2024-03-13 08:41:05.505724|2024-03-13 08:37:49.567258|"ctime"=>"11.1710319069", "euser"=>"11.pbsuser", "mtime"=>"11.1710319265", "queue"=>"11.S1", "egroup"=>"15.tstgrp00", "server"=>"11.ub22-single", "hop_count"=>"11.1", "partition"=>"11.pbs-default", "resv_nodes"=>"11.(ub22-single:ncpus=4)", "reserve_end"=>"11.1710322860", "schedselect"=>"15.1:ncpus=4", "Reserve_Name"=>"11.NULL", "Reserve_Owner"=>"11.pbsuser@ub22-single", "Variable_List"=>"11.PBS_O_LOGNAME=pbsuser,PBS_O_HOST=ub22-single,PBS_O_MAIL=/var/mail/pbsuser,PBS_TZID=UTC", "reserve_count"=>"11.4", "reserve_index"=>"11.1", "reserve_rrule"=>"11.FREQ=HOURLY;COUNT=4", "reserve_start"=>"11.1710322740", "reserve_state"=>"11.6", "Authorized_Users"=>"11.pbsuser@ub22-single", "reserve_duration"=>"11.120", "reserve_standing"=>"11.1", "reserve_substate"=>"11.6", "reserve_timezone"=>"11.UTC", "reserve_execvnodes"=>"11.2#(ub22-single:ncpus=4){0-1}", "Resource_List.ncpus"=>"15.4", "Resource_List.place"=>"11.free", "Resource_List.nodect"=>"15.1", "Resource_List.select"=>"9.1:ncpus=4", "Resource_List.walltime"=>"11.00:02:00"

Start PBS again

09:23:56 root ub22-single  ~ 
→ /etc/init.d/pbs start
Starting PBS
PBS comm
/opt/pbs/sbin/pbs_comm ready (pid=3758), Proxy Name:ub22-single:17001, Threads:4
PBS mom
PBS sched
Connecting to PBS dataservice....connected to PBS dataservice@ub22-single
PBS server

09:24:10 root ub22-single  ~ 
→ ps -ef | grep pbs
root        2924     243  0 08:35 pts/2    00:00:00 su pbsuser
pbsuser     2926       1  0 08:35 ?        00:00:00 /lib/systemd/systemd --user
pbsuser     2927    2926  0 08:35 ?        00:00:00 (sd-pam)
pbsuser     2932    2924  0 08:35 pts/2    00:00:00 bash
root        3530       1  0 09:01 ?        00:00:00 /opt/pbs/sbin/pbs_ds_monitor monitor
postgres    3552       1  0 09:01 ?        00:00:00 /usr/lib/postgresql/14/bin/postgres -D /var/spool/pbs/datastore -p 15007
root        3758       1  0 09:24 ?        00:00:00 /opt/pbs/sbin/pbs_comm
root        3768       1  0 09:24 ?        00:00:00 /opt/pbs/sbin/pbs_mom
root        3909     152  0 09:24 pts/1    00:00:00 grep --color=auto pbs

Notice that the server daemon (pbs_server.bin) is not in the list of running processes, because it crashed.

09:24:29 root ub22-single  ~ 
→ pbs_rstat
Connection refused
pbs_rstat: cannot connect to server (errno=15010)


```


**After fixing the issue:**

```bash


All daemons in one node: ub22-single

13:56:57 root ub22-single  ~ 
→ ps -ef | grep pbs
root       16175       1  0 13:56 ?        00:00:00 /opt/pbs/sbin/pbs_comm
root       16185       1  0 13:56 ?        00:00:00 /opt/pbs/sbin/pbs_mom
root       16197       1  0 13:56 ?        00:00:00 /opt/pbs/sbin/pbs_sched
root       16250       1  0 13:56 ?        00:00:00 /opt/pbs/sbin/pbs_ds_monitor monitor
postgres   16272       1  0 13:56 ?        00:00:00 /usr/lib/postgresql/14/bin/postgres -D /var/spool/pbs/datastore -p 15007
postgres   16313   16272  0 13:56 ?        00:00:00 postgres: postgres pbs_datastore 172.18.1.10(60538) idle
root       16315       1  0 13:56 ?        00:00:00 /opt/pbs/sbin/pbs_server.bin
root       16511     170  0 13:57 pts/1    00:00:00 grep --color=auto pbs


Submit a standing reservation

13:57:27 pbsuser ub22-single  ~ 
→ pbs_rsub -lselect=1:ncpus=4 -R 1359 -D 2:00 -r "FREQ=HOURLY;COUNT=4"
S2.ub22-single UNCONFIRMED

The reservation is confirmed:

13:58:11 pbsuser ub22-single  ~ 
→ pbs_rstat
Resv ID    Queue    User     State             Start / Duration / End              
---------------------------------------------------------------------
S2.ub22-si S2       pbsuser@ CO          Today 13:59 / 120 / Today 14:01 

13:58:19 pbsuser ub22-single  ~ 
→ sleep 60; pbs_rstat; sleep 120; pbs_rstat
Resv ID    Queue    User     State             Start / Duration / End              
---------------------------------------------------------------------
S2.ub22-si S2       pbsuser@ RN          Today 13:59 / 120 / Today 14:01      
Resv ID    Queue    User     State             Start / Duration / End              
---------------------------------------------------------------------
S2.ub22-si S2       pbsuser@ CO          Today 14:59 / 120 / Today 15:01   

Stop PBS: 

13:57:43 root ub22-single  ~ 
→ /etc/init.d/pbs stop 
Stopping PBS
Shutting server down with qterm.
PBS server - was pid: 16315
PBS mom - was pid: 16185
PBS sched - was pid: 16197
PBS comm - was pid: 16175
Waiting for shutdown to complete

Start the dataservice

14:01:39 root ub22-single  ~ 
→ /opt/pbs/sbin/pbs_dataservice start
Starting PBS Data Service..

14:02:21 root ub22-single  ~ 
→ ps -ef | grep pbs
root         250     213  0 13:42 pts/2    00:00:00 su pbsuser
pbsuser      252       1  0 13:42 ?        00:00:00 /lib/systemd/systemd --user
pbsuser      253     252  0 13:42 ?        00:00:00 (sd-pam)
pbsuser      258     250  0 13:42 pts/2    00:00:00 bash
root       16889       1  0 14:02 ?        00:00:00 /opt/pbs/sbin/pbs_ds_monitor monitor
postgres   16911       1  0 14:02 ?        00:00:00 /usr/lib/postgresql/14/bin/postgres -D /var/spool/pbs/datastore -p 15007
root       16936     170  0 14:02 pts/1    00:00:00 grep --color=auto pbs

Corrupt the reservation entry in the datastore.

state and substate set to RESV_FINISHED, 
reserve_index set to 1 but times corresponding to the second occurrence,
number of elements in reserve_execvnodes inconsistent (too short) with reserve_index.

14:03:11 pbsuser ub22-single  ~ 
→ cat corrupt_db_1.sql 
set search_path to pbs,public;
select * from resv;
update resv set ri_state = 6;
update resv set ri_substate = 6;
update resv set attributes = attributes || '"reserve_state"=>"11.6"';
update resv set attributes = attributes || '"reserve_substate"=>"11.6"';
update resv set attributes = attributes || '"reserve_index"=>"11.1"';
update resv set attributes = attributes || '"reserve_execvnodes"=>"11.2#(ub22-single:ncpus=4){0-1}"';
select * from resv;


14:03:16 pbsuser ub22-single  ~ 
→ /usr/lib/postgresql/14/bin/psql -A -t -p 15007 -U postgres -d pbs_datastore -f corrupt_db_1.sql
Password for user postgres: 
SET
S2.ub22-single|S2|2|2|1710341940|1710342060|120|1710338340|4097|2024-03-13 14:01:05.080243|2024-03-13 13:58:11.953114|"ctime"=>"11.1710338291", "euser"=>"11.pbsuser", "mtime"=>"11.1710338465", "queue"=>"11.S2", "egroup"=>"15.tstgrp00", "server"=>"11.ub22-single", "hop_count"=>"11.1", "partition"=>"11.pbs-default", "resv_nodes"=>"11.(ub22-single:ncpus=4)", "reserve_end"=>"11.1710342060", "schedselect"=>"15.1:ncpus=4", "Reserve_Name"=>"11.NULL", "Reserve_Owner"=>"11.pbsuser@ub22-single", "Variable_List"=>"11.PBS_O_LOGNAME=pbsuser,PBS_O_HOST=ub22-single,PBS_O_MAIL=/var/mail/pbsuser,PBS_TZID=UTC", "reserve_count"=>"11.4", "reserve_index"=>"11.2", "reserve_rrule"=>"11.FREQ=HOURLY;COUNT=4", "reserve_start"=>"11.1710341940", "reserve_state"=>"11.2", "Authorized_Users"=>"11.pbsuser@ub22-single", "reserve_duration"=>"11.120", "reserve_standing"=>"11.1", "reserve_substate"=>"11.2", "reserve_timezone"=>"11.UTC", "reserve_execvnodes"=>"11.4#(ub22-single:ncpus=4){0-3}", "Resource_List.ncpus"=>"15.4", "Resource_List.place"=>"11.free", "Resource_List.nodect"=>"15.1", "Resource_List.select"=>"9.1:ncpus=4", "Resource_List.walltime"=>"11.00:02:00"
UPDATE 1
UPDATE 1
UPDATE 1
UPDATE 1
UPDATE 1
UPDATE 1
S2.ub22-single|S2|6|6|1710341940|1710342060|120|1710338340|4097|2024-03-13 14:01:05.080243|2024-03-13 13:58:11.953114|"ctime"=>"11.1710338291", "euser"=>"11.pbsuser", "mtime"=>"11.1710338465", "queue"=>"11.S2", "egroup"=>"15.tstgrp00", "server"=>"11.ub22-single", "hop_count"=>"11.1", "partition"=>"11.pbs-default", "resv_nodes"=>"11.(ub22-single:ncpus=4)", "reserve_end"=>"11.1710342060", "schedselect"=>"15.1:ncpus=4", "Reserve_Name"=>"11.NULL", "Reserve_Owner"=>"11.pbsuser@ub22-single", "Variable_List"=>"11.PBS_O_LOGNAME=pbsuser,PBS_O_HOST=ub22-single,PBS_O_MAIL=/var/mail/pbsuser,PBS_TZID=UTC", "reserve_count"=>"11.4", "reserve_index"=>"11.1", "reserve_rrule"=>"11.FREQ=HOURLY;COUNT=4", "reserve_start"=>"11.1710341940", "reserve_state"=>"11.6", "Authorized_Users"=>"11.pbsuser@ub22-single", "reserve_duration"=>"11.120", "reserve_standing"=>"11.1", "reserve_substate"=>"11.6", "reserve_timezone"=>"11.UTC", "reserve_execvnodes"=>"11.2#(ub22-single:ncpus=4){0-1}", "Resource_List.ncpus"=>"15.4", "Resource_List.place"=>"11.free", "Resource_List.nodect"=>"15.1", "Resource_List.select"=>"9.1:ncpus=4", "Resource_List.walltime"=>"11.00:02:00"

Start PBS again

14:03:08 root ub22-single  ~ 
→ /etc/init.d/pbs start 
Starting PBS
PBS comm
/opt/pbs/sbin/pbs_comm ready (pid=17033), Proxy Name:ub22-single:17001, Threads:4
PBS mom
PBS sched
Connecting to PBS dataservice....connected to PBS dataservice@ub22-single

PBS server


14:04:49 root ub22-single  ~ 
→ ps -ef | grep pbs
root         250     213  0 13:42 pts/2    00:00:00 su pbsuser
pbsuser      252       1  0 13:42 ?        00:00:00 /lib/systemd/systemd --user
pbsuser      253     252  0 13:42 ?        00:00:00 (sd-pam)
pbsuser      258     250  0 13:42 pts/2    00:00:00 bash
root       16889       1  0 14:02 ?        00:00:00 /opt/pbs/sbin/pbs_ds_monitor monitor
postgres   16911       1  0 14:02 ?        00:00:00 /usr/lib/postgresql/14/bin/postgres -D /var/spool/pbs/datastore -p 15007
root       17033       1  0 14:04 ?        00:00:00 /opt/pbs/sbin/pbs_comm
root       17043       1  0 14:04 ?        00:00:00 /opt/pbs/sbin/pbs_mom
root       17055       1  0 14:04 ?        00:00:00 /opt/pbs/sbin/pbs_sched
postgres   17171   16911  0 14:04 ?        00:00:00 postgres: postgres pbs_datastore 172.18.1.10(54822) idle
root       17172       1  0 14:04 ?        00:00:00 /opt/pbs/sbin/pbs_server.bin
root       17183     170  0 14:04 pts/1    00:00:00 grep --color=auto pbs

Notice that the server daemon did not crash this time.

The reservation has been degraded due to the funny state it was left in. 


14:04:53 root ub22-single  ~ 
→ pbs_rstat
Resv ID    Queue    User     State             Start / Duration / End              
---------------------------------------------------------------------
S2.ub22-si S2       pbsuser@ DG          Today 14:59 / 120 / Today 15:01  

But it gets confirmed eventually. 

14:14:01 root ub22-single  ~ 
→ tracejob S2

Job: S2.ub22-single

03/13/2024 13:58:11  L    Confirming 4 Occurrences
03/13/2024 13:58:11  L    Reservation Confirmed
03/13/2024 13:58:11  S    created at request of pbs_server@ub22-single
03/13/2024 13:58:11  S    attributes set: resources_available.ncpus = 4
03/13/2024 13:58:11  S    attributes set: resources_max.ncpus = 4
03/13/2024 13:58:11  S    attributes set: queue_type = Execution
03/13/2024 13:58:11  S    attributes set: enabled = False
03/13/2024 13:58:11  S    attributes set: started = False
03/13/2024 13:58:11  S    attributes set: acl_users = pbsuser@ub22-single
03/13/2024 13:58:11  S    attributes set: acl_user_enable = True
03/13/2024 13:58:11  S    attributes set:  at request of pbs_server@ub22-single
03/13/2024 13:58:11  S    attributes set: enabled = True
03/13/2024 13:58:11  A    requestor=pbsuser@ub22-single recurrence_rrule=FREQ=HOURLY
03/13/2024 13:58:11  A    requestor=Scheduler@ub22-single start=1710338340 end=1710338460 nodes=(ub22-single:ncpus=4) count=4
03/13/2024 13:59:00  S    attributes set:  at request of pbs_server@ub22-single
03/13/2024 13:59:00  S    attributes set: started = True
03/13/2024 13:59:00  A    owner=pbsuser@ub22-single name=NULL queue=S2 ctime=1710338291 start=1710338340 end=1710338460 duration=120 nodes=(ub22-single:ncpus=4)
                          Authorized_Users=pbsuser@ub22-single Resource_List.ncpus=4 Resource_List.nodect=1 Resource_List.select=1:ncpus=4 Resource_List.place=free
                          Resource_List.walltime=00:02:00 
03/13/2024 14:01:00  S    reached end of occurrence 1/4
03/13/2024 14:01:00  S    attributes set:  at request of pbs_server@ub22-single
03/13/2024 14:01:00  S    attributes set: started = FALSE
03/13/2024 14:01:05  S    attributes set:  at request of pbs_server@ub22-single
03/13/2024 14:01:05  S    attributes set: enabled = True
03/13/2024 14:04:49  S    Reservation with corrupted nodes, degrading with retry time set to Wed Mar 13 14:05:49 2024
03/13/2024 14:04:49  S    An attempt to reconfirm reservation will be made on Wed Mar 13 14:05:49 2024
03/13/2024 14:04:49  L    query_reservations: occurence 2 has no execvnodes, using empty vector
03/13/2024 14:04:51  S    find_degraded_occurrence: attempt to find vnodes for for occurence 1 failed
03/13/2024 14:04:51  S    find_degraded_occurrence: attempt to find vnodes for for occurence 2 failed
03/13/2024 14:04:54  S    reached end of occurrence 1/4
03/13/2024 14:04:54  S    attributes set:  at request of pbs_server@ub22-single
03/13/2024 14:04:54  S    attributes set: started = FALSE
03/13/2024 14:04:59  S    Time4occurrenceFinish: attempt to find vnodes for for occurence 1 failed
03/13/2024 14:04:59  S    problem assigning resource to reservation occurrence (15089)
03/13/2024 14:04:59  S    Next attempt to reconfirm reservation will be made on Wed Mar 13 14:14:59 2024
03/13/2024 14:05:49  L    query_reservations: occurence 2 has no execvnodes, using empty vector
03/13/2024 14:14:59  L    query_reservations: occurence 2 has no execvnodes, using empty vector
03/13/2024 14:14:59  L    Event S2.ub22-single is a run/end event w/o nspec array, ignoring event
03/13/2024 14:14:59  L    Event S2.ub22-single is a run/end event w/o nspec array, ignoring event
03/13/2024 14:14:59  L    Confirming 4 Occurrences
03/13/2024 14:14:59  L    Reservation Confirmed
03/13/2024 14:14:59  A    requestor=Scheduler@ub22-single start=1710341940 end=1710342060 nodes=(ub22-single:ncpus=4) count=4

14:15:18 root ub22-single  ~ 
→ pbs_rstat
Resv ID    Queue    User     State             Start / Duration / End              
---------------------------------------------------------------------
S2.ub22-si S2       pbsuser@ CO          Today 14:59 / 120 / Today 15:01      


```

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
