### PR TITLE
fix possible job rerun over scheduled reservation/top job

### DIFF
--- a/src/resmom/mom_updates_bundle.c
+++ b/src/resmom/mom_updates_bundle.c
@@ -745,9 +745,9 @@ get_job_update(job *pjob)
 	}
 
 	/*
-	 * walltime must be set before encoded_used because in case of rerun
-	 * job without used walltime, the Resource_List.walltime could be used
-	 * as used.walltime for scheduling/calendaring.
+	 * The update_walltime() ensures the walltime is always set before encode_used().
+	 * A job without used walltime could occur in the first seconds of a job.
+	 * This ensures the used walltime is set even if the elapsed time is zero.
 	 */
 	update_walltime(pjob);
 

--- a/src/resmom/mom_updates_bundle.c
+++ b/src/resmom/mom_updates_bundle.c
@@ -744,6 +744,13 @@ get_job_update(job *pjob)
 							 job_attr_def[JOB_ATR_substate].at_name, NULL, ATR_ENCODE_CLIENT, NULL);
 	}
 
+	/*
+	 * walltime must be set before encoded_used because in case of rerun
+	 * job without used walltime, the Resource_List.walltime could be used
+	 * as used.walltime for scheduling/calendaring.
+	 */
+	update_walltime(pjob);
+
 	encode_used(pjob, &prused->ru_attr);
 
 	/* Now add certain others as required for updating at the Server */

--- a/test/tests/functional/pbs_sched_rerun.py
+++ b/test/tests/functional/pbs_sched_rerun.py
@@ -1,0 +1,119 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2021 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of both the OpenPBS software ("OpenPBS")
+# and the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# OpenPBS is free software. You can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# OpenPBS is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# PBS Pro is commercially licensed software that shares a common core with
+# the OpenPBS software.  For a copy of the commercial license terms and
+# conditions, go to: (http://www.pbspro.com/agreement.html) or contact the
+# Altair Legal Department.
+#
+# Altair's dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of OpenPBS and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair's trademarks, including but not limited to "PBS™",
+# "OpenPBS®", "PBS Professional®", and "PBS Pro™" and Altair's logos is
+# subject to Altair's trademark licensing policies.
+
+
+from tests.functional import *
+
+
+hook_body = """
+import pbs
+e = pbs.event()
+if e.type == pbs.EXECJOB_BEGIN:
+    e.job.resources_used["foo"] = 123
+    if e.job.run_count == 1:
+        for v in e.vnode_list:
+            if (v == "%s"):
+                e.vnode_list[v].state = pbs.ND_OFFLINE
+        e.job.rerun()
+        e.reject("reruen job")
+e.accept()
+"""
+
+
+class TestSchedRerun(TestFunctional):
+    """
+    Tests to verify scheduling of rerun jobs.
+    """
+
+    @requirements(num_moms=2)
+    def test_rerun_job_over_reservation(self):
+        """
+        Test that job will not run over reservation/top job
+        after first failed attempt to run (with used resource set).
+        """
+        now = int(time.time())
+
+        usage_string = 'test requires two moms,' + \
+                       'use -p "servers=M1,moms=M1:M2"'
+
+        if len(self.moms.values()) != 2:
+            self.skip_test(usage_string)
+
+        self.momA = self.moms.values()[0]
+        self.momB = self.moms.values()[1]
+        self.hostA = self.momA.shortname
+        self.hostB = self.momB.shortname
+
+        if not self.hostA or not self.hostB:
+            self.skip_test(usage_string)
+
+        self.server.manager(MGR_CMD_SET, SERVER,
+                            {'managers': (INCR, '%s@*' % TEST_USER)})
+
+        a = {'type': 'long', 'flag': 'i'}
+        r = 'foo'
+        self.server.manager(MGR_CMD_CREATE, RSC, a, id=r)
+
+        hook_name = "rerun_job"
+        a = {'event': 'execjob_begin',
+             'enabled': 'True'}
+        rv = self.server.create_import_hook(
+            hook_name, a, hook_body % self.hostA, overwrite=True)
+        self.assertTrue(rv)
+
+        a = {'reserve_start': now + 60,
+             'reserve_end': now + 7200}
+        h = [self.momB.shortname]
+        r = Reservation(TEST_USER, attrs=a, hosts=h)
+
+        self.server.submit(r)
+
+        a = {'Resource_List.select': '1:ncpus=1',
+             'Resource_List.walltime': '24:00:00'}
+        j = Job(TEST_USER, attrs=a)
+        j.set_sleep_time(1000)
+        jid = self.server.submit(j)
+
+        self.logger.info("Wait for the job to try to rerun (10 seconds)")
+        time.sleep(10)
+
+        # the job shoud not run because first mom is offline
+        # second mom is occupied by maintenance reservation
+        a = {'job_state': 'Q'}
+        self.server.expect(JOB, a, id=jid)

--- a/test/tests/functional/pbs_sched_rerun.py
+++ b/test/tests/functional/pbs_sched_rerun.py
@@ -48,7 +48,7 @@ if e.type == pbs.EXECJOB_BEGIN:
     e.job.resources_used["foo"] = 123
     if e.job.run_count == 1:
         for v in e.vnode_list:
-            if (v == "%s"):
+            if v == "%s":
                 e.vnode_list[v].state = pbs.ND_OFFLINE
         e.job.rerun()
         e.reject("reruen job")
@@ -99,7 +99,7 @@ class TestSchedRerun(TestFunctional):
 
         a = {'reserve_start': now + 60,
              'reserve_end': now + 7200}
-        h = [self.momB.shortname]
+        h = [self.hostB]
         r = Reservation(TEST_USER, attrs=a, hosts=h)
 
         self.server.submit(r)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->

If a job is rejected by a hook with a used resource set and a rerun is requested, the job can run over reservation/top job.

See the hook:
```
import pbs
e = pbs.event()
if e.type == pbs.EXECJOB_BEGIN:
	e.job.resources_used["foo"] = 123
	if e.job.run_count == 1:
		for v in e.vnode_list:
			if (v == 'torque4'):
				e.vnode_list[v].state = pbs.ND_OFFLINE
		e.job.rerun()
		e.reject("reruen job %s" % e.job.id)
e.accept()

```
the resource `foo` is:
```
create resource foo
set resource foo type = long
set resource foo flag = i
```
Let's have 2 nodes total.
```
torque4.grid.cesnet.cz$ pbsnodes -a
torque4
     Mom = torque4.grid.cesnet.cz
     Port = 15002
     pbs_version = 23.06.06
     ntype = PBS
     state = free
     pcpus = 2
     resources_available.arch = linux
     resources_available.host = torque4.grid.cesnet.cz
     resources_available.hpmem = 0b
     resources_available.mem = 1981mb
     resources_available.ncpus = 2
     resources_available.vmem = 2934mb
     resources_available.vnode = torque4
     resources_assigned.accelerator_memory = 0kb
     resources_assigned.hbmem = 0kb
     resources_assigned.mem = 0kb
     resources_assigned.naccelerators = 0
     resources_assigned.ncpus = 0
     resources_assigned.vmem = 0kb
     resv_enable = True
     sharing = default_shared
     license = l
     last_state_change_time = Thu Mar 14 13:54:09 2024

torque5
     Mom = torque5.grid.cesnet.cz
     Port = 15002
     pbs_version = 23.06.06
     ntype = PBS
     state = free
     pcpus = 2
     resv = M57.torque4.grid.cesnet.cz
     resources_available.arch = linux
     resources_available.host = torque5.grid.cesnet.cz
     resources_available.mem = 2030240kb
     resources_available.ncpus = 2
     resources_available.vnode = torque5
     resources_assigned.accelerator_memory = 0kb
     resources_assigned.hbmem = 0kb
     resources_assigned.mem = 0kb
     resources_assigned.naccelerators = 0
     resources_assigned.ncpus = 0
     resources_assigned.vmem = 0kb
     resv_enable = True
     sharing = default_shared
     license = l
     last_state_change_time = Thu Mar 14 13:54:10 2024
     last_used_time = Thu Mar 14 11:50:12 202
```
 * The first node is free and job can run on it.... but the job start fails for some reason (hook reject) and the node is switched offline -> some other node will be used for a rerun.
 * On the second node a reservation is scheduled and the job should not run, because the reservation starts before job's expected end time.

```
torque4.grid.cesnet.cz$ pbsnodes -a
torque4
     Mom = torque4.grid.cesnet.cz
     Port = 15002
     pbs_version = 23.06.06
     ntype = PBS
     state = offline
     pcpus = 2
     resources_available.arch = linux
     resources_available.host = torque4.grid.cesnet.cz
     resources_available.hpmem = 0b
     resources_available.mem = 1981mb
     resources_available.ncpus = 2
     resources_available.vmem = 2934mb
     resources_available.vnode = torque4
     resources_assigned.accelerator_memory = 0kb
     resources_assigned.hbmem = 0kb
     resources_assigned.mem = 0kb
     resources_assigned.naccelerators = 0
     resources_assigned.ncpus = 0
     resources_assigned.vmem = 0kb
     resv_enable = True
     sharing = default_shared
     license = l
     last_state_change_time = Thu Mar 14 13:54:51 2024

torque5
     Mom = torque5.grid.cesnet.cz
     Port = 15002
     pbs_version = 23.06.06
     ntype = PBS
     state = free
     pcpus = 2
     jobs = 68.torque4.grid.cesnet.cz/0
     resv = M57.torque4.grid.cesnet.cz
     resources_available.arch = linux
     resources_available.host = torque5.grid.cesnet.cz
     resources_available.mem = 2030240kb
     resources_available.ncpus = 2
     resources_available.vnode = torque5
     resources_assigned.accelerator_memory = 0kb
     resources_assigned.hbmem = 0kb
     resources_assigned.mem = 512000kb
     resources_assigned.naccelerators = 0
     resources_assigned.ncpus = 1
     resources_assigned.vmem = 0kb
     resv_enable = True
     sharing = default_shared
     license = l
     last_state_change_time = Thu Mar 14 13:54:10 2024
     last_used_time = Thu Mar 14 11:50:12 2024
```

The reservation:
```
torque4.grid.cesnet.cz$ pbs_rstat 
Resv ID    Queue    User     State             Start / Duration / End              
---------------------------------------------------------------------
M57.torque M57      vchlum@M CO          Today 16:00 / 25200 / Today 23:00 
```

The job:
```
echo "sleep 1000" | qsub -l select=ncpus=1:mem=500mb -l walltime=24:00:00
```

The job runs over the planned reservation.

Reason:
Once the attempt to rerun the job is invoked, the used resources are now set. Now, if a used resource is not available for some resource, the Resource_List is used instead. IMO, This is ok except for walltime. If the scheduler uses the Resource_List.walltime instead of used, the job end time is the current time. The reason is the simple `Resource_List.walltime - Resource_List.walltime = 0`.  The bug can be observed in `check_resources_for_node()`.
Here we have the line:
```
end_time = cur_time + calc_time_left(resresv, 1);
```
and due to the error the `calc_time_left(resresv, 1);` is 0. So the job can start because the scheduler thinks the job `end_time` is `cur_time` and the scheduler wrongly thinks the reservation/top job is not overlapped. 

See:
This is an attempt to rerun on the node torque5:
```
Thread 1 "pbs_sched" hit Breakpoint 1, is_ok_to_run (policy=policy@entry=0x5563357063a0, 
    sinfo=sinfo@entry=0x55633578fd30, qinfo=qinfo@entry=0x55633573d890, resresv=resresv@entry=0x55633579e240, 
    flags=0, perr=0x556335779660) at check.cpp:922
922			endtime = sinfo->server_time + calc_time_left(resresv, 1);
(gdb) s
calc_time_left (resresv=resresv@entry=0x55633579e240, use_hard_duration=use_hard_duration@entry=1) at misc.cpp:630
630		if (use_hard_duration && resresv->hard_duration == UNSPECIFIED)
(gdb) n
641		used_amount = calc_used_walltime(resresv);
(gdb) 
643		return IF_NEG_THEN_ZERO(duration - used_amount);
(gdb) print used_amount
$1 = 86400
(gdb) p *resresv->job->resused 
$2 = {name = 0x556335791160 "foo", type = {is_non_consumable = false, is_string = false, is_boolean = false, 
    is_consumable = true, is_num = true, is_long = true, is_float = false, is_size = false, is_time = false}, 
  amount = 123, res_str = 0x55633579c5a0 "123", def = 0x556335791150, next = 0x153580003700}
(gdb) p *resresv->job->resused->next->next->next->next->next->next 
$3 = {name = 0x556335790db0 "walltime", type = {is_non_consumable = false, is_string = false, is_boolean = false, 
    is_consumable = true, is_num = true, is_long = true, is_float = false, is_size = false, is_time = false}, 
  amount = 86400, res_str = 0x153580003900 "24:00:00", def = 0x556335790da0, next = 0x0}
(gdb) 
```

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

The walltime should be updated before `encode_used()` is processed on mom. I suggest to call `update_walltime()` in `get_job_update()`. This ensures the used.walltime is set in case of any used.resource is sent from mom to server. Even if the used.walltime is zero, which is desired in this case.

Alternatively, we could remove the used walltime from the job. Unfortunately, we do not know that the job will be rerun to remove the used walltime before trying to run.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Ptl test of a new test attached:
[ptl_rerun_over_reservation.txt](https://github.com/openpbs/openpbs/files/14602607/ptl_rerun_over_reservation.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
