### PR TITLE
improved acl hosts on queue

### DIFF
--- a/src/include/job.h
+++ b/src/include/job.h
@@ -1090,7 +1090,7 @@ extern int svr_chk_ownerResv(struct batch_request *, resc_resv *);
 #endif /* _BATCH_REQUEST_H */
 
 #ifdef _QUEUE_H
-extern int svr_chkque(job *, pbs_queue *, char *, int mtype);
+extern int svr_chkque(job *, pbs_queue *, char *, char *, int mtype);
 extern int default_router(job *, pbs_queue *, long);
 extern int site_alt_router(job *, pbs_queue *, long);
 extern int site_acl_check(job *, pbs_queue *);

--- a/src/server/req_movejob.c
+++ b/src/server/req_movejob.c
@@ -196,6 +196,8 @@ req_orderjob(struct batch_request *req)
 	long long rank;
 	int rc;
 	char tmpqn[PBS_MAXQUEUENAME + 1];
+	conn_t *conn = NULL;
+	char *physhost = NULL;
 
 	if ((pjob1 = chk_job_request(req->rq_ind.rq_move.rq_jid, req, &jt1, NULL)) == NULL)
 		return;
@@ -223,10 +225,18 @@ req_orderjob(struct batch_request *req)
 
 		/* Jobs are in different queues */
 
-		if ((rc = svr_chkque(pjob1, pjob2->ji_qhdr, get_jattr_str(pjob1, JOB_ATR_submit_host),
+		conn = get_conn(req->rq_conn);
+		if (conn) {
+			physhost = conn->cn_physhost;
+		}
+
+		if ((rc = svr_chkque(pjob1, pjob2->ji_qhdr,
+				     get_jattr_str(pjob1, JOB_ATR_submit_host),
+				     physhost,
 				     MOVE_TYPE_Order)) ||
 		    (rc = svr_chkque(pjob2, pjob1->ji_qhdr,
 				     get_jattr_str(pjob2, JOB_ATR_submit_host),
+				     physhost,
 				     MOVE_TYPE_Order))) {
 			req_reject(rc, 0, req);
 			return;

--- a/src/server/req_quejob.c
+++ b/src/server/req_quejob.c
@@ -303,6 +303,7 @@ req_quejob(struct batch_request *preq)
 	resource_def *prdefplc;
 	resource *presc;
 	conn_t *conn = NULL;
+	char *physhost = NULL;
 #else
 	mom_hook_input_t hook_input;
 	mom_hook_output_t hook_output;
@@ -968,6 +969,10 @@ req_quejob(struct batch_request *preq)
 		}
 	}
 
+	if (conn) {
+		physhost = conn->cn_physhost;
+	}
+
 	/*
 	 * See if the job is qualified to go into the requested queue.
 	 * Note, if an execution queue, then ji_qs.ji_un.ji_exect is set up
@@ -976,7 +981,7 @@ req_quejob(struct batch_request *preq)
 	 * job structure and attributes already set up.
 	 */
 
-	rc = svr_chkque(pj, pque, get_jattr_str(pj, JOB_ATR_submit_host), MOVE_TYPE_Move);
+	rc = svr_chkque(pj, pque, get_jattr_str(pj, JOB_ATR_submit_host), physhost, MOVE_TYPE_Move);
 	if (rc) {
 		if (pj->ji_clterrmsg)
 			reply_text(preq, rc, pj->ji_clterrmsg);

--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -1067,7 +1067,8 @@ chk_resc_limits(attribute *pattr, pbs_queue *pque)
  * 		set_objexid() will be called to set a uid/gid/name if not already set
  *
  * @param[in]	pjob	-	job structure
- * @param[in]	hostname	-	host machine
+ * @param[in]	submithost	-	job's submit machine
+ * @param[in]	hostname	-	host machine issued this check
  * @param[in]	mtype	-	MOVE_TYPE_* type;  see server_limits.h
  *
  * @return	int
@@ -1076,7 +1077,7 @@ chk_resc_limits(attribute *pattr, pbs_queue *pque)
  */
 
 int
-svr_chkque(job *pjob, pbs_queue *pque, char *hostname, int mtype)
+svr_chkque(job *pjob, pbs_queue *pque, char *submithost, char *hostname, int mtype)
 {
 	int i;
 
@@ -1157,8 +1158,10 @@ svr_chkque(job *pjob, pbs_queue *pque, char *hostname, int mtype)
 	/* 4. If enabled, check the queue's host ACL */
 
 	if (get_qattr_long(pque, QA_ATR_AclHostEnabled))
-		if (acl_check(get_qattr(pque, QA_ATR_AclHost),
-			      hostname, ACL_Host) == 0)
+		if ((acl_check(get_qattr(pque, QA_ATR_AclHost),
+			      submithost, ACL_Host) == 0) &&
+			(acl_check(get_qattr(pque, QA_ATR_AclHost),
+			      hostname, ACL_Host) == 0))
 			if (mtype != MOVE_TYPE_MgrMv) /* ok if mgr */
 				return (PBSE_BADHOST);
 

--- a/src/server/svr_movejob.c
+++ b/src/server/svr_movejob.c
@@ -201,6 +201,8 @@ local_move(job *jobp, struct batch_request *req)
 	long newtype = -1;
 	long long time_usec;
 	struct timeval tval;
+	conn_t *conn = NULL;
+	char *physhost = NULL;
 
 	/* search for destination queue */
 	if ((qp = find_queuebyname(destination)) == NULL) {
@@ -226,7 +228,14 @@ local_move(job *jobp, struct batch_request *req)
 		mtype = MOVE_TYPE_Move; /* non-privileged move */
 	}
 
-	pbs_errno = svr_chkque(jobp, qp, get_hostPart(get_jattr_str(jobp, JOB_ATR_job_owner)), mtype);
+	if (req != NULL) {
+		conn = get_conn(req->rq_conn);
+		if (conn) {
+			physhost = conn->cn_physhost;
+		}
+	}
+
+	pbs_errno = svr_chkque(jobp, qp, get_jattr_str(jobp, JOB_ATR_submit_host), physhost, mtype);
 	if (pbs_errno) {
 		/* should this queue be retried? */
 		return (should_retry_route(pbs_errno));

--- a/test/tests/functional/pbs_moved_job_local.py
+++ b/test/tests/functional/pbs_moved_job_local.py
@@ -1,0 +1,88 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2021 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of both the OpenPBS software ("OpenPBS")
+# and the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# OpenPBS is free software. You can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# OpenPBS is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# PBS Pro is commercially licensed software that shares a common core with
+# the OpenPBS software.  For a copy of the commercial license terms and
+# conditions, go to: (http://www.pbspro.com/agreement.html) or contact the
+# Altair Legal Department.
+#
+# Altair's dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of OpenPBS and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair's trademarks, including but not limited to "PBS™",
+# "OpenPBS®", "PBS Professional®", and "PBS Pro™" and Altair's logos is
+# subject to Altair's trademark licensing policies.
+
+
+from tests.functional import *
+
+
+class TestMovedJobLocal(TestFunctional):
+    """
+    This test suite tests moved jobs between two queues
+    """
+
+    def test_moved_job_acl_hosts_allow(self):
+        """
+        This test suite verifies that job can be moved
+        into queue with acl_host_enabled.
+        """
+        a = {'queue_type': 'Execution',
+             'enabled': 'True',
+             'started': 'True',
+             'acl_host_enable': 'True',
+             'acl_hosts': self.servers.keys()[0]}
+        self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='testq')
+        a = {'scheduling': 'False'}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+        j = Job(TEST_USER)
+        jid = self.server.submit(j)
+        self.server.movejob(jid, 'testq', runas=TEST_USER)
+        a = {'scheduling': 'True'}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+        self.server.expect(JOB, {ATTR_queue: 'testq', 'job_state': 'R'},
+                           attrop=PTL_AND)
+
+    def test_moved_job_acl_hosts_denial(self):
+        """
+        This test suite verifies that job can not be moved
+        into queue with acl_host_enabled without the right hostname.
+        """
+        a = {'queue_type': 'Execution',
+             'enabled': 'True',
+             'started': 'True',
+             'acl_host_enable': 'True',
+             'acl_hosts': 'foo'}
+        self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='testq')
+        a = {'scheduling': 'False'}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+        j = Job(TEST_USER)
+        jid = self.server.submit(j)
+        err = "Access from host not allowed, or unknown host " + jid
+        with self.assertRaises(PbsMoveError) as e:
+            self.server.movejob(jid, 'testq', runas=TEST_USER)
+        self.assertIn(err, e.exception.msg[0])

--- a/test/tests/functional/pbs_moved_job_local.py
+++ b/test/tests/functional/pbs_moved_job_local.py
@@ -51,20 +51,21 @@ class TestMovedJobLocal(TestFunctional):
         This test suite verifies that job can be moved
         into queue with acl_host_enabled.
         """
+        queue = 'testq'
         a = {'queue_type': 'Execution',
              'enabled': 'True',
              'started': 'True',
              'acl_host_enable': 'True',
              'acl_hosts': self.servers.keys()[0]}
-        self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='testq')
+        self.server.manager(MGR_CMD_CREATE, QUEUE, a, id=queue)
         a = {'scheduling': 'False'}
         self.server.manager(MGR_CMD_SET, SERVER, a)
         j = Job(TEST_USER)
         jid = self.server.submit(j)
-        self.server.movejob(jid, 'testq', runas=TEST_USER)
+        self.server.movejob(jid, queue, runas=TEST_USER)
         a = {'scheduling': 'True'}
         self.server.manager(MGR_CMD_SET, SERVER, a)
-        self.server.expect(JOB, {ATTR_queue: 'testq', 'job_state': 'R'},
+        self.server.expect(JOB, {ATTR_queue: queue, 'job_state': 'R'},
                            attrop=PTL_AND)
 
     def test_moved_job_acl_hosts_denial(self):
@@ -72,17 +73,18 @@ class TestMovedJobLocal(TestFunctional):
         This test suite verifies that job can not be moved
         into queue with acl_host_enabled without the right hostname.
         """
+        queue = 'testq'
         a = {'queue_type': 'Execution',
              'enabled': 'True',
              'started': 'True',
              'acl_host_enable': 'True',
              'acl_hosts': 'foo'}
-        self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='testq')
+        self.server.manager(MGR_CMD_CREATE, QUEUE, a, id=queue)
         a = {'scheduling': 'False'}
         self.server.manager(MGR_CMD_SET, SERVER, a)
         j = Job(TEST_USER)
         jid = self.server.submit(j)
         err = "Access from host not allowed, or unknown host " + jid
         with self.assertRaises(PbsMoveError) as e:
-            self.server.movejob(jid, 'testq', runas=TEST_USER)
+            self.server.movejob(jid, queue, runas=TEST_USER)
         self.assertIn(err, e.exception.msg[0])


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->

There is a bug with gss enabled. The acl_hosts on queues are checked with the hostname part of JOB_ATR_job_owner, which is a principal in gss and does not contain the hostname.

Fixing the bug unfolded into improving acl host like this:

Currently, the acl_hosts on queue checks the hosts the job was submitted from. But when a job is qmoved from one local queue to another, the acl hosts can deny the qmove even if the host that issued the qmove is in acl_hosts on the target queue.

This is also a bug because the user could equivalently delete the job and resubmit it to the target queue directly (instead of qmove).

Moreover, fixing this e.g. allows a new use-case of using acl_hosts on queues. We can enable acl_hosts on queue and set it to the `pbs_server_hostname` or `pbs_sched_hostname` only. This can be effectively used as a user-closed queue with the possibility of moving jobs into the queue from e.g.: a peer queue of a secondary scheduler.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

* Change hostname part of JOB_ATR_job_owner to JOB_ATR_submit_host in local_move().
* Add physhost parameter to svr_chkque(). This parameter is evaluated together with the submit host and if the submit host OR physhost is allowed in svr_chkque() then the acl_hosts is not rejected.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[ptl-acl_hosts_on_queue.txt](https://github.com/openpbs/openpbs/files/15316674/ptl-acl_hosts_on_queue.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
