### PR TITLE
fix segfault in printjob_svr.bin

### DIFF
--- a/src/tools/printjob.c
+++ b/src/tools/printjob.c
@@ -365,9 +365,9 @@ print_db_job(char *id, int no_attributes)
 			}
 		}
 		printf("\n");
+		free_attrlist(&dbjob.db_attr_list.attrs);
 	}
 
-	free_attrlist(&dbjob.db_attr_list.attrs);
 	return 0;
 }
 #endif


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->

`printjob_svr.bin -s <jobid>` ends with segfault:
```
[root@almalinux pbspro]# printjob_svr.bin -s 1118.almalinux
---------------------------------------------------
Jobscript for jobid:1118.almalinux
---------------------------------------------------
sleep 1000
 
Segmentation fault (core dumped)
[root@almalinux pbspro]# 
```

The `free_attrlist(&dbjob.db_attr_list.attrs)` is called even if the `dbjob` is uninitialized.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Call `free_attrlist()` in print_db_job() only after `dbjob` initialization.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

Manual test of the fix:
```
[root@almalinux pbspro]# printjob_svr.bin -s 1118.almalinux
---------------------------------------------------
Jobscript for jobid:1118.almalinux
---------------------------------------------------
sleep 1000
 
[root@almalinux pbspro]# 
```

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
