### PR TITLE
fix requestor_host in server hooks with gss enabled

### DIFF
--- a/src/server/hook_func.c
+++ b/src/server/hook_func.c
@@ -3884,6 +3884,8 @@ process_hooks(struct batch_request *preq, char *hook_msg, size_t msg_len,
 	int num_run = 0;
 	int rc = 1;
 	int event_initialized = 0;
+	conn_t *conn = NULL;
+	char *hostname = NULL;
 
 	if (!svr_interp_data.interp_started) {
 		log_event(PBSEVENT_DEBUG3, PBS_EVENTCLASS_HOOK,
@@ -4038,7 +4040,12 @@ process_hooks(struct batch_request *preq, char *hook_msg, size_t msg_len,
 			num_run++;
 			continue;
 		}
-		rc = server_process_hooks(preq->rq_type, preq->rq_user, preq->rq_host, phook,
+		if (preq->rq_conn >= 0 && (conn = get_conn(preq->rq_conn)) != NULL) {
+			hostname = conn->cn_physhost;
+		} else {
+			hostname = preq->rq_host;
+		}
+		rc = server_process_hooks(preq->rq_type, preq->rq_user, hostname, phook,
 					  hook_event, pjob, &req_ptr, hook_msg, msg_len, pyinter_func,
 					  &num_run, &event_initialized);
 		pbs_python_ext_free_global_dict(phook->script);

--- a/test/tests/functional/pbs_server_hook_attr.py
+++ b/test/tests/functional/pbs_server_hook_attr.py
@@ -1,0 +1,68 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2021 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of both the OpenPBS software ("OpenPBS")
+# and the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# OpenPBS is free software. You can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# OpenPBS is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# PBS Pro is commercially licensed software that shares a common core with
+# the OpenPBS software.  For a copy of the commercial license terms and
+# conditions, go to: (http://www.pbspro.com/agreement.html) or contact the
+# Altair Legal Department.
+#
+# Altair's dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of OpenPBS and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair's trademarks, including but not limited to "PBS™",
+# "OpenPBS®", "PBS Professional®", and "PBS Pro™" and Altair's logos is
+# subject to Altair's trademark licensing policies.
+
+
+from tests.functional import *
+
+
+class TestServerHookAttr(TestFunctional):
+
+    def test_queuejob_hook_requestor_host(self):
+        """
+        Check the requestor_host attribute is set properly in hook.
+        """
+        hook_body = f"""
+import pbs
+e = pbs.event()
+if e.requestor_host == "{self.servers.values()[0].name}":
+    e.accept()
+e.reject()
+"""
+        hook_name = "test_requestor_host"
+        a = {'event': 'queuejob',
+             'enabled': 'True'}
+        rv = self.server.create_import_hook(
+            hook_name, a, hook_body, overwrite=True)
+        self.assertTrue(rv)
+        self.server.manager(MGR_CMD_SET, SERVER,
+                            {'scheduling': 'False'})
+        j = Job(TEST_USER)
+        jid = self.server.submit(j)
+        a = {'job_state': 'Q'}
+        self.server.expect(JOB, a, id=jid)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->

With GSS/KRB5 enabled, the requestor_host attribute contains the Kerberos realm instead of the correct hostname in some server hooks (like queuejob).

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Check if the physical host is available for the batch request invoking the hook. If yes, use it. Otherwise, the current behavior is preserved.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[ptl-conn_host-to_server_hook.txt](https://github.com/openpbs/openpbs/files/15344584/ptl-conn_host-to_server_hook.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
