### PR TITLE
job.rerun() not working in MoM hook event 'execjob_epilogue' and 'execjob_preterm'

### DIFF
--- a/src/server/req_jobobit.c
+++ b/src/server/req_jobobit.c
@@ -1483,7 +1483,7 @@ job_obit(ruu *pruu, int stream)
 		local_exitstatus = get_jattr_long(pjob, JOB_ATR_exit_status);
 
 	if ((local_exitstatus == JOB_EXEC_HOOK_RERUN || local_exitstatus == JOB_EXEC_HOOK_DELETE) &&
-	    exitstatus != JOB_EXEC_FAILHOOK_RERUN && exitstatus != JOB_EXEC_FAILHOOK_DELETE && exitstatus < 0)
+	    exitstatus != JOB_EXEC_FAILHOOK_RERUN && exitstatus != JOB_EXEC_FAILHOOK_DELETE)
 		exitstatus = local_exitstatus;
 	else
 		set_jattr_l_slim(pjob, JOB_ATR_exit_status, exitstatus, SET);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->

The job.rerun() does not work in MoM hook events 'execjob_epilogue' and 'execjob_preterm'.

The following steps can be used to reproduce the issue:

1. create a mom hook having event execjob_epilogue or execjob_preterm with job.rerun()
2. submit a job.
3. Expected: The job should rerun when the hook is executed
4. Observed: Job doesn't run and finishes with Exit_status=0

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

The issue was observed after merging in this PR: https://github.com/openpbs/openpbs/pull/2592 . 

This PR brought in 2 code line changes: One of them (the one in req_jobobit.c) caused job.rerun() to stop working, and was restored to its original state. No other tests fail, or any other unexpected behavior has been observed. 

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

Attaching a manual test scenario:

1. Create a hook script that reruns the job only the first time it is called.
2. Run a job.
3. Normally the job should run, and then re-run a second time because of the hook.

This was not the case before the fix. After the fix the job reruns a second time as expected.
 
[fix-mom-hook-openpbs.txt](https://github.com/openpbs/openpbs/files/15430264/fix-mom-hook-openpbs.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
