### PR TITLE
fix deleting Exit_status on job rerun

### DIFF
--- a/src/include/job.h
+++ b/src/include/job.h
@@ -1047,6 +1047,7 @@ void free_jattr(job *pjob, int attr_idx);
 void mark_jattr_not_set(job *pjob, int attr_idx);
 void mark_jattr_set(job *pjob, int attr_idx);
 attribute *get_jattr(const job *pjob, int attr_idx);
+void clear_jattr(job *pjob, int attr_idx);
 
 /*
  *	The filesystem related recovery/save routines are renamed

--- a/src/include/job.h
+++ b/src/include/job.h
@@ -995,6 +995,7 @@ extern char *lookup_variable(void *, int, char *);
 extern void issue_track(job *);
 extern void issue_delete(job *);
 extern int job_abt(job *, char *);
+extern int job_delete_attr(job *, int);
 extern job *job_alloc(void);
 extern void job_free(job *);
 extern int modify_job_attr(job *, svrattrl *, int, int *);

--- a/src/lib/Libdb/pgsql/db_job.c
+++ b/src/lib/Libdb/pgsql/db_job.c
@@ -121,7 +121,7 @@ db_prepare_job_sqls(void *conn)
 
 	snprintf(conn_sql, MAX_SQL_LENGTH, "update pbs.job set "
 					   "ji_savetm = localtimestamp,"
-					   "attributes = attributes - hstore($2::text[]) "
+					   "attributes = attributes - $2::text[] "
 					   "where ji_jobid = $1");
 	if (db_prepare_stmt(conn, STMT_REMOVE_JOBATTRS, conn_sql, 2) != 0)
 		return -1;

--- a/src/server/jattr_get_set.c
+++ b/src/server/jattr_get_set.c
@@ -527,3 +527,18 @@ free_jattr(job *pjob, int attr_idx)
 	if (pjob != NULL)
 		free_attr(job_attr_def, get_jattr(pjob, attr_idx), attr_idx);
 }
+
+/**
+ * @brief	clear a job attribute
+ *
+ * @param[in]	pjob - pointer to job
+ * @param[in]	attr_idx - attribute index to clear
+ *
+ * @return	void
+ */
+void
+clear_jattr(job *pjob, int attr_idx)
+{
+	if (pjob != NULL)
+		clear_attr(get_jattr(pjob, attr_idx), &job_attr_def[attr_idx]);
+}

--- a/src/server/job_func.c
+++ b/src/server/job_func.c
@@ -329,7 +329,7 @@ job_delete_attr(job *pjob, int attr_idx)
 		}
 		free_db_attr_list(&db_attr_list);
 
-		clear_attr(get_jattr(pjob, JOB_ATR_exit_status), &attr_def);
+		clear_attr(get_jattr(pjob, attr_idx), &attr_def);
 	}
 
 	return 0;

--- a/src/server/job_func.c
+++ b/src/server/job_func.c
@@ -282,6 +282,58 @@ job_abt(job *pjob, char *text)
 
 	return (rc);
 }
+
+/**
+ * @brief
+ * 		job_delete_attr - delete a job attribute
+ *
+ *		The job attribute is removed from the memory and db.
+ *
+ * @param[in]	pjob - pointer to job structure
+ * @param[in]	attr_idx - attribute to remove
+ * 
+ * @return	int
+ * @retval	0	- success
+ * @retval	!=0	- fail
+ */
+
+int
+job_delete_attr(job *pjob, int attr_idx)
+{
+	void *conn = (void *) svr_db_conn;
+	int index;
+	pbs_db_obj_info_t obj;
+	pbs_db_attr_list_t db_attr_list;
+	attribute_def attr_def;
+	attribute *pattr;
+	int rc;
+
+	obj.pbs_db_un.pbs_db_job = NULL;
+	obj.pbs_db_obj_type = PBS_DB_JOB;
+
+	db_attr_list.attr_count = 0;
+	CLEAR_HEAD(db_attr_list.attrs);
+
+	if (is_jattr_set(pjob, attr_idx)) {
+		attr_def = job_attr_def[attr_idx];
+		if ((index = find_attr(job_attr_idx, job_attr_def, attr_def.at_name)) < 0) {
+			return -1;
+		}
+		pattr = pjob->ji_wattr;
+		if ((rc = encode_single_attr_db((job_attr_def + index), (pattr + index), &db_attr_list)) != 0) {
+			return rc;
+		}
+		if ((rc = pbs_db_delete_attr_obj(conn, &obj, pjob->ji_qs.ji_jobid, &db_attr_list)) < 0) {
+			free_db_attr_list(&db_attr_list);
+			return rc;
+		}
+		free_db_attr_list(&db_attr_list);
+
+		clear_attr(get_jattr(pjob, JOB_ATR_exit_status), &attr_def);
+	}
+
+	return 0;
+}
 #endif /* PBS_MOM */
 
 /**

--- a/src/server/job_func.c
+++ b/src/server/job_func.c
@@ -329,7 +329,7 @@ job_delete_attr(job *pjob, int attr_idx)
 		}
 		free_db_attr_list(&db_attr_list);
 
-		clear_attr(get_jattr(pjob, attr_idx), &attr_def);
+		clear_jattr(pjob, attr_idx);
 	}
 
 	return 0;

--- a/src/server/nattr_get_set.c
+++ b/src/server/nattr_get_set.c
@@ -338,7 +338,8 @@ free_nattr(struct pbsnode *pnode, int attr_idx)
 void
 clear_nattr(struct pbsnode *pnode, int attr_idx)
 {
-	clear_attr(get_nattr(pnode, attr_idx), &node_attr_def[attr_idx]);
+	if (pnode != NULL)
+		clear_attr(get_nattr(pnode, attr_idx), &node_attr_def[attr_idx]);
 }
 
 /**

--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -936,7 +936,9 @@ svr_startjob(job *pjob, struct batch_request *preq)
 			return (PBSE_SYSTEM);
 
 	/* clear Exit_status which may have been set in a hook and requeued */
-	clear_attr(get_jattr(pjob, JOB_ATR_exit_status), &job_attr_def[(int) JOB_ATR_exit_status]);
+	if (job_delete_attr(pjob, JOB_ATR_exit_status)) {
+		return PBSE_SYSTEM;
+	}
 
 	/* if exec_vnode already set and either (hotstart or checkpoint) */
 	/* then reuseuse the host(s) listed in the current exec_vnode	 */


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->

After merging the change #2645, the bug #2592 will be partially back.

The problem occurs when a job is rerun and rejected by a hook and the pbs is restarted before the job finishes. The job keeps its exit_status from the hook reject and reruns repeatedly until the run_count is reached even if the subsequent exit_codes are 0.

The `execjob_launch` hook example, which rejects job only once:

```
import pbs
import os
from pathlib import Path

f = "/tmp/do_not_reject"
e = pbs.event()
j = e.job
if os.path.exists(f):
	e.accept()
Path(f).touch()
j.rerun()
e.reject("rerun job")
```

The job is rejected and rerun by this hook. After exit_status evaluation, the exit_status is cleared in `svr_startjob()`. Here is the problem. The attribute is removed from the memory but not from the database as described in #2593. We use the SQL query containing `attributes = attributes || hstore($number::text[])`. This is OR, it can not remove an attribute.  To fix it, we need to delete the attribute from the db along with removing it from memory.

For this purpose, there is a function `pbs_db_delete_attr_obj()` but a bug for the job attribute case is here. The bug is in SQL query `STMT_REMOVE_JOBATTRS`. It is a forgotten change in refactoring #1847. The `attributes = attributes - hstore($2::text[])` should be obviously `attributes = attributes - $2::text[]`. The function `pbs_db_delete_attr_obj()` was not used before this PR to delete a job attribute; thus, the bug did not cause harm.


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

 * Fix `STMT_REMOVE_JOBATTRS` query
 * add function `job_delete_attr()`, which deletes job attribute from both the memory and database


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

Manual test:
```
torque4.grid.cesnet.cz$ qsub -l select=vnode=torque5 -- /bin/sleep 60
16005.torque4.grid.cesnet.cz

(BULLSEYE)root@torque4:~# qstat # <- wait for rejected job rerun
Job id            Name             User              Time Use S Queue
----------------  ---------------- ----------------  -------- - -----
16005.torque4     STDIN            vchlum                   0 R default         
(BULLSEYE)root@torque4:~# qstat -fw | grep Exit_status # <- check exit_status is removed properly
(BULLSEYE)root@torque4:~# systemctl restart pbs
(BULLSEYE)root@torque4:~# qstat -fw | grep Exit_status # <- check exit_status is still removed after PBS server restart
(BULLSEYE)root@torque4:~# qstat
Job id            Name             User              Time Use S Queue
----------------  ---------------- ----------------  -------- - -----
16005.torque4     STDIN            vchlum                   0 R default   
(BULLSEYE)root@torque4:~# qstat -x 16005.torque4 # <- job finished
Job id            Name             User              Time Use S Queue
----------------  ---------------- ----------------  -------- - -----
16005.torque4     STDIN            vchlum                   0 F default     
(BULLSEYE)root@torque4:~# qstat -xfw 16005.torque4 | grep run_count
    run_count = 2  # <- job rerun only once
  
```


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
