### PR TITLE
nasty char in select can shutdown a server with a route queue

### DIFF
--- a/src/lib/Libattr/attr_fn_resc.c
+++ b/src/lib/Libattr/attr_fn_resc.c
@@ -126,6 +126,11 @@ decode_resc(attribute *patr, char *name, char *rescn, char *val)
 	if (!(patr->at_flags & ATR_VFLAG_SET))
 		CLEAR_HEAD(patr->at_val.at_list);
 
+	/* check the resource name is not nasty e.g.: from user input */
+	if (verify_resc_name(rescn)) {
+		return (PBSE_BADATVAL);
+	}
+
 	prdef = find_resc_def(svr_resc_def, rescn);
 	if (prdef == NULL) {
 		/*


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
A nasty user can do this: Using a route queue and submitting in the route queue job with CR chars in select like this:

`qsub -q routeq -l $(echo -e 'select=ncpus=1\r:mem=1gb\r:arch=linux') -- /usr/bin/echo OK`

causes a server panic shutdown:

```
05/31/2024 10:54:11.940172;0001;Server@almalinux;Svr;Server@almalinux;Unknown resource (15035) in set_attr_generic, decode of Resource_List failed
05/31/2024 10:54:11.940266;0001;Server@almalinux;Svr;Server@almalinux;Unknown resource (15035) in set_attr_generic, decode of Resource_List failed
05/31/2024 10:54:11.940876;0100;Server@almalinux;Job;37.almalinux;enqueuing into routeq, state Q hop 1
05/31/2024 10:54:11.942241;0001;Server@almalinux;Svr;Server@almalinux;PBS server internal error (15011) in job_save_db, Failed to save job 37.almalinux Execution of Prepared statement insert_job failed: ERROR:  incorrect binary data format in bind parameter 17 22P03
05/31/2024 10:54:11.942296;0001;Server@almalinux;Svr;Server@almalinux;panic_stop_db, Panic shutdown of Server on database error.  Please check PBS_HOME file system for no space condition.
05/31/2024 10:54:13.475056;0002;Server@almalinux;Svr;Server@almalinux;Stopping PBS dataservice
05/31/2024 10:54:19.093086;0002;Server@almalinux;Svr;Log;Log closed
```

The resource is detected as unknown but the route queue can accept event jobs with unknown resources. That is why you need a route queue to exploit this bug.

My testing shows you need three resources and two CR chars.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

I suggest checking the resource name for bad chars in `decode_resc()`. The return code is PBSE_BADATVAL (different than PBSE_UNKRESC, which is accepted for a route queue). This way, the wrongly parsed resources are discovered across the system.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

[ptl_test-CR_in_select.txt](https://github.com/user-attachments/files/15511378/ptl_test-CR_in_select.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
