### PR TITLE
new server attribute 'validate_user' for checking user existence

### DIFF
--- a/doc/man1/pbs_server_attributes.7B
+++ b/doc/man1/pbs_server_attributes.7B
@@ -533,6 +533,30 @@ Default:
 .I False
 (authorization is required)
 
+.IP validate_user 8
+Used for checking the user is valid/exists on the server
+and thus can submit and alter jobs.
+.br
+Readable by all; settable by Manager.
+.br
+Format: 
+.I Boolean
+.br
+Python type:
+.I bool
+.br
+Behavior:
+.RS
+.IP True 3
+Check the password database for user existence
+(e.g., the local password file /etc/passwd).
+.IP False 3
+The existence of user on the pbs server is not required.
+.RE
+.IP
+Default: 
+.I False
+
 .IP FLicenses 8
 The number of licenses currently available for allocation to unlicensed
 hosts.

--- a/src/include/pbs_ifl.h
+++ b/src/include/pbs_ifl.h
@@ -287,6 +287,7 @@ extern "C" {
 #define ATTR_status "server_state"
 #define ATTR_syscost "system_cost"
 #define ATTR_FlatUID "flatuid"
+#define ATTR_valid_user "validate_user"
 #define ATTR_ResvEnable "resv_enable"
 #define ATTR_aclResvgren "acl_resv_group_enable"
 #define ATTR_aclResvgroup "acl_resv_groups"

--- a/src/lib/Libattr/master_svr_attr_def.xml
+++ b/src/lib/Libattr/master_svr_attr_def.xml
@@ -972,6 +972,23 @@
       </member_verify_function>
    </attributes>
    <attributes>
+      <member_index>SVR_ATR_ValidUser</member_index>
+      <member_name>ATTR_valid_user</member_name>
+      <member_at_decode>decode_b</member_at_decode>
+      <member_at_encode>encode_b</member_at_encode>
+      <member_at_set>set_b</member_at_set>
+      <member_at_comp>comp_b</member_at_comp>
+      <member_at_free>free_null</member_at_free>
+      <member_at_action>NULL_FUNC</member_at_action>
+      <member_at_flags>MGR_ONLY_SET</member_at_flags>
+      <member_at_type>ATR_TYPE_BOOL</member_at_type>
+      <member_at_parent>PARENT_TYPE_SERVER</member_at_parent>
+      <member_verify_function>
+         <ECL>verify_datatype_bool</ECL>
+         <ECL>NULL_VERIFY_VALUE_FUNC</ECL>
+      </member_verify_function>
+   </attributes>
+   <attributes>
       <member_index>SVR_ATR_ResvEnable</member_index>
       <member_name>ATTR_ResvEnable</member_name>
       <member_at_decode>decode_b</member_at_decode>

--- a/src/server/pbsd_init.c
+++ b/src/server/pbsd_init.c
@@ -250,6 +250,7 @@ init_server_attrs()
 	set_sattr_l_slim(SVR_ATR_has_runjob_hook, 0, SET);
 	set_sattr_l_slim(SVR_ATR_log_events, SVR_LOG_DFLT, SET);
 	*log_event_mask = get_sattr_long(SVR_ATR_log_events);
+	set_sattr_l_slim(SVR_ATR_ValidUser, 0, SET);
 	set_sattr_str_slim(SVR_ATR_mailer, SENDMAIL_CMD, NULL);
 	set_sattr_str_slim(SVR_ATR_mailfrom, PBS_DEFAULT_MAIL, NULL);
 	set_sattr_l_slim(SVR_ATR_query_others, 1, SET);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->

Currently, the pbs server does not require the user to be valid, and if the user does not exist, the mom recognizes the error on the job start. Openpbs can not recognize it earlier. I suggest adding an option to reject job submissions by non-existing users. So (not only) the admins can catch this situation earlier.

This is especially useful for gss/krb5-enabled servers because the ability to authenticate to the server does not imply that the account is valid, but I think other sites can benefit from it too.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

In functions `svr_chk_owner*`, check `owner` using the function `getpwnam()`. This checks the owner for /etc/passwd record.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

[ptl_validate_user.txt](https://github.com/user-attachments/files/15720326/ptl_validate_user.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
