### PR TITLE
fix writing to job stderr from cgroups hook

### DIFF
--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -3034,7 +3034,9 @@ class CgroupUtils(object):
                        % (str(filename), msg.strip()))
             if filename is None:
                 return
-            with open(filename, 'a') as desc:
+            # sticky bit requires leaving out os.O_CREAT
+            fd = os.open(filename, os.O_APPEND|os.O_WRONLY)
+            with os.fdopen(fd, 'a') as desc:
                 desc.write(msg)
         except Exception:
             # tough luck for user, but not fatal to system


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->

Since this kernel change: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=30aba6656f61ed44cba445a3c0d38b296fa9e8f5 a file in sticky bit directory can not be opened with O_CREAT by other users. Not even the root can open the file with O_CREAT. Earlier, this setting was disabled, but it is enabled by default in newer Linux flavors.

Since the spool directory uses the sticky bit, the appending of 'limit exceeded' to job stderr from cgroups hook has stopped working.

See the failed PTL test: [ptl_TestCgroupsHook.test_cgroup_enforce_memsw-failed.txt](https://github.com/user-attachments/files/15966312/ptl_TestCgroupsHook.test_cgroup_enforce_memsw-failed.txt)



#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Open the stderr file without os.O_CREAT in cgroups hook.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

Successful PTL test: [ptl_TestCgroupsHook.test_cgroup_enforce_memsw-success.txt](https://github.com/user-attachments/files/15966332/ptl_TestCgroupsHook.test_cgroup_enforce_memsw-success.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
