### PR TITLE
reporting cgroups limit exceedings into diag_messages job resource

### DIFF
--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -2546,6 +2546,8 @@ class NodeUtils(object):
         vnode_msg_cpu = '%s: vnode_list[%s].resources_available[ncpus] = %d'
         vnode_msg_mem = '%s: vnode_list[%s].resources_available[mem] = %s'
 
+        host_resc_avail['diag_messages'] = ''
+
         if not vnodes:
             # memory (global for host)
             mem = self.get_memory_on_node(ignore_reserved=False)
@@ -3040,6 +3042,33 @@ class CgroupUtils(object):
             # tough luck for user, but not fatal to system
             # Note: sometimes normal (e.g. interactive jobs)
             pass
+
+    def set_diag_messages(self, resc_used, msg, concate):
+        """
+        Sets the 'diag_messages' resource to msg. A json format of msg
+        is required in order to merge msgs from sis moms and primary mom.
+        Settting concate=true concates multiple string values of the
+        same dict key into one.
+        """
+        try:
+            json_msg = json.loads(msg)
+        except Exception:
+            json_msg = {}
+        if 'diag_messages' not in resc_used.keys():
+            resc_used['diag_messages'] = json.dumps(json_msg)
+        elif concate:
+            try:
+                json_resc = json.loads(resc_used['diag_messages'])
+            except Exception:
+                json_resc = {}
+            for k in json_msg.keys():
+                if k in json_resc.keys() and not json_msg[k] in json_resc[k]:
+                    json_resc[k] += ', %s' % json_msg[k]
+                else:
+                    json_resc[k] = json_msg[k]
+            resc_used['diag_messages'] = json.dumps(json_resc)
+        else:
+            resc_used['diag_messages'] = json.dumps(json_msg)
 
     def _target_subsystems(self):
         """
@@ -4932,6 +4961,11 @@ class CgroupUtils(object):
             pbs.logmsg(pbs.EVENT_DEBUG4, '%s: Job %s is not running' %
                        (caller_name(), jobid))
             return
+        if pbs.event().type == pbs.EXECHOST_PERIODIC or \
+           pbs.event().type == pbs.EXECJOB_EPILOGUE:
+            # Initialize diag_messages in order to be able
+            # to merge msgs only from sisters
+            self.set_diag_messages(resc_used, '{}', True)
         # Sort the subsystems so that we consistently look at the subsystems
         # in the same order every time
         self.subsystems.sort()
@@ -4960,6 +4994,13 @@ class CgroupUtils(object):
                             self.write_to_stderr(pbs.event().job,
                                                  "Cgroup mem limit "
                                                  "exceeded: %s\n" % (err_msg))
+                        if pbs.event().type == pbs.EXECHOST_PERIODIC or \
+                           pbs.event().type == pbs.EXECJOB_EPILOGUE:
+                            self.set_diag_messages(resc_used, '{"%s":'
+                                                   '"Cgroup mem limit '
+                                                   'exceeded"}'
+                                                   % pbs.get_local_nodename(),
+                                                   True)
             elif subsys == 'memsw':
                 max_vmem = self._get_max_memsw_usage(jobid)
                 if max_vmem is None:
@@ -4986,6 +5027,13 @@ class CgroupUtils(object):
                             self.write_to_stderr(pbs.event().job,
                                                  "Cgroup memsw limit "
                                                  "exceeded: %s" % (err_msg))
+                        if pbs.event().type == pbs.EXECHOST_PERIODIC or \
+                           pbs.event().type == pbs.EXECJOB_EPILOGUE:
+                            self.set_diag_messages(resc_used, '{"%s":'
+                                                   '"Cgroup memsw limit '
+                                                   'exceeded"}'
+                                                   % pbs.get_local_nodename(),
+                                                   True)
             elif subsys == 'hugetlb':
                 max_hpmem = self._get_max_hugetlb_usage(jobid)
                 if max_hpmem is None:
@@ -5006,6 +5054,13 @@ class CgroupUtils(object):
                         self.write_to_stderr(pbs.event().job,
                                              "Cgroup hugetlb limit "
                                              "exceeded: %s" % (err_msg))
+                    if pbs.event().type == pbs.EXECHOST_PERIODIC or \
+                       pbs.event().type == pbs.EXECJOB_EPILOGUE:
+                        self.set_diag_messages(resc_used, '{"%s":'
+                                               '"Cgroup hugetlb limit '
+                                               'exceeded"}'
+                                               % pbs.get_local_nodename(),
+                                               True)
                 resc_used['hpmem'] = pbs.size(convert_size(max_hpmem, 'kb'))
                 pbs.logjobmsg(jobid, '%s: Hugepage usage: %s' %
                               (caller_name(), resc_used['hpmem']))

--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -3054,16 +3054,16 @@ class CgroupUtils(object):
             json_msg = json.loads(msg)
         except Exception:
             json_msg = {}
-        if 'diag_messages' not in resc_used.keys():
+        if 'diag_messages' not in resc_used:
             resc_used['diag_messages'] = json.dumps(json_msg)
         elif concate:
             try:
                 json_resc = json.loads(resc_used['diag_messages'])
             except Exception:
                 json_resc = {}
-            for k in json_msg.keys():
+            for k in json_msg:
                 if k in json_resc.keys() and not json_msg[k] in json_resc[k]:
-                    json_resc[k] += ', %s' % json_msg[k]
+                    json_resc[k] += f", {json_msg[k]}"
                 else:
                     json_resc[k] = json_msg[k]
             resc_used['diag_messages'] = json.dumps(json_resc)
@@ -4961,8 +4961,7 @@ class CgroupUtils(object):
             pbs.logmsg(pbs.EVENT_DEBUG4, '%s: Job %s is not running' %
                        (caller_name(), jobid))
             return
-        if pbs.event().type == pbs.EXECHOST_PERIODIC or \
-           pbs.event().type == pbs.EXECJOB_EPILOGUE:
+        if pbs.event().type in [pbs.EXECHOST_PERIODIC, pbs.EXECJOB_EPILOGUE]:
             # Initialize diag_messages in order to be able
             # to merge msgs only from sisters
             self.set_diag_messages(resc_used, '{}', True)
@@ -4994,8 +4993,8 @@ class CgroupUtils(object):
                             self.write_to_stderr(pbs.event().job,
                                                  "Cgroup mem limit "
                                                  "exceeded: %s\n" % (err_msg))
-                        if pbs.event().type == pbs.EXECHOST_PERIODIC or \
-                           pbs.event().type == pbs.EXECJOB_EPILOGUE:
+                        if pbs.event().type in \
+                           [pbs.EXECHOST_PERIODIC, pbs.EXECJOB_EPILOGUE]:
                             self.set_diag_messages(resc_used, '{"%s":'
                                                    '"Cgroup mem limit '
                                                    'exceeded"}'
@@ -5027,8 +5026,8 @@ class CgroupUtils(object):
                             self.write_to_stderr(pbs.event().job,
                                                  "Cgroup memsw limit "
                                                  "exceeded: %s" % (err_msg))
-                        if pbs.event().type == pbs.EXECHOST_PERIODIC or \
-                           pbs.event().type == pbs.EXECJOB_EPILOGUE:
+                        if pbs.event().type in \
+                           [pbs.EXECHOST_PERIODIC, pbs.EXECJOB_EPILOGUE]:
                             self.set_diag_messages(resc_used, '{"%s":'
                                                    '"Cgroup memsw limit '
                                                    'exceeded"}'
@@ -5054,8 +5053,8 @@ class CgroupUtils(object):
                         self.write_to_stderr(pbs.event().job,
                                              "Cgroup hugetlb limit "
                                              "exceeded: %s" % (err_msg))
-                    if pbs.event().type == pbs.EXECHOST_PERIODIC or \
-                       pbs.event().type == pbs.EXECJOB_EPILOGUE:
+                    if pbs.event().type in \
+                       [pbs.EXECHOST_PERIODIC, pbs.EXECJOB_EPILOGUE]:
                         self.set_diag_messages(resc_used, '{"%s":'
                                                '"Cgroup hugetlb limit '
                                                'exceeded"}'

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -2765,7 +2765,6 @@ if %s e.job.in_ms_mom():
         a = {'job_history_enable': 'True'}
         rc = self.server.manager(MGR_CMD_SET, SERVER, a)
         self.assertEqual(rc, 0)
-        self.server.expect(SERVER, {'job_history_enable': 'True'})
 
         self.load_config(self.cfg3 % ('', 'false', '', self.mem, '',
                                       self.swapctl, ''))
@@ -2777,11 +2776,10 @@ if %s e.job.in_ms_mom():
         j.create_script(self.eatmem_job1)
         jid = self.server.submit(j)
         a = {'job_state': 'F'}
-        self.server.expect(JOB, a, jid, extend='x')
+        self.server.expect(JOB, a, jid, extend='x', offset=10)
         resc = ['resources_used.diag_messages']
         s = self.server.status(JOB, resc, id=jid, extend='x')
         dmsg = s[0]['resources_used.diag_messages'].replace("'", "")
-        self.logger.info(dmsg)
         json_exceeded = json.loads(dmsg)
         msg = json_exceeded[self.mom.shortname]
         self.assertEqual(msg, 'Cgroup mem limit exceeded, '

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -2741,6 +2741,52 @@ if %s e.job.in_ms_mom():
         self.logger.info('Joined stdout/stderr contained expected string: '
                          + foundstr)
 
+    def test_cgroup_diag_messages(self):
+        """
+        Test to verify that job that exceeded resources has the diag_message
+        set correctly.
+        """
+
+        if not self.paths[self.hosts_list[0]]['memory']:
+            self.skipTest('Test requires memory subystem mounted')
+        # run the test if swap space is available
+        if not self.mem or not self.swapctl:
+            self.skipTest('Test requires memory controller with memsw'
+                          'swap accounting enabled')
+        if have_swap() == 0:
+            self.skipTest('no swap space available on the local host')
+        # Get the grandparent directory
+        fn = self.paths[self.hosts_list[0]]['memory']
+        fn = os.path.join(fn, 'memory.memsw.limit_in_bytes')
+        if not self.is_file(fn, self.hosts_list[0]):
+            self.skipTest('vmem resource not present on node')
+
+        # Make sure job history is enabled to see when job is gone
+        a = {'job_history_enable': 'True'}
+        rc = self.server.manager(MGR_CMD_SET, SERVER, a)
+        self.assertEqual(rc, 0)
+        self.server.expect(SERVER, {'job_history_enable': 'True'})
+
+        self.load_config(self.cfg3 % ('', 'false', '', self.mem, '',
+                                      self.swapctl, ''))
+
+        a = {
+            'Resource_List.select':
+            '1:ncpus=1:mem=400mb:vmem=420mb:host=%s' % self.hosts_list[0]}
+        j = Job(TEST_USER, attrs=a)
+        j.create_script(self.eatmem_job1)
+        jid = self.server.submit(j)
+        a = {'job_state': 'F'}
+        self.server.expect(JOB, a, jid, extend='x')
+        resc = ['resources_used.diag_messages']
+        s = self.server.status(JOB, resc, id=jid, extend='x')
+        dmsg = s[0]['resources_used.diag_messages'].replace("'", "")
+        self.logger.info(dmsg)
+        json_exceeded = json.loads(dmsg)
+        msg = json_exceeded[self.mom.shortname]
+        self.assertEqual(msg, 'Cgroup mem limit exceeded, '
+                         'Cgroup memsw limit exceeded')
+
     def cgroup_offline_node(self, name, vnpernuma=False):
         """
         Per vnode_per_numa_node config setting, return True if able to


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->

I would like to offer you an improvement of cgroups hook. In this change, a new resource `diag_messages` is created by cgroups hook. This resource is used to inform the user that the jobs' limits were exceeded on nodes. As the resource is shown in qstat, the user can easily see it. It can also be shown in a custom GUI app etc... This resource diag_messages can be also used for other purposes in the future.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

The cgroups hook creates a new resource `diag_messages` on vnode creating. As only 'used' job resources can be changed from periodic hooks, this seems to be the convenient way. The cgroups periodic hook will write a msg that the limits were exceeded into this 'used' resource. Sister moms messages are merged by openpbs using JSON into one message. Hence the msg format is JSON. Also, more than one limit can be exceeded on a node - the messages of the node are concated. 


Resource value example for a job with exceeding limits on two moms:
```
resources_used.diag_messages = '{"torque2": "Cgroup memsw limit exceeded", "torque1": "Cgroup memsw limit exceeded"}'

```
I realize this change uses the 'used' resource in an alternative/creative way. I understand if you do not want to merge.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

[PTL_diag_messages.txt](https://github.com/user-attachments/files/16051521/PTL_diag_messages.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
