### PR TITLE
fix user site check with gss/krb

### DIFF
--- a/src/lib/Libattr/master_resv_attr_def.xml
+++ b/src/lib/Libattr/master_resv_attr_def.xml
@@ -814,6 +814,40 @@
          <ECL>NULL_VERIFY_VALUE_FUNC</ECL>
       </member_verify_function>
    </attributes>
+   <attributes>
+      <member_index>RESV_ATR_submit_host</member_index>
+      <member_name>ATTR_submit_host</member_name>
+      <member_at_decode>decode_str</member_at_decode>
+      <member_at_encode>encode_str</member_at_encode>
+      <member_at_set>set_str</member_at_set>
+      <member_at_comp>comp_str</member_at_comp>
+      <member_at_free>free_str</member_at_free>
+      <member_at_action>NULL_FUNC</member_at_action>
+      <member_at_flags>READ_WRITE | ATR_DFLAG_MOM | ATR_DFLAG_SvRD | ATR_DFLAG_SvWR</member_at_flags>
+      <member_at_type>ATR_TYPE_STR</member_at_type>
+      <member_at_parent>PARENT_TYPE_RESV</member_at_parent>
+      <member_verify_function>
+         <ECL>NULL_VERIFY_DATATYPE_FUNC</ECL>
+         <ECL>NULL_VERIFY_VALUE_FUNC</ECL>
+      </member_verify_function>
+   </attributes>
+   <attributes>
+      <member_index>RESV_ATR_cred_id</member_index>
+      <member_name>ATTR_cred_id</member_name>
+      <member_at_decode>decode_str</member_at_decode>
+      <member_at_encode>encode_str</member_at_encode>
+      <member_at_set>set_str</member_at_set>
+      <member_at_comp>comp_str</member_at_comp>
+      <member_at_free>free_str</member_at_free>
+      <member_at_action>NULL_FUNC</member_at_action>
+      <member_at_flags>READ_WRITE | ATR_DFLAG_MOM | ATR_DFLAG_SvRD | ATR_DFLAG_SvWR</member_at_flags>
+      <member_at_type>ATR_TYPE_STR</member_at_type>
+      <member_at_parent>PARENT_TYPE_RESV</member_at_parent>
+      <member_verify_function>
+         <ECL>NULL_VERIFY_DATATYPE_FUNC</ECL>
+         <ECL>NULL_VERIFY_VALUE_FUNC</ECL>
+      </member_verify_function>
+   </attributes>
    <attributes flag="SVR">
       <member_index>RESV_ATR_node_set</member_index>
       <member_name>


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->

**Using GSS/KRB**, the function site_check_user_map() has a serious bug. In this function, the 0 (success) is returned in the end instead of the intended -1 (denial).

If there is any other side using the gss/krb code, I urge you to apply this patch as soon as this PR is resolved.

It means the site_check_user_map() can be evaluated wrongly with gss/krb and the job can run as a different user (using qsub the -u parameter). Credentials are issued based on credential_id, so the job would have original credentials, which is OK.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

The job structure already has the `Submit_Host` and `credential_id` attributes. I added similar attributes to the reservations. The `credential_id` is set only if the submission auth method is GSS.

The need for the new attributes is because the `JOB_ATR_job_owner/RESV_ATR_resv_owner` does not contain the hostname if gss is used to compare it in `site_check_user_map()`.

`submit_host` is now used as the host to compare. If GSS is used, the function ends before `ruserok()` and denies the request. Otherwise, no change is made.

This way using the gss is safe and submitting without gss checks the users as expected/as it was orignaly.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

[PTL-test_auth_user.txt](https://github.com/user-attachments/files/16142410/PTL-test_auth_user.txt)

Manual test with GSS - success:
```
torque1.grid.cesnet.cz$ PBS_AUTH_METHOD=GSS PBS_ENCRYPT_METHOD=GSS qsub -I -u vchlum
qsub: waiting for job 12545.torque1.grid.cesnet.cz to start
qsub: job 12545.torque1.grid.cesnet.cz ready

torque1.grid.cesnet.cz$ exit
logout

qsub: job 12545.torque1.grid.cesnet.cz completed
```

Manual test with GSS - denial:
```
torque1.grid.cesnet.cz$ PBS_AUTH_METHOD=GSS PBS_ENCRYPT_METHOD=GSS qsub -I -u vchlum2
qsub: Bad UID for job execution
```

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
