### PR TITLE
Fix bogus error message about fscanf failed

### DIFF
--- a/src/resmom/linux/mom_mach.c
+++ b/src/resmom/linux/mom_mach.c
@@ -224,7 +224,7 @@ proc_get_btime(void)
 			if (fscanf(fp, "%*[^\n]%*c") == EOF) 
 				log_errf(-1, __func__, "fscanf failed. ERR : %s", strerror(errno));				
 		} else {
-			if (fscanf(fp, "%u", &linux_time)) 
+			if (fscanf(fp, "%u", &linux_time) == EOF) 
 				log_errf(-1, __func__, "fscanf failed. ERR : %s", strerror(errno));				
 			fclose(fp);
 			return;


### PR DESCRIPTION
As the title says.

Currently, I'm seeing error messages like

`07/09/2024 17:00:05;0001;pbs_mom;Svr;pbs_mom;proc_get_btime, fscanf failed. ERR : Inappropriate ioctl for device`

at each service restart on MoM's. Obviously, the specific errno refers to a previously failed system call, irrelevant for `proc_get_btime()` .