### PR TITLE
fix used resc updates from hook results in walltime zero at the multi…

### DIFF
--- a/src/resmom/mom_updates_bundle.c
+++ b/src/resmom/mom_updates_bundle.c
@@ -744,14 +744,19 @@ get_job_update(job *pjob)
 							 job_attr_def[JOB_ATR_substate].at_name, NULL, ATR_ENCODE_CLIENT, NULL);
 	}
 
-	/*
-	 * The update_walltime() ensures the walltime is always set before encode_used().
-	 * A job without used walltime could occur in the first seconds of a job.
-	 * This ensures the used walltime is set even if the elapsed time is zero.
+	/* sister moms update of used resources
+	 * is done by send_resc_used_to_ms(); do not send it here
 	 */
-	update_walltime(pjob);
+	if ((pjob->ji_qs.ji_svrflags & JOB_SVFLG_HERE)) {
+		/*
+		 * The update_walltime() ensures the walltime is always set before encode_used().
+		 * A job without used walltime could occur in the first seconds of a job.
+		 * This ensures the used walltime is set even if the elapsed time is zero.
+		 */
+		update_walltime(pjob);
 
-	encode_used(pjob, &prused->ru_attr);
+		encode_used(pjob, &prused->ru_attr);
+	}
 
 	/* Now add certain others as required for updating at the Server */
 	for (i = 0; mom_rtn_list[i] != JOB_ATR_LAST; ++i) {


### PR DESCRIPTION
…node job end

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->

I made this bug visible in PR #2634. I did not consider multinode jobs in this PR.

Using e.g. the cgroup hook, the multinode job can have used walltime zero once the job ends. More precisely, the resulting used resources on the finished job represent one of the sister mom values.

See with enable cgroup hook:
```
$ qsub  -l select=mem=500mb+mem=500mb -l place=scatter -- /usr/bin/pbsdsh -- /usr/bin/stress --cpu 1 --io 4 --vm 1 --vm-bytes 200M --timeout 30s
13027.torque1.grid.cesnet.cz
```

The used walltime is not zero while the job is running:
```
(BOOKWORM)root@torque1:~# qstat 13027.torque1.grid.cesnet.cz -fw | grep used
    resources_used.cpupercent = 0
    resources_used.cput = 00:00:00
    resources_used.mem = 0b
    resources_used.ncpus = 2
    resources_used.vmem = 0b
    resources_used.walltime = 00:00:27
```

Once the job ends, the used resources represent only one of the sisters mom used resources:
```
(BOOKWORM)root@torque1:~# qstat 13027.torque1.grid.cesnet.cz -x 
Job id            Name             User              Time Use S Queue
----------------  ---------------- ----------------  -------- - -----
13027.torque1     STDIN            vchlum            00:00:30 F default  

(BOOKWORM)root@torque1:~# qstat 13027.torque1.grid.cesnet.cz -fwx | grep used
    resources_used.cpupercent = 0
    resources_used.cput = 00:00:30
    resources_used.mem = 206328kb
    resources_used.ncpus = 2
    resources_used.vmem = 206328kb
    resources_used.walltime = 00:00:00
```

Just to let you know, sister moms keep the job walltime zero. Only the mother superior keeps track of used walltime.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

The problem is that `encode_used()` is called in `post_run_hook` for all nodes of the job. Thus the walltime is set to zero on sister moms. `encode_used()` sends used resources to the server. This is not OK because sister moms send used resources to mother superior via `IM_POLL_JOB` and `scan_for_exiting` by `send_resc_used_to_ms()` and mother superior accumulates used resources and sends the used resources to the server. It means the used resources of a multinode job are not stable on the server now. Sometimes it is the correct value and sometimes it is the value from one of the sisters.

In the job end, the used resources are rewritten by the hook from sister mom (`execjob_epilogue,execjob_end`).

We should call `encode_used()` in `get_job_update()` only on the mother superior. The mother superior will accumulate the used resources and send them to the server correctly.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

I ran all the tests in accumulate_resc_used (including the new one) to test this change is OK: 
[PTL-accumulate_resc_used.txt](https://github.com/user-attachments/files/16255193/PTL-accumulate_resc_used.txt)

I also ran the test from PR #2634: 
[PTL-rerun_over_reservation.txt](https://github.com/user-attachments/files/16255199/PTL-rerun_over_reservation.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
