### PR TITLE
qrun request can miss its scheduler in multi-sched environment

### DIFF
--- a/src/include/pbs_sched.h
+++ b/src/include/pbs_sched.h
@@ -107,7 +107,7 @@ extern pbs_sched *find_sched(char *sched_name);
 extern int validate_job_formula(attribute *pattr, void *pobject, int actmode);
 extern pbs_sched *find_sched_from_partition(char *partition);
 extern int recv_sched_cycle_end(int sock);
-extern void handle_deferred_cycle_close();
+extern void handle_deferred_cycle_close(pbs_sched *psched);
 
 attribute *get_sched_attr(const pbs_sched *psched, int attr_idx);
 char *get_sched_attr_str(const pbs_sched *psched, int attr_idx);

--- a/src/include/server.h
+++ b/src/include/server.h
@@ -184,7 +184,7 @@ extern void unlicense_nodes(void);
 extern void set_sched_default(pbs_sched *, int from_scheduler);
 extern void memory_debug_log(struct work_task *ptask);
 
-extern pbs_list_head *get_sched_deferred_request(pbs_sched *psched, int create);
+extern pbs_list_head *fetch_sched_deferred_request(pbs_sched *psched, bool create);
 extern void clear_sched_deferred_request(pbs_sched *psched);
 
 attribute *get_sattr(int attr_idx);

--- a/src/include/server.h
+++ b/src/include/server.h
@@ -184,6 +184,9 @@ extern void unlicense_nodes(void);
 extern void set_sched_default(pbs_sched *, int from_scheduler);
 extern void memory_debug_log(struct work_task *ptask);
 
+extern pbs_list_head *get_sched_deferred_request(pbs_sched *psched, int create);
+extern void clear_sched_deferred_request(pbs_sched *psched);
+
 attribute *get_sattr(int attr_idx);
 char *get_sattr_str(int attr_idx);
 struct array_strings *get_sattr_arst(int attr_idx);

--- a/src/include/svrfunc.h
+++ b/src/include/svrfunc.h
@@ -354,6 +354,12 @@ struct deferred_request {
 	int dr_sent; /* sent to Scheduler */
 };
 
+struct sched_deferred_request {
+	pbs_list_link sdr_link;
+	pbs_list_head sdr_deferred_req; /* list of deferred requests of the scheduler */
+	pbs_sched *sdr_psched; /* Scheduler */
+};
+
 #endif /* _LIST_LINK_H */
 
 /*

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -168,7 +168,7 @@ int shutdown_who;		  /* see req_shutdown() */
 char *mom_host = server_host;
 long new_log_event_mask = 0;
 int server_init_type = RECOV_WARM;
-pbs_list_head svr_deferred_req;
+pbs_list_head svr_deferred_req; /* list of lists, one for each scheduler */
 pbs_list_head svr_newjobs; /* list of incomming new jobs       */
 pbs_list_head svr_allscheds;
 extern pbs_list_head svr_creds_cache; /* all credentials available to send */

--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -236,7 +236,7 @@ clear_from_defr(int sd)
 	     psched;
 	     psched = (pbs_sched *) GET_NEXT(psched->sc_link)) {
 
-		deferred_req = get_sched_deferred_request(psched, FALSE);
+		deferred_req = fetch_sched_deferred_request(psched, false);
 		if (deferred_req == NULL) {
 			continue;
 		}
@@ -453,7 +453,7 @@ req_runjob(struct batch_request *preq)
 		pbs_strncpy(pdefr->dr_id, fixjid, PBS_MAXSVRJOBID + 1);
 		pdefr->dr_preq = preq;
 		pdefr->dr_sent = 0;
-		deferred_req = get_sched_deferred_request(psched, TRUE);
+		deferred_req = fetch_sched_deferred_request(psched, true);
 		if (deferred_req == NULL) {
 			req_reject(PBSE_SYSTEM, 0, preq);
 			return;
@@ -1861,7 +1861,7 @@ req_defschedreply(struct batch_request *preq)
 	}
 
 	find_assoc_sched_jid(preq->rq_ind.rq_defrpy.rq_id, &psched);
-	deferred_req = get_sched_deferred_request(psched, FALSE);
+	deferred_req = fetch_sched_deferred_request(psched, false);
 	if (deferred_req == NULL) {
 		req_reject(PBSE_IVALREQ, 0, preq);
 		return;

--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -139,7 +139,6 @@ extern char *msg_init_substate;
 extern char *msg_manager;
 extern char *msg_stageinfail;
 extern char *msg_job_abort;
-extern pbs_list_head svr_deferred_req;
 extern time_t time_now;
 extern int svr_totnodes; /* non-zero if using nodes */
 extern job *chk_job_request(char *, struct batch_request *, int *, int *);
@@ -229,29 +228,43 @@ check_and_provision_job(struct batch_request *preq, job *pjob, int *need_prov)
 static void
 clear_from_defr(int sd)
 {
+	pbs_sched *psched;
+	pbs_list_head *deferred_req;
 	struct deferred_request *pdefr;
 
-	for (pdefr = (struct deferred_request *) GET_NEXT(svr_deferred_req);
-	     pdefr;
-	     pdefr = (struct deferred_request *) GET_NEXT(pdefr->dr_link)) {
-		if (pdefr->dr_preq != NULL) {
-			if (pdefr->dr_preq->rq_conn == sd) {
-				/* found deferred run job request whose */
-				/* connection to the client has closed  */
-				if (pdefr->dr_sent != 0) {
-					/* request sent to scheduler, wait   */
-					/* for it to respond before removing */
-					/* this request, just null the qrun  */
-					/* request pointer                   */
-					pdefr->dr_preq = NULL;
-				} else {
-					/* unlink & free the deferred request */
-					delete_link(&pdefr->dr_link);
-					free(pdefr);
+	for (psched = (pbs_sched *) GET_NEXT(svr_allscheds);
+	     psched;
+	     psched = (pbs_sched *) GET_NEXT(psched->sc_link)) {
+
+		deferred_req = get_sched_deferred_request(psched, FALSE);
+		if (deferred_req == NULL) {
+			continue;
+		}
+
+		for (pdefr = (struct deferred_request *) GET_NEXT(*deferred_req);
+		     pdefr;
+		     pdefr = (struct deferred_request *) GET_NEXT(pdefr->dr_link)) {
+			if (pdefr->dr_preq != NULL) {
+				if (pdefr->dr_preq->rq_conn == sd) {
+					/* found deferred run job request whose */
+					/* connection to the client has closed  */
+					if (pdefr->dr_sent != 0) {
+						/* request sent to scheduler, wait   */
+						/* for it to respond before removing */
+						/* this request, just null the qrun  */
+						/* request pointer                   */
+						pdefr->dr_preq = NULL;
+					} else {
+						/* unlink & free the deferred request */
+						delete_link(&pdefr->dr_link);
+						free(pdefr);
+					}
+					break;
 				}
-				break;
 			}
 		}
+
+		clear_sched_deferred_request(psched);
 	}
 }
 
@@ -304,6 +317,7 @@ req_runjob(struct batch_request *preq)
 	int end;
 	int step;
 	int count;
+	pbs_list_head *deferred_req;
 	struct deferred_request *pdefr;
 	char hook_msg[HOOK_MSG_SIZE];
 	pbs_sched *psched;
@@ -439,7 +453,12 @@ req_runjob(struct batch_request *preq)
 		pbs_strncpy(pdefr->dr_id, fixjid, PBS_MAXSVRJOBID + 1);
 		pdefr->dr_preq = preq;
 		pdefr->dr_sent = 0;
-		append_link(&svr_deferred_req, &pdefr->dr_link, pdefr);
+		deferred_req = get_sched_deferred_request(psched, TRUE);
+		if (deferred_req == NULL) {
+			req_reject(PBSE_SYSTEM, 0, preq);
+			return;
+		}
+		append_link(deferred_req, &pdefr->dr_link, pdefr);
 		/* ensure that request is removed if client connect is closed */
 		net_add_close_func(preq->rq_conn, clear_from_defr);
 
@@ -1832,6 +1851,8 @@ assign_hosts(job *pjob, char *given, int set_exec_vnode)
 void
 req_defschedreply(struct batch_request *preq)
 {
+	pbs_sched *psched;
+	pbs_list_head *deferred_req;
 	struct deferred_request *pdefr;
 
 	if (preq->rq_ind.rq_defrpy.rq_cmd != SCH_SCHEDULE_AJOB) {
@@ -1839,7 +1860,14 @@ req_defschedreply(struct batch_request *preq)
 		return;
 	}
 
-	for (pdefr = (struct deferred_request *) GET_NEXT(svr_deferred_req);
+	find_assoc_sched_jid(preq->rq_ind.rq_defrpy.rq_id, &psched);
+	deferred_req = get_sched_deferred_request(psched, FALSE);
+	if (deferred_req == NULL) {
+		req_reject(PBSE_IVALREQ, 0, preq);
+		return;
+	}
+
+	for (pdefr = (struct deferred_request *) GET_NEXT(*deferred_req);
 	     pdefr;
 	     pdefr = (struct deferred_request *) GET_NEXT(pdefr->dr_link)) {
 		if (strcmp(preq->rq_ind.rq_defrpy.rq_id, pdefr->dr_id) == 0)
@@ -1877,6 +1905,8 @@ req_defschedreply(struct batch_request *preq)
 	/* unlink and free the deferred request entry */
 	delete_link(&pdefr->dr_link);
 	free(pdefr);
+
+	clear_sched_deferred_request(psched);
 
 	reply_send(preq);
 }

--- a/src/server/run_sched.c
+++ b/src/server/run_sched.c
@@ -336,7 +336,7 @@ schedule_jobs(pbs_sched *psched)
 
 		/* are there any qrun requests from manager/operator */
 		/* which haven't been sent,  they take priority      */
-		deferred_req = get_sched_deferred_request(psched, FALSE);
+		deferred_req = fetch_sched_deferred_request(psched, false);
 		if (deferred_req) {
 			pdefr = (struct deferred_request *) GET_NEXT(*deferred_req);
 		} /* else pdefr is NULL */
@@ -534,7 +534,7 @@ handle_deferred_cycle_close(pbs_sched *psched)
 	pbs_list_head *deferred_req;
 	struct deferred_request *pdefr;
 
-	deferred_req = get_sched_deferred_request(psched, FALSE);
+	deferred_req = fetch_sched_deferred_request(psched, false);
 	if (deferred_req == NULL) {
 		return;
 	}

--- a/src/server/run_sched.c
+++ b/src/server/run_sched.c
@@ -47,7 +47,6 @@
 extern struct server server;
 extern char server_name[];
 extern char *msg_sched_called;
-extern pbs_list_head svr_deferred_req;
 
 int scheduler_jobs_stat = 0; /* set to 1 once scheduler queried jobs in a cycle*/
 extern int svr_unsent_qrun_req;
@@ -265,7 +264,7 @@ recv_sched_cycle_end(int sock)
 	/* clear list of jobs which were altered/modified during cycle */
 	am_jobs.am_used = 0;
 	scheduler_jobs_stat = 0;
-	handle_deferred_cycle_close();
+	handle_deferred_cycle_close(psched);
 
 	if (rc == DIS_EOF)
 		rc = -1;
@@ -321,7 +320,8 @@ schedule_jobs(pbs_sched *psched)
 	int cmd;
 	int s;
 	static int first_time = 1;
-	struct deferred_request *pdefr;
+	struct deferred_request *pdefr = NULL;
+	pbs_list_head *deferred_req;
 	char *jid = NULL;
 
 	if (psched == NULL)
@@ -336,7 +336,10 @@ schedule_jobs(pbs_sched *psched)
 
 		/* are there any qrun requests from manager/operator */
 		/* which haven't been sent,  they take priority      */
-		pdefr = (struct deferred_request *) GET_NEXT(svr_deferred_req);
+		deferred_req = get_sched_deferred_request(psched, FALSE);
+		if (deferred_req) {
+			pdefr = (struct deferred_request *) GET_NEXT(*deferred_req);
+		} /* else pdefr is NULL */
 		while (pdefr) {
 			if (pdefr->dr_sent == 0) {
 				s = is_job_array(pdefr->dr_id);
@@ -371,7 +374,9 @@ schedule_jobs(pbs_sched *psched)
 
 		/* if there are more qrun requests queued up, reset cmd so */
 		/* they are sent when the Scheduler completes this cycle   */
-		pdefr = GET_NEXT(svr_deferred_req);
+		if (deferred_req) {
+			pdefr = GET_NEXT(*deferred_req);
+		} /* else pdefr is NULL */
 		while (pdefr) {
 			if (pdefr->dr_sent == 0) {
 				pbs_sched *target_sched;
@@ -433,7 +438,7 @@ scheduler_close(int sock)
 	am_jobs.am_used = 0;
 	scheduler_jobs_stat = 0;
 
-	handle_deferred_cycle_close();
+	handle_deferred_cycle_close(psched);
 }
 
 /**
@@ -524,9 +529,15 @@ set_scheduler_flag(int flag, pbs_sched *psched)
  * @return void
  */
 void
-handle_deferred_cycle_close(void)
+handle_deferred_cycle_close(pbs_sched *psched)
 {
+	pbs_list_head *deferred_req;
 	struct deferred_request *pdefr;
+
+	deferred_req = get_sched_deferred_request(psched, FALSE);
+	if (deferred_req == NULL) {
+		return;
+	}
 
 	/*
 	 * If a deferred (from qrun) had been sent to the Scheduler and is still
@@ -537,7 +548,7 @@ handle_deferred_cycle_close(void)
 	 * If any qrun request is pending in the deffered list, set svr_unsent_qrun_req so
 	 * they are sent when the Scheduler completes this cycle
 	 */
-	pdefr = (struct deferred_request *) GET_NEXT(svr_deferred_req);
+	pdefr = (struct deferred_request *) GET_NEXT(*deferred_req);
 
 	while (pdefr) {
 		struct deferred_request *next_pdefr = (struct deferred_request *) GET_NEXT(pdefr->dr_link);
@@ -554,4 +565,6 @@ handle_deferred_cycle_close(void)
 
 		pdefr = next_pdefr;
 	}
+
+	clear_sched_deferred_request(psched);
 }

--- a/src/server/svr_func.c
+++ b/src/server/svr_func.c
@@ -6881,7 +6881,7 @@ memory_debug_log(struct work_task *ptask)
  * @retval	pbs_list_head*	: list of scheduler deferred requests.
  */
 pbs_list_head *
-get_sched_deferred_request(pbs_sched *psched, int create)
+fetch_sched_deferred_request(pbs_sched *psched, bool create)
 {
 	struct sched_deferred_request *psdefr;
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->

Calling qrun without a destination in multi-sched environment can cause error "Scheduler can not find job" and the job is not started.

Let's have two schedulers A nad B. See the bug simulated in gdb:
 * qrun a job belonging to the B scheduler:
```
 (BOOKWORM)root@torque1:~# qrun 18006
```
 * simulate the B scheduler is in the cycle right now (break is on `schedule_jobs()`):
```
(gdb) bt
#0  schedule_jobs (psched=0x555555762d20) at run_sched.c:325
#1  0x00005555555e3a50 in req_runjob (preq=0x555555782250) at req_runjob.c:446
#2  0x00005555555bb449 in dispatch_request (sfds=24, request=0x555555782250) at process_request.c:1021
#3  0x00005555555baf01 in process_request (sfds=24) at process_request.c:762
#4  0x00005555556336ad in process_socket (sock=24) at net_server.c:510
#5  0x00005555556339ff in wait_request (waittime=2, priority_context=0x555555743cd0) at net_server.c:623
#6  0x00005555555b9273 in main (argc=2, argv=0x7fffffffea28) at pbsd_main.c:1404
(gdb) n
327		if (psched == NULL)
(gdb) 
330		if (first_time)
(gdb) 
333			cmd = psched->svr_do_schedule;
(gdb) 
335		if (psched->sc_cycle_started == 0) {
(gdb) set psched->sc_cycle_started=1
(gdb) n
387			return (1); /* scheduler was busy */
(gdb) set psched->sc_cycle_started=0
(gdb) c
```
 * the qrun still hangs, let's start some job in the scheduler A, to invoke the `schedule_jobs()` of the scheduler A, the error is:
```
07/19/2024 07:53:57;0080;pbs_sched;Req;;Starting Scheduling Cycle
07/19/2024 07:53:57;0008;pbs_sched;Job;18006.torque1.grid.cesnet.cz;Received qrun request
07/19/2024 07:53:57;0008;pbs_sched;Job;18006.torque1.grid.cesnet.cz;Could not find job to qrun.
07/19/2024 07:53:57;0080;pbs_sched;Req;;Leaving Scheduling Cycle
```
 * and the qrun fails:
```
(BOOKWORM)root@torque1:~# qrun 18006
qrun: PBS Error: Scheduler can not find job 18006.torque1.grid.cesnet.cz
```

The problem is that all the schedulers share the global variable `svr_deferred_req`. Each scheduler should have its list.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

The global variable `svr_deferred_req` is now the list of lists - one list for each scheduler. A scheduler list is created dynamically - only if needed and removed once it is empty.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

I do not see a way how to create a PTL test, so a manual test is here:

The same simulation via gdb as described in bug description:
```
schedule_jobs (psched=0x555555762d20) at run_sched.c:325
325		char *jid = NULL;
(gdb) n
327		if (psched == NULL)
(gdb) 
330		if (first_time)
(gdb) 
331			cmd = SCH_SCHEDULE_FIRST;
(gdb) 
335		if (psched->sc_cycle_started == 0) {
(gdb) set psched->sc_cycle_started=1
(gdb) n
395			return (1); /* scheduler was busy */
(gdb) set psched->sc_cycle_started=0
(gdb) c
Continuing.

```
the deferred request waits for the right `schedule_jobs()` and the job is started as expected within the right partition:
```
07/19/2024 08:23:23;0080;pbs_sched;Req;;Starting Scheduling Cycle
07/19/2024 08:23:23;0008;pbs_sched;Job;19000.torque1.grid.cesnet.cz;Received qrun request
07/19/2024 08:23:23;0080;pbs_sched;Job;19000.torque1.grid.cesnet.cz;Considering job to run
07/19/2024 08:23:23;0040;pbs_sched;Job;19000.torque1.grid.cesnet.cz;Job run
07/19/2024 08:23:23;0080;pbs_sched;Req;;Leaving Scheduling Cycle
```

qrun success:
```
(BOOKWORM)root@torque1:~# qrun 19000
(BOOKWORM)root@torque1:~# 
```


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
