### PR TITLE
skip PBS_JOBCOOKIE and PBS_INTERACTIVE_COOKIE

### DIFF
--- a/src/cmds/qsub.c
+++ b/src/cmds/qsub.c
@@ -502,9 +502,12 @@ expand_varlist(char *varlist)
 			*p2 = '\0';
 			vv = p2 + 1;
 		}
-		if ((vv == NULL) && (strncmp(vn, PBS_O_ENV, sizeof(PBS_O_ENV) - 1) != 0)) {
-			/* do not add PBS_O_* env variables, as these */
-			/* are set by qsub */
+		if ((vv == NULL) && (strncmp(vn, PBS_O_ENV, sizeof(PBS_O_ENV) - 1) != 0)
+				 && (strncmp(vn, PBS_JOBCOOKIE, sizeof(PBS_JOBCOOKIE) - 1) != 0)
+				 && (strncmp(vn, PBS_INTERACTIVE_COOKIE, sizeof(PBS_INTERACTIVE_COOKIE) - 1) != 0)) {
+			/* do not add PBS_O_* env variables, as these are set by qsub
+			 * Job related cookies should not be sent and are excluded to
+			 * prevent exposing internal PBS interactive session information. */
 
 			ev = getenv(vn);
 			if (ev == NULL) {
@@ -2137,6 +2140,7 @@ job_env_basic(void)
  *
  * @par	 NOTE: Variables in the list beginning with "PBS_O" are ignored
  *	 as these will be preconstructed somewhere else.
+ *	 PBS_JOBCOOKIE and PBS_INTERACTIVE_JOBCOOKIE are also ignored
  *
  * @param[in]	envp - aray of strings making up the current environment.
  *
@@ -2179,8 +2183,13 @@ env_array_to_varlist(char **envp)
 		while ((*s != '=') && *s)
 			++s;
 		*s = '\0';
-		if (strncmp(*evp, PBS_O_ENV, sizeof(PBS_O_ENV) - 1) != 0) {
-			/* do not add PBS_O_* env variables, as these are set by qsub */
+		/* Check for PBS_O_, PBS_JOBCOOKIE, and PBS_INTERACTIVE_COOKIE
+		 * PBS_O_* env variables, are set by qsub
+		 * Job related cookies should not be sent and are excluded to
+		 * prevent exposing internal PBS interactive session information. */
+		if ((strncmp(*evp, PBS_O_ENV, sizeof(PBS_O_ENV) - 1) != 0) &&
+			(strcmp(*evp, PBS_JOBCOOKIE) != 0) &&
+			(strcmp(*evp, PBS_INTERACTIVE_COOKIE)) != 0) {
 			strcat(job_env, ",");
 			strcat(job_env, *evp);
 			strcat(job_env, "=");

--- a/src/include/cmds.h
+++ b/src/include/cmds.h
@@ -85,6 +85,8 @@ struct svr_jobid_list {
 #define LARGE_BUF_LEN 4096
 #define MAXSERVERNAME PBS_MAXSERVERNAME + PBS_MAXPORTNUM + 2
 #define PBS_DEPEND_LEN 2040
+#define PBS_JOBCOOKIE "PBS_JOBCOOKIE"
+#define PBS_INTERACTIVE_COOKIE "PBS_INTERACTIVE_COOKIE"
 
 /* for calling pbs_parse_quote:  to accept whitespace as data or separators */
 #define QMGR_ALLOW_WHITE_IN_VALUE 1

--- a/test/tests/security/pbs_job_security.py
+++ b/test/tests/security/pbs_job_security.py
@@ -1,0 +1,83 @@
+
+# coding: utf-8
+# Copyright (C) 2023 Altair Engineering, Inc. All rights reserved.
+# Copyright notice does not imply publication.
+#
+# ALTAIR ENGINEERING INC. Proprietary and Confidential. Contains Trade Secret
+# Information. Not for use or disclosure outside of Licensee's organization.
+# The software and information contained herein may only be used internally and
+# is provided on a non-exclusive, non-transferable basis. License may not
+# sublicense, sell, lend, assign, rent, distribute, publicly display or
+# publicly perform the software or other information provided herein,
+# nor is Licensee permitted to decompile, reverse engineer, or
+# disassemble the software. Usage of the software and other information
+# provided by Altair(or its resellers) is only as explicitly stated in the
+# applicable end user license agreement between Altair and Licensee.
+# In the absence of such agreement, the Altair standard end user
+# license agreement terms shall govern.
+
+from tests.security import *
+
+
+class Test_job_security(TestSecurity):
+    """
+    This test suite is for testing job security
+    """
+
+    def setUp(self):
+        TestSecurity.setUp(self)
+        a = {'job_history_enable': 'True'}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+
+    def test_interactive_job_env_V(self):
+        """
+        This test checks if the PBS job related cookies are passed on to
+        the job that is submitted within the interactive job with -V.
+        """
+        self.pbs_conf = self.du.parse_pbs_config(self.server.shortname)
+        self.exec_path = os.path.join(self.pbs_conf['PBS_EXEC'], "bin")
+        j = Job(TEST_USER)
+        set_attr = {ATTR_inter: ''}
+        j.set_attributes(set_attr)
+        j.interactive_script = [('export PATH=$PATH:%s' %
+                                 self.exec_path, '.*'),
+                                ('qsub -V -- /bin/sleep 5', '.*'),
+                                ('sleep 30', '.*')]
+        jid = self.server.submit(j)
+        jid2 = str(int(jid.split('.')[0]) + 1)
+        self.server.expect(JOB, {'job_state=R': 2}, count=True)
+        stat = self.server.status(JOB, id=jid2, extend='x')
+        for s in stat:
+            variable_list = s.get('Variable_List', '')
+            if 'PBS_JOBCOOKIE' in variable_list or \
+                    'PBS_INTERACTIVE_COOKIE' in variable_list:
+                self.fail("Job Cookie(s) passed on to the inner job.")
+
+    def test_interactive_job_env_v(self):
+        """
+        This test checks if the PBS job related cookies are passed on to
+        the job that is submitted within the interactive job
+        with -v PBS_JOBCOOKIE.
+        """
+        self.pbs_conf = self.du.parse_pbs_config(self.server.shortname)
+        self.exec_path = os.path.join(self.pbs_conf['PBS_EXEC'], "bin")
+        j = Job(TEST_USER)
+        set_attr = {ATTR_inter: ''}
+        j.set_attributes(set_attr)
+        j.interactive_script = [('export PATH=$PATH:%s' %
+                                 self.exec_path, '.*'),
+                                ('qsub -v PBS_JOBCOOKIE -- \
+                                    /bin/sleep 5', '.*'),
+                                ('sleep 30', '.*')]
+        jid = self.server.submit(j)
+        jid2 = str(int(jid.split('.')[0]) + 1)
+        self.server.expect(JOB, {'job_state=R': 2}, count=True)
+        stat = self.server.status(JOB, id=jid2, extend='x')
+        for s in stat:
+            variable_list = s.get('Variable_List', '')
+            if 'PBS_JOBCOOKIE' in variable_list or \
+                    'PBS_INTERACTIVE_COOKIE' in variable_list:
+                self.fail("Job Cookie(s) passed on to the inner job.")
+
+    def tearDown(self):
+        TestSecurity.tearDown(self)


### PR DESCRIPTION
**Issue**

When submitting a job from within an interactive job using 'qsub -V', we should skip sending the interactive job's Cookie(s) (PBS_JOBCOOKIE and PBS_INTERACTIVE_COOKIE) to the inner job.

Added two new PTL tests that submit an interactive job and then a job from within the interactive job.
The test then checks if the interactive job's cookies are present in the inner job's Variable_List.