### PR TITLE
qdel special cases -> server core dump

### DIFF
--- a/src/server/req_delete.c
+++ b/src/server/req_delete.c
@@ -479,7 +479,9 @@ init_deljoblist(struct batch_request *preq)
 		if (!pjob)
 			continue;
 
-		pbs_idx_insert(preply->brp_un.brp_deletejoblist.undeleted_job_idx, pjob->ji_qs.ji_jobid, NULL);
+		if (pbs_idx_insert(preply->brp_un.brp_deletejoblist.undeleted_job_idx, pjob->ji_qs.ji_jobid, NULL) != PBS_IDX_RET_OK) {
+			return 1;
+		}
 		if (strcmp(jlist[tail], pjob->ji_qs.ji_jobid) != 0) {
 			free(jlist[tail]);
 			jlist[tail] = strdup(pjob->ji_qs.ji_jobid);

--- a/src/server/req_delete.c
+++ b/src/server/req_delete.c
@@ -464,6 +464,11 @@ init_deljoblist(struct batch_request *preq)
 	struct batch_reply *preply = &preq->rq_reply;
 	job *pjob;
 	char *temp;
+	int jt;
+	char *jid;
+	char *p1;
+	char *p2;
+	char range_jid[PBS_MAXSVRJOBID];
 
 	if (preq->rq_ind.rq_deletejoblist.rq_resume)
 		return 0;
@@ -475,18 +480,51 @@ init_deljoblist(struct batch_request *preq)
 
 	for (tail = 0; jlist[tail]; tail++) {
 
-		pjob = find_job(jlist[tail]);
+		jt = is_job_array(jlist[tail]);
+
+		if (jt == IS_ARRAY_Range) {
+			pjob = find_arrayparent(jlist[tail]);
+		} else {
+			pjob = find_job(jlist[tail]);
+		}
+
 		if (!pjob)
 			continue;
 
-		if (pbs_idx_insert(preply->brp_un.brp_deletejoblist.undeleted_job_idx, pjob->ji_qs.ji_jobid, NULL) != PBS_IDX_RET_OK) {
-			return 1;
-		}
-		if (strcmp(jlist[tail], pjob->ji_qs.ji_jobid) != 0) {
+		if (jt == IS_ARRAY_Range) {
+			/* append fqdn to range jid
+			 * the result is e.g.:
+			 * '123[1-3].full.domain.name'
+			 */
+			sprintf(range_jid, "%s", jlist[tail]);
+			p1 = strchr(pjob->ji_qs.ji_jobid, '.');
+			if (p1) {
+				p2 = strchr(range_jid, '.');
+				if (p2)
+					*p2 = '\0';
+				strncat(range_jid, p1, PBS_MAXSVRJOBID - 1);
+			}
 			free(jlist[tail]);
-			jlist[tail] = strdup(pjob->ji_qs.ji_jobid);
-			if (jlist[tail] == NULL)
+			jlist[tail] = strdup(range_jid);
+			if (jlist[tail] == NULL) {
 				return 1;
+			}
+
+			jid = jlist[tail];
+		} else {
+			/* use jid with fqdn */
+			if (strcmp(jlist[tail], pjob->ji_qs.ji_jobid) != 0) {
+				free(jlist[tail]);
+				jlist[tail] = strdup(pjob->ji_qs.ji_jobid);
+				if (jlist[tail] == NULL)
+					return 1;
+			}
+
+			jid = jlist[tail];
+		}
+
+		if (pbs_idx_insert(preply->brp_un.brp_deletejoblist.undeleted_job_idx, jid, NULL) != PBS_IDX_RET_OK) {
+			return 1;
 		}
 
 		if (head == -1) {

--- a/test/tests/functional/pbs_qdel.py
+++ b/test/tests/functional/pbs_qdel.py
@@ -566,3 +566,21 @@ class TestQdel(TestFunctional):
         self.server.delete(jid_list)
         rv = self.server.isUp()
         self.assertTrue(rv, "Server crashed")
+
+    @requirements(num_moms=1)
+    def test_qdel_mix_of_job_and_arrayjob_range(self):
+        """
+        Test that the server handles deleting mix of common job
+        and array job range in one request
+        """
+        j = Job(TEST_USER, {'Resource_List.select': 'ncpus=1'})
+        jid = self.server.submit(j)
+
+        ajid, array_id, sjids = self.array_job_start(20, 2, 2)
+
+        sj_list = [jid, f"{array_id}[1]", f"{array_id}[2]"]
+        self.server.delete(sj_list, wait=True)
+        self.server.expect(
+            JOB, {'job_state': 'F'}, id=jid, extend='x', max_attempts=20)
+        self.server.expect(
+            JOB, {'job_state': 'F'}, id=ajid, extend='x', max_attempts=20)

--- a/test/tests/functional/pbs_qdel.py
+++ b/test/tests/functional/pbs_qdel.py
@@ -210,7 +210,7 @@ class TestQdel(TestFunctional):
         j = Job(TEST_USER)
         jid = self.server.submit(j)
         self.server.expect(JOB, {ATTR_state: "R"}, id=jid)
-        self.server.delete([jid, jid, jid, jid, jid], wait=True)
+        self.server.delete([jid.split(".")[0], jid, jid, jid, jid], wait=True)
         self.server.expect(JOB, {'job_state': 'F', 'substate': 91}, id=jid,
                            extend='x', max_attempts=20)
 
@@ -478,7 +478,8 @@ class TestQdel(TestFunctional):
             self.server.delete(job_set)
             self.fail("qdel didn't throw 'Unknown job id' error")
         except PbsDeleteError as e:
-            self.assertEqual("qdel: Unknown Job Id " + unknown_jid, e.msg[0])
+            msg = f'qdel: Unknown Job Id {unknown_jid}'
+            self.assertTrue(e.msg[0].startswith(msg))
             self.server.expect(JOB, {'job_state': 'F'}, id=stripped_jid,
                                extend='x')
             self.server.expect(JOB, {'job_state': 'F'}, id=running_jid,


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->

qdel the same jobid with and without server name in a one line causes server crash.

> qdel 123 123.svr.name 

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

We already had a similar bug #2552, so I was inspired by its solution. The function `dedup_jobids()` can not recognize <short_jobid> and <long_jobid> as the same job.  I suggest adding the default server name to short job ids.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

I run full pbs_qdel.py with just s small modification to test this case: [ptl_qdel.txt](https://github.com/user-attachments/files/16570152/ptl_qdel.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
