### PR TITLE
Allow to override the default scp flags

### DIFF
--- a/doc/man8/pbs.conf.8B
+++ b/doc/man8/pbs.conf.8B
@@ -170,6 +170,9 @@ Port on which default scheduler listens.  Default value: 15004
 Location of scp command if scp is used; setting this parameter causes
 PBS to first try scp rather than rcp for file transport.
 
+.IP PBS_SCP_ARGS
+Arguments for the scp command if scp is used; if not set, defaults will be used.
+
 .IP PBS_SECONDARY   
 Hostname of secondary server.  Used only for failover configuration.  
 Overrides PBS_SERVER_HOST_NAME.

--- a/src/include/pbs_internal.h
+++ b/src/include/pbs_internal.h
@@ -219,7 +219,8 @@ struct pbs_config
 	char *pbs_exec_path;			/* path to the pbs exec dir */
 	char *pbs_server_name;		/* name of PBS Server, usually hostname of host on which PBS server is executing */
 	char *cp_path;			/* path to local copy function */
-	char *scp_path;			/* path to ssh */
+	char *scp_path;			/* path to scp, overriding the default (OS-dependent) one */
+	char *scp_args;			/* arguments for scp, overriding the default (OS-dependent) ones */
 	char *rcp_path;			/* path to pbs_rsh */
 	char *pbs_demux_path;			/* path to pbs demux */
 	char *pbs_environment;		/* path to pbs_environment file */
@@ -295,7 +296,8 @@ extern struct pbs_config pbs_conf;
 #define PBS_CONF_INSTALL_MODE    "PBS_INSTALL_MODE" /* PBS installation mode */
 #define PBS_CONF_RCP		"PBS_RCP"
 #define PBS_CONF_CP		"PBS_CP"
-#define PBS_CONF_SCP		"PBS_SCP"		      /* path to ssh */
+#define PBS_CONF_SCP		"PBS_SCP"		      /* path to scp */
+#define PBS_CONF_SCP_ARGS	"PBS_SCP_ARGS"		      /* args for scp */
 #define PBS_CONF_ENVIRONMENT    "PBS_ENVIRONMENT" /* path to pbs_environment */
 #define PBS_CONF_PRIMARY	"PBS_PRIMARY"  /* Primary Server in failover */
 #define PBS_CONF_SECONDARY	"PBS_SECONDARY"	/* Secondary Server failover */

--- a/src/lib/Libifl/pbs_loadconf.c
+++ b/src/lib/Libifl/pbs_loadconf.c
@@ -101,6 +101,7 @@ struct pbs_config pbs_conf = {
 	NULL,			    /* pbs_server_name */
 	NULL,			    /* cp_path */
 	NULL,			    /* scp_path */
+	NULL,			    /* scp_args */
 	NULL,			    /* rcp_path */
 	NULL,			    /* pbs_demux_path */
 	NULL,			    /* pbs_environment */
@@ -474,6 +475,9 @@ __pbs_loadconf(int reload)
 			} else if (!strcmp(conf_name, PBS_CONF_SCP)) {
 				free(pbs_conf.scp_path);
 				pbs_conf.scp_path = shorten_and_cleanup_path(conf_value);
+			} else if (!strcmp(conf_name, PBS_CONF_SCP_ARGS)) {
+				free(pbs_conf.scp_args);
+				pbs_conf.scp_args = strdup(conf_value);
 			} else if (!strcmp(conf_name, PBS_CONF_CP)) {
 				free(pbs_conf.cp_path);
 				pbs_conf.cp_path = shorten_and_cleanup_path(conf_value);
@@ -652,6 +656,10 @@ __pbs_loadconf(int reload)
 	if ((gvalue = getenv(PBS_CONF_SCP)) != NULL) {
 		free(pbs_conf.scp_path);
 		pbs_conf.scp_path = shorten_and_cleanup_path(gvalue);
+	}
+	if ((gvalue = getenv(PBS_CONF_SCP_ARGS)) != NULL) {
+		free(pbs_conf.scp_args);
+		pbs_conf.scp_args = strdup(gvalue);
 	}
 	if ((gvalue = getenv(PBS_CONF_CP)) != NULL) {
 		free(pbs_conf.cp_path);
@@ -1023,6 +1031,10 @@ err:
 	if (pbs_conf.scp_path) {
 		free(pbs_conf.scp_path);
 		pbs_conf.scp_path = NULL;
+	}
+	if (pbs_conf.scp_args) {
+		free(pbs_conf.scp_args);
+		pbs_conf.scp_args = NULL;
 	}
 	if (pbs_conf.cp_path) {
 		free(pbs_conf.cp_path);

--- a/src/lib/Libpython/pbs_python_svr_internal.c
+++ b/src/lib/Libpython/pbs_python_svr_internal.c
@@ -12192,13 +12192,14 @@ const char pbsv1mod_meth_get_pbs_conf_doc[] =
 PyObject *
 pbsv1mod_meth_get_pbs_conf(void)
 {
-	return (Py_BuildValue("{s:s,s:s,s:s,s:s,s:s,s:s,s:s,s:s,s:s,s:s,s:s}",
+	return (Py_BuildValue("{s:s,s:s,s:s,s:s,s:s,s:s,s:s,s:s,s:s,s:s,s:s,s:s,s:s}",
 			      "PBS_HOME", pbs_conf.pbs_home_path ? pbs_conf.pbs_home_path : "",
 			      "PBS_EXEC", pbs_conf.pbs_exec_path ? pbs_conf.pbs_exec_path : "",
 			      "PBS_ENVIRONMENT", pbs_conf.pbs_environment ? pbs_conf.pbs_environment : "",
 			      "PBS_RCP", pbs_conf.rcp_path ? pbs_conf.rcp_path : "",
 			      "PBS_CP", pbs_conf.cp_path ? pbs_conf.cp_path : "",
 			      "PBS_SCP", pbs_conf.scp_path ? pbs_conf.scp_path : "",
+			      "PBS_SCP_ARGS", pbs_conf.scp_args ? pbs_conf.scp_args : "",
 			      "PBS_MOM_HOME", pbs_conf.pbs_mom_home ? pbs_conf.pbs_mom_home : "",
 			      "PBS_TMPDIR", pbs_conf.pbs_tmpdir ? pbs_conf.pbs_tmpdir : "",
 			      "PBS_SERVER", pbs_conf.pbs_server_name ? pbs_conf.pbs_server_name : "",

--- a/src/resmom/linux/mom_mach.c
+++ b/src/resmom/linux/mom_mach.c
@@ -224,7 +224,7 @@ proc_get_btime(void)
 			if (fscanf(fp, "%*[^\n]%*c") == EOF) 
 				log_errf(-1, __func__, "fscanf failed. ERR : %s", strerror(errno));				
 		} else {
-			if (fscanf(fp, "%u", &linux_time)) 
+			if (fscanf(fp, "%u", &linux_time) == EOF) 
 				log_errf(-1, __func__, "fscanf failed. ERR : %s", strerror(errno));				
 			fclose(fp);
 			return;

--- a/src/resmom/stage_func.c
+++ b/src/resmom/stage_func.c
@@ -1631,7 +1631,11 @@ sys_copy(int dir, int rmtflg, char *owner, char *src, struct rqfpair *pair, int 
 			/* remote, try scp */
 		} else if (pbs_conf.scp_path != NULL && (loop % 2) == 1) {
 			ag0 = pbs_conf.scp_path;
-			ag1 = "-Brvp";
+			if (pbs_conf.scp_args != NULL) {
+				ag1 = pbs_conf.scp_args;
+                        } else {
+				ag1 = "-Brvp";
+                        }
 		} else {
 			ag0 = pbs_conf.rcp_path;
 			ag1 = "-rp";
@@ -1752,7 +1756,11 @@ sys_copy(int dir, int rmtflg, char *owner, char *src, struct rqfpair *pair, int 
 				/* let's try to copy using pbs_rcp now */
 				continue;
 			}
-			ag1 = "-Brv";
+			if (pbs_conf.scp_args != NULL) {
+				ag1 = pbs_conf.scp_args;
+                        } else {
+				ag1 = "-Brv";
+                        }
 		} else {
 			ag0 = pbs_conf.rcp_path;
 			if ((cred_buf != NULL) && (cred_len != 0)) {


### PR DESCRIPTION
I had to change the scp flags (specifically, add "-4" to stick to IPv4 in dual-stack nodes) and, to my surprise, found the default flags are hardcoded. So, this patch adds the functionality. The possibility to disable the excessively verbose "scp -v" output - when not debugging - is also a boon, IMO :).