### PR TITLE
check for cr,lf in script on job submit

### DIFF
--- a/src/cmds/qsub_sup.c
+++ b/src/cmds/qsub_sup.c
@@ -209,15 +209,14 @@ get_conf_path(void)
 
 /**
  * @brief
- *      Check the line does not end with win/mac.
+ *      Check the line does not end with win cr,lf.
  *
  * @param[in]	s	- input line
  *
  * @return      int
  * @retval -1 - input error
- * @retval 0 - unix (not win/mac)
- * @retval 1 - mac (line ends with '\r')
- * @retval 2 - win (line ends with '\r\n')
+ * @retval 0 - unix
+ * @retval 1 - win (cr, lf)
  */
 int
 check_crlf(char * s)
@@ -230,9 +229,6 @@ check_crlf(char * s)
 		return 0;
 	}
 	if (len > 1 && s[len - 2] == '\r' && s[len - 1] == '\n') {
-		return 2;
-	}
-	if (s[len - 1] == '\r') {
 		return 1;
 	}
 	return 0;
@@ -322,7 +318,7 @@ get_script(FILE *file, char *script, char *prefix)
 		}
 #ifndef WIN32
 		if (check_crlf(in)) {
-			fprintf(stderr, "qsub: incorrect script format\n");
+			fprintf(stderr, "qsub: script contains cr, lf\n");
 			fclose(TMP_FILE);
 			free(extend_in);
 			free(s_in);

--- a/src/cmds/qsub_sup.c
+++ b/src/cmds/qsub_sup.c
@@ -209,6 +209,37 @@ get_conf_path(void)
 
 /**
  * @brief
+ *      Check the line does not end with win/mac.
+ *
+ * @param[in]	s	- input line
+ *
+ * @return      int
+ * @retval -1 - input error
+ * @retval 0 - unix (not win/mac)
+ * @retval 1 - mac (line ends with '\r')
+ * @retval 2 - win (line ends with '\r\n')
+ */
+int
+check_crlf(char * s)
+{
+	if (s == NULL) {
+		return -1;
+	}
+	int len = strlen(s);
+	if (len == 0) {
+		return 0;
+	}
+	if (len > 1 && s[len - 2] == '\r' && s[len - 1] == '\n') {
+		return 2;
+	}
+	if (s[len - 1] == '\r') {
+		return 1;
+	}
+	return 0;
+}
+
+/**
+ * @brief
  *      Create a temporary file that will house the job script
  *
  * @param[in]	file	- Input file pointer
@@ -289,6 +320,15 @@ get_script(FILE *file, char *script, char *prefix)
 		} else if (!exec && pbs_isexecutable(s_in)) {
 			exec = TRUE;
 		}
+#ifndef WIN32
+		if (check_crlf(in)) {
+			fprintf(stderr, "qsub: incorrect script format\n");
+			fclose(TMP_FILE);
+			free(extend_in);
+			free(s_in);
+			return (5);
+		}
+#endif
 		if (fputs(in, TMP_FILE) < 0) {
 			perror("fputs");
 			fprintf(stderr, "qsub: error writing copy of script, %s\n",

--- a/test/tests/functional/pbs_qsub_script.py
+++ b/test/tests/functional/pbs_qsub_script.py
@@ -115,3 +115,16 @@ cat $0
         rc = self.du.cmp(fileA=expected_fn,
                          fileB=job_output_file, runas=TEST_USER)
         self.assertEqual(rc, 0, 'cmp of job files failed')
+
+    def test_qsub_crlf(self):
+        """
+        This test case check the qsub rejects script ending with cr,lf.
+        """
+        script = """#!/bin/sh\r\nhostname\r\n"""
+        j = Job(TEST_USER)
+        j.create_script(script)
+        fail_msg = 'qsub didn\'t throw an error'
+        with self.assertRaises(PbsSubmitError, msg=fail_msg) as c:
+            self.server.submit(j)
+        msg = 'qsub: incorrect script format'
+        self.assertEqual(c.exception.msg[0], msg)

--- a/test/tests/functional/pbs_qsub_script.py
+++ b/test/tests/functional/pbs_qsub_script.py
@@ -126,5 +126,5 @@ cat $0
         fail_msg = 'qsub didn\'t throw an error'
         with self.assertRaises(PbsSubmitError, msg=fail_msg) as c:
             self.server.submit(j)
-        msg = 'qsub: incorrect script format'
+        msg = 'qsub: script contains cr, lf'
         self.assertEqual(c.exception.msg[0], msg)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->

Our users often come from Windows and their incorrect script format is noticed on the mom as not runnable script:
```
cannot execute: required file not found
``` 

I would like to add the detection of `crlf` chars to the job submission so the user will have immediate feedback on the script format and not waste time in the queue.


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Check if any line of a script ends with '\r\n' or ''r' on job submission and return an error.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Ptl log of all tests in pbs_qsub_script.py:
[ptl_qsub.txt](https://github.com/user-attachments/files/17145365/ptl_qsub.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
