### PR TITLE
fix long attribute converting for storing to DB

### DIFF
--- a/test/tests/functional/pbs_passing_environment_variable.py
+++ b/test/tests/functional/pbs_passing_environment_variable.py
@@ -209,3 +209,24 @@ foo\n
         exp_string = 'ENV_TEST=N:\\\\\\\\aa\\\\\\\\bb\\\\\\\\cc\\\\\\\\dd'
         exp_string += '\\\\\\\\ee\\\\\\\\ff\\\\\\\\gg\\\\\\\\hh\\\\\\\\ii'
         self.assertIn(exp_string, var_list)
+
+    def test_long_env(self):
+        """
+        Test to verify that job is able to process
+        very long env attribute.
+        """
+
+        env = "VAR0=foobar"
+        for i in range(1, 300):
+            env = f"{env},VAR{i}=foobar"
+
+        a = {ATTR_v: env}
+        j = Job(TEST_USER, attrs=a)
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        qstat = self.server.status(JOB, ATTR_v, id=jid)
+        var_list = qstat[0]['Variable_List'].split(",")
+
+        for i in range(0, 300):
+            exp_string = f"VAR{i}=foobar"
+            self.assertIn(exp_string, var_list)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->

Storing or updating long attribute into DB results in `Panic shutdown of Server on database error` like:

```
10/31/2024 10:00:31.583830;0100;Server@almalinux;Job;3000.almalinux;enqueuing into workq, state Q hop 1
10/31/2024 10:00:31.605175;0001;Server@almalinux;Svr;Server@almalinux;PBS server internal error (15011) in job_save_db, Failed to save job 3000.almalinux Execution of Prepared statement insert_job failed: ERROR:  insufficient data left in message 08P01
10/31/2024 10:00:31.605241;0001;Server@almalinux;Svr;Server@almalinux;panic_stop_db, Panic shutdown of Server on database error.  Please check PBS_HOME file system for no space condition.
10/31/2024 10:00:33.218329;0002;Server@almalinux;Svr;Server@almalinux;Stopping PBS dataservice
10/31/2024 10:00:38.818688;0002;Server@almalinux;Svr;Log;Log closed
```

This bug was introduced in #2662.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

The problem is in converting long attributes to hstore in `attrlist_to_dbarray_ex()`. If the attribute is long enough for the need to reallocate the `array`, the `val` is not moved correctly. The `val` should not be moved by the constant of the size of the struct but by the real length to the start of the value. This is done by the variable `len_to_val` now.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

PTL log: 
[attribute_too_long.log](https://github.com/user-attachments/files/17585809/attribute_too_long.log)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
