### PR TITLE
Fix typo where function is passed instead of return value of function

### DIFF
--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -5374,7 +5374,7 @@ class CgroupUtils(object):
                 self.assigned_resources = self._get_assigned_cgroup_resources()
         if not assigned:
             pbs.logmsg(pbs.EVENT_DEBUG2, '%s: Assignment of resources failed '
-                       'for %s, attempting cleanup' % (caller_name, jobid))
+                       'for %s, attempting cleanup' % (caller_name(), jobid))
             # Cleanup cgroups for jobs not present on this node
             jobdict = node.gather_jobs_on_node(cgroup)
             if jobdict and jobid in jobdict:


### PR DESCRIPTION
Causes an error message to print a memory address instead of the actual caller_name.

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
This log message will print the memory address of the caller_name function instead of the actual caller_name.


#### Describe Your Change
Added parentheses to the function so its called, as it is in other parts of the code.