### PR TITLE
qstat: fix conflict handling for -F JSON with alternate option flags

### DIFF
--- a/src/cmds/qstat.c
+++ b/src/cmds/qstat.c
@@ -2685,7 +2685,7 @@ main(int argc, char **argv, char **envp) /* qstat */
 		fprintf(stderr, "%s", conflict);
 		errflg++;
 	}
-	if (!(output_format == FORMAT_DEFAULT || f_opt)) {
+	if (output_format != FORMAT_DEFAULT && alt_opt) {
 		fprintf(stderr, "%s", conflict);
 		errflg++;
 	}

--- a/test/tests/functional/pbs_qstat_formats.py
+++ b/test/tests/functional/pbs_qstat_formats.py
@@ -751,3 +751,60 @@ class TestQstatFormats(TestFunctional):
         except ValueError:
             self.logger.info(qstat_out)
             self.assertFalse(True, "Json failed to load")
+
+
+    def test_qstat_format_conflicts(self):
+        """
+        Test conflicting combinations of alt_opt flags with -F
+        """
+        binpath = os.path.join(self.server.pbs_conf['PBS_EXEC'], 'bin', 'qstat')
+        conflicting_opts = [
+            '-a -F JSON',
+            '-i -F JSON',
+            '-r -F JSON',
+            '-n -F JSON',
+            '-s -F JSON',
+            '-H -F JSON',
+            '-T -F JSON',
+            '-G -F JSON',
+            '-M -F JSON',
+            '-1 -F JSON',
+            '-w -F JSON',
+        ]
+
+        for flags in conflicting_opts:
+            qstat_cmd = binpath + ' ' + flags
+            ret = self.du.run_cmd(self.server.hostname, cmd=qstat_cmd)
+
+            self.assertNotEqual(ret['rc'], 0, f"Expected failure for: {flags}")
+            self.assertIn("conflicting options", ''.join(ret['err']).lower(),
+                          f"Missing conflict error for: {flags}")
+            self.assertEqual(len(ret['out']), 0, f"Unexpected stdout for: {flags}")
+
+
+    def test_qstat_format_valid_combos(self):
+        """
+        Test valid combinations of alt_opt flags with - JSON
+        i.e. should not throw errors
+        """
+        binpath = os.path.join(self.server.pbs_conf['PBS_EXEC'], 'bin', 'qstat')
+
+        j = Job(TEST_USER)
+        jid = self.server.submit(j)
+        ret = self.du.run_cmd(self.server.hostname, cmd="qstat -f " + jid)
+        self.assertIn("job_state", ''.join(ret['out']))
+
+        valid_opts = [
+            '-f -F JSON',
+            f'-f -F JSON {jid}',
+            '-Bf -F JSON',
+            '-Qf -F JSON'
+        ]
+
+        for flags in valid_opts:
+            qstat_cmd = binpath + ' ' + flags
+            ret = self.du.run_cmd(self.server.hostname, cmd=qstat_cmd)
+
+            self.assertEqual(ret['rc'], 0, f"Expected success for: {flags}")
+            self.assertEqual(len(ret['err']), 0, f"Unexpected stderr for: {flags}")
+            self.assertGreater(len(ret['out']), 0, f"No output for: {flags}")


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

### Describe Bug
Plaintext output being written alongside JSON output when using -F JSON with certain flags such as -u <user>, -a, -n, etc. Additionally, conflicting option errors for inconsistently raised.

For example, running `qstat -u $USER -fF JSON` produces mixed output like:
```
VMa: 
                                                            Req'd  Req'd   Elap
Job ID          Username Queue    Jobname    SessID NDS TSK Memory Time  S Time
--------------- -------- -------- ---------- ------ --- --- ------ ----- - -----
2000.VMa        amehm5   workq    STDIN        6410   1   1    --    --  R 25:26
{
	"timestamp":	1749572608,
	"pbs_version":	"23.06.06",
	"pbs_server":	"VMa"
}

```
This bug not only outputs unintended plaintext with JSON, but also causes the JSON to omit expected job data.

According to documentation, options like `-u <user>`, `-a`, and `-n` are formatting flags. Using these with `-F JSON` should produce a conflict error (`qstat: conflicting options.`) instead of mixed output. 

The root cause is that the `-f` flag was used incorrectly in the conflict check logic. 

### Describe Your Change
Original Code:
```
if (!(output_format == FORMAT_DEFAULT || f_opt)) {
  fprintf(stderr, "%s", conflict);
  errflg++;
}
```
Updated Code:
```
if (output_format != FORMAT_DEFAULT && alt_opt){
    fprintf(stderr, "%s", conflict);
    errflg++;
}
```

This fix replaces the check for `(NOT default format) OR (NOT -f)` with a correct check for `(NOT default format) AND (alternate option flag)`. 

This ensures that conflicting options are consistently rejected when `-F JSON` is specified, regardless of whether `-f` is included. 

### Link to Design Doc

### Attach Test and Valgrind Logs/Output
[conflicts.txt](https://github.com/user-attachments/files/20782409/conflicts.txt)
[no_conflicts.txt](https://github.com/user-attachments/files/20782410/no_conflicts.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
