### PR TITLE
qstat: fix mixed output and missing conflict for -F JSON with alt flags

### DIFF
--- a/src/cmds/qstat.c
+++ b/src/cmds/qstat.c
@@ -2685,7 +2685,7 @@ main(int argc, char **argv, char **envp) /* qstat */
 		fprintf(stderr, "%s", conflict);
 		errflg++;
 	}
-	if (!(output_format == FORMAT_DEFAULT || f_opt)) {
+	if (output_format != FORMAT_DEFAULT && alt_opt) {
 		fprintf(stderr, "%s", conflict);
 		errflg++;
 	}

--- a/src/cmds/qstat.c
+++ b/src/cmds/qstat.c
@@ -2685,7 +2685,7 @@ main(int argc, char **argv, char **envp) /* qstat */
 		fprintf(stderr, "%s", conflict);
 		errflg++;
 	}
-	if (output_format != FORMAT_DEFAULT && alt_opt) {
+	if (!(output_format == FORMAT_DEFAULT || f_opt) || (output_format != FORMAT_DEFAULT && alt_opt)){
 		fprintf(stderr, "%s", conflict);
 		errflg++;
 	}


### PR DESCRIPTION
### Describe Bug
Plaintext output being written alongside JSON output when using -F JSON with certain flags such as -u <user>, -a, -n, etc. Additionally, conflicting option errors for inconsistently raised.

For example, running `qstat -u $USER -fF JSON` produces mixed output like:
```
VMa: 
                                                            Req'd  Req'd   Elap
Job ID          Username Queue    Jobname    SessID NDS TSK Memory Time  S Time
--------------- -------- -------- ---------- ------ --- --- ------ ----- - -----
2000.VMa        amehm5   workq    STDIN        6410   1   1    --    --  R 25:26
{
	"timestamp":	1749572608,
	"pbs_version":	"23.06.06",
	"pbs_server":	"VMa"
}

```
This bug not only outputs unintended plaintext with JSON, but also causes the JSON to omit expected job data.

According to documentation, options like `-u <user>`, `-a`, and `-n` are formatting flags. Using these with `-F JSON` should produce a conflict error (`qstat: conflicting options.`) instead of mixed output. 

The root cause is that the `-f` flag was used incorrectly in the conflict check logic. 

### Describe Your Change
Original Code:
```
if (!(output_format == FORMAT_DEFAULT || f_opt)) {
  fprintf(stderr, "%s", conflict);
  errflg++;
}
```
Updated Code:
```
if (!(output_format == FORMAT_DEFAULT || f_opt) || (output_format != FORMAT_DEFAULT && alt_opt)){
    fprintf(stderr, "%s", conflict);
    errflg++;
}
```

This fix replaces the check for `(NOT default format) OR (NOT -f)` with a correct check for `(NOT default format) AND (alternate option flag)`. 

This ensures that conflicting options are consistently rejected when `-F JSON` is specified, regardless of whether `-f` is included. 

### Link to Design Doc

### Attach Test and Valgrind Logs/Output
[conflicts.txt](https://github.com/user-attachments/files/20782409/conflicts.txt)
[no_conflicts.txt](https://github.com/user-attachments/files/20782410/no_conflicts.txt)
