### PR TITLE
Addressing Security Vulnerabilities

### DIFF
--- a/doc/man8/pbs.conf.8B
+++ b/doc/man8/pbs.conf.8B
@@ -56,8 +56,12 @@ you may set
 .SH CONFIGURATION PARAMETERS
 
 .IP PBS_AUTH_METHOD 
-Authentication method to be used by PBS.  Only allowed value is
-"munge" (case-insensitive).  
+Authentication method to be used by PBS. Allowed values are
+"munge", "pwd", and "resvport" (case-insensitive). Defaults to "resvport".
+
+.IP PBS_AUTH_SERVICE_USERS
+List of daemon users allowed to connect to the communication daemon.
+Defaults to "root". 
 
 .IP PBS_BATCH_SERVICE_PORT  
 Port on which server listens.  Default: 15001
@@ -156,6 +160,10 @@ name.  Cannot contain a colon (":").
 .IP PBS_PRIMARY     
 Hostname of primary server.  Used only for failover configuration.  
 Overrides PBS_SERVER_HOST_NAME.
+
+.IP PBS_INTERACTIVE_AUTH_METHOD
+Authentication method to be used when establishing a qsub interactive session.
+Supported methods are "resvport", "munge" and "pwd" (case-insensitive). Defaults to "resvport".
 
 .IP PBS_CP 
 Location of local copy command. Default is cp on Linux systems and xcopy on Windows.

--- a/doc/man8/pbs.conf.8B
+++ b/doc/man8/pbs.conf.8B
@@ -57,7 +57,7 @@ you may set
 
 .IP PBS_AUTH_METHOD 
 Authentication method to be used by PBS. Allowed values are
-"munge", "pwd", and "resvport" (case-insensitive). Defaults to "resvport".
+"munge" and "resvport" (case-insensitive). Defaults to "resvport".
 
 .IP PBS_AUTH_SERVICE_USERS
 List of daemon users allowed to connect to the communication daemon.
@@ -163,7 +163,7 @@ Overrides PBS_SERVER_HOST_NAME.
 
 .IP PBS_INTERACTIVE_AUTH_METHOD
 Authentication method to be used when establishing a qsub interactive session.
-Supported methods are "resvport", "munge" and "pwd" (case-insensitive). Defaults to "resvport".
+Supported methods are "resvport" and "munge" (case-insensitive). Defaults to "resvport".
 
 .IP PBS_CP 
 Location of local copy command. Default is cp on Linux systems and xcopy on Windows.

--- a/src/cmds/qsub.c
+++ b/src/cmds/qsub.c
@@ -2833,7 +2833,8 @@ do_connect(char *server_out, char *retmsg)
 		sd_svr = cnt2server(server_out);
 
 	if (sd_svr <= 0) {
-		sprintf(retmsg, "qsub: cannot connect to server %s (errno=%d)\n", pbs_server, pbs_errno);
+		sprintf(retmsg, "qsub: cannot connect to server %s (errno=%d)\n",
+			pbs_default() == NULL ? "" : pbs_default(), pbs_errno);
 		return (pbs_errno);
 	}
 

--- a/src/cmds/qsub.c
+++ b/src/cmds/qsub.c
@@ -1980,6 +1980,11 @@ job_env_basic(void)
 		len += strlen(env);
 		free(env);
 	}
+	env = strdup_esc_commas(pbs_conf.interactive_auth_method);
+	if (env != NULL) {
+		len += strlen(env);
+		free(env);
+	}
 	len += PBS_MAXHOSTNAME;
 	len += MAXPATHLEN;
 	len *= 2; /* Double it for all the commas, etc. */
@@ -2039,7 +2044,15 @@ job_env_basic(void)
 		strcat(job_env, c);
 		free(c);
 	}
-
+	c = strdup_esc_commas(pbs_conf.interactive_auth_method);
+	if (c != NULL) {
+		if (*job_env)
+			strcat(job_env, ",PBS_O_INTERACTIVE_AUTH_METHOD=");
+		else
+			strcat(job_env, "PBS_O_INTERACTIVE_AUTH_METHOD=");
+		strcat(job_env, c);
+		free(c);
+	}
 	/*
 	 * Don't detect the hostname here because it utilizes network services
 	 * that slow everthing down. PBS_O_HOST is set in the daemon later on.
@@ -3287,6 +3300,10 @@ main(int argc, char **argv, char **envp) /* qsub */
 	if (command_flag == 0)
 		/* Read the job script from a file or stdin */
 		read_job_script(script);
+
+	/* Needs to be done before job_env_basic(), so that it gets the correct interactive auth method */
+	if (Interact_opt)
+		pbs_conf_load_interactive_auth_method();
 
 	/* Enable X11 Forwarding or GUI if specified */
 	enable_gui();

--- a/src/cmds/qsub.c
+++ b/src/cmds/qsub.c
@@ -3303,7 +3303,7 @@ main(int argc, char **argv, char **envp) /* qsub */
 
 	/* Needs to be done before job_env_basic(), so that it gets the correct interactive auth method */
 	if (Interact_opt)
-		pbs_conf_load_interactive_auth_method();
+		pbs_loadconf(0);
 
 	/* Enable X11 Forwarding or GUI if specified */
 	enable_gui();

--- a/src/include/auth.h
+++ b/src/include/auth.h
@@ -46,6 +46,8 @@ extern "C" {
 #include "libauth.h"
 
 #define AUTH_RESVPORT_NAME "resvport"
+#define AUTH_MUNGE_NAME "munge"
+#define AUTH_PWD_NAME "pwd"
 #define AUTH_GSS_NAME "gss"
 #ifndef MAXPATHLEN
 #define MAXPATHLEN 1024
@@ -125,7 +127,19 @@ pbs_auth_config_t *make_auth_config(char *, char *, char *, char *, void *);
 void free_auth_config(pbs_auth_config_t *);
 
 extern int engage_client_auth(int, const char *, int, char *, size_t);
-extern int engage_server_auth(int, char *, int, char *, size_t);
+extern int engage_server_auth(int, char *, int, int, char *, size_t);
+int handle_client_handshake(int fd, const char *hostname, char *method, int for_encrypt, pbs_auth_config_t *config, char *ebuf, size_t ebufsz);
+
+/* For qsub interactive - execution host authentication */
+enum INTERACTIVE_AUTH_STATUS {
+	INTERACTIVE_AUTH_SUCCESS = 0,
+	INTERACTIVE_AUTH_FAILED,
+	INTERACTIVE_AUTH_RETRY
+};
+int auth_exec_socket(int sock, unsigned short port, char *auth_method, char *jobid);
+int auth_with_qsub(int sock, unsigned short port, char* hostname, char *auth_method, char *jobid);
+int client_cipher_auth(int fd, char *text, char *ebuf, size_t ebufsz);
+int server_cipher_auth(int fd, char *text, char *ebuf, size_t ebufsz);
 
 #ifdef __cplusplus
 }

--- a/src/include/auth.h
+++ b/src/include/auth.h
@@ -47,7 +47,6 @@ extern "C" {
 
 #define AUTH_RESVPORT_NAME "resvport"
 #define AUTH_MUNGE_NAME "munge"
-#define AUTH_PWD_NAME "pwd"
 #define AUTH_GSS_NAME "gss"
 #ifndef MAXPATHLEN
 #define MAXPATHLEN 1024

--- a/src/include/libauth.h
+++ b/src/include/libauth.h
@@ -56,6 +56,8 @@ enum AUTH_ROLE {
 	AUTH_CLIENT,
 	/* Server role, aka who is authenticating incoming user/connection */
 	AUTH_SERVER,
+	/* qsub side, when authenticating an interactive connection (i.e. qsub -I) from an execution host */
+	AUTH_INTERACTIVE,
 	/* last role, mostly used while error checking for role value */
 	AUTH_ROLE_LAST
 };

--- a/src/include/libutil.h
+++ b/src/include/libutil.h
@@ -350,6 +350,10 @@ extern char *get_hostname_from_addr(struct in_addr addr);
 extern char *parse_servername(char *, unsigned int *);
 extern int rand_num(void);
 
+extern char *gen_hostkey(char *cluster_key, char *salt, size_t *len);
+extern int validate_hostkey(char *host_key, size_t host_keylen, char **cluster_key);
+void set_rand_str(char *str, int len);
+
 /* thread utils */
 extern int init_mutex_attr_recursive(void *attr);
 

--- a/src/include/libutil.h
+++ b/src/include/libutil.h
@@ -369,6 +369,8 @@ int get_index_from_jid(char *jid);
 char *get_range_from_jid(char *jid);
 char *create_subjob_id(char *parent_jid, int sjidx);
 
+#define GET_IP_PORT(x) ((struct sockaddr_in *) (x))->sin_port
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/include/libutil.h
+++ b/src/include/libutil.h
@@ -374,6 +374,7 @@ char *get_range_from_jid(char *jid);
 char *create_subjob_id(char *parent_jid, int sjidx);
 
 #define GET_IP_PORT(x) ((struct sockaddr_in *) (x))->sin_port
+#define IS_VALID_IP(x) (((struct sockaddr_in *)(x))->sin_family == AF_INET)
 
 #ifdef __cplusplus
 }

--- a/src/include/mom_func.h
+++ b/src/include/mom_func.h
@@ -379,6 +379,7 @@ extern void scan_for_terminated(void);
 extern int setwinsize(int);
 extern void set_termcc(int);
 extern int conn_qsub(char *host, long port);
+extern int conn_qsub_resvport(char *host, long port);
 extern int state_to_server(int, int);
 extern int send_hook_vnl(void *vnl);
 extern int hook_requests_to_server(pbs_list_head *);

--- a/src/include/net_connect.h
+++ b/src/include/net_connect.h
@@ -67,6 +67,7 @@ typedef unsigned long pbs_net_t; /* for holding host addresses */
 #define PBS_NET_CONN_NOTIMEOUT 0x04
 #define PBS_NET_CONN_FROM_QSUB_DAEMON 0x08
 #define PBS_NET_CONN_FORCE_QSUB_UPDATE 0x10
+#define PBS_NET_CONN_PREVENT_IP_SPOOFING 0x20
 
 #define QSUB_DAEMON "qsub-daemon"
 

--- a/src/include/pbs_internal.h
+++ b/src/include/pbs_internal.h
@@ -489,8 +489,6 @@ extern int pbs_query_max_connections(void);
 
 extern char *pbs_get_tmpdir(void);
 
-extern void pbs_conf_load_interactive_auth_method(void);
-
 extern FILE *pbs_popen(const char *, const char *);
 
 extern int pbs_pkill(FILE *, int);

--- a/src/include/pbs_internal.h
+++ b/src/include/pbs_internal.h
@@ -204,8 +204,10 @@ struct pbs_config
 	unsigned start_comm:1; 		/* should the comm daemon be started */
 	unsigned locallog:1;			/* do local logging */
 	char **supported_auth_methods;		/* supported auth methods on server */
+	char **auth_service_users;		/* recognised service users */
 	char encrypt_method[MAXAUTHNAME + 1];	/* auth method to used for encrypt/decrypt data */
 	char auth_method[MAXAUTHNAME + 1];	/* default auth_method to used by client */
+	char interactive_auth_method[MAXAUTHNAME + 1];	/* auth_method used in interactive qsub sessions */
 	unsigned int sched_modify_event:1;	/* whether to trigger modifyjob hook event or not */
 	unsigned syslogfac;		        /* syslog facility */
 	unsigned syslogsvr;			/* min priority to log to syslog */
@@ -309,9 +311,11 @@ extern struct pbs_config pbs_conf;
 #define PBS_CONF_OUTPUT_HOST_NAME "PBS_OUTPUT_HOST_NAME"
 #define PBS_CONF_SMTP_SERVER_NAME "PBS_SMTP_SERVER_NAME" /* Name of SMTP Host to send mail to */
 #define PBS_CONF_TMPDIR		"PBS_TMPDIR"     /* temporary file directory */
+#define PBS_CONF_INTERACTIVE_AUTH_METHOD	"PBS_INTERACTIVE_AUTH_METHOD"	/* Authentication method used in qsub interactive */
 #define PBS_CONF_AUTH		"PBS_AUTH_METHOD"
 #define PBS_CONF_ENCRYPT_METHOD	"PBS_ENCRYPT_METHOD"
 #define PBS_CONF_SUPPORTED_AUTH_METHODS	"PBS_SUPPORTED_AUTH_METHODS"
+#define PBS_CONF_AUTH_SERVICE_USERS	"PBS_AUTH_SERVICE_USERS"
 #define PBS_CONF_SCHEDULER_MODIFY_EVENT	"PBS_SCHEDULER_MODIFY_EVENT"
 #define PBS_CONF_MOM_NODE_NAME	"PBS_MOM_NODE_NAME"
 #define PBS_CONF_LOG_HIGHRES_TIMESTAMP	"PBS_LOG_HIGHRES_TIMESTAMP"
@@ -484,6 +488,8 @@ extern char *pbs_submit_with_cred(int, struct attropl *, char *,
 extern int pbs_query_max_connections(void);
 
 extern char *pbs_get_tmpdir(void);
+
+extern void pbs_conf_load_interactive_auth_method(void);
 
 extern FILE *pbs_popen(const char *, const char *);
 

--- a/src/include/port_forwarding.h
+++ b/src/include/port_forwarding.h
@@ -70,6 +70,9 @@ extern "C" {
 #define NI_MAXSERV 32
 #endif /* !NI_MAXSERV */
 
+#define QSUB_SIDE 1
+#define EXEC_HOST_SIDE 0
+
 /*
  * Structure which maintains the relationship between the producer/consumer
  * sockets and also about the length of the data read/written.
@@ -85,7 +88,9 @@ struct pfwdsock {
 	char buff[PF_BUF_SIZE];
 };
 /*Functions available in port_forwarding.h*/
-void port_forwarder(struct pfwdsock *, int (*connfunc)(char *phost, long pport), char *, int, int inter_read_sock, int (*readfunc)(int), void (*logfunc)(char *));
+void port_forwarder(struct pfwdsock *, int (*connfunc)(char *phost, long pport),
+		    char *, int, int inter_read_sock, int (*readfunc)(int), void (*logfunc)(char *),
+		    int is_qsub_side, char *auth_method, char *jobid);
 int connect_local_xsocket(u_int);
 int x11_connect_display(char *, long);
 int set_nonblocking(int);

--- a/src/lib/Libifl/auth.c
+++ b/src/lib/Libifl/auth.c
@@ -51,10 +51,13 @@
 #include "auth.h"
 #include "log.h"
 
+extern unsigned char pbs_aes_key[][16];
+extern unsigned char pbs_aes_iv[][16];
+#define SALT_SIZE 16
+
 static auth_def_t *loaded_auths = NULL;
 
 static int _invoke_pbs_iff(int psock, const char *server_name, int server_port, char *ebuf, size_t ebufsz);
-static int _handle_client_handshake(int fd, const char *hostname, char *method, int for_encrypt, pbs_auth_config_t *config, char *ebuf, size_t ebufsz);
 static char *_get_load_lib_error(int reset);
 static void *_load_lib(char *loc);
 static void *_load_symbol(char *libloc, void *libhandle, char *name, int required);
@@ -533,8 +536,8 @@ _invoke_pbs_iff(int psock, const char *server_name, int server_port, char *ebuf,
 	return rc;
 }
 
-static int
-_handle_client_handshake(int fd, const char *hostname, char *method, int for_encrypt, pbs_auth_config_t *config, char *ebuf, size_t ebufsz)
+int
+handle_client_handshake(int fd, const char *hostname, char *method, int for_encrypt, pbs_auth_config_t *config, char *ebuf, size_t ebufsz)
 {
 	void *data_in = NULL;
 	size_t len_in = 0;
@@ -764,14 +767,14 @@ engage_client_auth(int fd, const char *hostname, int port, char *ebuf, size_t eb
 	}
 
 	if (pbs_conf.encrypt_method[0] != '\0') {
-		rc = _handle_client_handshake(fd, hostname, pbs_conf.encrypt_method, FOR_ENCRYPT, config, ebuf, ebufsz);
+		rc = handle_client_handshake(fd, hostname, pbs_conf.encrypt_method, FOR_ENCRYPT, config, ebuf, ebufsz);
 		if (rc != 0)
 			return rc;
 	}
 
 	if (strcmp(pbs_conf.auth_method, AUTH_RESVPORT_NAME) != 0) {
 		if (strcmp(pbs_conf.auth_method, pbs_conf.encrypt_method) != 0) {
-			return _handle_client_handshake(fd, hostname, pbs_conf.auth_method, FOR_AUTH, config, ebuf, ebufsz);
+			return handle_client_handshake(fd, hostname, pbs_conf.auth_method, FOR_AUTH, config, ebuf, ebufsz);
 		} else {
 			transport_chan_set_ctx_status(fd, transport_chan_get_ctx_status(fd, FOR_ENCRYPT), FOR_AUTH);
 			transport_chan_set_authdef(fd, transport_chan_get_authdef(fd, FOR_ENCRYPT), FOR_AUTH);
@@ -788,6 +791,7 @@ engage_client_auth(int fd, const char *hostname, int port, char *ebuf, size_t eb
  * @param[in] fd - socket descriptor
  * @param[in] clienthost - hostname associate with fd
  * @param[in] for_encrypt - whether to handle incoming data for encrypt/decrypt auth or for authentication
+ * @param[in] auth_role - role used when initializing the auth context
  * @param[out] ebuf - error buffer
  * @param[in] ebufsz - size of error buffer
  *
@@ -797,7 +801,7 @@ engage_client_auth(int fd, const char *hostname, int port, char *ebuf, size_t eb
  *
  */
 int
-engage_server_auth(int fd, char *clienthost, int for_encrypt, char *ebuf, size_t ebufsz)
+engage_server_auth(int fd, char *clienthost, int for_encrypt, int auth_role, char *ebuf, size_t ebufsz)
 {
 	void *authctx;
 	auth_def_t *authdef;
@@ -827,7 +831,7 @@ engage_server_auth(int fd, char *clienthost, int for_encrypt, char *ebuf, size_t
 	}
 
 	if ((authctx = transport_chan_get_authctx(fd, for_encrypt)) == NULL) {
-		if (authdef->create_ctx(&authctx, AUTH_SERVER, AUTH_USER_CONN, clienthost)) {
+		if (authdef->create_ctx(&authctx, auth_role, AUTH_USER_CONN, clienthost)) {
 			snprintf(ebuf, ebufsz, "Failed to create auth context");
 			pbs_errno = PBSE_SYSTEM;
 			return -1;
@@ -891,4 +895,273 @@ engage_server_auth(int fd, char *clienthost, int for_encrypt, char *ebuf, size_t
 		}
 	}
 	return 0;
+}
+
+/**
+ * @brief
+ *	server_cipher_auth - Validate received cipher authentication data
+ *
+ * @param[in] fd - The exec host side socket
+ * @param[in] text - The text that will be compared against the one in the encrypted message.
+ * @param[in] ebuf - buffer to hold error msg if any
+ * @param[in] ebufsz - size of ebuf
+ *
+ * @return	int
+ * @retval	INTERACTIVE_AUTH_SUCCESS(0)	success
+ * @retval	INTERACTIVE_AUTH_FAILED(1)	failure
+ *
+ */
+int
+server_cipher_auth(int fd, char *text, char *ebuf, size_t ebufsz)
+{
+	size_t len_in = 0;
+	char *data_in = NULL;
+	int type;
+
+	DIS_tcp_funcs();
+
+	if (transport_recv_pkt(fd, &type, (void **) &data_in, &len_in) <= 0) {
+		snprintf(ebuf, ebufsz, "failed to receive auth token");
+		pbs_errno = PBSE_SYSTEM;
+		return INTERACTIVE_AUTH_FAILED;
+	}
+
+	if (type != AUTH_CTX_DATA || len_in <= 0) {
+		snprintf(ebuf, ebufsz, "received incorrect auth token");
+		pbs_errno = PBSE_SYSTEM;
+		return INTERACTIVE_AUTH_FAILED;
+	}
+
+	data_in[len_in - 1] = '\0';
+
+	if (validate_hostkey(data_in, len_in - 1, &text) != 0) {
+		snprintf(ebuf, ebufsz, "Failed to decrypt auth data");
+		pbs_errno = PBSE_BADCRED;
+		return INTERACTIVE_AUTH_FAILED;
+	}
+
+	if (transport_send_pkt(fd, AUTH_CTX_OK, "", 1) <= 0) {
+		snprintf(ebuf, ebufsz, "Failed to send auth context ok token");
+		pbs_errno = PBSE_SYSTEM;
+		return INTERACTIVE_AUTH_FAILED;
+	}
+
+	return INTERACTIVE_AUTH_SUCCESS;
+}
+
+/**
+ * @brief
+ *	client_cipher_auth - Generate random string, encode it and send it over to qsub
+ *
+ * @param[in] fd - The qsub side socket
+ * @param[in] text - The text that will be included in the encrypted message.
+ * @param[in] ebuf - buffer to hold error msg if any
+ * @param[in] ebufsz - size of ebuf
+ *
+ * @return	int
+ * @retval	INTERACTIVE_AUTH_SUCCESS(0)	success
+ * @retval	INTERACTIVE_AUTH_FAILED(1)	failure
+ *
+ */
+int
+client_cipher_auth(int fd, char *text, char *ebuf, size_t ebufsz)
+{
+	void *data_in = NULL;
+	size_t len = 0;
+	int type = 0;
+	char salt[SALT_SIZE];
+	char *msg;
+
+	DIS_tcp_funcs();
+
+	/* Generate random salt and append current time and text to it.
+	 * In the end the string will look like this: salt;timestr;text
+	 */
+	set_rand_str(salt, SALT_SIZE);
+	msg = gen_hostkey(text, salt, &len);
+	if (!msg) {
+		snprintf(ebuf, ebufsz, "Failed to encode auth data");
+		free(msg);
+		return INTERACTIVE_AUTH_FAILED;
+	}
+
+	if (transport_send_pkt(fd, AUTH_CTX_DATA, msg, len + 1) <= 0) {
+		snprintf(ebuf, ebufsz, "Failed to send auth context token");
+		pbs_errno = PBSE_SYSTEM;
+		free(msg);
+		return INTERACTIVE_AUTH_FAILED;
+	}
+	free(msg);
+	msg = NULL;
+
+	/* recieve ctx token */
+	if (transport_recv_pkt(fd, &type, &data_in, &len) <= 0) {
+		snprintf(ebuf, ebufsz, "Failed to receive auth token");
+		pbs_errno = PBSE_SYSTEM;
+		return INTERACTIVE_AUTH_FAILED;
+	}
+
+	if (type == AUTH_ERR_DATA) {
+		if (len > ebufsz)
+			len = ebufsz;
+		strncpy(ebuf, (char *) data_in, len);
+		ebuf[len] = '\0';
+		pbs_errno = PBSE_BADCRED;
+		return INTERACTIVE_AUTH_FAILED;
+	}
+
+	if (type != AUTH_CTX_OK) {
+		snprintf(ebuf, ebufsz, "incorrect auth token type");
+		pbs_errno = PBSE_SYSTEM;
+		return INTERACTIVE_AUTH_FAILED;
+	}
+
+	if (type == AUTH_CTX_OK)
+		data_in = NULL;
+
+	return INTERACTIVE_AUTH_SUCCESS;
+}
+
+/**
+ * @brief
+ *	Authenticate an incoming connection from an execution host.
+ *
+ * @param[in]	sock - An integer representing the socket file descriptor.
+ * @param[in]	port - The port from which the connection originated from
+ * @param[in]	auth_method - Authentication method used
+ * @param[in]	jobid - The job id.
+ * @return	int
+ * @retval	INTERACTIVE_AUTH_SUCCESS (0) - successful authentication
+ * @retval	INTERACTIVE_AUTH_FAILED (1) - authentication failed
+ * @retval	INTERACTIVE_AUTH_RETRY (2) - retry to connect
+ *
+ */
+int
+auth_exec_socket(int sock, unsigned short port, char *auth_method, char* jobid)
+{
+	char ebuf[LOG_BUF_SIZE] = "";
+	/* Reduce timeout to avoid blocking too long */
+	pbs_tcp_timeout = PBS_DIS_TCP_TIMEOUT_SHORT;
+
+	if (strcmp(auth_method, AUTH_RESVPORT_NAME) == 0) {
+		/* For resvport, simply verify that the remote port is prvileged */
+		if (port < IPPORT_RESERVED)
+			return INTERACTIVE_AUTH_SUCCESS;
+		else
+			return INTERACTIVE_AUTH_RETRY;
+	} else if (strcmp(auth_method, AUTH_PWD_NAME) == 0) {
+		if (server_cipher_auth(sock, jobid, ebuf, sizeof(ebuf) != 0)) {
+			if (ebuf[0] != '\0')
+				fprintf(stderr, "qsub: %s\n", ebuf);
+			/* If authentication process failed, retry to connect with another execution host */
+			return INTERACTIVE_AUTH_RETRY;
+		}
+	} else if ((strcmp(auth_method, AUTH_MUNGE_NAME) == 0)) {
+		char encrypt_method[MAXAUTHNAME + 1] = "";
+		pbs_auth_config_t *auth_config = NULL;
+		auth_def_t *authdef = NULL;
+
+		DIS_tcp_funcs();
+
+		if (load_auths(AUTH_CLIENT)) {
+			fprintf(stderr, "qsub: Failed to load auths\n");
+			return INTERACTIVE_AUTH_FAILED;
+		}
+
+		auth_config = make_auth_config(auth_method,
+					       encrypt_method,
+					       pbs_conf.pbs_exec_path,
+					       pbs_conf.pbs_home_path,
+					       NULL);
+		if (auth_config == NULL) {
+			fprintf(stderr, "qsub: Out of memory when allocating new auth config\n");
+			return INTERACTIVE_AUTH_FAILED;
+		}
+
+		authdef = get_auth(auth_method);
+		if (authdef == NULL) {
+			fprintf(stderr, "qsub: Auth method '%s' does not seem implemented\n", auth_method ? auth_method : "");
+			free_auth_config(auth_config);
+			return INTERACTIVE_AUTH_FAILED;
+		} else {
+			authdef->set_config((const pbs_auth_config_t *) auth_config);
+			transport_chan_set_authdef(sock, authdef, FOR_AUTH);
+			transport_chan_set_ctx_status(sock, AUTH_STATUS_CTX_ESTABLISHING, FOR_AUTH);
+		}
+		if (engage_server_auth(sock, "", FOR_AUTH, AUTH_INTERACTIVE, ebuf, sizeof(ebuf)) != 0) {
+			if (ebuf[0] != '\0')
+				fprintf(stderr, "qsub: %s\n", ebuf);
+			free_auth_config(auth_config);
+			/* If authentication process failed, retry to connect with another execution host */
+			return INTERACTIVE_AUTH_RETRY;
+		}
+		free_auth_config(auth_config);
+	} else {
+		fprintf(stderr, "qsub: Auth method '%s' not supported\n", auth_method ? auth_method : "");
+		return INTERACTIVE_AUTH_FAILED;
+	}
+	return INTERACTIVE_AUTH_SUCCESS;
+}
+
+/**
+ * @brief
+ *	Authenticate a connection to a remote qsub.
+ *
+ * @param[in]	sock - An integer representing the socket file descriptor.
+ * @param[in]	port - The port we connected to
+ * @param[in]	hostname - The qsub hostname.
+ * @param[in]	auth_method - The interactive auth method suggested by qsub.
+ * @param[in]	jobid - The job id.
+ *
+ * @return	int
+ * @retval	INTERACTIVE_AUTH_SUCCESS (0) - successful authentication
+ * @retval	INTERACTIVE_AUTH_FAILED (1) - authentication failed
+ *
+ */
+int auth_with_qsub(int sock, unsigned short port, char* hostname, char *auth_method, char *jobid)
+{
+	char ebuf[LOG_BUF_SIZE] = "";
+
+	if (strcmp(auth_method, AUTH_RESVPORT_NAME) == 0) {
+		/* If method is resvport, we have already connected with a privileged port */
+		return INTERACTIVE_AUTH_SUCCESS;
+	} else if (strcmp(auth_method, AUTH_PWD_NAME) == 0) {
+		if (client_cipher_auth(sock, jobid, ebuf, sizeof(ebuf)) !=0) {
+			log_eventf(PBSEVENT_ERROR, PBS_EVENTCLASS_JOB, LOG_ERR, jobid, "Error in handle client handshake: %s");
+			return INTERACTIVE_AUTH_FAILED;
+		}
+	} else {
+		char encrypt_method[MAXAUTHNAME + 1] = "";
+		pbs_auth_config_t *auth_config = NULL;
+
+		if (!is_string_in_arr(pbs_conf.supported_auth_methods, auth_method)) {
+			log_eventf(PBSEVENT_ERROR, PBS_EVENTCLASS_JOB, LOG_ERR, jobid, "Auth method '%s' not supported", auth_method ? auth_method : "");
+			return INTERACTIVE_AUTH_FAILED;
+		}
+
+		DIS_tcp_funcs();
+
+		if (load_auths(AUTH_CLIENT)) {
+			log_eventf(PBSEVENT_ERROR, PBS_EVENTCLASS_JOB, LOG_ERR, jobid, "Failed to load auths");
+			return INTERACTIVE_AUTH_FAILED;
+		}
+
+		auth_config = make_auth_config(auth_method,
+							encrypt_method,
+							pbs_conf.pbs_exec_path,
+							pbs_conf.pbs_home_path,
+							NULL);
+		if (auth_config == NULL) {
+			log_eventf(PBSEVENT_ERROR, PBS_EVENTCLASS_JOB, LOG_ERR, jobid, "Out of memory when allocating new auth config");
+			return INTERACTIVE_AUTH_FAILED;
+		}
+
+		if (handle_client_handshake(sock, hostname, auth_method, FOR_AUTH, auth_config, ebuf, sizeof(ebuf)) != 0) {
+			log_eventf(PBSEVENT_ERROR, PBS_EVENTCLASS_JOB, LOG_ERR, jobid, "Error in handle client handshake: %s", ebuf);
+			free_auth_config(auth_config);
+			return INTERACTIVE_AUTH_FAILED;
+		}
+		free_auth_config(auth_config);
+	}
+	return INTERACTIVE_AUTH_SUCCESS;
 }

--- a/src/lib/Libifl/auth.c
+++ b/src/lib/Libifl/auth.c
@@ -970,7 +970,7 @@ client_cipher_auth(int fd, char *text, char *ebuf, size_t ebufsz)
 	size_t len = 0;
 	int type = 0;
 	char salt[SALT_SIZE];
-	char *msg;
+	char *msg = NULL;
 
 	DIS_tcp_funcs();
 

--- a/src/lib/Libifl/auth.c
+++ b/src/lib/Libifl/auth.c
@@ -1049,13 +1049,6 @@ auth_exec_socket(int sock, unsigned short port, char *auth_method, char* jobid)
 			return INTERACTIVE_AUTH_SUCCESS;
 		else
 			return INTERACTIVE_AUTH_RETRY;
-	} else if (strcmp(auth_method, AUTH_PWD_NAME) == 0) {
-		if (server_cipher_auth(sock, jobid, ebuf, sizeof(ebuf) != 0)) {
-			if (ebuf[0] != '\0')
-				fprintf(stderr, "qsub: %s\n", ebuf);
-			/* If authentication process failed, retry to connect with another execution host */
-			return INTERACTIVE_AUTH_RETRY;
-		}
 	} else if ((strcmp(auth_method, AUTH_MUNGE_NAME) == 0)) {
 		char encrypt_method[MAXAUTHNAME + 1] = "";
 		pbs_auth_config_t *auth_config = NULL;
@@ -1125,11 +1118,6 @@ int auth_with_qsub(int sock, unsigned short port, char* hostname, char *auth_met
 	if (strcmp(auth_method, AUTH_RESVPORT_NAME) == 0) {
 		/* If method is resvport, we have already connected with a privileged port */
 		return INTERACTIVE_AUTH_SUCCESS;
-	} else if (strcmp(auth_method, AUTH_PWD_NAME) == 0) {
-		if (client_cipher_auth(sock, jobid, ebuf, sizeof(ebuf)) !=0) {
-			log_eventf(PBSEVENT_ERROR, PBS_EVENTCLASS_JOB, LOG_ERR, jobid, "Error in handle client handshake: %s");
-			return INTERACTIVE_AUTH_FAILED;
-		}
 	} else {
 		char encrypt_method[MAXAUTHNAME + 1] = "";
 		pbs_auth_config_t *auth_config = NULL;

--- a/src/lib/Libifl/pbs_loadconf.c
+++ b/src/lib/Libifl/pbs_loadconf.c
@@ -567,15 +567,10 @@ __pbs_loadconf(int reload)
 				}
 				free(value);
 			} else if (!strcmp(conf_name, PBS_CONF_AUTH_SERVICE_USERS)) {
-				char *value = convert_string_to_lowercase(conf_value);
-				if (value == NULL)
-					goto err;
-				pbs_conf.auth_service_users = break_comma_list(value);
+				pbs_conf.auth_service_users = break_comma_list(conf_value);
 				if (pbs_conf.auth_service_users == NULL) {
-					free(value);
 					goto err;
 				}
-				free(value);
 			} else if (!strcmp(conf_name, PBS_CONF_DAEMON_SERVICE_USER)) {
 				free(pbs_conf.pbs_daemon_service_user);
 				pbs_conf.pbs_daemon_service_user = strdup(conf_value);

--- a/src/lib/Libifl/pbs_loadconf.c
+++ b/src/lib/Libifl/pbs_loadconf.c
@@ -85,8 +85,10 @@ struct pbs_config pbs_conf = {
 	0,			    /* start comm */
 	0,			    /* locallog */
 	NULL,			    /* default to NULL for supported auths */
+	NULL,			    /* auth service users list, will default to just "root" if not set explicitly */
 	{'\0'},			    /* default no auth method to encrypt/decrypt data */
 	AUTH_RESVPORT_NAME,	    /* default to reserved port authentication */
+	AUTH_RESVPORT_NAME,	    /* default to reserved port qsub -I authentication. Possible values: resvport, munge, pwd */
 	0,			    /* sched_modify_event */
 	0,			    /* syslogfac */
 	3,			    /* syslogsvr - LOG_ERR from syslog.h */
@@ -533,7 +535,14 @@ __pbs_loadconf(int reload)
 				pbs_conf.pbs_conf_remote_viewer = strdup(conf_value);
 			}
 #endif
-			else if (!strcmp(conf_name, PBS_CONF_AUTH)) {
+			else if (!strcmp(conf_name, PBS_CONF_INTERACTIVE_AUTH_METHOD)) {
+				char *value = convert_string_to_lowercase(conf_value);
+				if (value == NULL)
+					goto err;
+				memset(pbs_conf.interactive_auth_method, '\0', sizeof(pbs_conf.interactive_auth_method));
+				strcpy(pbs_conf.interactive_auth_method, value);
+				free(value);
+			} else if (!strcmp(conf_name, PBS_CONF_AUTH)) {
 				char *value = convert_string_to_lowercase(conf_value);
 				if (value == NULL)
 					goto err;
@@ -553,6 +562,16 @@ __pbs_loadconf(int reload)
 					goto err;
 				pbs_conf.supported_auth_methods = break_comma_list(value);
 				if (pbs_conf.supported_auth_methods == NULL) {
+					free(value);
+					goto err;
+				}
+				free(value);
+			} else if (!strcmp(conf_name, PBS_CONF_AUTH_SERVICE_USERS)) {
+				char *value = convert_string_to_lowercase(conf_value);
+				if (value == NULL)
+					goto err;
+				pbs_conf.auth_service_users = break_comma_list(value);
+				if (pbs_conf.auth_service_users == NULL) {
 					free(value);
 					goto err;
 				}
@@ -914,6 +933,14 @@ __pbs_loadconf(int reload)
 		goto err;
 	}
 
+	if ((gvalue = getenv(PBS_CONF_INTERACTIVE_AUTH_METHOD)) != NULL) {
+		char *value = convert_string_to_lowercase(gvalue);
+		if (value == NULL)
+			goto err;
+		memset(pbs_conf.interactive_auth_method, '\0', sizeof(pbs_conf.interactive_auth_method));
+		strcpy(pbs_conf.interactive_auth_method, value);
+		free(value);
+	}
 	if ((gvalue = getenv(PBS_CONF_AUTH)) != NULL) {
 		char *value = convert_string_to_lowercase(gvalue);
 		if (value == NULL)
@@ -943,14 +970,30 @@ __pbs_loadconf(int reload)
 		}
 		free(value);
 	}
-
 	if (pbs_conf.supported_auth_methods == NULL) {
 		pbs_conf.supported_auth_methods = break_comma_list(AUTH_RESVPORT_NAME);
 		if (pbs_conf.supported_auth_methods == NULL) {
 			goto err;
 		}
 	}
-
+	if ((gvalue = getenv(PBS_CONF_AUTH_SERVICE_USERS)) != NULL) {
+		char *value = convert_string_to_lowercase(gvalue);
+		if (value == NULL)
+			goto err;
+		free_string_array(pbs_conf.auth_service_users);
+		pbs_conf.auth_service_users = break_comma_list(value);
+		if (pbs_conf.auth_service_users == NULL) {
+			free(value);
+			goto err;
+		}
+		free(value);
+	}
+	if (pbs_conf.auth_service_users == NULL) {
+		pbs_conf.auth_service_users = break_comma_list("root");
+		if (pbs_conf.auth_service_users == NULL) {
+			goto err;
+		}
+	}
 	if (pbs_conf.encrypt_method[0] != '\0') {
 		/* encryption is not disabled, validate encrypt method */
 		if (is_valid_encrypt_method(pbs_conf.encrypt_method) != 1) {
@@ -1064,6 +1107,10 @@ err:
 		free_string_array(pbs_conf.supported_auth_methods);
 		pbs_conf.supported_auth_methods = NULL;
 	}
+	if (pbs_conf.auth_service_users) {
+		free_string_array(pbs_conf.auth_service_users);
+		pbs_conf.auth_service_users = NULL;
+	}
 
 	pbs_conf.load_failed = 1;
 	(void) pbs_client_thread_unlock_conf();
@@ -1161,4 +1208,15 @@ pbs_get_tmpdir(void)
 		tmpdir[strlen(tmpdir) - 1] = '\0';
 #endif
 	return tmpdir;
+}
+
+void
+pbs_conf_load_interactive_auth_method(void)
+{
+	char *conf_value = pbs_get_conf_var(PBS_CONF_INTERACTIVE_AUTH_METHOD);
+
+	if (conf_value != NULL) {
+		strcpy(pbs_conf.interactive_auth_method, conf_value);
+		free(conf_value);
+	}
 }

--- a/src/lib/Libifl/pbs_loadconf.c
+++ b/src/lib/Libifl/pbs_loadconf.c
@@ -88,7 +88,7 @@ struct pbs_config pbs_conf = {
 	NULL,			    /* auth service users list, will default to just "root" if not set explicitly */
 	{'\0'},			    /* default no auth method to encrypt/decrypt data */
 	AUTH_RESVPORT_NAME,	    /* default to reserved port authentication */
-	AUTH_RESVPORT_NAME,	    /* default to reserved port qsub -I authentication. Possible values: resvport, munge, pwd */
+	AUTH_RESVPORT_NAME,	    /* default to reserved port qsub -I authentication. Possible values: resvport, munge */
 	0,			    /* sched_modify_event */
 	0,			    /* syslogfac */
 	3,			    /* syslogsvr - LOG_ERR from syslog.h */
@@ -1208,15 +1208,4 @@ pbs_get_tmpdir(void)
 		tmpdir[strlen(tmpdir) - 1] = '\0';
 #endif
 	return tmpdir;
-}
-
-void
-pbs_conf_load_interactive_auth_method(void)
-{
-	char *conf_value = pbs_get_conf_var(PBS_CONF_INTERACTIVE_AUTH_METHOD);
-
-	if (conf_value != NULL) {
-		strcpy(pbs_conf.interactive_auth_method, conf_value);
-		free(conf_value);
-	}
 }

--- a/src/lib/Libnet/net_server.c
+++ b/src/lib/Libnet/net_server.c
@@ -98,7 +98,7 @@ static void *poll_context; /* This is the context of the descriptors being polle
 void *priority_context;
 static int init_poll_context(); /* Initialize the tpp context */
 static void (*read_func[2])(int);
-static int (*ready_read_func)(conn_t *);
+static int (*ready_read_func[2])(conn_t *);
 static char logbuf[256];
 
 /* Private function within this file */
@@ -339,7 +339,7 @@ init_network_add(int sd, int (*readyreadfunc)(conn_t *), void (*readfunc)(int))
 	if (sd == -1)
 		return -1;
 
-	ready_read_func = readyreadfunc;
+	ready_read_func[initialized] = readyreadfunc;
 
 	/* for normal calls ...						*/
 	/* save the routine which should do the reading on connections	*/
@@ -689,7 +689,7 @@ accept_conn(int sd)
 	(void) add_conn(newsock, FromClientDIS,
 			(pbs_net_t) ntohl(from.sin_addr.s_addr),
 			(unsigned int) ntohs(from.sin_port),
-			ready_read_func,
+			ready_read_func[(int) svr_conn[idx]->cn_active],
 			read_func[(int) svr_conn[idx]->cn_active]);
 }
 
@@ -735,6 +735,7 @@ add_conn(int sd, enum conn_type type, pbs_net_t addr, unsigned int port, int (*r
 	conn->cn_func = func;
 	conn->cn_oncl = 0;
 	conn->cn_authen = 0;
+	conn->cn_authen |= PBS_NET_CONN_PREVENT_IP_SPOOFING;
 	conn->cn_prio_flag = 0;
 	conn->cn_auth_config = NULL;
 

--- a/src/lib/Libnet/port_forwarding.c
+++ b/src/lib/Libnet/port_forwarding.c
@@ -58,6 +58,8 @@
 #include "pbs_ifl.h"
 #include "log.h"
 #include "libutil.h"
+#include "auth.h"
+#include "dis.h"
 
 #define PF_LOGGER(logfunc, msg) \
 	if (logfunc != NULL) {  \
@@ -91,6 +93,9 @@ extern int set_nodelay(int fd);
  *                               readers read data.
  * @param readfunc[in] - function pointer pointing to the mom and qsub readers.
  * @param logfunc[in] - Function pointer for log function
+ * @param is_qsub_side[in] - Can be one of QSUB_SIDE (1) or EXEC_HOST_SIDE (0)
+ * @param auth_method[in] - Authentication method used
+ * @param jobid[in] - Job id
  *
  * @return void
  */
@@ -102,7 +107,10 @@ port_forwarder(
 	int pport,
 	int inter_read_sock,
 	int (*readfunc)(int),
-	void (*logfunc)(char *))
+	void (*logfunc)(char *),
+	int is_qsub_side,
+	char *auth_method,
+	char *jobid)
 {
 	fd_set rfdset, wfdset, efdset;
 	int rc;
@@ -113,8 +121,8 @@ port_forwarder(
 	char err_msg[LOG_BUF_SIZE];
 	int readfunc_ret;
 	/*
-         * Make the sockets in the socks structure non blocking
-         */
+	 * Make the sockets in the socks structure non blocking
+	 */
 	for (n = 0; n < NUM_SOCKS; n++) {
 		if (!(socks + n)->active || ((socks + n)->sock < 0))
 			continue;
@@ -215,15 +223,31 @@ port_forwarder(
 						(socks + n)->active = 0;
 						continue;
 					}
+
+					/* authenticate execution host socket */
+					if (is_qsub_side == QSUB_SIDE) {
+						if (auth_exec_socket(sock, ntohs(GET_IP_PORT(&from)), auth_method, jobid) != INTERACTIVE_AUTH_SUCCESS) {
+							snprintf(err_msg, sizeof(err_msg),
+								"Incoming connection from %s on socket %d rejected, authentication data incorrect, errno=%d",
+								netaddr((pbs_net_t *)&from), sock, errno);
+							PF_LOGGER(logfunc, err_msg);
+							shutdown(sock, SHUT_RDWR);
+							close(sock);
+							dis_destroy_chan(sock);
+							continue;
+						}
+					}
+
 					/*
-                                         * Make the sock non blocking
-                                         */
+					 * Make the sock non blocking
+					 */
 					if (set_nonblocking(sock) == -1) {
 						snprintf(err_msg, sizeof(err_msg),
 							 "set_nonblocking failed for socket=%d, errno=%d",
 							 sock, errno);
 						PF_LOGGER(logfunc, err_msg);
 						close(sock);
+						dis_destroy_chan(sock);
 						continue;
 					}
 					if (set_nodelay(sock) == -1) {
@@ -250,15 +274,30 @@ port_forwarder(
 					(socks + newsock)->listening = (socks + peersock)->listening = 0;
 					(socks + newsock)->active = (socks + peersock)->active = 1;
 					(socks + peersock)->sock = connfunc(phost, pport);
+
+					/* authenticate with qsub side */
+					if (is_qsub_side == EXEC_HOST_SIDE) {
+						if (auth_with_qsub((socks + peersock)->sock, pport, phost, auth_method, jobid) != 0) {
+							snprintf(err_msg, sizeof(err_msg),
+								"Authentication for outgoing connection to qsub from port %u on socket %d rejected by remote side, errno=%d",
+								pport, (socks + peersock)->sock, errno);
+							PF_LOGGER(logfunc, err_msg);
+							close((socks + peersock)->sock);
+							dis_destroy_chan((socks + peersock)->sock);
+							(socks + peersock)->active = 0;
+							continue;
+						}
+					}
 					/*
-                                         * Make sockets non-blocking
-                                         */
+					 * Make sockets non-blocking
+					 */
 					if (set_nonblocking((socks + peersock)->sock) == -1) {
 						snprintf(err_msg, sizeof(err_msg),
 							 "set_nonblocking failed for socket=%d, errno=%d",
 							 (socks + peersock)->sock, errno);
 						PF_LOGGER(logfunc, err_msg);
 						close((socks + peersock)->sock);
+						dis_destroy_chan((socks + peersock)->sock);
 						(socks + peersock)->active = 0;
 						continue;
 					}
@@ -285,6 +324,7 @@ port_forwarder(
 						}
 						shutdown((socks + n)->sock, SHUT_RDWR);
 						close((socks + n)->sock);
+						dis_destroy_chan((socks + n)->sock);
 						(socks + n)->active = 0;
 						snprintf(err_msg, sizeof(err_msg),
 							 "closing the socket %d after read failure, errno=%d",
@@ -293,6 +333,7 @@ port_forwarder(
 					} else if (rc == 0) {
 						shutdown((socks + n)->sock, SHUT_RDWR);
 						close((socks + n)->sock);
+						dis_destroy_chan((socks + n)->sock);
 						(socks + n)->active = 0;
 					} else {
 						(socks + n)->bufavail += rc;
@@ -313,6 +354,7 @@ port_forwarder(
 					}
 					shutdown((socks + n)->sock, SHUT_RDWR);
 					close((socks + n)->sock);
+					dis_destroy_chan((socks + n)->sock);
 					(socks + n)->active = 0;
 					snprintf(err_msg, sizeof(err_msg),
 						 "closing the socket %d after write failure, errno=%d",
@@ -321,6 +363,7 @@ port_forwarder(
 				} else if (rc == 0) {
 					shutdown((socks + n)->sock, SHUT_RDWR);
 					close((socks + n)->sock);
+					dis_destroy_chan((socks + n)->sock);
 					(socks + n)->active = 0;
 				} else {
 					(socks + peer)->bufwritten += rc;
@@ -334,6 +377,7 @@ port_forwarder(
 				if (!(socks + peer)->active && ((socks + peer)->bufwritten == (socks + peer)->bufavail)) {
 					shutdown((socks + n)->sock, SHUT_RDWR);
 					close((socks + n)->sock);
+					dis_destroy_chan((socks + n)->sock);
 					(socks + n)->active = 0;
 				}
 			}

--- a/src/lib/Libnet/port_forwarding.c
+++ b/src/lib/Libnet/port_forwarding.c
@@ -229,7 +229,7 @@ port_forwarder(
 						if (auth_exec_socket(sock, ntohs(GET_IP_PORT(&from)), auth_method, jobid) != INTERACTIVE_AUTH_SUCCESS) {
 							snprintf(err_msg, sizeof(err_msg),
 								"Incoming connection from %s on socket %d rejected, authentication data incorrect, errno=%d",
-								netaddr((pbs_net_t *)&from), sock, errno);
+								netaddr((struct sockaddr_in *)&from), sock, errno);
 							PF_LOGGER(logfunc, err_msg);
 							shutdown(sock, SHUT_RDWR);
 							close(sock);

--- a/src/lib/Libtpp/tpp_util.c
+++ b/src/lib/Libtpp/tpp_util.c
@@ -644,6 +644,24 @@ tpp_handle_auth_handshake(int tfd, int conn_fd, conn_auth_t *authdata, int for_e
 
 	if (is_handshake_done != 1)
 		return 0;
+
+	/* Verify user name is in list of service users */
+	if ((for_encrypt == FOR_AUTH) && (authdata->conn_type == AUTH_SERVER)) {
+		char *user = NULL;
+		char *host = NULL;
+		char *realm = NULL;
+		if (authdef->get_userinfo(authctx, &user, &host, &realm) != 0) {
+			tpp_log(LOG_CRIT, __func__, "tfd=%d, Could not retrieve username from auth ctx", tfd);
+			return -1;
+		}
+		if (user != NULL && !is_string_in_arr(pbs_conf.auth_service_users, user)) {
+			tpp_log(LOG_CRIT, __func__, "tfd=%d, User %s not in service users list", tfd, user);
+			return -1;
+		}
+		if (user)
+			free(user);
+	}
+
 	return 1;
 }
 

--- a/src/resmom/mom_inter.c
+++ b/src/resmom/mom_inter.c
@@ -458,6 +458,7 @@ int ptc;
  *
  * @param hostname[in] - hostname of the submission host where qsub is running.
  * @param port[in] - port number on which qsub is accepting connection.
+ * @param authport_falgs[in] - Authentication port flags to use. Values defined in net_connect.h
  *
  * @return int
  * @retval >=0 the socket obtained
@@ -465,8 +466,8 @@ int ptc;
  * @retval  -2 PBS_NET_RC_RETRY
  *
  */
-int
-conn_qsub(char *hostname, long port)
+static int
+_conn_qsub(char *hostname, long port, int authport_flags)
 {
 	pbs_net_t hostaddr;
 
@@ -478,7 +479,46 @@ conn_qsub(char *hostname, long port)
 	 * a client
 	 */
 
-	return (client_to_svr(hostaddr, (unsigned int) port, B_SVR));
+	return (client_to_svr(hostaddr, (unsigned int) port, authport_flags));
+}
+
+/**
+ * @brief
+ *      connect to the qsub that submitted this interactive job, using a privileged port
+ *
+ * @param hostname[in] - hostname of the submission host where qsub is running.
+ * @param port[in] - port number on which qsub is accepting connection.
+ *
+ * @return int
+ * @retval >=0 the socket obtained
+ * @retval  -1 PBS_NET_RC_FATAL
+ * @retval  -2 PBS_NET_RC_RETRY
+ *
+ */
+int
+conn_qsub_resvport(char *hostname, long port)
+{
+	return _conn_qsub(hostname, port, B_SVR | B_RESERVED);
+}
+
+
+/**
+ * @brief
+ *      connect to the qsub that submitted this interactive job
+ *
+ * @param hostname[in] - hostname of the submission host where qsub is running.
+ * @param port[in] - port number on which qsub is accepting connection.
+ *
+ * @return int
+ * @retval >=0 the socket obtained
+ * @retval  -1 PBS_NET_RC_FATAL
+ * @retval  -2 PBS_NET_RC_RETRY
+ *
+ */
+int
+conn_qsub(char *hostname, long port)
+{
+	return _conn_qsub(hostname, port, B_SVR);
 }
 
 /**

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -535,7 +535,7 @@ tcp_pre_process(conn_t *conn)
 
 		if (rc < (int) AUTH_STATUS_CTX_READY) {
 			errbuf[0] = '\0';
-			rc = engage_server_auth(conn->cn_sock, conn->cn_hostname, FOR_ENCRYPT, errbuf, sizeof(errbuf));
+			rc = engage_server_auth(conn->cn_sock, conn->cn_hostname, FOR_ENCRYPT, AUTH_SERVER, errbuf, sizeof(errbuf));
 			if (errbuf[0] != '\0') {
 				if (rc != 0)
 					log_event(PBSEVENT_ERROR | PBSEVENT_FORCE, PBS_EVENTCLASS_SERVER, LOG_ERR, __func__, errbuf);
@@ -552,7 +552,7 @@ tcp_pre_process(conn_t *conn)
 
 	if (rc < (int) AUTH_STATUS_CTX_READY) {
 		errbuf[0] = '\0';
-		rc = engage_server_auth(conn->cn_sock, conn->cn_hostname, FOR_AUTH, errbuf, sizeof(errbuf));
+		rc = engage_server_auth(conn->cn_sock, conn->cn_hostname, FOR_AUTH, AUTH_SERVER, errbuf, sizeof(errbuf));
 		if (errbuf[0] != '\0') {
 			if (rc != 0)
 				log_event(PBSEVENT_ERROR | PBSEVENT_FORCE, PBS_EVENTCLASS_SERVER, LOG_ERR, __func__, errbuf);

--- a/test/fw/ptl/utils/plugins/ptl_test_runner.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_runner.py
@@ -857,7 +857,6 @@ class PTLTestRunner(Plugin):
                 return _msg
         if _comms & _servers:
             if eff_tc_req['no_comm_on_server'] or _no_comm_on_server:
-                return False
                 _msg = 'no comm on server'
                 logger.error(_msg)
                 return _msg

--- a/test/tests/security/pbs_multiple_auth.py
+++ b/test/tests/security/pbs_multiple_auth.py
@@ -1,0 +1,1331 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2021 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of both the OpenPBS software ("OpenPBS")
+# and the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# OpenPBS is free software. You can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# OpenPBS is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# PBS Pro is commercially licensed software that shares a common core with
+# the OpenPBS software.  For a copy of the commercial license terms and
+# conditions, go to: (http://www.pbspro.com/agreement.html) or contact the
+# Altair Legal Department.
+#
+# Altair's dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of OpenPBS and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair's trademarks, including but not limited to "PBS™",
+# "OpenPBS®", "PBS Professional®", and "PBS Pro™" and Altair's logos is
+# subject to Altair's trademark licensing policies.
+
+from tests.security import *
+
+
+class TestMultipleAuthMethods(TestSecurity):
+    """
+    This test suite contains tests for Multiple authentication added to PBS
+    """
+    node_list = []
+
+    def setUp(self):
+        TestSecurity.setUp(self)
+        attrib = {'log_events': 2047}
+        self.server.manager(MGR_CMD_SET, SERVER, attrib)
+        self.mom.add_config({'$logevent': '4095'})
+        self.server.manager(MGR_CMD_SET, SCHED, {'log_events': 4095})
+        self.cur_user = self.du.get_current_user()
+        self.svr_hostname = self.server.shortname
+        self.node_list.append(self.svr_hostname)
+        self.client_host = None
+
+    def update_pbs_conf(self, conf_param, host_name=None,
+                        restart=True, op='set', check_state=True):
+        """
+        This function updates pbs conf file.
+
+        :param conf_param: PBS confs 'key/value' need to update in pbs.conf
+        :type conf_param: Dictionary
+        :param host_name: Name of the host on which pbs.conf
+                          has to be updated
+        :param restart: Restart PBS or not after update pbs.conf
+        :type restart: Boolean
+        :param op: Operation need to perform on pbs.conf
+                   Set or Unset operation will perform.
+        :type set: String
+        :param check_state: Check node state to be free
+        :type check_state: Bool
+        """
+
+        check_sched_log = False
+        if host_name == None:
+            host_name = self.svr_hostname
+        pbsconfpath = self.du.get_pbs_conf_file(host_name)
+        if op == 'set':
+            check_sched_log = True
+            self.du.set_pbs_config(hostname=host_name,
+                                   fin=pbsconfpath,
+                                   confs=conf_param)
+        else:
+            self.du.unset_pbs_config(hostname=host_name,
+                                     fin=pbsconfpath,
+                                     confs=conf_param)
+        if restart:
+            self.pbs_restart(host_name, node_state=check_state,
+                             sched_log=check_sched_log)
+            # Wait for Server to be ready after restart
+            time.sleep(5)
+
+    def munge_operation(self, host_name, op=None):
+        """
+        This function starts the munge dameon on a given host
+
+        :param host_name: Name of the host on which munge
+                          service has to be start.
+        :type host_name: String
+        :param op: Operation perform on munge daemon.
+        :type op: String
+        """
+        cmd = 'service munge %s' % (op)
+        status = self.du.run_cmd(hosts=host_name, cmd=cmd, sudo=True)
+        if op == 'status':
+            if status['rc'] == 0:
+                return True
+            else:
+                return False
+        else:
+            msg = "Failed to %s Munge on %s, Error: %s" % (op, host_name,
+                                                           str(status['err']))
+            self.assertEquals(status['rc'], 0, msg)
+
+    def pbs_restart(self, host_name=None, node_state=True, daemon=None,
+                    sched_log=True):
+        """
+        This function restarts PBS on host.
+        :param host_name: Name of the host on which pbs daemons
+                          has to be restarted
+        :type host_name: String
+        :param node_state: Check node state to be free
+        :type node_state: Bool
+        """
+        if host_name == None:
+            host_name = self.mom.shortname
+        if daemon == "pbs_comm":
+            self.comm.restart
+            pi = PBSInitServices(hostname=self.server.shortname)
+            pi.restart_comm()
+        else:
+            start_time = time.time()
+            pi = PBSInitServices(hostname=host_name)
+            pi.restart()
+        if node_state:
+            self.server.expect(NODE, {'state': 'free'}, id=host_name)
+
+    def perform_op(self, choice, host_name, node_state=True):
+        """
+        This function check if munge is installed or not installed
+        based on test case. If installed then check if munge daemon
+        is active or not,if not active then start it.
+
+        param choice: which operation want to perform on host.
+        type choice: String
+        param host_name: Hostname on which operation want to perform.
+        type host_name: String or None
+        :param node_state: Check node state to be free
+        :type node_state: Bool
+        """
+        munge_cmd = self.du.which(exe="munge", hostname=host_name)
+        if choice == 'check_installed_and_run':
+            if munge_cmd == 'munge':
+                self.skipTest(reason='Munge is not installed')
+            else:
+                _msg = "Munge is installed as per test suite requirement,"
+                _msg += " proceeding to check if munge is active"
+                self.logger.info(_msg)
+                if not self.munge_operation(host_name, op='status'):
+                    _msg = "Munge daemon is not running, trying to start it..."
+                    self.logger.info(_msg)
+                    self.munge_operation(host_name=host_name,
+                                         op='start')
+                    self.logger.info(
+                        "Munge started successfully, proceeding further")
+                    self.pbs_restart(
+                        host_name=host_name, node_state=node_state)
+                else:
+                    _msg = "Munge is running as per test suite requirement, "
+                    _msg += "proceeding with test case execution"
+                    self.logger.info(_msg)
+        else:
+            if munge_cmd != 'munge':
+                _msg = 'Munge is installed which is not a pre-requiste'
+                _msg += ' for test cases, skipping test case'
+                self.skipTest(reason=_msg)
+            else:
+                _msg = "Munge is not installed as per test suite requirement,"
+                _msg += " proceeding with test case execution"
+                self.logger.info(_msg)
+
+    def match_logs(self, exp_msg, nt_exp_msg=None):
+        """
+        This function verifies the expected log msgs with respect
+                to authentication in daemon logs
+
+        param exp_msg: Expected log messages in daemons log file.
+        type exp_msg: Dictionary
+        param nt_exp_msg: Not expected message in daemons log file.
+        type exp_msg: String
+        """
+
+        st_time = self.server.ctime
+        if 'mom' in exp_msg:
+            self.mom.log_match(exp_msg['mom'], starttime=st_time)
+        for msg in exp_msg.get('server', []):
+            self.server.log_match(msg, starttime=st_time)
+        for msg in exp_msg.get('comm', []):
+            self.comm.log_match(msg, starttime=st_time)
+
+        if nt_exp_msg:
+            self.mom.log_match(nt_exp_msg, starttime=st_time,
+                               existence=False)
+            self.server.log_match(nt_exp_msg, starttime=st_time,
+                                  existence=False)
+            self.comm.log_match(nt_exp_msg, starttime=st_time,
+                                existence=False)
+
+    def common_commands_steps(self, set_attr=None, job_script=False,
+                              resv_attr=None, client=None):
+        """
+        This function check all pbs commands are authenticated via
+        respective auth method.
+
+        :param set_attr: Job attributes to set
+        :type set_attr: Dictionary. Defaults to None
+        :param job_script: Whether to submit a job using job script
+        :type job_script: Bool. Defaults to False
+        :param resv_set_attr: Reservation attributes to set
+        :type resv_set_attr: Dictionary. Defaults to None
+        :param client: Name of the client
+        :type client: String. Defaults to None
+        """
+        if client is None:
+            self.server.client = self.svr_hostname
+        else:
+            self.server.client = client
+        # Verify that PBS commands are authenticated
+        exp_msg = "Type 95 request received"
+        start_time = time.time()
+        self.server.status(SERVER)
+        self.server.log_match(exp_msg, starttime=start_time)
+
+        if resv_attr is None:
+            resv_attr = {'reserve_start': time.time() + 30,
+                         'reserve_end': time.time() + 60}
+
+        r = Reservation(TEST_USER, resv_attr)
+        rid = self.server.submit(r)
+        exp_state = {'reserve_state': (MATCH_RE, "RESV_CONFIRMED")}
+        self.server.expect(RESV, exp_state, id=rid)
+
+        start_time = time.time()
+        self.server.delete(rid)
+        self.server.log_match(exp_msg, starttime=start_time)
+
+        start_time = time.time()
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
+        self.server.log_match(exp_msg, starttime=start_time)
+
+        start_time = time.time()
+        j = Job(TEST_USER)
+        if set_attr is not None:
+            j.set_attributes(set_attr)
+        if job_script:
+            pbsdsh_path = os.path.join(self.server.pbs_conf['PBS_EXEC'],
+                                       "bin", "pbsdsh")
+            script = "#!/bin/sh\n%s sleep 30" % pbsdsh_path
+            j.create_script(script, hostname=self.server.client)
+        else:
+            j.set_sleep_time(30)
+        jid = self.server.submit(j)
+
+        self.server.log_match(exp_msg, starttime=start_time)
+
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid)
+
+        start_time = time.time()
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
+        self.server.log_match(exp_msg, starttime=start_time)
+
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+
+        start_time = time.time()
+        self.server.alterjob(jid, {ATTR_N: 'test'})
+        self.server.log_match(exp_msg, starttime=start_time)
+
+        start_time = time.time()
+        self.server.expect(JOB, 'queue', id=jid, op=UNSET, offset=30)
+        self.server.log_match("%s;Exit_status=0" % jid)
+
+    def common_setup(self, req_moms=2, req_comms=1):
+        """
+        This function sets the shortnames of server, moms, comms and
+        Client in the cluster
+        Server shortname : self.hostA
+        Mom objects : self.momB, self.momC
+        Mom shortnames : self.hostB, self.hostC
+        Comm objects : self.comm2, self.comm3
+        Comm shortnames : self.hostD, self.hostE
+        Client name : self.hostF
+        :param req_moms: No of required moms
+        :type req_moms: Integer. Defaults to 2
+        :param req_comms: No of required comms
+        :type req_comms: Integer. Defaults to 1
+        """
+        num_moms = len(self.moms)
+        num_comms = len(self.comms)
+        if (req_moms != num_moms) and (req_comms != num_comms):
+            msg = "Test requires exact %s moms and %s" % (req_moms, req_comms)
+            msg += " comms as input"
+            self.skipTest(msg)
+        if num_moms == 2 and num_comms == 2:
+            self.hostA = self.server.shortname
+            self.momB = self.moms.values()[0]
+            self.hostB = self.momB.shortname
+            self.momC = self.moms.values()[1]
+            self.hostC = self.momC.shortname
+            self.comm2 = self.comms.values()[0]
+            self.hostD = self.comm2.shortname
+            self.comm3 = self.comms.values()[1]
+            self.hostE = self.comm3.shortname
+            self.hostF = self.client_host = self.server.client
+            self.node_list = [self.hostA, self.hostB,
+                              self.hostC, self.hostD,
+                              self.hostE, self.hostF]
+        elif num_moms == 2 and num_comms == 3:
+            self.hostA = self.server.shortname
+            self.momB = self.moms.values()[0]
+            self.hostB = self.momB.shortname
+            self.momC = self.moms.values()[1]
+            self.hostC = self.momC.shortname
+            self.comm2 = self.comms.values()[1]
+            self.hostD = self.comm2.shortname
+            self.comm3 = self.comms.values()[2]
+            self.hostE = self.comm3.shortname
+            self.hostF = self.client_host = self.server.client
+            self.node_list = [self.hostA, self.hostB,
+                              self.hostC, self.hostD,
+                              self.hostE, self.hostF]
+
+    def simple_interactive_job(self):
+        self.svr_mode = self.server.get_op_mode()
+        if self.svr_mode != PTL_CLI:
+            self.server.set_op_mode(PTL_CLI)
+
+        j = Job(TEST_USER, attrs={ATTR_inter: ''})
+        j.interactive_script = [('hostname', '.*'),
+                                ('sleep 100', '.*')]
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        self.server.delete(jid)
+
+    def test_default_auth_method(self):
+        """
+        Test to verify all PBS daemons and commands are authenticated
+        via default authentication method
+        default authentication method is resvport
+        """
+        conf_param = {'PBS_COMM_LOG_EVENTS': "2047"}
+        if self.server.shortname != self.mom.shortname:
+            check_state = False
+        else:
+            check_state = True
+        self.update_pbs_conf(conf_param, check_state=check_state)
+        common_msg = 'TPP authentication method = resvport'
+        common_msg1 = 'Supported authentication method: resvport'
+        exp_msg = {'server': [common_msg, common_msg1],
+                   'comm': [common_msg1],
+                   'mom': common_msg}
+        self.match_logs(exp_msg)
+        self.common_commands_steps()
+
+    def test_munge_auth_method(self):
+        """
+        Test to verify all PBS daemons and commands are authenticated
+        via munge authentication method
+        """
+        if self.server.shortname != self.mom.shortname:
+            self.node_list.append(self.mom.shortname)
+            check_state = False
+        else:
+            check_state = True
+
+        # Function call to check if munge is installed and enabled
+        for host_name in self.node_list:
+            self.perform_op(choice='check_installed_and_run',
+                            host_name=host_name)
+
+        conf_param = {'PBS_SUPPORTED_AUTH_METHODS': 'MUNGE',
+                      'PBS_AUTH_METHOD': 'MUNGE',
+                      'PBS_COMM_LOG_EVENTS': "2047"}
+        self.update_pbs_conf(conf_param, check_state=check_state)
+
+        if self.server.shortname != self.mom.shortname:
+            conf_param = {'PBS_AUTH_METHOD': 'MUNGE'}
+            self.update_pbs_conf(conf_param, host_name=self.mom.shortname)
+
+        common_msg = 'TPP authentication method = munge'
+        common_msg1 = 'Supported authentication method: munge'
+
+        exp_msg = {'server': [common_msg, common_msg1],
+                   'comm': [common_msg1],
+                   'mom': common_msg}
+
+        nt_exp_msg = 'TPP authentication method = resvport'
+        self.match_logs(exp_msg, nt_exp_msg)
+        self.common_commands_steps()
+
+    def test_multiple_supported_auth_methods(self):
+        """
+        Test to verify all PBS daemons and commands are authenticated
+        via multiple authentication method.
+        we authenticated with resvport and munge.
+        """
+        if self.server.shortname != self.mom.shortname:
+            self.node_list.append(self.mom.shortname)
+            check_state = False
+        else:
+            check_state = True
+
+        # Function call to check if munge is installed and enabled
+        for host_name in self.node_list:
+            self.perform_op(choice='check_installed_and_run',
+                            host_name=host_name)
+
+        conf_param = {'PBS_SUPPORTED_AUTH_METHODS': 'MUNGE,resvport',
+                      'PBS_AUTH_METHOD': 'MUNGE',
+                      'PBS_COMM_LOG_EVENTS': "2047"}
+        self.update_pbs_conf(conf_param, check_state=check_state)
+
+        if self.server.shortname != self.mom.shortname:
+            conf_param = {'PBS_AUTH_METHOD': 'MUNGE'}
+            self.update_pbs_conf(conf_param, host_name=self.mom.shortname)
+
+        common_msg = 'TPP authentication method = munge'
+        common_msg1 = 'Supported authentication method: munge'
+        common_msg2 = 'Supported authentication method: resvport'
+
+        exp_msg = {'server': [common_msg, common_msg1, common_msg2],
+                   'comm': [common_msg, common_msg1, common_msg2],
+                   'mom': common_msg}
+        nt_exp_msg = 'TPP authentication method = resvport'
+        self.match_logs(exp_msg, nt_exp_msg)
+        self.common_commands_steps()
+
+        confs = ['PBS_AUTH_METHOD']
+        self.update_pbs_conf(confs, op='unset', restart=False)
+
+        common_msg = 'TPP authentication method = resvport'
+        conf_param = {'PBS_AUTH_METHOD': 'resvport'}
+        for host_name in self.node_list:
+            if host_name == self.svr_hostname:
+                check_state = False
+            else:
+                check_state = True
+            self.update_pbs_conf(conf_param, host_name=host_name,
+                                 check_state=check_state)
+
+        exp_msg['server'][0] = exp_msg['comm'][0] = common_msg
+        exp_msg['mom'] = common_msg
+        self.match_logs(exp_msg)
+        self.common_commands_steps()
+
+    def test_multiple_auth_method(self):
+        """
+        Test to verify getting expected error message
+        with multiple PBS_AUTH_METHOD.
+        """
+        conf_param = {'PBS_SUPPORTED_AUTH_METHODS': 'MUNGE',
+                      'PBS_AUTH_METHOD': 'resvport,MUNGE',
+                      'PBS_COMM_LOG_EVENTS': "2047"}
+        self.update_pbs_conf(conf_param, restart=False)
+
+        if self.server.shortname != self.mom.shortname:
+            self.node_list.append(self.mom.shortname)
+            conf_param = {'PBS_AUTH_METHOD': 'resvport,MUNGE'}
+            self.update_pbs_conf(conf_param, host_name=self.mom.shortname,
+                                 restart=False)
+
+        lib_path = os.path.join(self.server.pbs_conf['PBS_EXEC'],
+                                'lib')
+        msg = "/libauth_resvport,munge.so: cannot open shared object file:"
+        msg += " No such file or directory"
+        matchs = lib_path + msg
+
+        # Restart PBS and it should fail with expected error message
+        try:
+            self.pbs_restart(self.server.shortname)
+        except PbsInitServicesError as e:
+            self.assertIn(matchs, e.msg)
+            _msg = "PBS start up failed with logger info: " + str(e.msg)
+            self.logger.info(_msg)
+        else:
+            err_msg = "Failed to get expected error message in PBS restart: "
+            err_msg += msg
+            self.fail(err_msg)
+
+    def test_not_listed_auth_method(self):
+        """
+        test to verify that pbs give appropiate error message
+        if we use not listed PBS_AUTH_METHOD.
+        """
+        conf_param = {'PBS_SUPPORTED_AUTH_METHODS': 'resvport',
+                      'PBS_AUTH_METHOD': 'MUNGE',
+                      'PBS_COMM_LOG_EVENTS': "2047"}
+        self.update_pbs_conf(conf_param, restart=False)
+
+        if self.server.shortname != self.mom.shortname:
+            self.node_list.append(self.mom.shortname)
+            conf_param = {'PBS_AUTH_METHOD': 'MUNGE'}
+            self.update_pbs_conf(conf_param, host_name=self.mom.shortname,
+                                 restart=False)
+
+        err_msg = ['auth: error returned: 15029',
+                   'auth: Failed to send auth request',
+                   'No support for requested service.',
+                   f'qstat: cannot connect to server {self.server.shortname} (errno=15029)']
+
+        try:
+            self.server.status(SERVER)
+        except PbsStatusError as e:
+            for msg in err_msg:
+                self.assertIn(msg, e.msg)
+        else:
+            err_msg = "Failed to get expected error message"
+            err_msg += " while checking server status."
+            self.fail(err_msg)
+
+    def test_null_authentication_value(self):
+        """
+        Set PBS_AUTH_METHOD to NULL (empty).
+        Check for error message
+        """
+
+        conf_param = {'PBS_SUPPORTED_AUTH_METHODS': 'resvport',
+                      'PBS_AUTH_METHOD': '',
+                      'PBS_COMM_LOG_EVENTS': "2047"}
+        self.update_pbs_conf(conf_param, restart=False)
+
+        if self.server.shortname != self.mom.shortname:
+            self.node_list.append(self.mom.shortname)
+            conf_param = {'PBS_AUTH_METHOD': ''}
+            self.update_pbs_conf(conf_param, host_name=self.mom.shortname,
+                                 restart=False)
+
+        comm_path = os.path.join(self.server.pbs_conf['PBS_EXEC'],
+                                 'sbin', 'pbs_comm')
+        matchs = comm_path + ": Configuration error"
+
+        # Restart PBS and it should fail with expected error message
+        _msg = "PBS start up failed with logger info: "
+        try:
+            self.pbs_restart(self.server.shortname)
+        except PbsInitServicesError as e:
+            self.assertIn(matchs, e.msg)
+            self.logger.info(_msg + str(e.msg))
+        else:
+            err_msg = "Failed to get expected error message in PBS restart: "
+            err_msg += matchs
+            self.fail(err_msg)
+
+        if self.mom.shortname != self.svr_hostname:
+            try:
+                self.pbs_restart()
+            except PbsInitServicesError as e:
+                matchs = "pbs_mom startup failed, exit 1 aborting"
+                self.assertIn(matchs, e.msg)
+                self.logger.info(_msg + str(e.msg))
+            else:
+                err_msg = "Failed to get expected error message in PBS restart: "
+                err_msg += matchs
+                self.fail(err_msg)
+
+    def test_munge_not_running_state(self):
+        """
+        Submit a job when munge process is not running on server host.
+        Job submit error should occur because of
+        Munge encode failure
+        """
+        if self.server.shortname != self.mom.shortname:
+            self.node_list.append(self.mom.shortname)
+            check_state = False
+        else:
+            check_state = True
+
+        # Function call to check if munge is installed and enabled
+        for host_name in self.node_list:
+            self.perform_op(choice='check_installed_and_run',
+                            host_name=host_name)
+
+        conf_param = {'PBS_SUPPORTED_AUTH_METHODS': 'MUNGE',
+                      'PBS_AUTH_METHOD': 'MUNGE',
+                      'PBS_COMM_LOG_EVENTS': "2047"}
+        self.update_pbs_conf(conf_param, check_state=check_state)
+
+        if self.server.shortname != self.mom.shortname:
+            conf_param = {'PBS_AUTH_METHOD': 'MUNGE'}
+            self.update_pbs_conf(conf_param, host_name=self.mom.shortname)
+
+        common_msg = 'MUNGE user-authentication on encode failed with '
+        err_msg1 = common_msg + '`Munged communication error`'
+        err_msg2 = common_msg + '`Socket communication error`'
+
+        # To stop munge process and check if successfull
+        self.munge_operation(host_name=self.svr_hostname, op='stop')
+
+        msg = f"qsub: cannot connect to server {self.server.hostname}"
+        msg += " (errno=15010)"
+        exp_msg = ['munge_get_auth_data: ' + err_msg1,
+                    'auth: error returned: 15010',
+                    'auth: ' + err_msg1,
+                    'System call failure.',
+                    msg
+                    ]
+
+        exp_msg1 = copy.copy(exp_msg)
+
+        exp_msg1[0] = 'munge_get_auth_data: ' + err_msg2
+        exp_msg1[2] = 'auth: ' + err_msg2
+
+        # Submit a job and it should fail resulting in expected error
+        j = Job(self.cur_user)
+        _msg = "Trying to start munge daemon"
+        try:
+            j1id = self.server.submit(j)
+        except PbsSubmitError as e:
+            self.assertTrue(exp_msg == e.msg or exp_msg1 == e.msg)
+            self.logger.info("Job submit failed as expected with" + str(e.msg))
+        else:
+            err_msg = "Failed to get expected error message"
+            err_msg += " while submiting job."
+            self.fail(err_msg)
+        # Clean Up: To start munge that was stopped in first step
+        finally:
+            self.logger.info(_msg)
+            self.munge_operation(host_name=self.svr_hostname, op='start')
+            self.logger.info("Munge started as a part of cleanup")
+
+    def test_invalid_authentication_value(self):
+        """
+        Set PBS_AUTH_METHOD to invalid value.
+        Check for error message on restart of daemons
+        """
+        conf_param = {'PBS_SUPPORTED_AUTH_METHODS': 'resvport',
+                      'PBS_AUTH_METHOD': 'testing',
+                      'PBS_COMM_LOG_EVENTS': "2047"}
+        self.update_pbs_conf(conf_param, restart=False)
+
+        if self.server.shortname != self.mom.shortname:
+            self.node_list.append(self.mom.shortname)
+            conf_param = {'PBS_AUTH_METHOD': 'testing'}
+            self.update_pbs_conf(conf_param, host_name=self.mom.shortname,
+                                 restart=False)
+
+        matchs = "/opt/pbs/lib/libauth_testing.so:"
+        matchs += " cannot open shared object file: No such file or directory"
+
+        # Restart PBS and it should fail with expected error message
+        _msg = "PBS restart failed as expected, error message: "
+        try:
+            self.pbs_restart()
+        except PbsInitServicesError as e:
+            self.assertIn(matchs, e.msg)
+            self.logger.info(_msg + str(e.msg))
+        else:
+            err_msg = "Failed to get expected error message in PBS restart: "
+            err_msg += matchs
+            self.fail(err_msg)
+
+    @requirements(num_moms=2)
+    def test_munge_disabled_on_mom_host(self):
+        """
+        Test behavior when munge is stopped on Mom host
+        Configuration:
+        Node 1 : Server, Sched, Comm, Mom (self.hostA)
+        Node 2 : Mom (self.hostB)
+        """
+        if len(self.moms) != 2:
+            msg = "Test requires exactly 2 mom host as input"
+            msg += " host as input"
+            self.skipTest(msg)
+
+        self.momA = self.moms.values()[0]
+        self.hostA = self.momA.shortname
+        self.momB = self.moms.values()[1]
+        self.hostB = self.momB.shortname
+        self.node_list.extend([self.hostA, self.hostB])
+        for host in self.node_list:
+            self.perform_op('check_installed_and_run', host, node_state=False)
+
+        # Update pbs.conf of Server host
+        conf_param = {'PBS_COMM_LOG_EVENTS': '2047',
+                      'PBS_SUPPORTED_AUTH_METHODS': 'MUNGE,resvport',
+                      'PBS_AUTH_METHOD': 'munge'}
+        self.update_pbs_conf(
+            conf_param,
+            host_name=self.svr_hostname, check_state=False)
+
+        # Update pbs.conf of Mom hosts
+        del conf_param['PBS_COMM_LOG_EVENTS']
+        del conf_param['PBS_SUPPORTED_AUTH_METHODS']
+        for mom in self.moms.values():
+            if mom.name != self.server.hostname:
+                self.update_pbs_conf(
+                  conf_param,
+                  host_name=mom.name)
+
+        self.munge_operation(self.hostB, op="stop")
+        self.pbs_restart(self.hostB, node_state=False)
+        self.server.expect(NODE, {'state': 'down'}, id=self.hostB)
+        set_attr = {ATTR_l + '.select': '2:ncpus=1',
+                    ATTR_l + '.place': 'scatter'}
+        j = Job(attrs=set_attr)
+        jid = self.server.submit(j)
+
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid)
+
+    @requirements(no_mom_on_server=True, num_client=1)
+    def test_munge_without_supported_auth_method_on_server(self):
+        """
+        Verify appropriate error msg is thrown when
+        PBS_SUPPORTED_AUTH_METHODS is not added to pbs.conf on server host
+        Configuration:
+        Node 1 : Server, Sched, Comm (self.hostA)
+        Node 2 : Mom (self.hostB)
+        Node 3 : Client (self.hostC)
+        """
+        if self.server.client == self.server.hostname:
+            msg = "Test requires 2 moms and 1 client which is on non server"
+            msg += " host as input"
+            self.skipTest(msg)
+
+        self.hostA = self.server.shortname
+        self.momA = self.moms.values()[0]
+        self.hostB = self.momA.shortname
+        self.hostC = self.server.client
+
+        self.node_list = [self.hostA, self.hostB, self.hostC]
+
+        # Verify if munge is installed on all the hosts
+        for host in self.node_list:
+            self.perform_op('check_installed_and_run', host)
+
+        conf_param = {'PBS_AUTH_METHOD': 'MUNGE'}
+        for host in self.node_list:
+            self.update_pbs_conf(conf_param, host_name=host, check_state=False)
+
+        err_msg = ['auth: error returned: 15029',
+                   'auth: Failed to send auth request',
+                   'No support for requested service.',
+                   f'qstat: cannot connect to server {self.server.shortname} (errno=15029)']
+
+        try:
+            self.server.status(SERVER)
+        except PbsStatusError as e:
+            for msg in err_msg:
+                self.assertIn(msg, e.msg)
+        else:
+            err_msg = "Failed to get expected error message"
+            err_msg += " while checking server status."
+            self.fail(err_msg)
+
+    def common_steps_without_munge(self, client=None):
+        """
+        This function contains common steps for tests which
+        verify behavior when munge is not installed on one of the host
+        :param client: Name of the client
+        :type client: String. Defaults to None
+        """
+        if client is None:
+            self.server.client = self.svr_hostname
+        else:
+            self.server.client = client
+
+        cmd_path = os.path.join(self.server.pbs_conf['PBS_EXEC'], 'bin')
+
+        err_msg = ": cannot connect to server %s" % self.server.hostname
+        err_msg += ", error=15010"
+
+        pbsnodes_cmd = os.path.join(cmd_path, 'pbsnodes')
+        msg = pbsnodes_cmd + err_msg
+        exp_msgs = ['init_munge: libmunge.so not found',
+                    'auth: error returned: 15010',
+                    'auth: Munge lib is not loaded',
+                    'System call failure.',
+                    msg
+                    ]
+        try:
+            self.server.status(NODE, id=self.server.client)
+        except PbsStatusError as e:
+            for msg in exp_msgs:
+                self.assertIn(msg, e.msg)
+            cmd_exp_msg = "Getting expected error message."
+            self.logger.info(cmd_exp_msg)
+        else:
+            cmd_msg = "Failed to get expected error message "
+            cmd_msg = "while checking Node status."
+            self.fail(cmd_msg)
+
+        err_msg = "qstat: cannot connect to server %s" % self.server.hostname
+        err_msg += " (errno=15010)"
+        exp_msgs[4] = err_msg
+        try:
+            self.server.status(SERVER, id=self.svr_hostname)
+        except PbsStatusError as e:
+            for msg in exp_msgs:
+                self.assertIn(msg, e.msg)
+            cmd_exp_msg = "Getting expected error message."
+            self.logger.info(cmd_exp_msg)
+        else:
+            cmd_msg = "Failed to get expected error message "
+            cmd_msg += "while checking Server status."
+            self.fail(cmd_msg)
+
+    def test_without_munge_on_server_host(self):
+        """
+        Munge is not installed on server host.
+        Set PBS_AUTH_METHOD=munge in conf and check respective error message.
+        """
+        # Function call to check if munge is not installed and then proceeding
+        # with test case execution
+        self.perform_op(choice='check_not_installed',
+                        host_name=self.svr_hostname)
+
+        conf_attrib = {'PBS_SUPPORTED_AUTH_METHODS': 'MUNGE',
+                       'PBS_AUTH_METHOD': 'MUNGE',
+                       'PBS_COMM_LOG_EVENTS': "2047"}
+        self.update_pbs_conf(conf_attrib, check_state=False)
+
+        if self.svr_hostname != self.mom.shortname:
+            self.node_list.append(self.mom.shortname)
+            conf_param = {'PBS_AUTH_METHOD': 'munge'}
+            self.update_pbs_conf(
+                conf_param,
+                host_name=self.mom.shortname,
+                check_state=False)
+        exp_log = "libmunge.so not found"
+        self.server.log_match(exp_log)
+        self.mom.log_match(exp_log)
+        self.common_steps_without_munge(self.svr_hostname)
+
+    @requirements(num_moms=2)
+    def test_without_munge_on_mom_host(self):
+        """
+        Test behavior when PBS_AUTH_METHOD is set to munge on remote
+        mom host where munge is not installed.
+        Node 1: Server, Sched, Mom, Comm [self.hostA]
+        Node 2: Mom [self.hostB]
+        """
+        self.momA = self.moms.values()[0]
+        self.hostA = self.momA.shortname
+        self.momB = self.moms.values()[1]
+        self.hostB = self.momB.shortname
+
+        self.perform_op(choice='check_not_installed',
+                        host_name=self.hostB)
+        self.node_list.extend([self.hostA, self.hostB])
+
+        conf_attrib = {'PBS_SUPPORTED_AUTH_METHODS': 'MUNGE',
+                       'PBS_AUTH_METHOD': 'MUNGE',
+                       'PBS_COMM_LOG_EVENTS': "2047"}
+        self.update_pbs_conf(conf_attrib, check_state=False)
+
+        conf_param = {'PBS_AUTH_METHOD': 'munge'}
+        for mom in self.moms.values():
+            if mom.shortname != self.svr_hostname:
+                self.update_pbs_conf(
+                    conf_param, host_name=mom.name, check_state=False)
+
+        exp_log = "libmunge.so not found"
+        self.momB.log_match(exp_log)
+        self.common_steps_without_munge(self.hostB)
+
+    @requirements(num_moms=2, num_comms=1, no_comm_on_server=True)
+    def test_without_munge_on_comm_host(self):
+        """
+        Test behavior when PBS_AUTH_METHOD is set to munge on
+        comm host where munge is not installed.
+        when pbs_comm and client are on non-server host
+        Configuration:
+        Node 1: Server, Sched, Mom [self.hostA]
+        Node 2: Mom [self.hostB]
+        Node 3: Comm [self.hostC]
+        """
+        if self.svr_hostname == self.comm.shortname:
+            msg = "Test requires a comm host which is present on "
+            msg += "non server host"
+            self.skip_test(msg)
+
+        self.momA = self.moms.values()[0]
+        self.hostA = self.momA.shortname
+        self.momB = self.moms.values()[1]
+        self.hostB = self.momB.shortname
+        self.hostC = self.comm.shortname
+
+        self.perform_op(choice='check_not_installed',
+                        host_name=self.hostC)
+        self.node_list.extend([self.hostA, self.hostB, self.hostC])
+
+
+        conf_param = {'PBS_SUPPORTED_AUTH_METHODS': 'MUNGE',
+                      'PBS_AUTH_METHOD': 'MUNGE',
+                      'PBS_LEAF_ROUTERS': self.hostC}
+        self.update_pbs_conf(conf_param, check_state=False)
+
+        del conf_param['PBS_LEAF_ROUTERS']
+        conf_param['PBS_COMM_LOG_EVENTS'] = 2047
+        self.update_pbs_conf(
+            conf_param,
+            host_name=self.hostC,
+            check_state=False)
+
+        del conf_param['PBS_SUPPORTED_AUTH_METHODS']
+        conf_param['PBS_LEAF_ROUTERS'] = self.hostC
+        for mom in self.moms.values():
+            if mom.shortname != self.svr_hostname:
+                self.update_pbs_conf(
+                    conf_param, host_name=mom.name, check_state=False)
+
+        self.common_steps_without_munge(self.hostC)
+
+    @requirements(num_client=1, num_moms=2)
+    def test_without_munge_on_client_host(self):
+        """
+        Test behavior when PBS_AUTH_METHOD is set to munge on
+        comm host where munge is not installed.
+        when pbs_comm and client are on non-server host
+        Configuration:
+        Node 1: Server, Sched, Mom, Comm [self.hostA]
+        Node 2: Mom [self.hostB]
+        Node 3: Client [self.hostC]
+        """
+        if self.svr_hostname == self.server.client:
+            msg = "Test requires a client host which is present on "
+            msg += "non server host"
+            self.skip_test(msg)
+
+        self.momA = self.moms.values()[0]
+        self.hostA = self.momA.shortname
+        self.momB = self.moms.values()[1]
+        self.hostB = self.momB.shortname
+        self.hostC = self.server.client
+
+        self.perform_op(choice='check_not_installed',
+                        host_name=self.hostC)
+        self.node_list.extend([self.hostA, self.hostB, self.hostC])
+
+        conf_param = {'PBS_SUPPORTED_AUTH_METHODS': 'MUNGE',
+                      'PBS_AUTH_METHOD': 'MUNGE',
+                      'PBS_COMM_LOG_EVENTS': "2047"}
+        self.update_pbs_conf(conf_param, check_state=False)
+        del conf_param['PBS_COMM_LOG_EVENTS']
+        self.update_pbs_conf(conf_param, host_name=self.hostC,
+                             restart=False)
+        conf_param = {'PBS_AUTH_METHOD': 'MUNGE'}
+        for mom in self.moms.values():
+            if mom.shortname != self.svr_hostname:
+                self.update_pbs_conf(
+                    conf_param, host_name=mom.name, check_state=False)
+
+        self.common_steps_without_munge(self.hostC)
+
+    @requirements(num_client=1)
+    def test_diff_auth_method_on_client(self):
+        """
+        Verify all PBS daemons and commands are authenticated when
+        different authentication method is on client
+        Configuration:
+        Node 1 : Server, Sched, Comm, Mom (self.hostA)
+        Node 2 : Client (self.hostB)
+        """
+        if self.svr_hostname == self.server.client:
+            msg = "Test requires a client host which is present on "
+            msg += "non server host"
+            self.skip_test(msg)
+
+        if self.server.shortname != self.mom.shortname:
+            check_state = False
+        else:
+            check_state = True
+
+        self.hostB = self.server.client
+        self.server.client = self.svr_hostname
+        # Update pbs.conf on server host (self.hostA)
+        conf_param = {'PBS_SUPPORTED_AUTH_METHODS': 'MUNGE',
+                      'PBS_AUTH_METHOD': 'MUNGE',
+                      'PBS_COMM_LOG_EVENTS': "2047"}
+        self.update_pbs_conf(conf_param, check_state=check_state)
+
+        self.server.client = self.hostB
+
+        msg = "auth: Unable to authenticate connection"
+        msg += " (%s:15001)" % self.server.hostname
+        err_msg = ['auth: error returned: -1',
+                   msg,
+                   'qstat: cannot connect to server %s (errno=-1)'
+                   % (self.server.shortname)]
+        try:
+            self.server.status(SERVER)
+        except PbsStatusError as e:
+            for msg in err_msg:
+                self.assertIn(msg, e.msg)
+        else:
+            err_msg = "Failed to get expected error message"
+            err_msg += " while checking server status."
+            self.fail(err_msg)
+
+    @requirements(num_moms=2)
+    def test_diff_auth_methods_on_moms(self):
+        """
+        Verify all PBS daemons and commands are authenticated when
+        different authentication method are used on execution host.
+        This also tests the behavior when authentication mechanism
+        is different on server and execution host.
+        """
+        comm_list = [x.shortname for x in self.comms.values()]
+        if not(len(self.moms) == 2) or self.server.shortname not in comm_list:
+            msg = "Test needs 2 moms as input and a comm which is present"
+            msg += " on server host"
+            self.skip_test(msg)
+
+        self.momA = self.moms.values()[0]
+        self.hostA = self.momA.shortname
+        self.momB = self.moms.values()[1]
+        self.hostB = self.momB.shortname
+
+        self.node_list.extend([self.hostA, self.hostB])
+        self.perform_op('check_installed_and_run', self.hostA,
+                        node_state=False)
+
+        # Update pbs.conf of Server
+        conf_param = {'PBS_COMM_LOG_EVENTS': '2047',
+                      'PBS_SUPPORTED_AUTH_METHODS': 'MUNGE,resvport',
+                      'PBS_AUTH_METHOD': 'MUNGE'
+                      }
+        self.update_pbs_conf(
+            conf_param,
+            check_state=False)
+
+        server_ip = socket.gethostbyname(self.svr_hostname)
+        mom2_ip = socket.gethostbyname(self.hostB)
+
+        if self.hostA != self.svr_hostname:
+            conf_param = {'PBS_AUTH_METHOD': 'MUNGE'}
+            self.update_pbs_conf(conf_param, host_name=self.hostA)
+            mom1_ip = socket.gethostbyname(self.hostA)
+            self.momA = self.moms.values()[0]
+            attrib = {self.server.hostname: [server_ip, 15001],
+                      self.momB.hostname: [mom2_ip, 15003],
+                      self.momA.hostname: [mom1_ip, 15003]}
+        else:
+            self.pbs_restart(host_name=self.svr_hostname)
+            attrib = {self.server.hostname: [server_ip, 15001, 15003],
+                      self.momB.hostname: [mom2_ip, 15003]}
+
+        msg = "Unauthenticated connection from %s" % self.server.shortname
+        self.comm.log_match(msg, existence=False, starttime=self.server.ctime)
+        ip = []
+        port = []
+        for host, host_attribs in attrib.items():
+            ip = host_attribs.pop(0)
+            for port in host_attribs:
+                exp_msg = "Leaf registered address %s:%s" % (ip, port)
+                self.comm.log_match(exp_msg)
+
+        # Submit a job on the execution hosts with different
+        # authentication mechanism
+        set_attr = {ATTR_l + '.select': '2:ncpus=1',
+                    ATTR_l + '.place': 'scatter', ATTR_k: 'oe'}
+        resv_attr = {ATTR_l + '.select': '2:ncpus=1',
+                     'reserve_start': time.time() + 30,
+                     'reserve_end': time.time() + 60}
+        self.common_commands_steps(resv_attr=resv_attr,
+                                   set_attr=set_attr)
+
+    def test_daemon_not_in_service_users_with_munge(self):
+        """
+        Test behavior when the daemon user is not in the PBS_AUTH_SERVICE_USERS
+        list when using munge for authentication. No daemon should be able to
+        establish a connection with comm.
+
+        Node 1: Server, Sched, Mom, Comm [self.hostA]
+        """
+        auth_method = 'munge'
+        conf_param = {'PBS_COMM_LOG_EVENTS': "2047",
+                      'PBS_SUPPORTED_AUTH_METHODS': auth_method,
+                      'PBS_AUTH_METHOD': auth_method,
+                      'PBS_AUTH_SERVICE_USERS': 'random_user'}
+
+        if self.server.shortname != self.mom.shortname:
+            self.node_list.append(self.mom.shortname)
+
+        # Function call to check if munge is installed and enabled
+        for host_name in self.node_list:
+            self.perform_op(choice='check_installed_and_run',
+                            host_name=host_name)
+
+        common_msg = f'Connection to pbs_comm {self.server.shortname}:17001 down'
+        common_msg1 = f'Supported authentication method: {auth_method}'
+        common_msg2 = f'TPP authentication method = {auth_method}'
+
+        exp_msg = {'comm': [common_msg1, common_msg2, f'User {str(ROOT_USER)} not in service users list'],
+                   'mom': common_msg,
+                   'server': [common_msg, common_msg1, common_msg2]
+                   }
+        self.update_pbs_conf(conf_param, check_state=False)
+        self.match_logs(exp_msg)
+
+    def test_daemon_not_in_service_users_with_resvport(self):
+        """
+        Test behavior when the daemon user is not in the PBS_AUTH_SERVICE_USERS
+        list when using resvport for authentication. The daemon user name is not
+        available with using resvport. Therefore we expect that the daemons will
+        connect to comm successfully.
+
+        Node 1: Server, Sched, Mom, Comm [self.hostA]
+        """
+        auth_method = 'resvport'
+        conf_param = {'PBS_COMM_LOG_EVENTS': "2047",
+                      'PBS_SUPPORTED_AUTH_METHODS': auth_method,
+                      'PBS_AUTH_METHOD': auth_method,
+                      'PBS_AUTH_SERVICE_USERS': 'random_user'}
+
+        nt_exp_msg = f'Connection to pbs_comm {self.server.shortname}:17001 down'
+        common_msg1 = f'Supported authentication method: {auth_method}'
+        common_msg2 = f'TPP authentication method = {auth_method}'
+
+        exp_msg = {'comm': [common_msg1],
+                   'mom': common_msg2,
+                   'server': [common_msg1, common_msg2]
+                   }
+        self.update_pbs_conf(conf_param, check_state=False)
+        self.match_logs(exp_msg, nt_exp_msg)
+        self.common_commands_steps()
+
+    def test_default_interactive_auth_method(self):
+        """
+        Test that we can successfully run interactive jobs when using the default
+        (resvport) interactive authentication method.
+
+        Node 1: Server, Sched, Mom, Comm [self.hostA]
+        """
+        conf_param = {'PBS_COMM_LOG_EVENTS': "2047"}
+        if self.server.shortname != self.mom.shortname:
+            check_state = False
+        else:
+            check_state = True
+
+        auth_method = 'resvport'
+        common_msg1 = f'TPP authentication method = {auth_method}'
+        common_msg2 = f'Supported authentication method: {auth_method}'
+        mom_msg = f'interactive authentication method = {auth_method}'
+        exp_msg = {'server': [common_msg1, common_msg2],
+                   'comm': [common_msg2]}
+
+        self.update_pbs_conf(conf_param, check_state=check_state)
+        self.match_logs(exp_msg)
+        self.simple_interactive_job()
+        self.match_logs({'mom': mom_msg})
+
+    def test_interactive_job_with_resvport(self):
+        """
+        Test that we can successfully run interactive jobs when using resvport
+        as the interactive authentication method.
+
+        Node 1: Server, Sched, Mom, Comm [self.hostA]
+        """
+        auth_method = 'resvport'
+        conf_param = {'PBS_COMM_LOG_EVENTS': "2047",
+                      'PBS_SUPPORTED_AUTH_METHODS': auth_method,
+                      'PBS_AUTH_METHOD': auth_method,
+                      'PBS_INTERACTIVE_AUTH_METHOD': auth_method}
+        if self.server.shortname != self.mom.shortname:
+            check_state = False
+        else:
+            check_state = True
+
+        common_msg1 = f'TPP authentication method = {auth_method}'
+        common_msg2 = f'Supported authentication method: {auth_method}'
+        mom_msg = f'interactive authentication method = {auth_method}'
+        exp_msg = {'server': [common_msg1, common_msg2],
+                   'comm': [common_msg2]}
+
+        self.update_pbs_conf(conf_param, check_state=check_state)
+        self.match_logs(exp_msg)
+        self.simple_interactive_job()
+        self.match_logs({'mom': mom_msg})
+
+    def test_interactive_job_with_munge(self):
+        """
+        Test that we can successfully run interactive jobs when using munge
+        as the interactive authentication method.
+
+        Node 1: Server, Sched, Mom, Comm [self.hostA]
+        """
+        auth_method = 'munge'
+        conf_param = {'PBS_COMM_LOG_EVENTS': "2047",
+                      'PBS_SUPPORTED_AUTH_METHODS': f"resvport,{auth_method}",
+                      'PBS_INTERACTIVE_AUTH_METHOD': auth_method}
+
+        if self.server.shortname != self.mom.shortname:
+            self.node_list.append(self.mom.shortname)
+            check_state = False
+        else:
+            check_state = True
+
+        # Function call to check if munge is installed and enabled
+        for host_name in self.node_list:
+            self.perform_op(choice='check_installed_and_run',
+                            host_name=host_name)
+
+        common_msg1 = f'TPP authentication method = resvport'
+        common_msg2 = f'Supported authentication method: resvport'
+        common_msg3 = f'Supported authentication method: {auth_method}'
+        mom_msg = f'interactive authentication method = {auth_method}'
+        exp_msg = {'server': [common_msg1, common_msg2, common_msg3],
+                   'comm': [common_msg2, common_msg3]}
+
+        self.update_pbs_conf(conf_param, check_state=check_state)
+        self.match_logs(exp_msg)
+        self.simple_interactive_job()
+        self.match_logs({'mom': mom_msg})
+
+    def test_multiple_interactive_auth_methods(self):
+        """
+        Test that we can successfully run itneractive jobs when supporting
+        multiple interactive auth methods.
+
+        Node 1: Server, Sched, Mom, Comm [self.hostA]
+        """
+        conf_param = {'PBS_COMM_LOG_EVENTS': "2047",
+                      'PBS_SUPPORTED_AUTH_METHODS': 'munge,resvport'}
+        if self.server.shortname != self.mom.shortname:
+            self.node_list.append(self.mom.shortname)
+            check_state = False
+        else:
+            check_state = True
+
+        # Function call to check if munge is installed and enabled
+        for host_name in self.node_list:
+            self.perform_op(choice='check_installed_and_run',
+                            host_name=host_name)
+
+        common_msg1 = f'Supported authentication method: munge'
+        common_msg2 = f'Supported authentication method: resvport'
+
+        exp_msg = {'server': [common_msg1, common_msg2],
+                   'comm': [common_msg1, common_msg2]}
+
+        for auth_method in ['resvport', 'munge']:
+            conf_param['PBS_INTERACTIVE_AUTH_METHOD'] = auth_method
+            self.update_pbs_conf(conf_param, check_state=check_state)
+            if self.server.shortname != self.mom.shortname:
+                self.update_pbs_conf(conf_param, host_name=self.mom.shortname)
+            self.match_logs(exp_msg)
+            self.simple_interactive_job()
+            self.match_logs({'mom': f'interactive authentication method = {auth_method}'})
+            self.update_pbs_conf(['PBS_INTERACTIVE_AUTH_METHOD'], op='unset', restart=False)
+
+    def test_not_listed_interactive_auth_method(self):
+        """
+        Test behavior when the provided interactive auth method is not in
+        supported methods.
+
+        Node 1: Server, Sched, Mom, Comm [self.hostA]
+        """
+        self.svr_mode = self.server.get_op_mode()
+        if self.svr_mode != PTL_CLI:
+            self.server.set_op_mode(PTL_CLI)
+
+        auth_method = 'munge'
+        conf_param = {'PBS_COMM_LOG_EVENTS': "2047",
+                      'PBS_SUPPORTED_AUTH_METHODS': 'resvport',
+                      'PBS_INTERACTIVE_AUTH_METHOD': auth_method}
+        if self.server.shortname != self.mom.shortname:
+            check_state = False
+        else:
+            check_state = True
+
+        self.update_pbs_conf(conf_param, check_state=check_state)
+        common_msg1 = f'Supported authentication method: resvport'
+
+        exp_msg = {'server': [common_msg1],
+                   'comm': [common_msg1]}
+        self.match_logs(exp_msg)
+        j = Job(TEST_USER, attrs={ATTR_inter: ''})
+        j.interactive_script = [('sleep 100', '.*')]
+        jid = self.server.submit(j)
+        self.match_logs({'mom': f'interactive authentication method {auth_method} not supported'})
+
+    def test_invalid_interactive_auth_method(self):
+        """
+        Test behavior when the provided interactive auth method is invalid.
+
+        Node 1: Server, Sched, Mom, Comm [self.hostA]
+        """
+        self.svr_mode = self.server.get_op_mode()
+        if self.svr_mode != PTL_CLI:
+            self.server.set_op_mode(PTL_CLI)
+
+        auth_method = 'testing'
+        conf_param = {'PBS_COMM_LOG_EVENTS': "2047",
+                      'PBS_SUPPORTED_AUTH_METHODS': 'resvport',
+                      'PBS_INTERACTIVE_AUTH_METHOD': auth_method}
+        if self.server.shortname != self.mom.shortname:
+            check_state = False
+        else:
+            check_state = True
+
+        self.update_pbs_conf(conf_param, check_state=check_state)
+        common_msg1 = f'Supported authentication method: resvport'
+
+        exp_msg = {'server': [common_msg1],
+                   'comm': [common_msg1]}
+        self.match_logs(exp_msg)
+        j = Job(TEST_USER, attrs={ATTR_inter: ''})
+        j.interactive_script = [('sleep 100', '.*')]
+        jid = self.server.submit(j)
+        self.match_logs({'mom': f'interactive authentication method {auth_method} not supported'})
+
+    def tearDown(self):
+        conf_param = ['PBS_SUPPORTED_AUTH_METHODS',
+                      'PBS_AUTH_METHOD',
+                      'PBS_COMM_LOG_EVENTS',
+                      'PBS_COMM_ROUTERS',
+                      'PBS_LEAF_ROUTERS',
+                      'PBS_INTERACTIVE_AUTH_METHOD',
+                      'PBS_AUTH_SERVICE_USERS']
+        restart = True
+        self.node_list = set(self.node_list)
+        for host_name in self.node_list:
+            if host_name == self.client_host:
+                restart = False
+            self.update_pbs_conf(conf_param, host_name, op='unset',
+                                 restart=restart, check_state=False)
+        self.node_list.clear()


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature

This PR addresses the following security vulnerabilities: 

1. A denial of service vulnerability was discovered when the server sends data to the MoM via TCP. The trusted address model was insufficient, as implemented.
Affected Component - Mom
Attack Type - Local
Impact Denial of Service - true
Attack Vectors - interference with client and Mom sockets
 
 
2. Resource Monitoring requests to MoM over TCP are vulnerable to information leakage. This type of request is used to for custom resource monitoring.
Affected Component - Mom
Attack Type - Local
Impact Denial of Service - true
Attack Vectors - interference with Mom sockets
 
 
3. The client command used to submit interactive job sessions could enable a Denial of Service (DoS) attack or information leakage, issue 1 of 2. OpenPBS is also affected.
Additional Information - A vulnerability was discovered in the client command used to submit interactive job sessions and was found present since very early versions of PBS Professional and OpenPBS, which could enable a Denial of Service (DoS) attack or information leakage.
Affected Component - daemons, Mom
Attack Type - Local
Impact Denial of Service - true
Attack Vectors - Misuse of valid authentication tokens 
 
4. The client command used to submit interactive job sessions could enable a Denial of Service (DoS) attack or information leakage. OpenPBS is also affected.
Affected Component - daemons, Mom
Attack Type - Local
Impact Denial of Service - true

#### Describe Your Change

1. Added interactive job authentication with two methods: resvport and munge.
  * New authentication method: resvport.
      * pbs_mom grabs a privileged port when connecting to qsub, and qsub verifies that the connection originated from a privileged port. If not, the connection is rejected.
  * New authentication method: munge.
    * pbs_mom sends a munge token to qsub, and qsub verifies that the token belongs to the root user (uid = 0). The connection is rejected otherwise.
  * The pbs.conf variable PBS_INTERACTIVE_AUTH_METHOD is added to control the qsub -I auth method that will be used. If not defined, it defaults to resvport. 
  * If an incoming connection to qsub fails to authenticate, it is rejected and qsub goes back to listening for new connections. This is important to avoid DoS exploits.
  * Both the main qsub -I connection is authenticated, as well as the X11 connections created when launching X11 applications inside a qsub -I -X session.


2. Client to Server TCP requests on port 15001:
* client - server authentication has been reinforced with username verification when using munge.


3. Inter-daemon communication through TPP:
* pbs_comm authentication has been reinforced with username verification when using munge.
* Added conf variable PBS_AUTH_SERVICE_USERS that is a comma separated list of users that are recognized by pbs_comm.
        * When a daemon (Server or MoM) connects to pbs_comm, the daemon's username is extracted from the authdata it sends (when using munge), and it is compared against the list of PBS_AUTH_SERVICE_USERS.
        * The connection is successfully authenticated only if the daemon's name is in the list of recognized daemons.
        * PBS_AUTH_SERVICE_USERS defaults to "root". This is enough it typicall Linux environments.

4. Server to MOM TCP requests on port 15002:

* Additional step when authenticating a server - MoM connection in port 15002 for TCP traffic:
        * Originally, there was an IP address check together with resvport.
        * However, this does not prevent against IP spoofing.
        * Now, when a new connection is initiated, the server sends an encrypted message in the form: "salt;encrypted(salt;timestr;cluster_key)", and the MoM verifies that the salt matches the encrypted one, the timestr is recent (<5 min) and the cluster_key is the same as the one got from the socket descriptor.
        * The cluster_key is random string generated by the server when the first mom connects via TPP, and sends it to the mom.


5. System verified process owner in tm_attach requests

* When receiving a new tm_attach request:
        * We read the uid found in the received packet
        * We then extract from the socket descriptor the local and remote end IPs.
        * The IPs need to match, if not there's an error. This check was already in place.
        * We extract the ports too. Then we open /proc/net/tcp or /proc/net/tcp6, and index it based on the two port numbers
        * We extract the uid field from the matching line, let's call that system_uid
        * system_uid should match uid. If not, an error is returned and the tm_attach request is rejected.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output

Attaching the following test logs:
* New test class TestMultipleAuthMethods with 24 tests. They verify the operation of the reinforced authentication methods.:
[ptl-test_munge_without_supported_auth_method_on_server.txt](https://github.com/user-attachments/files/21593081/ptl-test_munge_without_supported_auth_method_on_server.txt)
[ptl-test_without_munge_on_client_host.txt](https://github.com/user-attachments/files/21593082/ptl-test_without_munge_on_client_host.txt)
[ptl-test_without_munge_on_comm_host.txt](https://github.com/user-attachments/files/21593083/ptl-test_without_munge_on_comm_host.txt)
[ptl-test_without_munge_on_mom_host.txt](https://github.com/user-attachments/files/21593085/ptl-test_without_munge_on_mom_host.txt)
[ptl-test_without_munge_on_server_host.txt](https://github.com/user-attachments/files/21593087/ptl-test_without_munge_on_server_host.txt)
[ptl-TestMultipleAuthMethods.txt](https://github.com/user-attachments/files/21593088/ptl-TestMultipleAuthMethods.txt)
[ptl-test_diff_auth_method_on_client.txt](https://github.com/user-attachments/files/21593089/ptl-test_diff_auth_method_on_client.txt)
[ptl-test_diff_auth_methods_on_moms.txt](https://github.com/user-attachments/files/21593090/ptl-test_diff_auth_methods_on_moms.txt)
[ptl-test_munge_disabled_on_mom_host.txt](https://github.com/user-attachments/files/21593091/ptl-test_munge_disabled_on_mom_host.txt)
 
* TestOnlySmallFilowsOverTPP: 3 tests that verify MOM TCP requests on port 15002 (for large files): 
[ptl-TestOnlySmallFilesOverTPP.txt](https://github.com/user-attachments/files/21593096/ptl-TestOnlySmallFilesOverTPP.txt)

* qsub Interactive manual testing: 
[qsub_interactive-manual-testing.txt](https://github.com/user-attachments/files/21593098/qsub_interactive-manual-testing.txt)

* qsub Interactive with X11 manual testing: 
[qsub_interactive_X11-manual-testing.txt](https://github.com/user-attachments/files/21593102/qsub_interactive_X11-manual-testing.txt)

* Penetration tests for the new authentication mechanisms: 
[pentest-ptl.txt](https://github.com/user-attachments/files/21593103/pentest-ptl.txt)

* Test_RootOwnedScript: Verifies new tm_attach process owner verification mechanism 
[Test_RootOwnedScript.txt](https://github.com/user-attachments/files/21593107/Test_RootOwnedScript.txt)

* Finally all smoketests to verify correct basic operation: 
[ptl-TestSmoke.txt](https://github.com/user-attachments/files/21593110/ptl-TestSmoke.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
