### PR TITLE
fix: include stdbool.h and avoid typedef

### DIFF
--- a/src/lib/Libutil/avltree.c
+++ b/src/lib/Libutil/avltree.c
@@ -72,6 +72,7 @@
 #include "avltree.h"
 #include <limits.h>
 #include <pthread.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -375,8 +376,6 @@ way3ix(way3 x) /* assume x != 0 */
 /******************************************************************************
  TREE
  ******************************************************************************/
-
-typedef int bool;
 
 /**
  * @brief


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->

With GCC 15.1.1, build fails:

```console
$ make
…
gcc -DHAVE_CONFIG_H -I. -I../../../src/include  -I../../../src/include    -Wno-incompatible-pointer-types -Werror=old-style-definition -MT libutil_a-avltree.o -MD -MP -MF .deps/libutil_a-avltree.Tpo -c -o libutil_a-avltree.o `test -f 'avltree.c' || echo './'`avltree.c
avltree.c:379:13: error: 'bool' cannot be defined via 'typedef'
  379 | typedef int bool;
      |             ^~~~
avltree.c:379:13: note: 'bool' is a keyword with '-std=c23' onwards
avltree.c:379:1: warning: useless type name in empty declaration
  379 | typedef int bool;
      | ^~~~~~~
make[3]: *** [Makefile:660: libutil_a-avltree.o] Error 1
```

https://github.com/openpbs/openpbs/blob/42cb7a44b578c6ae09b2d9104a3a48f58b55831c/src/lib/Libutil/avltree.c#L379

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

include \<stdbool.h\> as e.g. https://github.com/openpbs/openpbs/blob/42cb7a44b578c6ae09b2d9104a3a48f58b55831c/src/include/libutil.h#L48 does.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
