### PR TITLE
refactor: avoid K&R style declaration (removed in C23)

### DIFF
--- a/src/lib/Libattr/attr_fn_arst.c
+++ b/src/lib/Libattr/attr_fn_arst.c
@@ -706,12 +706,12 @@ parse_comma_string_bs(char *start)
  * 	variables.
  *
  *	See also count_substrings
+ *
+ * @param val comma separated string of substrings
+ * @param pcnt where to return the value
  */
 int
-count_substrings_bs(val, pcnt)
-char *val; /*comma separated string of substrings*/
-int *pcnt; /*where to return the value*/
-
+count_substrings_bs(char *val, int *pcnt)
 {
 	int rc = 0;
 	int ns;

--- a/src/resmom/mom_inter.c
+++ b/src/resmom/mom_inter.c
@@ -119,8 +119,7 @@ read_net(int sock, char *buf, int amt)
  */
 
 char *
-rcvttype(sock)
-int sock;
+rcvttype(int sock)
 {
 	static char buf[PBS_TERM_BUF_SZ];
 
@@ -151,7 +150,7 @@ int sock;
  */
 
 void
-	set_termcc(fd) int fd;
+	set_termcc(int fd)
 {
 	struct termios slvtio;
 
@@ -234,8 +233,7 @@ rcvwinsize(int sock)
  *
  */
 int
-setwinsize(pty)
-int pty;
+setwinsize(int pty)
 {
 	if (ioctl(pty, TIOCSWINSZ, &wsz) < 0) {
 		perror("ioctl TIOCSWINSZ");
@@ -251,7 +249,7 @@ int pty;
  *
  * @param[in] s - filr descriptor
  * @param[in] ptc - master file descriptor
- * @param[in] command - shell command
+ * @param[in] command - shell command(s) to be sent to the PTY before user data from the socket
  *
  * @return    error code
  * @retval    0     Success
@@ -260,10 +258,7 @@ int pty;
  * 
  */
 int
-mom_reader(s, ptc, command)
-int s;
-int ptc;
-char *command; /* shell command(s) to be sent to the PTY before user data from the socket */
+mom_reader(int s, int ptc, char *command)
 {
 	char buf[PF_BUF_SIZE];
 	int c;
@@ -416,9 +411,7 @@ mom_reader_Xjob(int s)
  *
  */
 int
-mom_writer(s, ptc)
-int s;
-int ptc;
+mom_writer(int s, int ptc)
 {
 	char buf[PF_BUF_SIZE];
 	int c;

--- a/src/resmom/mom_server.c
+++ b/src/resmom/mom_server.c
@@ -160,8 +160,7 @@ node *okclients = NULL; /* tree of ip addrs */
  * @retval 	0     if not
  */
 int
-	addrfind(key)
-		const u_long key; /* key to be located */
+	addrfind(const u_long key)
 {
 	node **rootp = &okclients; /* address of tree root */
 

--- a/src/resmom/prolog.c
+++ b/src/resmom/prolog.c
@@ -133,11 +133,7 @@ resc_to_string(job *pjob, int attr_idx, char *buf, int buflen)
  */
 
 static int
-pelog_err(pjob, file, n, text)
-job *pjob;
-char *file;
-int n;
-char *text;
+pelog_err(job *pjob, char *file, int n, char *text)
 {
 	sprintf(log_buffer, "pro/epilogue failed, file: %s, exit: %d, %s",
 		file, n, text);
@@ -156,7 +152,7 @@ char *text;
  *
  */
 static void
-	pelogalm(sig) int sig;
+	pelogalm(int sig)
 {
 	run_exit = -4;
 }
@@ -198,11 +194,7 @@ static void
  */
 
 int
-run_pelog(which, pelog, pjob, pe_io_type)
-int which;
-char *pelog;
-job *pjob;
-int pe_io_type;
+run_pelog(int which, char *pelog, job *pjob, int pe_io_type)
 {
 	char *arg[12];
 	char exitcode[20];

--- a/src/server/req_delete.c
+++ b/src/server/req_delete.c
@@ -1755,7 +1755,7 @@ resend:
  */
 
 static void
-	post_deljobfromresv_req(pwt) struct work_task *pwt;
+	post_deljobfromresv_req(struct work_task *pwt)
 {
 	resc_resv *presv;
 	job *pjob = NULL;

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -168,9 +168,7 @@ struct pul_store {
  * @retval	FALSE	- No Admin-privilege
  */
 int
-is_local_root(user, host)
-char *user;
-char *host;
+is_local_root(char *user, char *host)
 {
 	/* Similar method used in svr_get_privilege() */
 	if (strcmp(user, PBS_DEFAULT_ADMIN) == 0) {
@@ -1131,7 +1129,7 @@ mgr_unset_attr(attribute *pattr, void *pidx, attribute_def *pdef, int limit, svr
  */
 
 void
-	mgr_queue_create(preq) struct batch_request *preq;
+	mgr_queue_create(struct batch_request *preq)
 {
 	int bad;
 	char *badattr;
@@ -3131,7 +3129,7 @@ mgr_sched_delete(struct batch_request *preq)
  */
 
 static void
-	mgr_node_delete(preq) struct batch_request *preq;
+	mgr_node_delete(struct batch_request *preq)
 {
 	int numnodes = 1;
 	struct pbsnode *pnode;

--- a/src/server/svr_func.c
+++ b/src/server/svr_func.c
@@ -1857,10 +1857,7 @@ action_entlim_res(attribute *pattr, void *pobject, int actmode)
  * @retval	PBSE_MIXENTLIMS	: here is a new style entlim limit set
  */
 int
-check_no_entlim(pattr, pobject, actmode)
-attribute *pattr;
-void *pobject;
-int actmode;
+check_no_entlim(attribute *pattr, void *pobject, int actmode)
 {
 	int i;
 	pbs_queue *pq;

--- a/src/tools/pbs_tclWrap.c
+++ b/src/tools/pbs_tclWrap.c
@@ -102,11 +102,7 @@ int (*local_disconnect)(int connection) = __pbs_disconnect;
 #endif
 
 int
-OpenRM(clientData, interp, objc, objv)
-ClientData clientData;
-Tcl_Interp *interp;
-int objc;
-Tcl_Obj *CONST objv[];
+OpenRM(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 {
 	int port = 0;
 	int fd;
@@ -135,11 +131,7 @@ Tcl_Obj *CONST objv[];
 }
 
 int
-CloseRM(clientData, interp, objc, objv)
-ClientData clientData;
-Tcl_Interp *interp;
-int objc;
-Tcl_Obj *CONST objv[];
+CloseRM(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 {
 	int fd, ret;
 	char *cmd;
@@ -168,11 +160,7 @@ Tcl_Obj *CONST objv[];
 }
 
 int
-DownRM(clientData, interp, objc, objv)
-ClientData clientData;
-Tcl_Interp *interp;
-int objc;
-Tcl_Obj *CONST objv[];
+DownRM(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 {
 	int fd, ret;
 	char *cmd;
@@ -201,11 +189,7 @@ Tcl_Obj *CONST objv[];
 }
 
 int
-ConfigRM(clientData, interp, objc, objv)
-ClientData clientData;
-Tcl_Interp *interp;
-int objc;
-Tcl_Obj *CONST objv[];
+ConfigRM(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 {
 	int fd, ret;
 	char *cmd, *filename;
@@ -237,11 +221,7 @@ Tcl_Obj *CONST objv[];
 }
 
 int
-AddREQ(clientData, interp, objc, objv)
-ClientData clientData;
-Tcl_Interp *interp;
-int objc;
-Tcl_Obj *CONST objv[];
+AddREQ(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 {
 	int fd, ret;
 	char *cmd, *request;
@@ -273,11 +253,7 @@ Tcl_Obj *CONST objv[];
 }
 
 int
-AllREQ(clientData, interp, argc, argv)
-ClientData clientData;
-Tcl_Interp *interp;
-int argc;
-char *argv[];
+AllREQ(ClientData clientData, Tcl_Interp *interp, int argc, char *argv[])
 {
 	int ret;
 
@@ -294,11 +270,7 @@ char *argv[];
 }
 
 int
-GetREQ(clientData, interp, objc, objv)
-ClientData clientData;
-Tcl_Interp *interp;
-int objc;
-Tcl_Obj *CONST objv[];
+GetREQ(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 {
 	int fd;
 	char *ret, *getreq();
@@ -340,11 +312,7 @@ Tcl_Obj *CONST objv[];
 }
 
 int
-FlushREQ(clientData, interp, argc, argv)
-ClientData clientData;
-Tcl_Interp *interp;
-int argc;
-char *argv[];
+FlushREQ(ClientData clientData, Tcl_Interp *interp, int argc, char *argv[])
 {
 	if (argc != 1) {
 		sprintf(log_buffer, badparm, (char *) argv[0]);
@@ -359,11 +327,7 @@ char *argv[];
 }
 
 int
-ActiveREQ(clientData, interp, argc, argv)
-ClientData clientData;
-Tcl_Interp *interp;
-int argc;
-char *argv[];
+ActiveREQ(ClientData clientData, Tcl_Interp *interp, int argc, char *argv[])
 {
 	int ret;
 
@@ -389,11 +353,7 @@ char *argv[];
 }
 
 int
-FullResp(clientData, interp, argc, argv)
-ClientData clientData;
-Tcl_Interp *interp;
-int argc;
-char *argv[];
+FullResp(ClientData clientData, Tcl_Interp *interp, int argc, char *argv[])
 {
 	int flag;
 
@@ -412,11 +372,7 @@ char *argv[];
 }
 
 int
-PBS_Connect(clientData, interp, argc, argv)
-ClientData clientData;
-Tcl_Interp *interp;
-int argc;
-char *argv[];
+PBS_Connect(ClientData clientData, Tcl_Interp *interp, int argc, char *argv[])
 {
 	char *server = NULL;
 
@@ -447,11 +403,7 @@ char *argv[];
 }
 
 int
-PBS_Disconnect(clientData, interp, argc, argv)
-ClientData clientData;
-Tcl_Interp *interp;
-int argc;
-char *argv[];
+PBS_Disconnect(ClientData clientData, Tcl_Interp *interp, int argc, char *argv[])
 {
 	if (argc != 1) {
 		sprintf(log_buffer, badparm, argv[0]);
@@ -469,9 +421,7 @@ char *argv[];
 }
 
 Tcl_Obj *
-attrlist(interp, ap)
-Tcl_Interp *interp;
-struct attrl *ap;
+attrlist(Tcl_Interp *interp, struct attrl *ap)
 {
 	Tcl_Obj *ret;
 
@@ -497,9 +447,7 @@ struct attrl *ap;
 }
 
 void
-	batresult(interp, bs)
-		Tcl_Interp *interp;
-struct batch_status *bs;
+	batresult(Tcl_Interp *interp, struct batch_status *bs)
 {
 	Tcl_Obj *batchl;
 	struct batch_status *bp;
@@ -520,11 +468,7 @@ struct batch_status *bs;
 }
 
 int
-PBS_StatServ(clientData, interp, argc, argv)
-ClientData clientData;
-Tcl_Interp *interp;
-int argc;
-char *argv[];
+PBS_StatServ(ClientData clientData, Tcl_Interp *interp, int argc, char *argv[])
 {
 	char *msg;
 	struct batch_status *bs;
@@ -570,11 +514,7 @@ char *argv[];
 }
 
 int
-PBS_StatJob(clientData, interp, argc, argv)
-ClientData clientData;
-Tcl_Interp *interp;
-int argc;
-char *argv[];
+PBS_StatJob(ClientData clientData, Tcl_Interp *interp, int argc, char *argv[])
 {
 	char *msg;
 	struct batch_status *bs;
@@ -616,11 +556,7 @@ char *argv[];
 }
 
 int
-PBS_SelStat(clientData, interp, argc, argv)
-ClientData clientData;
-Tcl_Interp *interp;
-int argc;
-char *argv[];
+PBS_SelStat(ClientData clientData, Tcl_Interp *interp, int argc, char *argv[])
 {
 	char *msg;
 	struct batch_status *bs;
@@ -671,11 +607,7 @@ char *argv[];
 }
 
 int
-PBS_StatQue(clientData, interp, argc, argv)
-ClientData clientData;
-Tcl_Interp *interp;
-int argc;
-char *argv[];
+PBS_StatQue(ClientData clientData, Tcl_Interp *interp, int argc, char *argv[])
 {
 	char *msg;
 	struct batch_status *bs;
@@ -713,11 +645,7 @@ char *argv[];
 }
 
 int
-PBS_StatNode(clientData, interp, objc, objv)
-ClientData clientData;
-Tcl_Interp *interp;
-int objc;
-Tcl_Obj *CONST objv[];
+PBS_StatNode(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 {
 	char *msg, *cmd;
 	char *node = NULL;
@@ -758,11 +686,7 @@ Tcl_Obj *CONST objv[];
 }
 
 int
-PBS_AsyRunJob(clientData, interp, argc, argv)
-ClientData clientData;
-Tcl_Interp *interp;
-int argc;
-char *argv[];
+PBS_AsyRunJob(ClientData clientData, Tcl_Interp *interp, int argc, char *argv[])
 {
 	char *msg;
 	char *location = NULL;
@@ -792,11 +716,7 @@ char *argv[];
 }
 
 int
-PBS_RunJob(clientData, interp, argc, argv)
-ClientData clientData;
-Tcl_Interp *interp;
-int argc;
-char *argv[];
+PBS_RunJob(ClientData clientData, Tcl_Interp *interp, int argc, char *argv[])
 {
 	char *msg;
 	char *location = NULL;
@@ -826,11 +746,7 @@ char *argv[];
 }
 
 int
-PBS_ReRun(clientData, interp, argc, argv)
-ClientData clientData;
-Tcl_Interp *interp;
-int argc;
-char *argv[];
+PBS_ReRun(ClientData clientData, Tcl_Interp *interp, int argc, char *argv[])
 {
 	char *msg;
 	char *extend = "0";
@@ -859,11 +775,7 @@ char *argv[];
 }
 
 int
-PBS_MoveJob(clientData, interp, argc, argv)
-ClientData clientData;
-Tcl_Interp *interp;
-int argc;
-char *argv[];
+PBS_MoveJob(ClientData clientData, Tcl_Interp *interp, int argc, char *argv[])
 {
 	char *msg;
 	char *location = NULL;
@@ -903,11 +815,7 @@ char *argv[];
 }
 
 int
-PBS_DelJob(clientData, interp, argc, argv)
-ClientData clientData;
-Tcl_Interp *interp;
-int argc;
-char *argv[];
+PBS_DelJob(ClientData clientData, Tcl_Interp *interp, int argc, char *argv[])
 {
 	char *msg;
 	char *message = NULL;
@@ -937,11 +845,7 @@ char *argv[];
 }
 
 int
-PBS_HoldJob(clientData, interp, argc, argv)
-ClientData clientData;
-Tcl_Interp *interp;
-int argc;
-char *argv[];
+PBS_HoldJob(ClientData clientData, Tcl_Interp *interp, int argc, char *argv[])
 {
 	char *msg;
 
@@ -968,12 +872,7 @@ char *argv[];
 }
 
 int
-PBS_QueueOp(clientData, interp, argc, argv, attr)
-ClientData clientData;
-Tcl_Interp *interp;
-int argc;
-char *argv[];
-struct attropl *attr;
+PBS_QueueOp(ClientData clientData, Tcl_Interp *interp, int argc, char *argv[], struct attropl *attr)
 {
 	int merr;
 
@@ -1007,55 +906,35 @@ struct attropl *attr;
 }
 
 int
-PBS_EnableQueue(clientData, interp, argc, argv)
-ClientData clientData;
-Tcl_Interp *interp;
-int argc;
-char *argv[];
+PBS_EnableQueue(ClientData clientData, Tcl_Interp *interp, int argc, char *argv[])
 {
 	static struct attropl attr = {NULL, "enabled", NULL, "TRUE", SET};
 	return PBS_QueueOp(clientData, interp, argc, argv, &attr);
 }
 
 int
-PBS_DisableQueue(clientData, interp, argc, argv)
-ClientData clientData;
-Tcl_Interp *interp;
-int argc;
-char *argv[];
+PBS_DisableQueue(ClientData clientData, Tcl_Interp *interp, int argc, char *argv[])
 {
 	static struct attropl attr = {NULL, "enabled", NULL, "FALSE", SET};
 	return PBS_QueueOp(clientData, interp, argc, argv, &attr);
 }
 
 int
-PBS_StartQueue(clientData, interp, argc, argv)
-ClientData clientData;
-Tcl_Interp *interp;
-int argc;
-char *argv[];
+PBS_StartQueue(ClientData clientData, Tcl_Interp *interp, int argc, char *argv[])
 {
 	static struct attropl attr = {NULL, "started", NULL, "TRUE", SET};
 	return PBS_QueueOp(clientData, interp, argc, argv, &attr);
 }
 
 int
-PBS_StopQueue(clientData, interp, argc, argv)
-ClientData clientData;
-Tcl_Interp *interp;
-int argc;
-char *argv[];
+PBS_StopQueue(ClientData clientData, Tcl_Interp *interp, int argc, char *argv[])
 {
 	static struct attropl attr = {NULL, "started", NULL, "FALSE", SET};
 	return PBS_QueueOp(clientData, interp, argc, argv, &attr);
 }
 
 int
-PBS_AlterJob(clientData, interp, objc, objv)
-ClientData clientData;
-Tcl_Interp *interp;
-int objc;
-Tcl_Obj *CONST objv[];
+PBS_AlterJob(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 {
 	static char id[] = "PBS_AlterJob";
 	char *msg;
@@ -1165,11 +1044,7 @@ done:
 }
 
 int
-PBS_RescQuery(clientData, interp, objc, objv)
-ClientData clientData;
-Tcl_Interp *interp;
-int objc;
-Tcl_Obj *CONST objv[];
+PBS_RescQuery(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 {
 	static char id[] = "PBS_RescQuery";
 	char *msg;
@@ -1294,11 +1169,7 @@ Tcl_Obj *CONST objv[];
 }
 
 int
-PBS_RescReserve(clientData, interp, objc, objv)
-ClientData clientData;
-Tcl_Interp *interp;
-int objc;
-Tcl_Obj *CONST objv[];
+PBS_RescReserve(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 {
 	static char id[] = "PBS_RescReserve";
 	char *msg;
@@ -1361,11 +1232,7 @@ Tcl_Obj *CONST objv[];
 }
 
 int
-PBS_RescRelease(clientData, interp, objc, objv)
-ClientData clientData;
-Tcl_Interp *interp;
-int objc;
-Tcl_Obj *CONST objv[];
+PBS_RescRelease(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 {
 	char *msg;
 	int ret;
@@ -1406,11 +1273,7 @@ Tcl_Obj *CONST objv[];
 }
 
 int
-PBS_ResvStatus(clientData, interp, argc, argv)
-ClientData clientData;
-Tcl_Interp *interp;
-int argc;
-char *CONST argv[];
+PBS_ResvStatus(ClientData clientData, Tcl_Interp *interp, int argc, char *CONST argv[])
 {
 	char *msg;
 	struct batch_status *bs;
@@ -1445,11 +1308,7 @@ char *CONST argv[];
 }
 
 int
-PBS_ResvConfirm(clientData, interp, argc, argv)
-ClientData clientData;
-Tcl_Interp *interp;
-int argc;
-char *CONST argv[];
+PBS_ResvConfirm(ClientData clientData, Tcl_Interp *interp, int argc, char *CONST argv[])
 {
 	char *msg = NULL;
 	unsigned long stime = 0;
@@ -1481,11 +1340,7 @@ char *CONST argv[];
 }
 
 int
-PBS_ResvDelete(clientData, interp, argc, argv)
-ClientData clientData;
-Tcl_Interp *interp;
-int argc;
-char *CONST argv[];
+PBS_ResvDelete(ClientData clientData, Tcl_Interp *interp, int argc, char *CONST argv[])
 {
 	char *msg = NULL;
 
@@ -1511,11 +1366,7 @@ char *CONST argv[];
 }
 
 int
-LogMsg(clientData, interp, objc, objv)
-ClientData clientData;
-Tcl_Interp *interp;
-int objc;
-Tcl_Obj *CONST objv[];
+LogMsg(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 {
 	char *tag = NULL;
 	char *msg = NULL;
@@ -1546,11 +1397,7 @@ Tcl_Obj *CONST objv[];
 }
 
 int
-DateTime(clientData, interp, argc, argv)
-ClientData clientData;
-Tcl_Interp *interp;
-int argc;
-char *argv[];
+DateTime(ClientData clientData, Tcl_Interp *interp, int argc, char *argv[])
 {
 	time_t when;
 	struct tm tm, *t = NULL;
@@ -1675,11 +1522,7 @@ char *argv[];
 }
 
 int
-StrFtime(clientData, interp, objc, objv)
-ClientData clientData;
-Tcl_Interp *interp;
-int objc;
-Tcl_Obj *CONST objv[];
+StrFtime(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 {
 	struct tm *t;
 	long hold;
@@ -1706,11 +1549,7 @@ Tcl_Obj *CONST objv[];
 }
 
 int
-PBS_PbsPortInfoCmd(clientData, interp, objc, objv)
-ClientData clientData;
-Tcl_Interp *interp;
-int objc;
-Tcl_Obj *CONST objv[];
+PBS_PbsPortInfoCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 {
 	int index, result;
 	static const char *subCmds[] = {
@@ -1754,8 +1593,7 @@ Tcl_Obj *CONST objv[];
 }
 
 void
-	add_cmds(interp)
-		Tcl_Interp *interp;
+	add_cmds(Tcl_Interp *interp)
 {
 	extern void site_cmds(Tcl_Interp * interp);
 

--- a/src/tools/site_tclWrap.c
+++ b/src/tools/site_tclWrap.c
@@ -317,8 +317,7 @@ Tcl_Obj *CONST objv[];
  **	for whatever C code which may be required for your scheduler.
  */
 void
-	site_cmds(interp)
-		Tcl_Interp *interp;
+	site_cmds(Tcl_Interp *interp)
 {
 	DBPRT(("%s: entered\n", __func__))
 #ifdef NAS


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->

Some of the C codes still use K&R style function declaration that is removed in C23.

<https://en.cppreference.com/w/c/language/function_declaration.html>

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Avoid K&R style declaration.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
