### PR TITLE
fix match_resource() type in scheduler

### DIFF
--- a/src/scheduler/check.cpp
+++ b/src/scheduler/check.cpp
@@ -1108,13 +1108,13 @@ find_check_resource(schd_resource *reslist, resource_req *resreq, unsigned int f
  * @param[in] flags to modify behavior (@see check_avail_resources())
  * @param[in] fail_code - fail code to use in schd_error if resources don't match
  * @param[out] err - if resources don't match, reason not matched
- * @return int
+ * @return long long
  * @retval number of chunks matched if matched and consumable
  * @retval SCHD_INFINITY if matched and non-consumable
  * @retval 0 of resources failed to match
  */
 
-int
+long long
 match_resource(schd_resource *res, resource_req *resreq, unsigned int flags, enum sched_error_code fail_code, schd_error *err)
 {
 	sch_resource_t avail; /* amount of available resource */


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->

There is the wrong type of match_resource() function in the scheduler. The result returned in this function is long long, and indeed, the value can be large enough not to fit int - the current type. If the value exceeds int, the value becomes negative in check_avail_resources(). Thus, it can even mislead the scheduler into running a job without sufficient resources available.

See the gdb output:

```
1166			if (avail != SCHD_INFINITY_RES && resreq->amount != 0) {
(gdb) 
1167				if (avail < resreq->amount) {
(gdb) 
1185						num_chunk = cur_chunk;
(gdb) 
1190		return num_chunk;
(gdb) p cur_chunk
$36 = 2211969830
(gdb) n
check_avail_resources (reslist=0x7f153400fee0, reqlist=<optimized out>, flags=flags@entry=56, 
    checklist=std::unordered_set with 10 elements = {...}, 
    fail_code=fail_code@entry=INSUFFICIENT_RESOURCE, perr=perr@entry=0x55ec1c1efe30)
    at /tmp/openpbs-src/src/scheduler/check.cpp:1253
1253				if (num_chunk == SCHD_INFINITY)
(gdb) p match_chunk
$37 = -2082997466
```

Both match_chunk and cur_chunk are long long.

E.g.: The example requests a small amount of size resource (like 1kb) and a large number of ncpus in select: `-l select scratch_local=100b:ncpus=100`. Also, the size must be before ncpus to mislead the scheduler. Now, the job is run even on a node without 100 ncpus available.



#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Change match_resource() to long long so it fits the result in the function and passes it into check_avail_resources() correctly.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

No logs available. The test job will not start anymore. 



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
