### PR TITLE
make show_nonprint_chars() working with non-ASCII chars

### DIFF
--- a/test/fw/ptl/lib/ptl_batchutils.py
+++ b/test/fw/ptl/lib/ptl_batchutils.py
@@ -78,7 +78,7 @@ class BatchUtils(object):
                             r"[.]*[(?P<server>.*)]*")
 
     pbsobjname_re = re.compile(r"^(?P<tag>[\w\d][\d\w\s]*:?[\s]+)" +
-                               r"*(?P<name>[\w@\.\d\[\]-]+)$")
+                               r"*(?P<name>[\^\\\w@\.\d\[\]-]+)$")
     pbsobjattrval_re = re.compile(r"""
                             [\s]*(?P<attribute>[\w\d\.-]+)
                             [\s]*=[\s]*
@@ -636,6 +636,20 @@ class BatchUtils(object):
             _js.append(_jdict)
         return _js
 
+    def convert_to_ascii(self, s):
+        """
+        Convert char sequences within string like ^A, ^B, ... to
+        ASCII 0x01, ...
+
+        :param s: string to convert
+        :type s: string
+        :returns: converted string
+        """
+        def repl(m):
+            c = m.group(1)
+            return chr(ord(c) - 64) if "@" < c <= "_" else m.group(0)
+        return re.sub(r"\^(.)", repl, s)
+
     def convert_to_dictlist(self, l, attribs=None, mergelines=True, id=None,
                             obj_type=None):
         """
@@ -682,7 +696,7 @@ class BatchUtils(object):
                     if id is None or (id is not None and d['id'] == id):
                         objlist.append(d.copy())
                 d = {}
-                d['id'] = m.group('name')
+                d['id'] = self.convert_to_ascii(m.group('name'))
                 _t = m.group('tag')
                 if _t == 'Resv ID: ':
                     d[_t.replace(': ', '')] = d['id']

--- a/test/tests/functional/pbs_passing_environment_variable.py
+++ b/test/tests/functional/pbs_passing_environment_variable.py
@@ -230,3 +230,29 @@ foo\n
         for i in range(0, 300):
             exp_string = f"VAR{i}=foobar"
             self.assertIn(exp_string, var_list)
+
+    def test_passing_non_ascii_env(self):
+        """
+        Test to verify that job is able to process
+        non-ascii env attribute.
+        """
+
+        import locale
+        target_locale = 'cs_CZ.UTF-8'
+        try:
+            locale.setlocale(locale.LC_ALL, target_locale)
+        except:
+            msg = f"Target locale ${target_locale} not available."
+            self.skipTest(msg)
+
+        env = "VAR=ěščřžýáíéů"
+
+        a = {ATTR_v: env}
+        j = Job(TEST_USER, attrs=a)
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        qstat = self.server.status(JOB, ATTR_v, id=jid)
+        var_list = qstat[0]['Variable_List'].split(",")
+
+        exp_string = f"VAR=ěščřžýáíéů"
+        self.assertIn(exp_string, var_list)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->

 1. OpenPBS not showing non-ASCII chars correctly. See:
```
torque2.grid.cesnet.cz$ qsub -I -v FOO='ěščřžýáíéů' -l select=vnode=torque2
qsub: waiting for job 117390.torque1.grid.cesnet.cz to start
qsub: job 117390.torque1.grid.cesnet.cz ready

torque2.grid.cesnet.cz$ qstat -fw 117390.torque1.grid.cesnet.cz | grep FOO
    Variable_List = PBS_O_HOME=/storage/praha1/home/vchlum,PBS_O_LANG=en_US.UTF-8,PBS_O_LOGNAME=vchlum,PBS_O_PATH=/cvmfs/software.metacentrum.cz/modulefiles/5.3.1/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games:/usr/bin:/software/meta-utils/public,PBS_O_SHELL=/bin/bash,PBS_O_WORKDIR=/storage/praha1/home/vchlum,PBS_O_SYSTEM=Linux,FOO=^^�^^�^^�^^�^^�^^�^^�^^�^^�^^�,PBS_O_QUEUE=default,PBS_O_HOST=torque2.grid.cesnet.cz,PBS_RESC_MEM=419430400,TORQUE_RESC_MEM=419430400,PBS_NUM_PPN=1,PBS_NCPUS=1,TORQUE_RESC_PROC=1,PBS_NGPUS=0,PBS_RESC_TOTAL_MEM=419430400,TORQUE_RESC_TOTAL_MEM=419430400,PBS_RESC_TOTAL_PROCS=1,TORQUE_RESC_TOTAL_PROCS=1,PBS_NUM_NODES=1,PBS_RESC_TOTAL_WALLTIME=86400,TORQUE_RESC_TOTAL_WALLTIME=86400,SCRATCHDIR=/var/tmp/pbs.117390.torque1.grid.cesnet.cz,SCRATCH=/var/tmp/pbs.117390.torque1.grid.cesnet.cz,SINGULARITY_TMPDIR=/var/tmp/pbs.117390.torque1.grid.cesnet.cz,SINGULARITY_CACHEDIR=/var/tmp/pbs.117390.torque1.grid.cesnet.cz,SCRATCH_VOLUME=0,PBS_RESC_SCRATCH_VOLUME=0,TORQUE_RESC_SCRATCH_VOLUME=0,SCRATCH_TYPE=none,PBS_RESC_TOTAL_SCRATCH_VOLUME=0,TORQUE_RESC_TOTAL_SCRATCH_VOLUME=0
    Submit_arguments = -I -v FOO=^^�^^�^^�^^�^^�^^�^^�^^�^^�^^� -l select=vnode=torque2
torque2.grid.cesnet.cz$ 
```
 2. While testing, I dicovered the PTL test `TestNonprintingCharacters.test_nonprint_character_hook_name` is broken. See:  
[TestNonprintingCharacters.test_nonprint_character_hook_name-failed.log](https://github.com/user-attachments/files/23208702/TestNonprintingCharacters.test_nonprint_character_hook_name-failed.log)

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

 1. The function `show_nonprint_chars()` is fixed by detecting wide chars with `mbtowc()` and not adding 64 to non-wide chars.
 2. The PTL issue consists of two problems:
    * The regex `pbsobjname_re` ignores chars: `^\`, which is added to the regex now. The hook name (like `h^Ad`) was not always recognized by PTL.
    * The char sequences like `^A`, `^B`, ... (printed by pbs clients) needs to be converted back to `0x01`, `0x02` ... in order to recognized the object/hook name correctly by PTL. This is done by converter function `convert_to_ascii()`.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

PTL smoke test: [ptl_smoketest.txt](https://github.com/user-attachments/files/23210307/ptl_smoketest.txt)


 1: New PTL test: [ptl_Test_passing_environment_variable_via_qsub.test_passing_non_ascii_env.txt](https://github.com/user-attachments/files/23209751/ptl_Test_passing_environment_variable_via_qsub.test_passing_non_ascii_env.txt)

 1+2: Fixed PTL test + non-printable ASCII tests: [ptl_TestNonprintingCharacters.txt](https://github.com/user-attachments/files/23209760/ptl_TestNonprintingCharacters.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
