### PR TITLE
initialize assigned value of server_dyn_res

### DIFF
--- a/src/scheduler/server_info.h
+++ b/src/scheduler/server_info.h
@@ -69,6 +69,11 @@ server_info *query_server_info(status *pol, struct batch_status *server);
 int query_server_dyn_res(server_info *sinfo);
 
 /*
+ * 	calc_server_dyn_res_assigned - initialize assigned value of server_dyn_res
+ */
+void calc_server_dyn_res_assigned(server_info *sinfo);
+
+/*
  *	find_alloc_resource[_by_str] - try and find a resource, and if it is
  *                                     not there allocate space for it and
  *                                     add it to the resource list


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->

I would like to offer a patch to initialize the assigned value of server dynamic resources in the scheduler.

The assigned value is not initialized now, and if a job is estimated in the calendar and can not run now due to other resources, it produces lines like "turned negative" in the log.

See:
```
10/31/2025 19:55:59.131440;0080;pbs_sched;Job;7636.almalinux;Considering job to run
10/31/2025 19:55:59.131518;0080;pbs_sched;Svr;update_server_on_end;foobar turned negative -4.00, setting it to 0
10/31/2025 19:55:59.131550;0080;pbs_sched;Job;7636.almalinux;Job is a top job and will run at Wed Oct 30 19:55:56 2030
10/31/2025 19:55:59.131562;0040;pbs_sched;Job;7636.almalinux;Not enough free nodes available
```

Fixing this can improve the estimates in the scheduler. Although I realize dynamic resources can change suddenly in general, and we can not really predict the value surely, as the manual PBSAdminGuide2022.1, page AG-111, chapter 4.9.3.10.iii mentions. It warns against using the calendar and dynamic resources together. We usually use server dynamic resources as license resources, which are released altogether with the job, and here it can help. So it can, in this case, behave like a static resource...

I believe initializing the assigned value is useful, and it is worse not to initialize them. The current value is totally unrealistic. IMO, the reason not to initialize is the increase in the asymptotic complexity of the scheduler, which has a lot on its plate already.

So, let me know if I should withdraw this pull request. 


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

The initialization of assigned value of the server dynamic resources is added in the query_server() function, and the annoying line is gone:
```
10/31/2025 19:59:34.156237;0080;pbs_sched;Req;;Starting Scheduling Cycle
10/31/2025 19:59:34.411107;0080;pbs_sched;Job;7638.almalinux;Considering job to run
10/31/2025 19:59:34.411209;0080;pbs_sched;Job;7638.almalinux;Job is a top job and will run at Wed Oct 30 19:59:32 2030
10/31/2025 19:59:34.411222;0040;pbs_sched;Job;7638.almalinux;Not enough free nodes available
10/31/2025 19:59:34.411271;0080;pbs_sched;Req;;Leaving Scheduling Cycle
```



#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

The new ptl test log: [ptl_test_res_dyn_res_assigned_calendar.txt](https://github.com/user-attachments/files/23268639/ptl_test_res_dyn_res_assigned_calendar.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
