### PR TITLE
Fix loop condition in parse_servername(...)

### DIFF
--- a/src/lib/Libutil/misc_utils.c
+++ b/src/lib/Libutil/misc_utils.c
@@ -2396,7 +2396,7 @@ parse_servername(char *name, unsigned int *service)
 	/* look for a ':', '+' or '/' in the string */
 
 	pc = name;
-	while (*pc && (i < PBS_MAXSERVERNAME + PBS_MAXPORTNUM + 2)) {
+	while (*pc && (i < PBS_MAXSERVERNAME + PBS_MAXPORTNUM + 1)) {
 		if ((*pc == '+') || (*pc == '/')) {
 			break;
 		} else if (*pc == ':') {


### PR DESCRIPTION
#### Describe Your Change
Fixes the buffer overflow error due to off by one access as described in #2697. The only change made is to the loop condition by changing it from `i < PBS_MAXSERVERNAME + PBS_MAXPORTNUM + 2` to `i < PBS_MAXSERVERNAME + PBS_MAXPORTNUM + 1`. This avoids the potential for out of bounds access while maintaining the intended behavior.
