### PR TITLE
Increase size of `host` array by 1 for null char

### DIFF
--- a/src/lib/Libcmds/parse_at.c
+++ b/src/lib/Libcmds/parse_at.c
@@ -152,7 +152,7 @@ parse_at_list(char *list, int use_count, int abs_path)
 	char *b, *c, *s, *list_dup;
 	int rc = 0;
 	char user[MAXPATHLEN + 1];
-	char host[PBS_MAXSERVERNAME];
+	char host[PBS_MAXSERVERNAME + 1];
 	struct hostlist *ph, *nh, *hostlist = NULL;
 
 	if ((list == NULL) || (*list == '\0'))


### PR DESCRIPTION
#### Describe Bug or Feature
Fixes the buffer overflow error described in #2699 

#### Describe Your Change
Increased the size of stack allocated `char host[]` by 1 in `int parse_at_list(char *list, int use_count, int abs_path)` to take into account the size for null terminator.