### PR TITLE
Fixed compilation errors and warnings

### DIFF
--- a/m4/with_tcl.m4
+++ b/m4/with_tcl.m4
@@ -91,6 +91,10 @@ AC_DEFUN([PBS_AC_WITH_TCL],
     [tcl_lib="$TCL_LIB_SPEC $TCL_LIBS"]
     [tk_inc="$TK_INCLUDE_SPEC"]
     [tk_lib=`echo "$TCL_LIB_SPEC $TK_LIB_SPEC $TK_LIBS" | ${SED} -e 's/-lXss //'`])
+  save_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$CPPFLAGS $tcl_inc"
+  AC_CHECK_TYPES([Tcl_Size], [], [], [[#include <tcl.h>]])
+  CPPFLAGS="$save_CPPFLAGS"
   AC_SUBST(tcl_inc)
   AC_SUBST(tcl_lib)
   AC_SUBST(tk_inc)

--- a/src/cmds/qstat.c
+++ b/src/cmds/qstat.c
@@ -489,8 +489,9 @@ prt_attr(char *name, char *resource, char *value, int one_line, json_data * json
 						*buf++ = '\0';
 						val = buf;
 						value++;
+					} else {
+						*buf++ = *value++;
 					}
-					*buf++ = *value++;
 				}
 				*buf = '\0';
 				if (pbs_json_insert_parsed(json_attr, key, val, 0))

--- a/src/cmds/qstat.c
+++ b/src/cmds/qstat.c
@@ -460,12 +460,13 @@ prt_attr(char *name, char *resource, char *value, int one_line, json_data * json
 	char *buf = NULL;
 	char *temp = NULL;
 	json_data *json_attr = NULL;
+	int item_type = 0;
 
 	if (value == NULL)
 		return;
 	switch (output_format) {
 	case FORMAT_JSON:
-		int item_type = batch_item_json_type_triage (name, resource);
+		item_type = batch_item_json_type_triage (name, resource);
 		switch (item_type) {
 		case BATCH_ITEM_IS_ATTR_V:
 			if ((json_attr = pbs_json_create_object()) == NULL)

--- a/src/cmds/qstat.c
+++ b/src/cmds/qstat.c
@@ -1789,10 +1789,6 @@ display_statque(struct batch_status *status, int prtheader, int full, int alt_op
 		type = "not defined";
 		prev_resc_name = NULL;
 
-		char *new_type_restr_acc = NULL;
-		size_t acc_len = 0;
-
-		char *new_type_attr_name = NULL;
 		char *attr_names[MAX_ATTRS] = {0};
 		char *attr_values[MAX_ATTRS] = {0};
 		int attr_count = 0;
@@ -1820,8 +1816,7 @@ display_statque(struct batch_status *status, int prtheader, int full, int alt_op
 						}
 						else { /* new type but not a sub resource */
 							accumulate_restriction(attr_names, attr_values, &attr_count, MAX_ATTRS, a->name, a->value);
-							new_type_attr_name = a->name;
-						} 
+						}
 					} else { /* not new-type queue restriction */
 						prt_attr(a->name, a->resource, a->value,
 							alt_opt & ALT_DISPLAY_w, json_queue);

--- a/src/resmom/mom_inter.c
+++ b/src/resmom/mom_inter.c
@@ -667,8 +667,6 @@ mom_writer_pkt(int s, int ptc)
 	while (1) {
 		c = read(ptc, buf, sizeof(buf));
 		if (c > 0) {
-			int wc;
-			char *p = buf;
 			transport_send_pkt(s, AUTH_ENCRYPTED_DATA, buf, c);
 		} else if (c == 0) {
 			return (0);

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -7923,7 +7923,7 @@ degrade_offlined_nodes_reservations(void)
  * @par MT-safe: No
  */
 void
-degrade_downed_nodes_reservations(struct work_task *)
+degrade_downed_nodes_reservations(struct work_task *pwt)
 {
 	int i;
 	struct pbsnode *pn;

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -3612,7 +3612,7 @@ check_resource_set_on_jobs_or_resvs(struct batch_request *preq, resource_def *pr
  * 		helper function to send/update resourcedef file.
  */
 static void
-timed_send_rescdef(struct work_task *)
+timed_send_rescdef(struct work_task *pwt)
 {
 	send_rescdef(1); /* forcing with 1 to avoid failures due to intermittent file stamp race issues */
 	rescdef_wt_g = NULL;

--- a/src/tools/pbs_tclWrap.c
+++ b/src/tools/pbs_tclWrap.c
@@ -57,10 +57,6 @@
 #include "cmds.h"
 #include "attribute.h"
 
-#if !defined(CONST)
-#define CONST const
-#endif
-
 #if !defined(HAVE_TCL_SIZE)
 typedef int Tcl_Size;
 #endif
@@ -110,7 +106,7 @@ int (*local_disconnect)(int connection) = __pbs_disconnect;
 #endif
 
 int
-OpenRM(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+OpenRM(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	int port = 0;
 	int fd;
@@ -139,7 +135,7 @@ OpenRM(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[
 }
 
 int
-CloseRM(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+CloseRM(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	int fd, ret;
 	char *cmd;
@@ -168,7 +164,7 @@ CloseRM(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv
 }
 
 int
-DownRM(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+DownRM(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	int fd, ret;
 	char *cmd;
@@ -197,7 +193,7 @@ DownRM(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[
 }
 
 int
-ConfigRM(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+ConfigRM(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	int fd, ret;
 	char *cmd, *filename;
@@ -229,7 +225,7 @@ ConfigRM(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST obj
 }
 
 int
-AddREQ(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+AddREQ(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	int fd, ret;
 	char *cmd, *request;
@@ -278,7 +274,7 @@ AllREQ(ClientData clientData, Tcl_Interp *interp, int argc, const char *argv[])
 }
 
 int
-GetREQ(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+GetREQ(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	int fd;
 	char *ret;
@@ -653,7 +649,7 @@ PBS_StatQue(ClientData clientData, Tcl_Interp *interp, int argc, const char *arg
 }
 
 int
-PBS_StatNode(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+PBS_StatNode(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	char *msg, *cmd;
 	char *node = NULL;
@@ -942,7 +938,7 @@ PBS_StopQueue(ClientData clientData, Tcl_Interp *interp, int argc, const char *a
 }
 
 int
-PBS_AlterJob(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+PBS_AlterJob(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	static char id[] = "PBS_AlterJob";
 	char *msg;
@@ -1054,7 +1050,7 @@ done:
 }
 
 int
-PBS_RescQuery(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+PBS_RescQuery(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	static char id[] = "PBS_RescQuery";
 	char *msg;
@@ -1180,7 +1176,7 @@ PBS_RescQuery(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONS
 }
 
 int
-PBS_RescReserve(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+PBS_RescReserve(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	static char id[] = "PBS_RescReserve";
 	char *msg;
@@ -1244,7 +1240,7 @@ PBS_RescReserve(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CO
 }
 
 int
-PBS_RescRelease(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+PBS_RescRelease(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	char *msg;
 	int ret;
@@ -1378,7 +1374,7 @@ PBS_ResvDelete(ClientData clientData, Tcl_Interp *interp, int argc, const char *
 }
 
 int
-LogMsg(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+LogMsg(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	char *tag = NULL;
 	char *msg = NULL;
@@ -1534,7 +1530,7 @@ DateTime(ClientData clientData, Tcl_Interp *interp, int argc, const char *argv[]
 }
 
 int
-StrFtime(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+StrFtime(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	struct tm *t;
 	long hold;
@@ -1561,7 +1557,7 @@ StrFtime(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST obj
 }
 
 int
-PBS_PbsPortInfoCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
+PBS_PbsPortInfoCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
 {
 	int index, result;
 	static const char *subCmds[] = {

--- a/src/tools/pbs_tclWrap.c
+++ b/src/tools/pbs_tclWrap.c
@@ -57,6 +57,14 @@
 #include "cmds.h"
 #include "attribute.h"
 
+#if !defined(CONST)
+#define CONST const
+#endif
+
+#if !defined(HAVE_TCL_SIZE)
+typedef int Tcl_Size;
+#endif
+
 char badparm[] = "%s: bad parameter";
 char missingfd[] = "%s: missing file descriptor";
 char not_connected[] = "not connected";
@@ -374,7 +382,7 @@ FullResp(ClientData clientData, Tcl_Interp *interp, int argc, const char *argv[]
 int
 PBS_Connect(ClientData clientData, Tcl_Interp *interp, int argc, const char *argv[])
 {
-	char *server = NULL;
+	const char *server = NULL;
 
 	if (argc == 2)
 		server = argv[1];
@@ -938,7 +946,9 @@ PBS_AlterJob(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST
 {
 	static char id[] = "PBS_AlterJob";
 	char *msg;
-	int i, num, tre, ret;
+	int i, ret;
+	Tcl_Size num;
+	Tcl_Size tre;
 	Tcl_Obj **listp, **indp;
 	struct attrl *attrs, *atp = NULL;
 	char *cmd, *jobid;
@@ -1048,7 +1058,8 @@ PBS_RescQuery(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONS
 {
 	static char id[] = "PBS_RescQuery";
 	char *msg;
-	int i, num, ret;
+	int i, ret;
+	Tcl_Size num;
 	Tcl_Obj **listp, *fourl[4], *retl;
 	char *cmd;
 	char **res_array;
@@ -1173,7 +1184,8 @@ PBS_RescReserve(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CO
 {
 	static char id[] = "PBS_RescReserve";
 	char *msg;
-	int i, num, ret;
+	int i, ret;
+	Tcl_Size num;
 	Tcl_Obj **listp;
 	char *cmd;
 	char **res_array;
@@ -1310,7 +1322,7 @@ PBS_ResvStatus(ClientData clientData, Tcl_Interp *interp, int argc, const char *
 int
 PBS_ResvConfirm(ClientData clientData, Tcl_Interp *interp, int argc, const char *argv[])
 {
-	char *msg = NULL;
+	const char *msg = NULL;
 	unsigned long stime = 0;
 
 	if (argc < 2 || argc > 4) {
@@ -1342,7 +1354,7 @@ PBS_ResvConfirm(ClientData clientData, Tcl_Interp *interp, int argc, const char 
 int
 PBS_ResvDelete(ClientData clientData, Tcl_Interp *interp, int argc, const char *argv[])
 {
-	char *msg = NULL;
+	const char *msg = NULL;
 
 	if (argc < 2 || argc > 3) {
 		sprintf(log_buffer,


### PR DESCRIPTION
#### Describe Your Change
This PR largely contains changes to fix compilations errors and warnings for various versions of gcc.  It also contains a fix for a failing test case that was part of the smoke tests.  It does not address compilation warnings from clang, so `-Wall -Werror` with recent versions of clang still fail.  A few of the clang warnings may be indicative of actual issues and thus should be looked at later.
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

#### Attach Test and Valgrind Logs/Output
```
{
  "command": "pbs_benchpress -F --db-name test-pdw-up-suse15-0-20260408215621.json -o test-pdw-up-suse15-0-20260408215621.log --tags=smoke",
  "user": "root",
  "product_version": "23.06.06.89.g1b711789",
  "run_id": "1775685400",
  "test_conf": {},
  "machine_info": {
    "pdw-up-suse15-0-s1.pdw-up-suse15-0.local": {
      "platform": "Linux pdw-up-suse15-0-s1 6.19.8-200.fc43.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 13 22:06:06 UTC 2026 x86_64 x86_64",
      "os_info": "Linux-6.19.8-200.fc43.x86_64-x86_64-with-glibc2.31",
      "pbs_install_type": "communication"
    }
  },
  ...,
  "test_summary": {
    "1": {
      "result_summary": {
        "run": 89,
        "succeeded": 85,
        "failed": 0,
        "errors": 0,
        "skipped": 4,
        "timedout": 0
      },
      "test_start_time": "2026-04-08 21:56:40.197782",
      "tests_with_failures": [],
      "test_suites_with_failures": [],
      "test_end_time": "2026-04-08 22:24:26.329553",
      "tests_duration": "0:27:46.131771"
    }
  },
  ...,
  "result": {
    "tests_with_failures": [],
    "test_suites_with_failures": [],
    "start": "2026-04-08 21:56:24.214060",
    "end": "2026-04-08 22:24:26.343389",
    "duration": "0:28:02.129329"
  }
}
```
