### PR TITLE
Prevent server crash when deleting nonexistent jobs

### DIFF
--- a/src/server/req_delete.c
+++ b/src/server/req_delete.c
@@ -256,8 +256,8 @@ all_jobs_deleted(struct batch_reply *preply)
  * @param[in]	errcode - Job's error code 
  *
  * @return	bool
- * @retval	TRUE	- all jobs deleted
- * @retval	FALSE	- jobs remaining to be deleted
+ * @retval	TRUE	- all jobs in the preq have been processed and deleted
+ * @retval	FALSE	- jobs remaining to be processed or deleted
  */
 bool
 update_deljob_rply(struct batch_request *preq, char *jid, int errcode)
@@ -294,7 +294,8 @@ update_deljob_rply(struct batch_request *preq, char *jid, int errcode)
 		log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_SERVER, LOG_DEBUG,
 			  __func__, "update_deljob_rply invoked with empty job id");
 
-	return all_jobs_deleted(preply);
+	return all_jobs_deleted(preply) &&
+	       (preq->rq_ind.rq_deletejoblist.jobid_to_resume == preq->rq_ind.rq_deletejoblist.rq_count - 1);
 }
 
 /**
@@ -551,8 +552,8 @@ init_deljoblist(struct batch_request *preq)
  * @param[in] preq - request structure
  * 
  * @return bool
- * @retval TRUE: no more jobs to be deleted
- * @reval  FALSE: more jobs pending to be deleted
+ * @retval	TRUE	- all jobs in the preq have been processed and deleted
+ * @retval	FALSE	- jobs remaining to be processed or deleted
  */
 bool
 delete_pending_arrayjobs(struct batch_request *preq)
@@ -573,7 +574,8 @@ delete_pending_arrayjobs(struct batch_request *preq)
 
 	pbs_idx_free_ctx(idx_ctx);
 
-	return all_jobs_deleted(preply);
+	return all_jobs_deleted(preply) &&
+	       (preq->rq_ind.rq_deletejoblist.jobid_to_resume == preq->rq_ind.rq_deletejoblist.rq_count - 1);
 }
 
 /**

--- a/test/tests/functional/pbs_qdel.py
+++ b/test/tests/functional/pbs_qdel.py
@@ -544,6 +544,129 @@ class TestQdel(TestFunctional):
         rv = self.server.isUp()
         self.assertTrue(rv, "Server crashed")
 
+    def test_qdel_with_nonexistent_jobids_at_end(self):
+        """
+        Test if the server crashes when deleting a list of existing queued
+        jobs and job ids that are not yet in existence.  The reason the jobs
+        must be queued as opposed to running is that sending a signal message
+        to the running jobs creates a race condition.
+        """
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'false'})
+        stime = int(time.time())
+        j = Job(TEST_USER)
+        jid1 = self.server.submit(j)
+        jid2 = self.server.submit(j)
+        i_str, s = jid1.split('.', 1)
+        i = int(i_str)
+        ni = i + 10000
+        njid1 = "%d.%s" % (ni, s)
+        njid2 = "%d.%s" % (ni + 1, s)
+        jid_list = [jid1, jid2,  njid1, njid2]
+        # jid_short_list = [j.split('.')[0] for j in jid_list]
+        self.server.expect(JOB, {'job_state': 'Q'}, jid2)
+        try:
+            # self.server.delete(jid_short_list)
+            self.server.delete(jid_list)
+        except PbsDeleteError as e:
+            for msg in e.msg:
+                if "Unknown Job Id" not in msg:
+                    raise
+        rv = self.server.isUp()
+        self.assertTrue(rv, "Server crashed")
+        self.server.log_match("Job;%s;Job to be deleted" % (jid1), starttime=stime, max_attempts=1)
+        self.server.log_match("Job;%s;Job to be deleted" % (jid2), starttime=stime, max_attempts=1)
+        self.server.log_match("Job;%s;Unknown Job Id" % (njid1), starttime=stime, max_attempts=1)
+        self.server.log_match("Job;%s;Unknown Job Id" % (njid2), starttime=stime, max_attempts=1)
+
+    def test_qdel_with_nonexistent_array_jobids_at_begin_end(self):
+        """
+        Test if the server or qdel crashes when deleting a list of existing
+        jobs surrounded by array jobids that are not yet in existence.
+        """
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'false'})
+        stime = int(time.time())
+        j = Job(TEST_USER)
+        jid1 = self.server.submit(j)
+        jid2 = self.server.submit(j)
+        i_str, s = jid1.split('.', 1)
+        i = int(i_str)
+        ni = i + 10000
+        a = {ATTR_J: '1-20', 'Resource_List.select': 'ncpus=1'}
+        j = Job(TEST_USER, a)
+        ajid1 = self.server.submit(j)
+        ajid2 = self.server.submit(j)
+        najid1 = "%d[].%s" % (ni, s)
+        najid2 = "%d[].%s" % (ni + 1, s)
+        najid3 = "%d[].%s" % (ni + 2, s)
+        najid4 = "%d[].%s" % (ni + 3, s)
+        jid_list = [najid1, najid2, ajid1, jid1, jid2, ajid2, najid3, najid4]
+        # jid_short_list = [j.split('.')[0] for j in jid_list]
+        self.server.expect(JOB, {'job_state': 'Q'}, ajid2)
+        try:
+            # self.server.delete(jid_short_list)
+            self.server.delete(jid_list)
+        except PbsDeleteError as e:
+            for msg in e.msg:
+                if "Unknown Job Id" not in msg:
+                    raise
+        rv = self.server.isUp()
+        self.assertTrue(rv, "Server crashed")
+        self.server.log_match("Job;%s;Unknown Job Id" % (najid1), starttime=stime, max_attempts=1)
+        self.server.log_match("Job;%s;Unknown Job Id" % (najid2), starttime=stime, max_attempts=1)
+        self.server.log_match("Job;%s;Unknown Job Id" % (najid3), starttime=stime, max_attempts=1)
+        self.server.log_match("Job;%s;Unknown Job Id" % (najid4), starttime=stime, max_attempts=1)
+        self.server.log_match("Job;%s;Job to be deleted" % (ajid1), starttime=stime, max_attempts=1)
+        self.server.log_match("Job;%s;Job to be deleted" % (jid1), starttime=stime, max_attempts=1)
+        self.server.log_match("Job;%s;Job to be deleted" % (ajid2), starttime=stime, max_attempts=1)
+
+    def test_qdel_with_nonexistent_subjobids_at_begin_end(self):
+        """
+        Test if the server or qdel crashes when deleting a list of existing
+        jobs surrounded by array subjobids that are not yet in existence.
+        """
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'false'})
+        stime = int(time.time())
+        j = Job(TEST_USER)
+        jid1 = self.server.submit(j)
+        jid2 = self.server.submit(j)
+        i_str, s = jid1.split('.', 1)
+        i = int(i_str)
+        ni = i + 10000
+        a = {ATTR_J: '1-20', 'Resource_List.select': 'ncpus=1'}
+        j = Job(TEST_USER, a)
+        ajid1 = self.server.submit(j)
+        sjid1a = ajid1.replace("[]", "[3]")
+        sjid1b = ajid1.replace("[]", "[5]")
+        sjid1c = ajid1.replace("[]", "[7]")
+        ajid2 = self.server.submit(j)
+        sjid2a = ajid2.replace("[]", "[11]")
+        sjid2b = ajid2.replace("[]", "[13]")
+        sjid2c = ajid2.replace("[]", "[17]")
+        nsjid1a = "%d[10].%s" % (ni, s)
+        nsjid1b = "%d[20].%s" % (ni, s)
+        nsjid1c = "%d[30].%s" % (ni, s)
+        nsjid2a = "%d[40].%s" % (ni + 1, s)
+        nsjid2b = "%d[50].%s" % (ni + 1, s)
+        nsjid2c = "%d[60].%s" % (ni + 1, s)
+        jid_list = [
+            nsjid1a, nsjid1b, nsjid1c, jid1, sjid1a, sjid1b, sjid1c, sjid2a, sjid2b,
+              sjid2c, jid2, nsjid2a, nsjid2b, nsjid2c
+        ]
+        # jid_short_list = [j.split('.')[0] for j in jid_list]
+        self.server.expect(JOB, {'job_state': 'Q'}, ajid2)
+        try:
+            # self.server.delete(jid_short_list)
+            self.server.delete(jid_list)
+        except PbsDeleteError as e:
+            for msg in e.msg:
+                if "Unknown Job Id" not in msg:
+                    raise
+        rv = self.server.isUp()
+        self.assertTrue(rv, "Server crashed")
+        self.server.log_match("Job;%s;Job to be deleted" % (jid1), starttime=stime, max_attempts=1)
+        self.server.log_match("Job;%s;Job to be deleted" % (jid2), starttime=stime, max_attempts=1)
+        # TODO: add subjob state checks on deleted and non-deleted subjobs
+
     def test_qdel_with_overlaping_array_jobs(self):
         """
         Test server crash with overlaping array jobs


### PR DESCRIPTION
This PR fixes a server segmentation fault that occurs when a PBS_BATCH_DeleteJobList request includes nonexistent jobs at the end of the list.  The server could crash while iterating through the job list, especially if none of the jobs listed are actively running.  This change ensures the entire job list is processed before completing the request and freeing the batch request structure.

It was unclear if the change to `delete_pending_arrayjobs()` was necessary, but the code fit the pattern needing to be addressed and the patch does not appear to have negatively affected functionality.

Additional issues were found during the testing of this fix, and is the reason for the commented out code in the tests provided.  They will be addressed subsequent PRs.

#### Test Results for Smoke Tests
```
{
  "command": "pbs_benchpress -F --db-name test-pdw-up-suse15-0-20260428182749.json -o test-pdw-up-suse15-0-20260428182749.log --tags=smoke",
  "user": "root",
  "product_version": "23.06.06.86.gd3ccc972",
  "run_id": "1777400888",
  "test_conf": {},
  "machine_info": {
    "pdw-up-suse15-0-s1.pdw-up-suse15-0.local": {
      "platform": "Linux pdw-up-suse15-0-s1 6.19.8-200.fc43.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 13 22:06:06 UTC 2026 x86_64 x86_64",
      "os_info": "Linux-6.19.8-200.fc43.x86_64-x86_64-with-glibc2.31",
      "pbs_install_type": "communication"
    }
  },
  ...,
  "test_summary": {
    "1": {
      "result_summary": {
        "run": 89,
        "succeeded": 85,
        "failed": 0,
        "errors": 0,
        "skipped": 4,
        "timedout": 0
      },
      "test_start_time": "2026-04-28 18:28:08.253397",
      "tests_with_failures": [],
      "test_suites_with_failures": [],
      "test_end_time": "2026-04-28 18:54:55.214820",
      "tests_duration": "0:26:46.961423"
    }
  },
  ...,
    "result": {
    "tests_with_failures": [],
    "test_suites_with_failures": [],
    "start": "2026-04-28 18:27:51.978900",
    "end": "2026-04-28 18:54:55.226111",
    "duration": "0:27:03.247211"
  }
}
```

#### Test Results for TestQdel
```
{
  "command": "pbs_benchpress -F --db-name test-pdw-up-suse15-0-20260428190047.json -o test-pdw-up-suse15-0-20260428190047.log -t TestQdel",
  "user": "root",
  "product_version": "23.06.06.86.gd3ccc972",
  "run_id": "1777402865",
  "test_conf": {},
  "machine_info": {
    "pdw-up-suse15-0-s1.pdw-up-suse15-0.local": {
      "platform": "Linux pdw-up-suse15-0-s1 6.19.8-200.fc43.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 13 22:06:06 UTC 2026 x86_64 x86_64",
      "os_info": "Linux-6.19.8-200.fc43.x86_64-x86_64-with-glibc2.31",
      "pbs_install_type": "communication"
    }
  },
  ...,
  "test_summary": {
    "1": {
      "result_summary": {
        "run": 28,
        "succeeded": 28,
        "failed": 0,
        "errors": 0,
        "skipped": 0,
        "timedout": 0
      },
      "test_start_time": "2026-04-28 19:01:05.536183",
      "tests_with_failures": [],
      "test_suites_with_failures": [],
      "test_end_time": "2026-04-28 19:14:53.737374",
      "tests_duration": "0:13:48.201191"
    }
  },
  ...,
  "result": {
    "tests_with_failures": [],
    "test_suites_with_failures": [],
    "start": "2026-04-28 19:00:49.563745",
    "end": "2026-04-28 19:14:53.744299",
    "duration": "0:14:04.180554"
  }
}
```